### PR TITLE
Allow PV with permission less than 0777

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test: install-unittest-plugin manifests generate fmt vet lint
 .PHONY: lint
 lint: helm-create-resources ## Lint the helm charts and the Go operator
 	helm lint helm-charts/verticadb-operator
-ifneq (${GOLANGCI_LINT_VER}, "$(shell ./bin/golangci-lint version --format short 2>&1)")
+ifneq (${GOLANGCI_LINT_VER}, $(shell ./bin/golangci-lint version --format short 2>&1))
 	@echo "golangci-lint missing or not version '${GOLANGCI_LINT_VER}', downloading..."
 	curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/v${GOLANGCI_LINT_VER}/install.sh" | sh -s -- -b ./bin "v${GOLANGCI_LINT_VER}"
 endif

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ To minimize the number of errors, we will validate that the image can only chang
 
 # Persistence
 
-Each pod uses a PV to store local data. The PV is mounted in the container at `/home/dbadmin/local-data`. You must set permissions on the PV mount to 0777, or you get a "Permissions Denied" error when the container starts. If the PV was dynamically provisioned, you might need to manually change permissions with `chmod` after it is created.
+Each pod uses a PV to store local data. The PV is mounted in the container at `/home/dbadmin/local-data`. You must set permissions on the PV mount to 0775, or the operator could get a "Permissions Denied" error. If the PV was dynamically provisioned, you might need to manually change permissions with `chmod` after it is created.
 
 The local-data directory contains the following subdirectories:
 

--- a/docker-vertica/docker-entrypoint.sh
+++ b/docker-vertica/docker-entrypoint.sh
@@ -42,9 +42,11 @@ start_agent_when_ready(){
 }
 
 # We copy back the logrotate files in their original location /opt/vertica/config/
-# that's because we have a Persistent Volume that backs /opt/vertica/config, so it starts up empty and must be populated
+# that's because we have a Persistent Volume that backs /opt/vertica/config, so
+# it starts up empty and must be populated
 copy_logrotate_files(){
-    cp -r /home/dbadmin/logrotate/* /opt/vertica/config/
+    # We must use sudo in case the PV was created with permissions less than 0777.
+    sudo cp -r /home/dbadmin/logrotate/* /opt/vertica/config/
     rm -rf /home/dbadmin/logrotate
 }
 

--- a/pkg/controllers/dbaddnode_reconcile.go
+++ b/pkg/controllers/dbaddnode_reconcile.go
@@ -98,6 +98,10 @@ func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, sc *vapi.Subcluste
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	if err := changeDepotPermissions(ctx, d.Vdb, d.PRunner, pods); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	for _, pod := range pods {
 		// admintools will not cleanup the local directories after a failed attempt
 		// to add node. So we ensure those directories are clear at each pod before

--- a/pkg/controllers/init_db.go
+++ b/pkg/controllers/init_db.go
@@ -102,6 +102,10 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{}, err
 	}
 
+	if err := changeDepotPermissions(ctx, g.Vdb, g.PRunner, podList); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	debugDumpAdmintoolsConf(ctx, g.PRunner, atPod)
 
 	cmd := g.initializer.genCmd(getHostList(podList))

--- a/tests/e2e/private-pvc/00-assert.yaml
+++ b/tests/e2e/private-pvc/00-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: v-private-pv-local-path-provisioner
+status:
+  replicas: 1
+  readyReplicas: 1
+

--- a/tests/e2e/private-pvc/00-setup-private-storage-class.yaml
+++ b/tests/e2e/private-pvc/00-setup-private-storage-class.yaml
@@ -1,0 +1,31 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Setup and use a plugin that allows us to treat a git repository as a helm chart.
+  - command: helm plugin install https://github.com/aslafy-z/helm-git --version 0.10.0
+    ignoreFailure: true # The plugin may already exist
+  - command: helm repo add local-path-provisioner git+https://github.com/rancher/local-path-provisioner@deploy/chart?ref=v0.0.19
+  - command: helm repo update
+
+  # Cleanup any cluster scope objects from a prior helm install.
+  - command: kubectl delete storageclass v-private-pv-local-path
+    ignoreFailure: true # storageClass may not exist
+  - command: kubectl delete clusterrole v-private-pv-local-path-provisioner
+    ignoreFailure: true # clusterrole may not exist
+  - command: kubectl delete clusterrolebinding v-private-pv-local-path-provisioner
+    ignoreFailure: true # clusterrolebinding may not exist
+  - command: helm install v-private-pv local-path-provisioner/local-path-provisioner --values local-path-helm-overrides.yaml
+    namespaced: true

--- a/tests/e2e/private-pvc/05-assert.yaml
+++ b/tests/e2e/private-pvc/05-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/tests/e2e/private-pvc/05-deploy-operator.yaml
+++ b/tests/e2e/private-pvc/05-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e/private-pvc/10-assert.yaml
+++ b/tests/e2e/private-pvc/10-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio
+status:
+  currentState: Initialized
+  availableReplicas: 1
+  pools:
+    - ssName: minio-ss-0
+      state: PoolInitialized

--- a/tests/e2e/private-pvc/10-minio-create.yaml
+++ b/tests/e2e/private-pvc/10-minio-create.yaml
@@ -1,0 +1,47 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-creds-secret
+type: Opaque
+data:
+  ## Access Key for MinIO Tenant, base64 encoded (echo -n 'minio' | base64)
+  accesskey: bWluaW8=
+  ## Secret Key for MinIO Tenant, base64 encoded (echo -n 'minio123' | base64)
+  secretkey: bWluaW8xMjM=
+---
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: minio
+spec:
+  image: minio/minio:RELEASE.2021-02-24T18-44-45Z
+  imagePullPolicy: IfNotPresent
+  credsSecret:
+    name: minio-creds-secret
+  pools:
+    - servers: 1
+      volumesPerServer: 4
+      volumeClaimTemplate:
+        metadata:
+          name: data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 250Mi
+  mountPath: /export
+  requestAutoCert: false

--- a/tests/e2e/private-pvc/15-assert.yaml
+++ b/tests/e2e/private-pvc/15-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: create-s3-bucket
+status:
+  containerStatuses:
+    - name: aws
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e/private-pvc/15-create-bucket.yaml
+++ b/tests/e2e/private-pvc/15-create-bucket.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: create-s3-bucket
+spec:
+  containers:
+    - name: aws
+      image: amazon/aws-cli
+      command:
+        ["aws", "s3", "mb", "--endpoint", "http://minio", "s3://nimbusdb/db"]
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          value: minio
+        - name: AWS_SECRET_ACCESS_KEY
+          value: minio123
+  restartPolicy: Never

--- a/tests/e2e/private-pvc/20-assert.yaml
+++ b/tests/e2e/private-pvc/20-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-private-pv
+status:
+  subclusters:
+    - installCount: 2

--- a/tests/e2e/private-pvc/20-setup-vdb.yaml
+++ b/tests/e2e/private-pvc/20-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e/private-pvc/25-assert.yaml
+++ b/tests/e2e/private-pvc/25-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-private-pv
+status:
+  subclusters:
+    - installCount: 2
+      addedToDBCount: 2
+      upNodeCount: 2

--- a/tests/e2e/private-pvc/25-wait-for-createdb.yaml
+++ b/tests/e2e/private-pvc/25-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e/private-pvc/30-assert.yaml
+++ b/tests/e2e/private-pvc/30-assert.yaml
@@ -1,0 +1,25 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-private-pv
+status:
+  subclusters:
+    - installCount: 2
+      addedToDBCount: 2
+      upNodeCount: 2
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e/private-pvc/30-scale-new-sc.yaml
+++ b/tests/e2e/private-pvc/30-scale-new-sc.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-private-pv
+spec:
+  subclusters:
+    - name: sc1
+      size: 2
+    - name: sc2
+      size: 1

--- a/tests/e2e/private-pvc/35-assert.yaml
+++ b/tests/e2e/private-pvc/35-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-private-pv
+status:
+  installCount: 3
+  addedToDBCount: 3
+  upNodeCount: 0

--- a/tests/e2e/private-pvc/35-kill-pods.yaml
+++ b/tests/e2e/private-pvc/35-kill-pods.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete pod v-private-pv-sc1-0
+    namespaced: true
+  - command: kubectl delete pod v-private-pv-sc1-1
+    namespaced: true
+  - command: kubectl delete pod v-private-pv-sc2-0
+    namespaced: true

--- a/tests/e2e/private-pvc/40-assert.yaml
+++ b/tests/e2e/private-pvc/40-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-private-pv
+status:
+  installCount: 3
+  addedToDBCount: 3
+  upNodeCount: 3

--- a/tests/e2e/private-pvc/40-wait-for-restart.yaml
+++ b/tests/e2e/private-pvc/40-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e/private-pvc/90-cleanup-private-storage-class.yaml
+++ b/tests/e2e/private-pvc/90-cleanup-private-storage-class.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: helm uninstall v-private-pv
+    namespaced: true

--- a/tests/e2e/private-pvc/90-errors.yaml
+++ b/tests/e2e/private-pvc/90-errors.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: v-private-pv-local-path-provisioner

--- a/tests/e2e/private-pvc/95-delete-crd.yaml
+++ b/tests/e2e/private-pvc/95-delete-crd.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: minio.min.io/v2
+    kind: Tenant

--- a/tests/e2e/private-pvc/95-errors.yaml
+++ b/tests/e2e/private-pvc/95-errors.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e/private-pvc/99-errors.yaml
+++ b/tests/e2e/private-pvc/99-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e/private-pvc/99-uninstall-operator.yaml
+++ b/tests/e2e/private-pvc/99-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e/private-pvc/README.txt
+++ b/tests/e2e/private-pvc/README.txt
@@ -1,0 +1,3 @@
+Tests the deployment against a provisioner that creates the PVC with private
+(0775) access.  We use a version of Rancher's local-path-provisioner,
+configured so that the PV is created with 0775 permissions.

--- a/tests/e2e/private-pvc/local-path-helm-overrides.yaml
+++ b/tests/e2e/private-pvc/local-path-helm-overrides.yaml
@@ -1,0 +1,36 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+storageClass:
+  name: v-private-pv-local-path
+
+configmap:
+  # Setup was taken from https://github.com/rancher/local-path-provisioner/blob/master/deploy/local-path-storage.yaml
+  # Permission was changed on the mkdir to be 0775 instead of 0777.
+  setup: |-
+    #!/bin/sh
+    while getopts "m:s:p:" opt
+    do
+        case $opt in
+            p)
+            absolutePath=$OPTARG
+            ;;
+            s)
+            sizeInBytes=$OPTARG
+            ;;
+            m)
+            volMode=$OPTARG
+            ;;
+        esac
+    done
+    mkdir -m 0775 -p ${absolutePath}

--- a/tests/e2e/private-pvc/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e/private-pvc/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bases:
+  - ../../../../kustomize-base
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e/private-pvc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/private-pvc/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-private-pv
+spec:
+  image: replace-with-kustomize
+  communal:
+    path: "s3://nimbusdb/db"
+    endpoint: "http://minio"
+    credentialSecret: minio-creds-secret
+  local:
+    storageClass: v-private-pv-local-path
+  dbName: vertdb
+  subclusters:
+    - name: sc1
+      size: 2
+  kSafety: "0"


### PR DESCRIPTION
This is for VER-77261.

This relaxes the requirement that PV must have 0777 permissions.  We can
allow 0775 now, which is the default permission for local data in EKS.

Vertica handles changing the ownership of most of the directories,
except the depot.  The depot directory had to be handled specifically.

I created an e2e test that mimics the reduced permission using a custom
config for Rancher's local-path-provisioner.