### PR TITLE
Operator to control starting of vertica agent

### DIFF
--- a/docker-vertica/docker-entrypoint.sh
+++ b/docker-vertica/docker-entrypoint.sh
@@ -6,41 +6,6 @@ start_cron(){
     sudo /usr/sbin/crond
 }
 
-# Kubernetes start-up is a little weird
-#  - in order to configure the host-list correctly, k8s
-#    has to do an install_vertica, which writes to
-#    non-volatile store
-#  - but the agent needs things that will be created by
-#    that install.
-#  - so we don't start the agent until we find the database running 
-start_agent_when_ready(){
-    agent_started=No
-    while [ $agent_started == No ]; do
-        if [ -f /opt/vertica/config/admintools.conf ]; then
-            # safe to try to run admintools
-            db=$(/opt/vertica/bin/admintools -t show_active_db) || true
-            # If we ask too early --- before this container's database has been
-            # created, the output is not a database name (nor is it empty), it
-            # is an error message that begins "admintools cannot be run..."
-            case "$db"x in
-                x|*admintools*cannot*)
-                    sleep 15
-                    ;;
-                *)
-                    echo "Starting vertica agent for db $db"
-                    sudo /opt/vertica/sbin/vertica_agent start \
-                         2> /tmp/agent_start.err \
-                         1> /tmp/agent_start.out
-                    echo "Agent started"
-                    agent_started=Yes
-                    ;;
-            esac
-        else
-            sleep 15
-        fi
-    done 
-}
-
 # We copy back the logrotate files in their original location /opt/vertica/config/
 # that's because we have a Persistent Volume that backs /opt/vertica/config, so
 # it starts up empty and must be populated
@@ -52,7 +17,6 @@ copy_logrotate_files(){
 
 start_cron
 copy_logrotate_files
-start_agent_when_ready &
 
 echo "Vertica container is now running"
 sudo /usr/sbin/sshd -D

--- a/docker-vertica/packages/init.d.functions
+++ b/docker-vertica/packages/init.d.functions
@@ -86,3 +86,10 @@ echo_success() {
   return 0
 }
 
+echo_failure() {
+    echo -n "["
+    echo -n $"FAILED"
+    echo -n "]"
+    echo -ne "\r"
+    return 1
+}

--- a/docker-vertica/packages/init.d.functions
+++ b/docker-vertica/packages/init.d.functions
@@ -26,7 +26,7 @@ __pids_var_run() {
 	        if [ -n "$pid" ]; then
 	                return 0
 	        fi
-y		return 1 # "Program is dead and /var/run pid file exists"
+		return 1 # "Program is dead and /var/run pid file exists"
 	fi
 	return 3 # "Program is not running"
 }

--- a/pkg/controllers/actor.go
+++ b/pkg/controllers/actor.go
@@ -31,6 +31,11 @@ import (
 // reconciliation process.
 type ReconcileActor interface {
 	Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error)
+}
+
+// ScaledownActor is an interface that handles a part of scale down, either
+// db_remove_node or uninstall.
+type ScaledownActor interface {
 	GetClient() client.Client
 	GetVDB() *vapi.VerticaDB
 	CollectPFacts(ctx context.Context) error
@@ -40,7 +45,7 @@ type ReconcileActor interface {
 // This is a common function that is used by the DBRemoveNodeReconciler and
 // UninstallReconciler. It will call a func (scaleDownFunc) for a range of pods
 // that are to be scaled down.
-func scaledownSubcluster(ctx context.Context, act ReconcileActor, sc *vapi.Subcluster,
+func scaledownSubcluster(ctx context.Context, act ScaledownActor, sc *vapi.Subcluster,
 	scaleDownFunc func(context.Context, *vapi.Subcluster, int32, int32) (ctrl.Result, error)) (ctrl.Result, error) {
 	if sc == nil {
 		return ctrl.Result{}, nil

--- a/pkg/controllers/agent_reconcile_test.go
+++ b/pkg/controllers/agent_reconcile_test.go
@@ -1,0 +1,75 @@
+/*
+ (c) Copyright [2021] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"yunion.io/x/pkg/tristate"
+)
+
+var _ = Describe("agent_reconcile", func() {
+	ctx := context.Background()
+
+	It("should start the agent if it isn't running", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters[0].Size = 2
+		createPods(ctx, vdb, AllPodsRunning)
+		defer deletePods(ctx, vdb)
+
+		cmds := reconcileAndFindVerticaAgentStart(ctx, vdb)
+		Expect(len(cmds)).Should(Equal(2))
+	})
+
+	It("should avoid starting the agent if ipv6", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters[0].Size = 3
+		createIPv6Pods(ctx, vdb, AllPodsRunning)
+		defer deletePods(ctx, vdb)
+
+		cmds := reconcileAndFindVerticaAgentStart(ctx, vdb)
+		Expect(len(cmds)).Should(Equal(0))
+	})
+
+	It("should avoid starting the agent if DB is not included", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters[0].Size = 1
+		createPods(ctx, vdb, AllPodsRunning)
+		defer deletePods(ctx, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr)
+		pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)].dbExists = tristate.False
+		r := MakeAgentReconciler(vrec, logger, vdb, fpr, pfacts)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		cmds := fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
+		Expect(len(cmds)).Should(Equal(0))
+	})
+})
+
+func reconcileAndFindVerticaAgentStart(ctx context.Context, vdb *vapi.VerticaDB) []cmds.CmdHistory {
+	fpr := &cmds.FakePodRunner{}
+	pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr)
+	r := MakeAgentReconciler(vrec, logger, vdb, fpr, pfacts)
+	Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+	return fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
+}

--- a/pkg/controllers/agent_reconciler.go
+++ b/pkg/controllers/agent_reconciler.go
@@ -55,7 +55,7 @@ func (a *AgentReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctr
 		}
 		// We don't start the vertica agent if running ipv6 since the agent
 		// currently doesn't work in that mode.  This can be removed once
-		// VER-77406 is addressed.
+		// that is addressed.
 		if isIPv6(pod.podIP) {
 			continue
 		}

--- a/pkg/controllers/agent_reconciler.go
+++ b/pkg/controllers/agent_reconciler.go
@@ -22,7 +22,6 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // AgentReconciler will ensure the agent is running
@@ -38,18 +37,6 @@ type AgentReconciler struct {
 func MakeAgentReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &AgentReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
-}
-
-func (a *AgentReconciler) GetClient() client.Client {
-	return a.VRec.Client
-}
-
-func (a *AgentReconciler) GetVDB() *vapi.VerticaDB {
-	return a.Vdb
-}
-
-func (a *AgentReconciler) CollectPFacts(ctx context.Context) error {
-	return a.PFacts.Collect(ctx, a.Vdb)
 }
 
 // Reconcile will ensure the agent is running and start it if it isn't

--- a/pkg/controllers/agent_reconciler.go
+++ b/pkg/controllers/agent_reconciler.go
@@ -1,0 +1,94 @@
+/*
+ (c) Copyright [2021] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AgentReconciler will ensure the agent is running
+type AgentReconciler struct {
+	VRec    *VerticaDBReconciler
+	Log     logr.Logger
+	Vdb     *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	PRunner cmds.PodRunner
+	PFacts  *PodFacts
+}
+
+// MakeAgentReconciler will build a AgentReonciler object
+func MakeAgentReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
+	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
+	return &AgentReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
+}
+
+func (a *AgentReconciler) GetClient() client.Client {
+	return a.VRec.Client
+}
+
+func (a *AgentReconciler) GetVDB() *vapi.VerticaDB {
+	return a.Vdb
+}
+
+func (a *AgentReconciler) CollectPFacts(ctx context.Context) error {
+	return a.PFacts.Collect(ctx, a.Vdb)
+}
+
+// Reconcile will ensure the agent is running and start it if it isn't
+func (a *AgentReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if err := a.PFacts.Collect(ctx, a.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for _, pod := range a.PFacts.Detail {
+		if pod.agentRunning {
+			continue
+		}
+		// Only start the agent for pods that have been added to a database
+		if !pod.dbExists.IsTrue() {
+			continue
+		}
+		// We don't start the vertica agent if running ipv6 since the agent
+		// currently doesn't work in that mode.  This can be removed once
+		// VER-77406 is addressed.
+		if isIPv6(pod.podIP) {
+			continue
+		}
+		if err := a.startAgentInPod(ctx, pod); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Invalidate the pod facts cache since its out of date due to the agent starting
+		a.PFacts.Invalidate()
+	}
+	return ctrl.Result{}, nil
+}
+
+// startAgentInPod will start the agent in the given pod.
+func (a *AgentReconciler) startAgentInPod(ctx context.Context, pod *PodFact) error {
+	cmd := []string{
+		"sudo", "/opt/vertica/sbin/vertica_agent", "start",
+	}
+	if _, _, err := a.PRunner.ExecInPod(ctx, pod.name, ServerContainer, cmd...); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controllers/createdb_reconcile.go
+++ b/pkg/controllers/createdb_reconcile.go
@@ -32,7 +32,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -54,18 +53,6 @@ type CreateDBReconciler struct {
 func MakeCreateDBReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &CreateDBReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
-}
-
-func (c *CreateDBReconciler) GetClient() client.Client {
-	return c.VRec.Client
-}
-
-func (c *CreateDBReconciler) GetVDB() *vapi.VerticaDB {
-	return c.Vdb
-}
-
-func (c *CreateDBReconciler) CollectPFacts(ctx context.Context) error {
-	return c.PFacts.Collect(ctx, c.Vdb)
 }
 
 // Reconcile will ensure a DB exists and create one if it doesn't

--- a/pkg/controllers/dbaddnode_reconcile.go
+++ b/pkg/controllers/dbaddnode_reconcile.go
@@ -27,7 +27,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"yunion.io/x/pkg/tristate"
 )
 
@@ -44,18 +43,6 @@ type DBAddNodeReconciler struct {
 func MakeDBAddNodeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &DBAddNodeReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
-}
-
-func (d *DBAddNodeReconciler) GetClient() client.Client {
-	return d.VRec.Client
-}
-
-func (d *DBAddNodeReconciler) GetVDB() *vapi.VerticaDB {
-	return d.Vdb
-}
-
-func (d *DBAddNodeReconciler) CollectPFacts(ctx context.Context) error {
-	return d.PFacts.Collect(ctx, d.Vdb)
 }
 
 // Reconcile will ensure a DB exists and create one if it doesn't

--- a/pkg/controllers/dbaddsubcluster_reconcile.go
+++ b/pkg/controllers/dbaddsubcluster_reconcile.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DBAddSubclusterReconciler will create a new subcluster if necessary
@@ -45,18 +44,6 @@ type SubclustersSet map[string]bool
 func MakeDBAddSubclusterReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &DBAddSubclusterReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
-}
-
-func (d *DBAddSubclusterReconciler) GetClient() client.Client {
-	return d.VRec.Client
-}
-
-func (d *DBAddSubclusterReconciler) GetVDB() *vapi.VerticaDB {
-	return d.Vdb
-}
-
-func (d *DBAddSubclusterReconciler) CollectPFacts(ctx context.Context) error {
-	return d.PFacts.Collect(ctx, d.Vdb)
 }
 
 // Reconcile will ensure a subcluster exists for each one defined in the vdb.

--- a/pkg/controllers/dbremovesubcluster_reconcile.go
+++ b/pkg/controllers/dbremovesubcluster_reconcile.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DBRemoveSubclusterReconciler will remove subclusters from the database
@@ -43,18 +42,6 @@ type DBRemoveSubclusterReconciler struct {
 func MakeDBRemoveSubclusterReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &DBRemoveSubclusterReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
-}
-
-func (d *DBRemoveSubclusterReconciler) GetClient() client.Client {
-	return d.VRec.Client
-}
-
-func (d *DBRemoveSubclusterReconciler) GetVDB() *vapi.VerticaDB {
-	return d.Vdb
-}
-
-func (d *DBRemoveSubclusterReconciler) CollectPFacts(ctx context.Context) error {
-	return d.PFacts.Collect(ctx, d.Vdb)
 }
 
 // Reconcile will remove any subcluster that no longer exists in the vdb.

--- a/pkg/controllers/install_reconcile.go
+++ b/pkg/controllers/install_reconcile.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // InstallReconciler will handle reconcile for install of vertica
@@ -53,18 +52,6 @@ func MakeInstallReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 		PRunner: prunner,
 		PFacts:  pfacts,
 	}
-}
-
-func (d *InstallReconciler) GetClient() client.Client {
-	return d.VRec.Client
-}
-
-func (d *InstallReconciler) GetVDB() *vapi.VerticaDB {
-	return d.Vdb
-}
-
-func (d *InstallReconciler) CollectPFacts(ctx context.Context) error {
-	return d.PFacts.Collect(ctx, d.Vdb)
 }
 
 // Reconcile will ensure Vertica is installed and running in the pods.
@@ -99,7 +86,7 @@ func (d *InstallReconciler) runUpdateVerticaAddHosts(ctx context.Context) error 
 		return nil
 	}
 
-	licensePath, err := license.GetPath(ctx, d.GetClient(), d.Vdb)
+	licensePath, err := license.GetPath(ctx, d.VRec.Client, d.Vdb)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/install_reconcile_test.go
+++ b/pkg/controllers/install_reconcile_test.go
@@ -211,7 +211,7 @@ func createInstallPodsHelper(ctx context.Context, ipv6 bool) (podList []*PodFact
 	pfact := MakePodFacts(k8sClient, fpr)
 	actor := MakeInstallReconciler(vrec, logger, vdb, fpr, &pfact)
 	drecon := actor.(*InstallReconciler)
-	licensePath, _ := license.GetPath(ctx, drecon.GetClient(), drecon.Vdb)
+	licensePath, _ := license.GetPath(ctx, k8sClient, drecon.Vdb)
 	verticaUpdateCmd = drecon.genCmdInstall(podList, licensePath)
 
 	return podList, verticaUpdateCmd

--- a/pkg/controllers/obj_reconcile.go
+++ b/pkg/controllers/obj_reconcile.go
@@ -52,18 +52,6 @@ func MakeObjReconciler(cli client.Client, scheme *runtime.Scheme, log logr.Logge
 	return &ObjReconciler{Client: cli, Scheme: scheme, Log: log, Vdb: vdb, PFacts: pfacts}
 }
 
-func (o *ObjReconciler) GetClient() client.Client {
-	return o.Client
-}
-
-func (o *ObjReconciler) GetVDB() *vapi.VerticaDB {
-	return o.Vdb
-}
-
-func (o *ObjReconciler) CollectPFacts(ctx context.Context) error {
-	return o.PFacts.Collect(ctx, o.Vdb)
-}
-
 // Reconcile is the main driver for reconciliation of Kubernetes objects.
 // This will ensure the desired svc and sts objects exist and are in the correct state.
 func (o *ObjReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -280,14 +280,12 @@ func (p *PodFacts) checkIfNodeIsUp(ctx context.Context, pf *PodFact) error {
 
 // checkIfAgentRunning will check if the Vertica agent is running and set state in pf.agentRunning
 func (p *PodFacts) checkIfAgentRunning(ctx context.Context, pf *PodFact) error {
+	pf.agentRunning = false
 	if !pf.isPodRunning {
-		pf.agentRunning = false
 		return nil
 	}
 
-	if _, _, err := p.PRunner.ExecInPod(ctx, pf.name, ServerContainer, "/opt/vertica/sbin/vertica_agent", "status"); err != nil {
-		pf.agentRunning = false
-	} else {
+	if _, _, err := p.PRunner.ExecInPod(ctx, pf.name, ServerContainer, "/opt/vertica/sbin/vertica_agent", "status"); err == nil {
 		pf.agentRunning = true
 	}
 	return nil

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -77,6 +77,9 @@ type PodFact struct {
 	// The compat21 node name that Vertica assignes to the pod. This is only set
 	// if installation has occurred.
 	compat21NodeName string
+
+	// Is the agent running in this pod?
+	agentRunning bool
 }
 
 type PodFactDetail map[types.NamespacedName]*PodFact
@@ -181,9 +184,13 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		return err
 	}
 
-	// set pf.upNode, but we can skip if the db doesn't exist
+	// set pf.upNode and pf.agentRunning, but we can skip if the db doesn't
+	// exist
 	if !pf.dbExists.IsFalse() {
 		if err := p.checkIfNodeIsUp(ctx, &pf); err != nil {
+			return err
+		}
+		if err := p.checkIfAgentRunning(ctx, &pf); err != nil {
 			return err
 		}
 	}
@@ -268,6 +275,21 @@ func (p *PodFacts) checkIfNodeIsUp(ctx context.Context, pf *PodFact) error {
 		pf.upNode = true
 	}
 
+	return nil
+}
+
+// checkIfAgentRunning will check if the Vertica agent is running and set state in pf.agentRunning
+func (p *PodFacts) checkIfAgentRunning(ctx context.Context, pf *PodFact) error {
+	if !pf.isPodRunning {
+		pf.agentRunning = false
+		return nil
+	}
+
+	if _, _, err := p.PRunner.ExecInPod(ctx, pf.name, ServerContainer, "/opt/vertica/sbin/vertica_agent", "status"); err != nil {
+		pf.agentRunning = false
+	} else {
+		pf.agentRunning = true
+	}
 	return nil
 }
 

--- a/pkg/controllers/revivedb_reconcile.go
+++ b/pkg/controllers/revivedb_reconcile.go
@@ -31,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ReviveDBReconciler will revive a database if one doesn't exist in the vdb yet.
@@ -47,18 +46,6 @@ type ReviveDBReconciler struct {
 func MakeReviveDBReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &ReviveDBReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
-}
-
-func (r *ReviveDBReconciler) GetClient() client.Client {
-	return r.VRec.Client
-}
-
-func (r *ReviveDBReconciler) GetVDB() *vapi.VerticaDB {
-	return r.Vdb
-}
-
-func (r *ReviveDBReconciler) CollectPFacts(ctx context.Context) error {
-	return r.PFacts.Collect(ctx, r.Vdb)
 }
 
 // Reconcile will ensure a DB exists and revive one if it doesn't

--- a/pkg/controllers/status_reconcile.go
+++ b/pkg/controllers/status_reconcile.go
@@ -45,18 +45,6 @@ func MakeStatusReconciler(cli client.Client, scheme *runtime.Scheme, log logr.Lo
 	return &StatusReconciler{Client: cli, Scheme: scheme, Log: log, Vdb: vdb, PFacts: pfacts}
 }
 
-func (s *StatusReconciler) GetClient() client.Client {
-	return s.Client
-}
-
-func (s *StatusReconciler) GetVDB() *vapi.VerticaDB {
-	return s.Vdb
-}
-
-func (s *StatusReconciler) CollectPFacts(ctx context.Context) error {
-	return s.PFacts.Collect(ctx, s.Vdb)
-}
-
 // Reconcile will update the status of the Vdb based on the pod facts
 func (s *StatusReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
 	// We base our status on the pod facts, so ensure our facts are up to date.

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -277,6 +277,15 @@ func createPodFactsWithRestartNeeded(ctx context.Context, vdb *vapi.VerticaDB, s
 	return &pfacts
 }
 
+func createPodFactsWithAgentNotRunning(ctx context.Context, vdb *vapi.VerticaDB, fpr *cmds.FakePodRunner) *PodFacts {
+	pfacts := MakePodFacts(k8sClient, fpr)
+	ExpectWithOffset(1, pfacts.Collect(ctx, vdb)).Should(Succeed())
+	for _, pod := range pfacts.Detail {
+		pod.agentRunning = false
+	}
+	return &pfacts
+}
+
 const testAccessKey = "dummy"
 const testSecretKey = "dummy"
 

--- a/pkg/controllers/version_reconciler.go
+++ b/pkg/controllers/version_reconciler.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // VersionReconciler will set the version as annotations in the vdb.
@@ -42,18 +41,6 @@ type VersionReconciler struct {
 func MakeVersionReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &VersionReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
-}
-
-func (v *VersionReconciler) GetClient() client.Client {
-	return v.VRec.Client
-}
-
-func (v *VersionReconciler) GetVDB() *vapi.VerticaDB {
-	return v.Vdb
-}
-
-func (v *VersionReconciler) CollectPFacts(ctx context.Context) error {
-	return v.PFacts.Collect(ctx, v.Vdb)
 }
 
 // Reconcile will update the annotation in the Vdb with Vertica version info

--- a/pkg/controllers/verticadb_controller.go
+++ b/pkg/controllers/verticadb_controller.go
@@ -132,6 +132,8 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Create and revive are mutually exclusive exclusive, so this handles
 		// status updates after both of them.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, &pfacts),
+		// Ensure the vertica agent is running on each pod
+		MakeAgentReconciler(r, log, vdb, prunner, &pfacts),
 		// Handle calls to admintools -t db_add_subcluster
 		MakeDBAddSubclusterReconciler(r, log, vdb, prunner, &pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, &pfacts),


### PR DESCRIPTION
Prior to this, the vertica agent was being started in the docker entrypoint.  This led to some race conditions -- starting the agent at the same time we are doing create_db or scale-out.  The race conditions often ended up causing the admintools.conf to be corrupted.  The file had all of the host information removed and it was owned by root.

The fix was to give the operator the control over when the agent starts.  This avoids the race conditions because there is only a single operator thread running.  A new `ReconcileActor` called `AgentReconciler` was added.  This is called right after the database is created or revived.

This also has some cleanup for `ReconcilerActor`.  All of the actors had to have common boilerplate functions (`GetClient`, `GetVDB`, `CollectPFacts`).  Only two of the actor's made use of this.   The rest of the actors defined them but had no use.  I cleaned this up by making an interface that the two actors can use.

This fixes VER-77811