### PR TITLE
Include minio output in ancillary.log for e2e runs

### DIFF
--- a/tests/e2e-disabled/restart-node-multi-sc/00-minio.yaml
+++ b/tests/e2e-disabled/restart-node-multi-sc/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/auto-restart-vertica/00-minio.yaml
+++ b/tests/e2e/auto-restart-vertica/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/client-access/05-minio-create.yaml
+++ b/tests/e2e/client-access/05-minio-create.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/crash-before-createdb/00-minio.yaml
+++ b/tests/e2e/crash-before-createdb/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/createdb-failures/30-setup-minio-tenant.yaml
+++ b/tests/e2e/createdb-failures/30-setup-minio-tenant.yaml
@@ -15,6 +15,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/k-safety-0-scaling/00-minio.yaml
+++ b/tests/e2e/k-safety-0-scaling/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/k-safety-1-scaling/00-minio.yaml
+++ b/tests/e2e/k-safety-1-scaling/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/kill-controller/00-minio.yaml
+++ b/tests/e2e/kill-controller/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/kill-during-add-node/05-minio.yaml
+++ b/tests/e2e/kill-during-add-node/05-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/multi-sc/02-minio.yaml
+++ b/tests/e2e/multi-sc/02-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/private-pvc/10-minio-create.yaml
+++ b/tests/e2e/private-pvc/10-minio-create.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/restart/00-minio.yaml
+++ b/tests/e2e/restart/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/revivedb-1-node/05-minio-create.yaml
+++ b/tests/e2e/revivedb-1-node/05-minio-create.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/revivedb-3-node/05-minio-create.yaml
+++ b/tests/e2e/revivedb-3-node/05-minio-create.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/revivedb-failures/05-minio-create.yaml
+++ b/tests/e2e/revivedb-failures/05-minio-create.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/revivedb-multi-sc/05-minio-create.yaml
+++ b/tests/e2e/revivedb-multi-sc/05-minio-create.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/update-strategy/00-minio.yaml
+++ b/tests/e2e/update-strategy/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/upgrade-vertica/00-minio.yaml
+++ b/tests/e2e/upgrade-vertica/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/vdb-gen/00-minio.yaml
+++ b/tests/e2e/vdb-gen/00-minio.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent

--- a/tests/e2e/webhook/05-minio-create.yaml
+++ b/tests/e2e/webhook/05-minio-create.yaml
@@ -26,6 +26,8 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: minio
+  labels:
+    stern: include
 spec:
   image: minio/minio:RELEASE.2021-02-24T18-44-45Z
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Adding a label 'stern=include' to minio so that it is included in the ancillary.log when running e2e tests (see logic in scripts/save-ancillary-logs.sh)