### PR TITLE
Reduce disk usage of e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
 
-  build:
+  e2e:
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
 
-  build:
+  ut:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ endif
 
 .PHONY: run-int-tests
 run-int-tests: install-kuttl-plugin vdb-gen ## Run the integration tests
-	kubectl kuttl test --report xml --artifacts-dir ${LOGDIR} --parallel $(E2E_PARALLELISM)
+	kubectl kuttl test --report xml --artifacts-dir ${LOGDIR} --parallel $(E2E_PARALLELISM) --test client-access
 
 .PHONY: run-soak-tests
 run-soak-tests: install-kuttl-plugin kuttl-step-gen  ## Run the soak tests

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ endif
 
 .PHONY: run-int-tests
 run-int-tests: install-kuttl-plugin vdb-gen ## Run the integration tests
-	kubectl kuttl test --report xml --artifacts-dir ${LOGDIR} --parallel $(E2E_PARALLELISM) --test client-access
+	kubectl kuttl test --report xml --artifacts-dir ${LOGDIR} --parallel $(E2E_PARALLELISM)
 
 .PHONY: run-soak-tests
 run-soak-tests: install-kuttl-plugin kuttl-step-gen  ## Run the soak tests

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ By default, we use the [Community Edition (CE)](https://www.vertica.com/landing-
 To use your own license, add it to a secret in the same namespace as the operator. The following command copies the license into a secret named `license`:
 
 ```
-$ kubectl create secret generic license –from-file=license.key=/path/to/license.key
+$ kubectl create secret generic license --from-file=license.key=/path/to/license.key
 ```
 
 Next, specify the name of the secret in the CR by populating the `licenseSecret` field:

--- a/scripts/kind.sh
+++ b/scripts/kind.sh
@@ -100,7 +100,6 @@ EOF
     cat <<- EOF >> $tmpfile
 nodes:
 - role: control-plane
-- role: worker
 EOF
     if [[ -n "$PORT" ]]
     then

--- a/scripts/run-k8s-int-tests.sh
+++ b/scripts/run-k8s-int-tests.sh
@@ -77,6 +77,7 @@ export VLOGGER_IMG=vertica-logger:$TAG
 
 # cleanup the deployed k8s cluster
 function cleanup {
+    df -h
     scripts/kind.sh term $CLUSTER_NAME
 }
 


### PR DESCRIPTION
One of the e2e tests was failing consistently because we were hitting disk full.  I reduced the disk usage by changing the kind cluster we set from 2 nodes to 1 node.  This helps reduced the amount of disk needed because we only had to push the containers to 1 k8s node now instead of 2.

Also changed the name of the tests in GitHub actions from build to e2e/ut.