### PR TITLE
Rename kustomize marker for the vertica image

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -40,12 +40,12 @@ commands:
 
   # We do a pre-pull of the vertica-k8s image version latest and 10.1.1-0
   # that we will use for the test upgrade-vertica.
-  - command: bash -c "sed 's+replace-with-kustomize+verticadocker/vertica-k8s:10.1.1-0+g' tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
+  - command: bash -c "sed 's+kustomize-vertica-image+verticadocker/vertica-k8s:10.1.1-0+g' tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
   - command: kubectl wait --for=condition=Ready pod --timeout=10m vertica-k8s-image-pull
     namespaced: true
   - command: kubectl delete pod vertica-k8s-image-pull --grace-period=1
     namespaced: true
-  - command: bash -c "sed 's+replace-with-kustomize+verticadocker/vertica-k8s:latest+g' tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
+  - command: bash -c "sed 's+kustomize-vertica-image+verticadocker/vertica-k8s:latest+g' tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
   - command: kubectl wait --for=condition=Ready pod --timeout=10m vertica-k8s-image-pull
     namespaced: true
   - command: kubectl delete pod vertica-k8s-image-pull --grace-period=1

--- a/tests/create-kustomize-overlay.sh
+++ b/tests/create-kustomize-overlay.sh
@@ -75,7 +75,7 @@ function create_kustomization {
     BASE_DIR=$1
     echo "" > kustomization.yaml
     kustomize edit add base $BASE_DIR
-    kustomize edit set image replace-with-kustomize=$VERTICA_IMAGE_NAME
+    kustomize edit set image kustomize-vertica-image=$VERTICA_IMAGE_NAME
     kustomize edit set image kustomize-vlogger-image=$VLOGGER_IMAGE_NAME
 
     # If license was specified we create a patch file to set that.

--- a/tests/e2e-disabled/restart-node-multi-sc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-disabled/restart-node-multi-sc/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-mc-restart
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/e2e/auto-restart-vertica/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/auto-restart-vertica/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-auto-restart-vertica
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/e2e/client-access/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/client-access/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-client-access
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://client-access"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/client-access/verify-vsql-access/base/verify-vsql-access.yaml
+++ b/tests/e2e/client-access/verify-vsql-access/base/verify-vsql-access.yaml
@@ -43,7 +43,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: test
-      image: replace-with-kustomize
+      image: kustomize-vertica-image
       command: ["/home/dbadmin/test.sh"]
       volumeMounts:
         - name: test-script

--- a/tests/e2e/crash-before-createdb/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/crash-before-createdb/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-crash-before-createdb
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://crash-before-createdb"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: verticadb-sample
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://nimbusdb/db"
     endpoint: "https://minio"

--- a/tests/e2e/createdb-failures/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/createdb-failures/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-createdb-failures
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://nimbusdb/db"
     endpoint: "http://minio"

--- a/tests/e2e/k-safety-0-scaling/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/k-safety-0-scaling/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-k-safety-0-scaling
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/e2e/k-safety-0-scaling/verify-vsql-ksafety/base/verify-vsql-ksafety.yaml
+++ b/tests/e2e/k-safety-0-scaling/verify-vsql-ksafety/base/verify-vsql-ksafety.yaml
@@ -45,7 +45,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: test
-      image: replace-with-kustomize
+      image: kustomize-vertica-image
       command: ["/home/dbadmin/test.sh"]
       volumeMounts:
         - name: test-script

--- a/tests/e2e/k-safety-1-scaling/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/k-safety-1-scaling/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-scale-up-and-down
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/e2e/k-safety-1-scaling/verify-vsql-ksafety/base/verify-vsql-ksafety.yaml
+++ b/tests/e2e/k-safety-1-scaling/verify-vsql-ksafety/base/verify-vsql-ksafety.yaml
@@ -45,7 +45,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: test
-      image: replace-with-kustomize
+      image: kustomize-vertica-image
       command: ["/home/dbadmin/test.sh"]
       volumeMounts:
         - name: test-script

--- a/tests/e2e/kill-controller/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/kill-controller/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-kill-controller
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://kill-controller"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/kill-during-add-node/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/kill-during-add-node/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-kill
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/e2e/labels-annotations/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/labels-annotations/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: vdb-label-ant
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://nimbusdb/db"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/multi-sc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/multi-sc/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-multi-sc
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
   communal:
     path: "s3://multi-sc"

--- a/tests/e2e/restart/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/restart/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-restart
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
   communal:
     path: "s3://restart"

--- a/tests/e2e/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-create-1-node
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
   communal:
     path: "s3://revivedb-1-node"

--- a/tests/e2e/revivedb-1-node/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-1-node/vdb-to-revive/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-1-node
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
   ignoreClusterLease: true
   communal:

--- a/tests/e2e/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-create-3-node
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://revivedb-3-node"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-3-node
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   ignoreClusterLease: true
   communal:
     path: "s3://revivedb-3-node"

--- a/tests/e2e/revivedb-failures/vdb-create-db/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-create-db/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://revivedb-failures"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/revivedb-failures/vdb-revive-bad-creds/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-revive-bad-creds/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures-custom-creds
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://revivedb-failures"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/revivedb-failures/vdb-revive-cluster-lease/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-revive-cluster-lease/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures-cluster-lease
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   ignoreClusterLease: false
   communal:
     path: "s3://revivedb-failures"

--- a/tests/e2e/revivedb-failures/vdb-revive-communal-path-empty/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-revive-communal-path-empty/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures-communal-path-empty
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://revivedb-failures/empty"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/revivedb-failures/vdb-revive-local-path-mismatch/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-revive-local-path-mismatch/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures-local-path-mismatch
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   ignoreClusterLease: true
   communal:
     path: "s3://revivedb-failures"

--- a/tests/e2e/revivedb-failures/vdb-revive-too-few-nodes/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-revive-too-few-nodes/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures-too-few-nodes
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   ignoreClusterLease: true
   communal:
     path: "s3://revivedb-failures"

--- a/tests/e2e/revivedb-failures/vdb-revive-too-many-nodes/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-revive-too-many-nodes/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures-too-many-nodes
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   ignoreClusterLease: true
   communal:
     path: "s3://revivedb-failures"

--- a/tests/e2e/revivedb-failures/vdb-revive-wrong-db-name/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-revive-wrong-db-name/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures-wrong-db-name
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   ignoreClusterLease: true
   communal:
     path: "s3://revivedb-failures"

--- a/tests/e2e/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-create-multi-sc
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/e2e/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-multi-sc
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/e2e/update-strategy/setup-vdb-ks-0/base/setup-ks-0-vdb.yaml
+++ b/tests/e2e/update-strategy/setup-vdb-ks-0/base/setup-ks-0-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-ks-0-update-strategy
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://update-strategy/ks-0"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/update-strategy/setup-vdb-ks-1/base/setup-ks-1-vdb.yaml
+++ b/tests/e2e/update-strategy/setup-vdb-ks-1/base/setup-ks-1-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-ks-1-update-strategy
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://update-strategy/ks-1"
     endpoint: "http://minio.kuttl-e2e-communal"

--- a/tests/e2e/update-strategy/verify-ksafety/base/verify-vsql-ksafety.yaml
+++ b/tests/e2e/update-strategy/verify-ksafety/base/verify-vsql-ksafety.yaml
@@ -51,7 +51,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: test
-      image: replace-with-kustomize
+      image: kustomize-vertica-image
       command: ["/home/dbadmin/test.sh"]
       volumeMounts:
         - name: test-script

--- a/tests/e2e/vdb-gen/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/vdb-gen/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-vdb-gen
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
   communal:
     path: "s3://vdb-gen"

--- a/tests/e2e/webhook/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/webhook/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-webhook
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   sidecars:
     - name: vlogger
       image: kustomize-vlogger-image

--- a/tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml
+++ b/tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   containers:
     - name: vsql
-      image: replace-with-kustomize
+      image: kustomize-vertica-image
       command:
         - sleep
         - infinity

--- a/tests/manifests/soak-setup/base/setup-vdb.yaml
+++ b/tests/manifests/soak-setup/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v
 spec:
-  image: replace-with-kustomize
+  image: kustomize-vertica-image
   communal:
     path: "s3://nimbusdb/db"
     endpoint: "http://minio.kuttl-e2e-communal"


### PR DESCRIPTION
Renaming this:
  replace-with-kustomize => kustomize-vertica-image

All of the e2e tests use replace-with-kustomize string to denote what
to replace the actual vertica image with.  When I added the ability to
use kustomize for the vlogger image, the original string lost a lot of
its meaning.  Doing a rename to clarify that part.