### PR TITLE
Fix to allow create DB to work on AWS s3

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -173,12 +173,14 @@ This method runs the operator synchronously in your shell. It is the fastest way
 Enter the following command:
 
 ```
-$ make install run
+$ make install run ENABLE_WEBHOOKS=false
 ```
 
 Press **Ctrl+C** to stop the operator.
 
 **NOTE:** When you run the operator locally, you can run only ad-hoc tests, not integration and e2e tests
+
+This disabled the webhook from runing too, as running the webhook requires that TLS certs are available.
 
 ### Option 2: Kubernetes Deployment
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -180,7 +180,7 @@ Press **Ctrl+C** to stop the operator.
 
 **NOTE:** When you run the operator locally, you can run only ad-hoc tests, not integration and e2e tests
 
-This disabled the webhook from runing too, as running the webhook requires that TLS certs are available.
+This disables the webhook from runing too, as running the webhook requires TLS certs to be available.
 
 ### Option 2: Kubernetes Deployment
 

--- a/changes/unreleased/Fixed-20210831-083212.yaml
+++ b/changes/unreleased/Fixed-20210831-083212.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'Communal storage on AWS s3.  The timeouts the operator had set were too low
+  preventing a create DB from succeeding. '

--- a/kuttl-soak-test-iteration-0.yaml
+++ b/kuttl-soak-test-iteration-0.yaml
@@ -33,7 +33,7 @@ commands:
 
   # Create minio tenant and the vdb
   - command: kubectl krew update
-  - command: kubectl krew install minio
+  - command: kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/95d35f73fd3c57465c837bed2cf9ad2d933328b2/plugins/minio.yaml
   # If these images ever change, they must be updated in tests/external-images.txt
   - command: kubectl minio init --console-image minio/console:v0.6.3 --image minio/operator:v4.0.2
   - command: bash -c "bin/kustomize build tests/manifests/soak-setup/overlay | kubectl -n soak apply -f -"

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -55,7 +55,7 @@ commands:
     ignoreFailure: true
   - command: kubectl create namespace kuttl-e2e-communal
   - command: kubectl krew update
-  - command: kubectl krew install minio
+  - command: kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/95d35f73fd3c57465c837bed2cf9ad2d933328b2/plugins/minio.yaml
   # If these images ever change, they must be updated in tests/external-images.txt
   - command: kubectl minio init --console-image minio/console:v0.6.3 --image minio/operator:v4.0.2
   - command: kubectl apply -f tests/manifests/minio/01-creds.yaml -n kuttl-e2e-communal

--- a/pkg/controllers/createdb_reconcile.go
+++ b/pkg/controllers/createdb_reconcile.go
@@ -119,13 +119,10 @@ func isCommunalPathNotEmpty(op string) bool {
 // preCmdSetup will generate the file we include with the create_db.
 // This file runs any custom SQL for the create_db.
 func (c *CreateDBReconciler) preCmdSetup(ctx context.Context, atPod types.NamespacedName) error {
-	// We include SQL to reset the AWS connection parms we temporarily set in the
-	// auth file (see constructAuthParms).  We also rename the default
-	// subcluster to match the name of the first subcluster in the spec -- any
-	// remaining subclusters will be added by DBAddSubclusterReconciler.
-	sql := "alter database default clear AWSConnectTimeout;\n" +
-		"alter database default clear AWSMaxRetryCount;\n" +
-		"alter subcluster default_subcluster rename to " + c.Vdb.Spec.Subclusters[0].Name + ";\n"
+	// We include SQL to rename the default subcluster to match the name of the
+	// first subcluster in the spec -- any remaining subclusters will be added
+	// by DBAddSubclusterReconciler.
+	sql := "alter subcluster default_subcluster rename to " + c.Vdb.Spec.Subclusters[0].Name + ";\n"
 	if c.Vdb.Spec.KSafety == vapi.KSafety0 {
 		sql += "select set_preferred_ksafe(0);\n"
 	}
@@ -133,12 +130,6 @@ func (c *CreateDBReconciler) preCmdSetup(ctx context.Context, atPod types.Namesp
 		"bash", "-c", "cat > "+PostDBCreateSQLFile+"<<< '"+sql+"'",
 	)
 	return err
-}
-
-// getAdditionalAuthParms returns additional auth parms that we need to set for create_db
-func (c *CreateDBReconciler) getAdditionalAuthParms() string {
-	// No-op for create_db.
-	return ""
 }
 
 // getPodList gets a list of all of the pods we are going to use with create db.

--- a/pkg/controllers/createdb_reconcile.go
+++ b/pkg/controllers/createdb_reconcile.go
@@ -137,16 +137,8 @@ func (c *CreateDBReconciler) preCmdSetup(ctx context.Context, atPod types.Namesp
 
 // getAdditionalAuthParms returns additional auth parms that we need to set for create_db
 func (c *CreateDBReconciler) getAdditionalAuthParms() string {
-	// We temporarily lower the connect time and retry count for AWS. This is
-	// done so that we fail fast if the S3 endpoint isn't setup. These are
-	// cleared at the end of the create_db.
-	const TempAWSConnectTime = "20"
-	const TempMaxRetryCount = "3"
-
-	return fmt.Sprintf("%s = %s\n%s = %s\n",
-		"AWSConnectTimeout", TempAWSConnectTime,
-		"AWSMaxRetryCount", TempMaxRetryCount,
-	)
+	// No-op for create_db.
+	return ""
 }
 
 // getPodList gets a list of all of the pods we are going to use with create db.

--- a/pkg/controllers/revivedb_reconcile.go
+++ b/pkg/controllers/revivedb_reconcile.go
@@ -152,12 +152,6 @@ func (r *ReviveDBReconciler) preCmdSetup(ctx context.Context, atPod types.Namesp
 	return nil
 }
 
-// getAdditionalAuthParms returns additional auth parms that we need to set for revive_db.
-// This is only needed by the GenericDatabaseInitializer interface and isn't used by revive.
-func (r *ReviveDBReconciler) getAdditionalAuthParms() string {
-	return ""
-}
-
 // getPodList gets a list of the pods we are going to use in revive db.
 // If it was not able to generate a list, possibly due to a bad reviveOrder, it
 // return false for the bool return value.

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -50,4 +50,5 @@ const (
 	SuperuserPasswordSecretNotFound = "SuperuserPasswordSecretNotFound"
 	UnsupportedVerticaVersion       = "UnsupportedVerticaVersion"
 	ATConfPartiallyCopied           = "ATConfPartiallyCopied"
+	S3AuthParmsCopyFailed           = "S3AuthParmsCopyFailed"
 )

--- a/scripts/kuttl-test-loop.sh
+++ b/scripts/kuttl-test-loop.sh
@@ -23,7 +23,7 @@ function usage() {
     echo "usage: $(basename $0) [-t <testcase>]"
     echo
     echo "Options:"
-    echo "  -c <testcase>   Run only the following testcase.  By default it"
+    echo "  -t <testcase>   Run only the following testcase.  By default it"
     echo "                  runs all of the testcases."
     exit 1
 }

--- a/tests/e2e/createdb-failures/18-assert.yaml
+++ b/tests/e2e/createdb-failures/18-assert.yaml
@@ -13,7 +13,7 @@
 
 apiVersion: v1
 kind: Event
-reason: S3EndpointIssue
+reason: S3AuthParmsCopyFailed
 source:
   component: verticadb-operator
 involvedObject:

--- a/tests/e2e/createdb-failures/18-bad-creds-forcing-auth-parms-cp-failure.yaml
+++ b/tests/e2e/createdb-failures/18-bad-creds-forcing-auth-parms-cp-failure.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-creds-secret
+type: Opaque
+data:
+  accesskey: zzzxxxwww123
+  secretkey: 5g5swxFcAamMz1cA


### PR DESCRIPTION
The operator had set AWS timeouts low so that during create_db we get quick feedback in case the s3 endpoint isn't setup correctly.  These low timeouts were interfering with the create_db in such a way as preventing a successful create on aws s3.  The timeouts were removed in this commit.  This also means we cannot reliable check for this error in the createdb-failures testcase.

A few other minor changed in included:
- adding event recording for when the s3 auth parms copy fails.  It is possible that if the secret was not setup correctly that the copy would contain undisplayable characters causing the entire copy to fail.  We log an event now so that end users have a better idea of what issue the operator is hitting.
- when running the operator with the 'make run' target, we need the ability to disable the webhook.  Otherwise, it will fail to start due to lack of TLS certs causing the operator to fail.  Added a check for the ENABLE_WEBHOOKS environment variable.