### PR TITLE
Add ScheduleOnly initPolicy

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -204,6 +204,13 @@ const (
 	// The database in the communal path will be initialized in the VerticaDB
 	// through a revive_db.  The communal path must have a preexisting database.
 	CommunalInitPolicyRevive = "Revive"
+	// Only schedule pods to run with the vertica container.  The boostrap of
+	// the database, either create_db or revive_db, is not handled.  Use this
+	// policy when you have a vertica cluster running outside of Kubernetes and
+	// you want to provision new nodes to run inside Kubernetes, such as a
+	// secondary cluster.  Most of the automation is disabled when running in
+	// this mode.
+	CommunalInitPolicyScheduleOnly = "ScheduleOnly"
 )
 
 type KSafetyType string
@@ -227,11 +234,12 @@ type SubclusterPodCount struct {
 
 // Holds details about the communal storage
 type CommunalStorage struct {
-	// +kubebuilder:validation:required
+	// +kubebuilder:validation:Optional
 	// The path to the communal storage. This must be the s3 bucket. You specify
 	// this using the s3:// bucket notation. For example:
 	// s3://bucket-name/key-name. The bucket must be created prior to creating
-	// the VerticaDB.  This field is required and cannot change after creation.
+	// the VerticaDB.  When initPolicy is Create or Revive, this field is
+	// required and cannot change after creation.
 	Path string `json:"path"`
 
 	// +kubebuilder:validation:Optional
@@ -241,16 +249,17 @@ type CommunalStorage struct {
 	// forces each database path to be unique.
 	IncludeUIDInPath bool `json:"includeUIDInPath,omitempty"`
 
-	// +kubebuilder:validation:required
+	// +kubebuilder:validation:Optional
 	// The URL to the s3 endpoint. The endpoint must be prefaced with http:// or
-	// https:// to know what protocol to connect with. This field is required
-	// and cannot change after creation.
+	// https:// to know what protocol to connect with. When initPolicy is Create
+	// or Revive, this field is required and cannot change after creation.
 	Endpoint string `json:"endpoint"`
 
-	// +kubebuilder:validation:required
+	// +kubebuilder:validation:Optional
 	// The name of a secret that contains the credentials to connect to the
 	// communal S3 endpoint. The secret must have the following keys set:
-	// accessey and secretkey.
+	// accessey and secretkey.  When initPolicy is Create or Revive, this field
+	// is required.
 	CredentialSecret string `json:"credentialSecret"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -143,6 +143,7 @@ type VerticaDBSpec struct {
 	// of 20 minutes.
 	RestartTimeout int `json:"restartTimeout,omitempty"`
 
+	// +kubebuilder:validation:Optional
 	// Contains details about the communal storage.
 	Communal CommunalStorage `json:"communal"`
 

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -205,12 +205,11 @@ const (
 	// The database in the communal path will be initialized in the VerticaDB
 	// through a revive_db.  The communal path must have a preexisting database.
 	CommunalInitPolicyRevive = "Revive"
-	// Only schedule pods to run with the vertica container.  The boostrap of
+	// Only schedule pods to run with the vertica container.  The bootstrap of
 	// the database, either create_db or revive_db, is not handled.  Use this
 	// policy when you have a vertica cluster running outside of Kubernetes and
-	// you want to provision new nodes to run inside Kubernetes, such as a
-	// secondary cluster.  Most of the automation is disabled when running in
-	// this mode.
+	// you want to provision new nodes to run inside Kubernetes.  Most of the
+	// automation is disabled when running in this mode.
 	CommunalInitPolicyScheduleOnly = "ScheduleOnly"
 )
 

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -326,6 +326,9 @@ func (v *VerticaDB) hasPrimarySubcluster(allErrs field.ErrorList) field.ErrorLis
 }
 
 func (v *VerticaDB) validateKsafety(allErrs field.ErrorList) field.ErrorList {
+	if v.Spec.InitPolicy == CommunalInitPolicyScheduleOnly {
+		return allErrs
+	}
 	sizeSum := v.getClusterSize()
 	switch v.Spec.KSafety {
 	case KSafety0:

--- a/changes/unreleased/Added-20210920-171923.yaml
+++ b/changes/unreleased/Added-20210920-171923.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: New initPolicy called ScheduleOnly.  Aside from Vertica node restart, all other
+  automation by the operator is skipped.  You can use this if you have an existing
+  on-prem Vertica cluster that and you want to scale out to Kubernetes.

--- a/changes/unreleased/Added-20210920-171923.yaml
+++ b/changes/unreleased/Added-20210920-171923.yaml
@@ -1,4 +1,5 @@
 kind: Added
-body: New initPolicy called ScheduleOnly.  Aside from Vertica node restart, all other
-  automation by the operator is skipped.  You can use this if you have an existing
-  on-prem Vertica cluster that and you want to scale out to Kubernetes.
+body: New initPolicy called ScheduleOnly.  The bootstrap of the database, either
+  create_db or revive_db, is not handled.  Use this policy when you have a vertica
+  cluster running outside of Kubernetes and you want to provision new nodes to run
+  inside Kubernetes.  Most of the automation is disabled when running in this mode.

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -35,19 +35,6 @@ commands:
   - command: kubectl delete pod vertica-k8s-image-pull
     namespaced: true
 
-  # We do a pre-pull of the vertica-k8s image version latest and 10.1.1-0
-  # that we will use for the test upgrade-vertica.
-  - command: bash -c "sed 's+kustomize-vertica-image+vertica/vertica-k8s:11.0.0-0-minimal+g' tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
-  - command: kubectl wait --for=condition=Ready pod --timeout=10m vertica-k8s-image-pull
-    namespaced: true
-  - command: kubectl delete pod vertica-k8s-image-pull
-    namespaced: true
-  - command: bash -c "sed 's+kustomize-vertica-image+vertica/vertica-k8s:latest+g' tests/manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
-  - command: kubectl wait --for=condition=Ready pod --timeout=10m vertica-k8s-image-pull
-    namespaced: true
-  - command: kubectl delete pod vertica-k8s-image-pull
-    namespaced: true
-
   # We use stern to collect the pod output of any test that creates a pod with
   # the 'stern=include' label.  By default, the output of this is stored in a
   # file in int-tests-output/

--- a/pkg/controllers/dbaddnode_reconcile.go
+++ b/pkg/controllers/dbaddnode_reconcile.go
@@ -48,6 +48,11 @@ func MakeDBAddNodeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 
 // Reconcile will ensure a DB exists and create one if it doesn't
 func (d *DBAddNodeReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy
+	if d.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	if err := d.PFacts.Collect(ctx, d.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/dbaddsubcluster_reconcile.go
+++ b/pkg/controllers/dbaddsubcluster_reconcile.go
@@ -49,6 +49,11 @@ func MakeDBAddSubclusterReconciler(vdbrecon *VerticaDBReconciler, log logr.Logge
 
 // Reconcile will ensure a subcluster exists for each one defined in the vdb.
 func (d *DBAddSubclusterReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy
+	if d.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	// We need to collect pod facts, to find a pod to run AT and vsql commands from.
 	if err := d.PFacts.Collect(ctx, d.Vdb); err != nil {
 		return ctrl.Result{}, err

--- a/pkg/controllers/dbremovenode_reconcile.go
+++ b/pkg/controllers/dbremovenode_reconcile.go
@@ -72,6 +72,11 @@ func (d *DBRemoveNodeReconciler) CollectPFacts(ctx context.Context) error {
 // everything in Vdb. We will know if we are scaling down by comparing the
 // expected subcluster size with the current.
 func (d *DBRemoveNodeReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy
+	if d.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	// Use the finder so that we check only the subclusters that are in the vdb.
 	// Any nodes that are in subclusters that we are removing are handled by the
 	// DBRemoveSubcusterReconciler.

--- a/pkg/controllers/dbremovesubcluster_reconcile.go
+++ b/pkg/controllers/dbremovesubcluster_reconcile.go
@@ -47,6 +47,11 @@ func MakeDBRemoveSubclusterReconciler(vdbrecon *VerticaDBReconciler, log logr.Lo
 
 // Reconcile will remove any subcluster that no longer exists in the vdb.
 func (d *DBRemoveSubclusterReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy
+	if d.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	// We need to collect pod facts, to find a pod to run AT and vsql commands from.
 	if err := d.PFacts.Collect(ctx, d.Vdb); err != nil {
 		return ctrl.Result{}, err

--- a/pkg/controllers/imagechange_reconcile.go
+++ b/pkg/controllers/imagechange_reconcile.go
@@ -50,6 +50,11 @@ func MakeImageChangeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 // Reconcile will handle the process of the vertica image changing.  For
 // example, this can automate the process for an upgrade.
 func (u *ImageChangeReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy
+	if u.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	if err := u.PFacts.Collect(ctx, u.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/install_reconcile.go
+++ b/pkg/controllers/install_reconcile.go
@@ -58,6 +58,11 @@ func MakeInstallReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 
 // Reconcile will ensure Vertica is installed and running in the pods.
 func (d *InstallReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy
+	if d.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	// The reconcile loop works by collecting all of the facts about the running
 	// pods. We then analyze those facts to determine a course of action to take.
 	if err := d.PFacts.Collect(ctx, d.Vdb); err != nil {

--- a/pkg/controllers/restart_reconcile.go
+++ b/pkg/controllers/restart_reconcile.go
@@ -84,9 +84,10 @@ func (r *RestartReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (c
 	}
 
 	// We have two paths.  If the entire cluster is down we have separate
-	// admintools commands to run.
-
-	if r.PFacts.getUpNodeCount() == 0 {
+	// admintools commands to run.  Cluster operations only apply if the entire
+	// vertica cluster is managed by k8s.  We skip that if initPolicy is
+	// ScheduleOnly.
+	if r.PFacts.getUpNodeCount() == 0 && r.Vdb.Spec.InitPolicy != vapi.CommunalInitPolicyScheduleOnly {
 		return r.reconcileCluster(ctx)
 	}
 	return r.reconcileNodes(ctx)

--- a/pkg/controllers/restart_reconcile.go
+++ b/pkg/controllers/restart_reconcile.go
@@ -166,6 +166,14 @@ func (r *RestartReconciler) reconcileNodes(ctx context.Context) (ctrl.Result, er
 		}
 	}
 
+	// The rest of the steps depend on knowing the compat21 node name for the
+	// pod.  If ScheduleOnly, we cannot reliable know that since the operator
+	// didn't originate the install.  So we will skip the rest if running in
+	// that mode.
+	if r.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	// Find any pods that need to have their IP updated.  These are nodes that
 	// have been installed but not yet added to a database.
 	reIPPods := r.PFacts.findReIPPods(true)

--- a/pkg/controllers/uninstall_reconcile.go
+++ b/pkg/controllers/uninstall_reconcile.go
@@ -74,6 +74,11 @@ func (s *UninstallReconciler) CollectPFacts(ctx context.Context) error {
 // everything in Vdb. We will know if we are scaling down by comparing the
 // expected subcluster size with the current.
 func (s *UninstallReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy
+	if s.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
+		return ctrl.Result{}, nil
+	}
+
 	if err := s.PFacts.Collect(ctx, s.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/tests/e2e/schedule-only/00-create-communal-creds.yaml
+++ b/tests/e2e/schedule-only/00-create-communal-creds.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/s3-creds/base | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e/schedule-only/05-assert.yaml
+++ b/tests/e2e/schedule-only/05-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: create-s3-bucket
+status:
+  containerStatuses:
+    - name: aws
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e/schedule-only/05-create-bucket.yaml
+++ b/tests/e2e/schedule-only/05-create-bucket.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build create-s3-bucket/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e/schedule-only/06-assert.yaml
+++ b/tests/e2e/schedule-only/06-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/tests/e2e/schedule-only/06-deploy-operator.yaml
+++ b/tests/e2e/schedule-only/06-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e/schedule-only/10-assert.yaml
+++ b/tests/e2e/schedule-only/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-managed
+status:
+  subclusters:
+    - installCount: 1

--- a/tests/e2e/schedule-only/10-setup-managed-vdb.yaml
+++ b/tests/e2e/schedule-only/10-setup-managed-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-managed-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e/schedule-only/11-assert.yaml
+++ b/tests/e2e/schedule-only/11-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-managed
+status:
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e/schedule-only/11-wait-for-createdb.yaml
+++ b/tests/e2e/schedule-only/11-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e/schedule-only/15-assert.yaml
+++ b/tests/e2e/schedule-only/15-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-schedule-only-k8s-0
+status:
+  phase: Running

--- a/tests/e2e/schedule-only/15-setup-schedule-only-vdb.yaml
+++ b/tests/e2e/schedule-only/15-setup-schedule-only-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-schedule-only-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e/schedule-only/30-rbac.yaml
+++ b/tests/e2e/schedule-only/30-rbac.yaml
@@ -1,0 +1,44 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: integration-test-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - pods
+      - pods/exec
+      - pods/log
+      - configmaps
+      - secrets
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: integration-test-role
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/tests/e2e/schedule-only/35-assert.yaml
+++ b/tests/e2e/schedule-only/35-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-install-pod
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e/schedule-only/35-install-pod.yaml
+++ b/tests/e2e/schedule-only/35-install-pod.yaml
@@ -1,0 +1,58 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-install-pod
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    SOURCE_POD=v-managed-sc1-0
+    TARGET_POD_IP=$(kubectl get pods v-schedule-only-k8s-0 --no-headers -o custom-columns=":status.podIP")
+    
+    kubectl exec $SOURCE_POD -i -- sudo /opt/vertica/sbin/update_vertica \
+      --accept-eula \
+      --failure-threshold NONE \
+      --dba-user-password-disabled \
+      --no-system-configuration \
+      --no-package-checks \
+      --point-to-point \
+      --data-dir /data \
+      --add-hosts $TARGET_POD_IP
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-install-pod
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-install-pod

--- a/tests/e2e/schedule-only/40-assert.yaml
+++ b/tests/e2e/schedule-only/40-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-db-add-node
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e/schedule-only/40-db-add-node.yaml
+++ b/tests/e2e/schedule-only/40-db-add-node.yaml
@@ -1,0 +1,54 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-db-add-node
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    SOURCE_POD=v-managed-sc1-0
+    TARGET_POD_IP=$(kubectl get pods v-schedule-only-k8s-0 --no-headers -o custom-columns=":status.podIP")
+    
+    kubectl exec $SOURCE_POD -i -- /opt/vertica/bin/admintools \
+      -t db_add_node \
+      --hosts $TARGET_POD_IP \
+      --database vertdb \
+      --noprompt
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-db-add-node
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-db-add-node

--- a/tests/e2e/schedule-only/45-assert.yaml
+++ b/tests/e2e/schedule-only/45-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-managed
+status:
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1
+    - addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e/schedule-only/45-scale-out-managed.yaml
+++ b/tests/e2e/schedule-only/45-scale-out-managed.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-managed
+spec:
+  subclusters:
+    - name: sc1
+      size: 1
+    - name: sc2
+      size: 1

--- a/tests/e2e/schedule-only/50-change-ksafety-to-1.yaml
+++ b/tests/e2e/schedule-only/50-change-ksafety-to-1.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We need to change ksafety to 1 so that we can test restart of a single node.
+  - command: kubectl exec --namespace $NAMESPACE v-schedule-only-k8s-0 -- vsql -c "select mark_design_ksafe(1); select rebalance_shards()"

--- a/tests/e2e/schedule-only/55-kill-schedule-only-pod.yaml
+++ b/tests/e2e/schedule-only/55-kill-schedule-only-pod.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete pod v-schedule-only-k8s-0
+    namespaced: true

--- a/tests/e2e/schedule-only/60-assert.yaml
+++ b/tests/e2e/schedule-only/60-assert.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-managed
+status:
+  subclusters:
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-schedule-only-k8s
+status:
+  replicas: 1
+  readyReplicas: 1

--- a/tests/e2e/schedule-only/60-wait-for-restart.yaml
+++ b/tests/e2e/schedule-only/60-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e/schedule-only/95-errors.yaml
+++ b/tests/e2e/schedule-only/95-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e/schedule-only/95-uninstall-operator.yaml
+++ b/tests/e2e/schedule-only/95-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e/schedule-only/99-delete-crd.yaml
+++ b/tests/e2e/schedule-only/99-delete-crd.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-s3-bucket/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e/schedule-only/99-errors.yaml
+++ b/tests/e2e/schedule-only/99-errors.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e/schedule-only/README.txt
+++ b/tests/e2e/schedule-only/README.txt
@@ -1,0 +1,4 @@
+This will test out 'initPolicy: ScheduleOnly'.  It will create a 1-node fully
+managed cluster, then create another cluster with ScheduleOnly.  The tests will
+manually added the second cluster to the first one, then try out a few restart
+scenarios.

--- a/tests/e2e/schedule-only/setup-managed-vdb/base/kustomization.yaml
+++ b/tests/e2e/schedule-only/setup-managed-vdb/base/kustomization.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bases:
+  - ../../../../kustomize-base
+
+resources:
+  - setup-vdb.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: e2e
+      fieldPath: data.endpoint
+    targets:
+      - select:
+          kind: VerticaDB
+        fieldPaths:
+          - spec.communal.endpoint

--- a/tests/e2e/schedule-only/setup-managed-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/schedule-only/setup-managed-vdb/base/setup-vdb.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-managed
+spec:
+  image: kustomize-vertica-image
+  sidecars:
+    - name: vlogger
+      image: kustomize-vlogger-image
+  communal:
+    path: "s3://schedule-only"
+    endpoint: kustomize-s3-endpoint
+    credentialSecret:  minio-creds-secret
+    caFile: /certs/communal-ep-cert/ca.crt
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  dbName: vertdb
+  kSafety: "0"
+  subclusters:
+    - name: sc1
+      size: 1
+  certSecrets:
+    - name: communal-ep-cert
+  requeueTime: 4

--- a/tests/e2e/schedule-only/setup-schedule-only-vdb/base/kustomization.yaml
+++ b/tests/e2e/schedule-only/setup-schedule-only-vdb/base/kustomization.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bases:
+  - ../../../../kustomize-base
+
+resources:
+  - setup-vdb.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: e2e
+      fieldPath: data.endpoint
+    targets:
+      - select:
+          kind: VerticaDB
+        fieldPaths:
+          - spec.communal.endpoint

--- a/tests/e2e/schedule-only/setup-schedule-only-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/schedule-only/setup-schedule-only-vdb/base/setup-vdb.yaml
@@ -1,0 +1,28 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-schedule-only
+spec:
+  initPolicy: ScheduleOnly
+  image: kustomize-vertica-image
+  local:
+    requestSize: 100Mi
+  subclusters:
+    - name: k8s
+      size: 1
+  certSecrets:
+    - name: communal-ep-cert
+  requeueTime: 4

--- a/tests/e2e/upgrade-vertica/08-pull-images.yaml
+++ b/tests/e2e/upgrade-vertica/08-pull-images.yaml
@@ -1,0 +1,26 @@
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "sed 's+kustomize-vertica-image+vertica/vertica-k8s:11.0.0-0-minimal+g' ../../manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
+  - command: kubectl wait --for=condition=Ready pod --timeout=10m vertica-k8s-image-pull
+    namespaced: true
+  - command: kubectl delete pod vertica-k8s-image-pull
+    namespaced: true
+  - command: bash -c "sed 's+kustomize-vertica-image+vertica/vertica-k8s:latest+g' ../../manifests/image-pull/base/vertica-k8s-image-pull.yaml | kubectl -n $NAMESPACE apply -f - "
+  - command: kubectl wait --for=condition=Ready pod --timeout=10m vertica-k8s-image-pull
+    namespaced: true
+  - command: kubectl delete pod vertica-k8s-image-pull
+    namespaced: true


### PR DESCRIPTION


This introduces a new initPolicy called ScheduleOnly.  The bootstrap of the database, either create_db or revive_db, is not handled.  Use this policy when you have a vertica cluster running outside of Kubernetes and you want to provision new nodes to run inside Kubernetes.  

Most of the automation is disabled when running in this mode.  The only automation that is done is attempting to restart any down pods with 'admintools -t restart_node'.  The user is resonsible for adding the pods as nodes to a vertica cluster (update_vertica), adding them to a database (admintools -t db_add_node), and handling any restart of the cluster (admintools -t re_ip/start_db).

Here is a sample CR:
```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: sample
spec:
  initPolicy: ScheduleOnly
  subclusters:
    - name: sc1
      size: 3
    - name: sc2
      size: 3
```

Notice that the entire `.spec.communal` section is omitted.

The number of pods that are created is dictated by the size of each subcluster.  However, subclusters aren't added by the operator.  We group by subcluster to control the name of each of the pod.  The actual subcluster the pod is part of does not have to match the name in the CR.