### PR TITLE
Added possibility to set S3 region

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -247,6 +247,10 @@ type CommunalStorage struct {
 	// and cannot change after creation.
 	Endpoint string `json:"endpoint"`
 
+	// +kubebuilder:validation:Optional
+	// The s3 region.
+	Region string `json:"region"`
+
 	// +kubebuilder:validation:required
 	// The name of a secret that contains the credentials to connect to the
 	// communal S3 endpoint. The secret must have the following keys set:

--- a/pkg/controllers/init_db.go
+++ b/pkg/controllers/init_db.go
@@ -183,6 +183,7 @@ func (g *GenericDatabaseInitializer) ConstructAuthParms(ctx context.Context, atP
 			"awsendpoint = "+g.getS3Endpoint()+"\n"+
 			"awsenablehttps = "+g.getEnableHTTPS()+"\n"+
 			g.getCAFile()+"\n"+
+			g.getS3Region()+"\n"+
 			"'",
 	)
 
@@ -246,6 +247,14 @@ func (g *GenericDatabaseInitializer) getS3Endpoint() string {
 		}
 	}
 	return g.Vdb.Spec.Communal.Endpoint
+}
+
+// getS3Region  will return an entry for awsregion if one needs to be included
+func (g *GenericDatabaseInitializer) getS3Region() string {
+	if g.Vdb.Spec.Communal.Region == "" {
+		return ""
+	}
+	return fmt.Sprintf("awsregion = %s", g.Vdb.Spec.Communal.Region)
 }
 
 // getEnableHTTPS will return "1" if connecting to https otherwise return "0"

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -73,6 +73,7 @@ func (d *DBGenerator) Create() (*KObjs, error) {
 		d.setShardCount,
 		d.fetchDatabaseConfig,
 		d.setCommunalEndpoint,
+		d.setCommunalRegion,
 		d.setLocalPaths,
 		d.setSubclusterDetail,
 		d.setCommunalPath,
@@ -218,6 +219,21 @@ func (d *DBGenerator) setCommunalEndpoint(ctx context.Context) error {
 		controllers.S3AccessKeyName: []byte(auth[0]),
 		controllers.S3SecretKeyName: []byte(auth[1]),
 	}
+
+	return nil
+}
+
+// setCommunalRegion will fetch the communal region and set it in v.vdb
+func (d *DBGenerator) setCommunalRegion(ctx context.Context) error {
+	const AWSRegion = "AWSRegion"
+
+	// The db cfg is already loaded in fetchDatabaseConfig
+	value, ok := d.DBCfg[AWSRegion]
+	if !ok {
+		return fmt.Errorf("missing '%s' in query '%s'", AWSRegion, Queries[DBCfgKey])
+	}
+
+	d.Objs.Vdb.Spec.Communal.Region = value
 
 	return nil
 }


### PR DESCRIPTION
Currently, it is not possible to use S3 bucket in region other then us-east-1. 
This PR introduces new field `communal.region` to fix this.
```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: verticatest
spec:
  dbName: vert
  initPolicy: Create
  communal:
    path: "s3://vertica-k8s-test"
    endpoint: "https://s3.eu-central-1.amazonaws.com"
    region: "eu-central-1"
    credentialSecret: s3-creds
  subclusters:
    - name: defaultsubcluster
      size: 1
```