### PR TITLE
Allow s3 region to be specified

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -257,7 +257,13 @@ type CommunalStorage struct {
 	// The path to a CA cert file for use when connecting to an https:// s3
 	// endpoint.  The path is relative to inside the Vertica container.
 	// Typically this would refer to a cert that was included in certSecrets.
-	CaFile string `json:"caFile"`
+	CaFile string `json:"caFile,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// The region containing the S3 bucket.  If you do not set the correct
+	// region, you might experience a delay before the bootstrap fails because
+	// Vertica retries several times before giving up.
+	Region string `json:"region,omitempty"`
 }
 
 type LocalStorage struct {
@@ -505,6 +511,8 @@ const (
 	VersionAnnotation   = "vertica.com/version"
 	BuildDateAnnotation = "vertica.com/buildDate"
 	BuildRefAnnotation  = "vertica.com/buildRef"
+
+	DefaultS3Region = "us-east-1"
 )
 
 // ExtractNamespacedName gets the name and returns it as a NamespacedName

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -68,6 +68,9 @@ func (v *VerticaDB) Default() {
 	if strings.HasSuffix(v.Spec.Image, ":latest") {
 		v.Spec.ImagePullPolicy = v1.PullAlways
 	}
+	if v.Spec.Communal.Region == "" {
+		v.Spec.Communal.Region = DefaultS3Region
+	}
 }
 
 //+kubebuilder:webhook:path=/validate-vertica-com-v1beta1-verticadb,mutating=false,failurePolicy=fail,sideEffects=None,groups=vertica.com,resources=verticadbs,verbs=create;update,versions=v1beta1,name=vverticadb.kb.io,admissionReviewVersions={v1,v1beta1}

--- a/changes/unreleased/Fixed-20210921-104327.yaml
+++ b/changes/unreleased/Fixed-20210921-104327.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Allow the AWS region to be specified in the CR.

--- a/pkg/controllers/createdb_reconcile_test.go
+++ b/pkg/controllers/createdb_reconcile_test.go
@@ -121,6 +121,8 @@ var _ = Describe("createdb_reconciler", func() {
 			"Unable to connect to endpoint",
 			"The specified bucket does not exist.",
 			"Communal location [s3://blah] is not empty",
+			"You are trying to access your S3 bucket using the wrong region. If you are using S3",
+			"The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-central-1'.",
 		}
 
 		for i := range errStrings {

--- a/pkg/controllers/init_db.go
+++ b/pkg/controllers/init_db.go
@@ -182,6 +182,7 @@ func (g *GenericDatabaseInitializer) ConstructAuthParms(ctx context.Context, atP
 			"awsauth = "+auth+"\n"+
 			"awsendpoint = "+g.getS3Endpoint()+"\n"+
 			"awsenablehttps = "+g.getEnableHTTPS()+"\n"+
+			g.getRegion()+"\n"+
 			g.getCAFile()+"\n"+
 			"'",
 	)
@@ -262,4 +263,15 @@ func (g *GenericDatabaseInitializer) getCAFile() string {
 		return ""
 	}
 	return fmt.Sprintf("awscafile = %s", g.Vdb.Spec.Communal.CaFile)
+}
+
+// getRegion will return an entry for awsregion
+func (g *GenericDatabaseInitializer) getRegion() string {
+	const FieldName = "awsregion"
+	// We have a webhook to set the default value, but for legacy purposes we
+	// always check for the empty string.
+	if g.Vdb.Spec.Communal.Region == "" {
+		return fmt.Sprintf("%s = %s", FieldName, vapi.DefaultS3Region)
+	}
+	return fmt.Sprintf("%s = %s", FieldName, g.Vdb.Spec.Communal.Region)
 }

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -35,6 +35,7 @@ const (
 	S3CredsWrongKey                 = "S3CredsWrongKey"
 	S3EndpointIssue                 = "S3EndpointIssue"
 	S3BucketDoesNotExist            = "S3BucketDoesNotExist"
+	S3WrongRegion                   = "S3WrongRegion"
 	CommunalPathIsNotEmpty          = "CommunalPathIsNotEmpty"
 	RemoveNodesStart                = "RemoveNodesStart"
 	RemoveNodesSucceeded            = "RemoveNodesSucceeded"

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -185,6 +185,7 @@ func (d *DBGenerator) setCommunalEndpoint(ctx context.Context) error {
 	const HTTPSKey = "AWSEnableHttps"
 	const EndpointKey = "AWSEndpoint"
 	const AWSAuth = "AWSAuth"
+	const RegionKey = "AWSRegion"
 	var protocol, endpoint string
 	var auth []string
 
@@ -212,6 +213,12 @@ func (d *DBGenerator) setCommunalEndpoint(ctx context.Context) error {
 	authRE := regexp.MustCompile(`:`)
 	const NumAuthComponents = 2
 	auth = authRE.Split(value, NumAuthComponents)
+
+	// The region may not be present if the default was never overridden.
+	value, ok = d.DBCfg[RegionKey]
+	if ok {
+		d.Objs.Vdb.Spec.Communal.Region = value
+	}
 
 	d.Objs.Vdb.Spec.Communal.Endpoint = fmt.Sprintf("%s://%s", protocol, endpoint)
 	d.Objs.CredSecret.Data = map[string][]byte{


### PR DESCRIPTION
This adds a new parameter to `.spec.communal` to allow the s3 region to be specified.  Prior to this, we would always use the Vertica default of us-east-1.  The webhook was updated to fill in the region if it wasn't set.  This way it will be clear what the default region rather than relying on the default set in the server.  The events were added to make it more visible when the region is misconfigured.

Closes #60.

