### PR TITLE
Add missing changie entries for next release

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,7 +6,7 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '* {{.Body}}'
+changeFormat: '* [#{{.Custom.Issue}}](https://github.com/vertica/vertica-kubernetes/issues/{{.Custom.Issue}}) {{.Body}}'
 kinds:
 - Added
 - Changed
@@ -14,3 +14,7 @@ kinds:
 - Removed
 - Fixed
 - Security
+custom:
+ - key: Issue
+   type: int
+   minInt: 1

--- a/changes/unreleased/Added-20210825-151346.yaml
+++ b/changes/unreleased/Added-20210825-151346.yaml
@@ -1,2 +1,4 @@
 kind: Added
 body: Added the ability to specify custom volumes for use within sidecars.
+custom:
+  Issue: 42

--- a/changes/unreleased/Added-20210916-144455.yaml
+++ b/changes/unreleased/Added-20210916-144455.yaml
@@ -1,3 +1,5 @@
 kind: Added
 body: Added the ability to specify a custom CA file to authenticate s3 communal
   storage over https.  Previously https was only allowed for AWS.
+custom:
+  Issue: 57

--- a/changes/unreleased/Added-20210920-171923.yaml
+++ b/changes/unreleased/Added-20210920-171923.yaml
@@ -3,3 +3,5 @@ body: New initPolicy called ScheduleOnly.  The bootstrap of the database, either
   create_db or revive_db, is not handled.  Use this policy when you have a vertica
   cluster running outside of Kubernetes and you want to provision new nodes to run
   inside Kubernetes.  Most of the automation is disabled when running in this mode.
+custom:
+  Issue: 59

--- a/changes/unreleased/Added-20210923-133214.yaml
+++ b/changes/unreleased/Added-20210923-133214.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added the ability to mount additional certs in the Vertica container.  These
+  certs can be specified through the new '.spec.certSecrets' parameter.

--- a/changes/unreleased/Added-20210923-133214.yaml
+++ b/changes/unreleased/Added-20210923-133214.yaml
@@ -1,3 +1,5 @@
 kind: Added
 body: Added the ability to mount additional certs in the Vertica container.  These
   certs can be specified through the new '.spec.certSecrets' parameter.
+custom:
+  Issue: 54

--- a/changes/unreleased/Changed-20210823-142529.yaml
+++ b/changes/unreleased/Changed-20210823-142529.yaml
@@ -2,3 +2,5 @@ kind: Changed
 body: Calls to update_vertica are removed.  The operator will modify
   admintools.conf for install/uninstall now.  This speeds up the time
   it takes to scale out.
+custom:
+  Issue: 39

--- a/changes/unreleased/Changed-20210825-091644.yaml
+++ b/changes/unreleased/Changed-20210825-091644.yaml
@@ -4,3 +4,5 @@ body: Start the admission controller webhook as part of the operator pod.  This 
   scoped operator, the NamespaceDefaultLabelName feature gate must be enabled (on
   by default in 1.21+) or the namespace must have the label 'kubernetes.io/metadata.name=<nsName>'
   set.
+custom:
+  Issue: 43

--- a/changes/unreleased/Changed-20210827-140240.yaml
+++ b/changes/unreleased/Changed-20210827-140240.yaml
@@ -2,3 +2,5 @@ kind: Changed
 body: Relax the dependency that the webhook requires cert-manager.  The default
   behaviour is to continue to depend on cert-manager.  But we now allow custom
   certs to be added through new helm chart parameters.
+custom:
+  Issue: 46

--- a/changes/unreleased/Changed-20210923-133510.yaml
+++ b/changes/unreleased/Changed-20210923-133510.yaml
@@ -2,3 +2,5 @@ kind: Changed
 body: The operator automatically follows the upgrade procedure when the '.spec.image'
   is changed.  This removes the upgrade-vertica.sh script that previously handled
   this outside of the operator.
+custom:
+  Issue: 51

--- a/changes/unreleased/Changed-20210923-133510.yaml
+++ b/changes/unreleased/Changed-20210923-133510.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: The operator automatically follows the upgrade procedure when the '.spec.image'
+  is changed.  This removes the upgrade-vertica.sh script that previously handled
+  this outside of the operator.

--- a/changes/unreleased/Fixed-20210831-083212.yaml
+++ b/changes/unreleased/Fixed-20210831-083212.yaml
@@ -1,3 +1,5 @@
 kind: Fixed
-body: 'Communal storage on AWS s3.  The timeouts the operator had set were too low
-  preventing a create DB from succeeding. '
+body: Communal storage on AWS s3.  The timeouts the operator had set were too low
+  preventing a create DB from succeeding.
+custom:
+  Issue: 47

--- a/changes/unreleased/Fixed-20210920-092151.yaml
+++ b/changes/unreleased/Fixed-20210920-092151.yaml
@@ -1,3 +1,5 @@
 kind: Fixed
 body: Increased the memory limit for the operator pod and made it configurable as
   a helm parameter.
+custom:
+  Issue: 58

--- a/changes/unreleased/Fixed-20210921-104327.yaml
+++ b/changes/unreleased/Fixed-20210921-104327.yaml
@@ -1,2 +1,4 @@
 kind: Fixed
 body: Allow the AWS region to be specified in the CR.
+custom:
+  Issue: 61


### PR DESCRIPTION
There were some changie entries that were missed in the current release.  This also adds issue numbers to each changie entry so that we can include a link to the PR in the changelog.