### PR TITLE
Install krew through make target

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,19 +50,7 @@ jobs:
         curl $VERTICA_CE_URL -o vertica-x86_64.RHEL6.latest.rpm
       
     - name: Run e2e tests
-      env:
-          KREW_URL: "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz"
       run: |
-        (
-        set -x; cd "$(mktemp -d)" &&
-        OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
-        ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
-        curl -fsSLO $KREW_URL &&
-        tar zxvf krew.tar.gz &&
-        KREW=./krew-"${OS}_${ARCH}" &&
-        "$KREW" install krew
-        )
-        export PATH=$PATH:$HOME/.krew/bin
         E2E_PARALLELISM=${{ github.event.inputs.parallel }}
         [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
         scripts/run-k8s-int-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ endif
 run-unit-tests: test ## Run unit tests
 
 .PHONY: install-kuttl-plugin
-install-kuttl-plugin:
+install-kuttl-plugin: krew
 ifeq ($(KUTTL_PLUGIN_INSTALLED), 0)
 	kubectl krew install kuttl
 endif
@@ -296,6 +296,11 @@ GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
+
+krew: $(HOME)/.krew/bin/kubectl-krew ## Download krew plugin locally if necessary
+
+$(HOME)/.krew/bin/kubectl-krew:
+	scripts/setup-krew.sh
 
 .PHONY: bundle ## Generate bundle manifests and metadata, then validate generated files.
 bundle: manifests kustomize

--- a/scripts/run-k8s-int-tests.sh
+++ b/scripts/run-k8s-int-tests.sh
@@ -73,6 +73,7 @@ export INT_TEST_OUTPUT_DIR
 export VERTICA_IMG=vertica-k8s:$TAG
 export OPERATOR_IMG=verticadb-operator:$TAG
 export VLOGGER_IMG=vertica-logger:$TAG
+export PATH=$PATH:$HOME/.krew/bin
 
 # cleanup the deployed k8s cluster
 function cleanup {

--- a/scripts/setup-krew.sh
+++ b/scripts/setup-krew.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script that download krew locally and set it up
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+
+KREW_URL=https://github.com/kubernetes-sigs/krew/releases/download/v0.4.1/krew.tar.gz
+
+cd "$(mktemp -d)"
+OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+curl -fsSLO $KREW_URL &&
+tar zxvf krew.tar.gz &&
+KREW=./krew-"${OS}_${ARCH}" &&
+"$KREW" install krew


### PR DESCRIPTION
Will download and install krew through a make target.  This will also harden the krew version rather than always getting latest.