### PR TITLE
Fix timing issue with install reconcile

### DIFF
--- a/pkg/controllers/install_reconcile.go
+++ b/pkg/controllers/install_reconcile.go
@@ -81,9 +81,13 @@ func (d *InstallReconciler) analyzeFacts(ctx context.Context) (ctrl.Result, erro
 	}
 
 	fns := []func(context.Context) error{
-		d.addHostsToATConf,
 		d.acceptEulaIfMissing,
 		d.checkConfigDir,
+		// This has to be after accepting the EULA.  re_ip will not succeed if
+		// the EULA is not accepted and a re_ip can happen before coming to this
+		// reconcile function.  So if the pod is rescheduled after adding
+		// hosts to the config, we have to know that a re_ip will succeed.
+		d.addHostsToATConf,
 	}
 	for _, fn := range fns {
 		if err := fn(ctx); err != nil {


### PR DESCRIPTION
There was a small timing window that is closed with this change.  It was
caught in the crash-before-createdb testcase.  The order in install was
to add hosts to admintools.conf then accept the EULA.  If the pod is
rescheduled between these, we would attempt a re_ip before coming back
and completing the install.  But the re_ip kept failing because the EULA
wasn't accepted.   The solution was to accept the EULA *before* adding
the hosts to the admintools.conf.