### PR TITLE
Fix restart reconciler timing scenarios

### DIFF
--- a/pkg/controllers/imagechange_reconcile.go
+++ b/pkg/controllers/imagechange_reconcile.go
@@ -217,6 +217,7 @@ func (u *ImageChangeReconciler) deleteStatefulSets(ctx context.Context) (ctrl.Re
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+			u.PFacts.Invalidate()
 		}
 	}
 	return ctrl.Result{}, nil

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -502,7 +502,7 @@ func (p *PodFacts) filterPods(filterFunc func(p *PodFact) bool) []*PodFact {
 // and none of the pods have an installation.
 func (p *PodFacts) areAllPodsRunningAndZeroInstalled() bool {
 	for _, v := range p.Detail {
-		if (v.exists && !v.isPodRunning) || v.isInstalled.IsTrue() {
+		if !v.exists || !v.isPodRunning || v.isInstalled.IsTrue() {
 			return false
 		}
 	}

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -509,15 +509,33 @@ func (p *PodFacts) areAllPodsRunningAndZeroInstalled() bool {
 	return true
 }
 
-// countRunningAndInstalled returns number of pods that are running and have an install
-func (p *PodFacts) countRunningAndInstalled() int {
+// countPods is a generic function to do a count across the pod facts
+func (p *PodFacts) countPods(countFunc func(p *PodFact) int) int {
 	count := 0
 	for _, v := range p.Detail {
-		if v.isPodRunning && v.isInstalled.IsTrue() {
-			count++
-		}
+		count += countFunc(v)
 	}
 	return count
+}
+
+// countRunningAndInstalled returns number of pods that are running and have an install
+func (p *PodFacts) countRunningAndInstalled() int {
+	return p.countPods(func(v *PodFact) int {
+		if v.isPodRunning && v.isInstalled.IsTrue() {
+			return 1
+		}
+		return 0
+	})
+}
+
+// countNotRunning returns number of pods that aren't running yet
+func (p *PodFacts) countNotRunning() int {
+	return p.countPods(func(v *PodFact) int {
+		if !v.isPodRunning {
+			return 1
+		}
+		return 0
+	})
 }
 
 // getUpNodeCount returns the number of up nodes.

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -56,6 +56,11 @@ type PodFact struct {
 	// process of starting or restarting.
 	isPodRunning bool
 
+	// true means the statefulset exists and its size includes this pod.  The
+	// cases where this would be false are (a) statefulset doesn't yet exist or
+	// (b) statefulset exists but it isn't sized to include this pod yet.
+	managedByParent bool
+
 	// Have we run install for this pod? None means we are unable to determine
 	// whether it is run.
 	isInstalled tristate.TriState
@@ -143,20 +148,20 @@ func (p *PodFacts) Invalidate() {
 // collectSubcluster will collect facts about each pod in a specific subcluster
 func (p *PodFacts) collectSubcluster(ctx context.Context, vdb *vapi.VerticaDB, sc *vapi.Subcluster) error {
 	sts := &appsv1.StatefulSet{}
+	maxStsSize := sc.Size
 	if err := p.Client.Get(ctx, names.GenStsName(vdb, sc), sts); err != nil {
 		// If the statefulset doesn't exist, none of the pods within it exist.  So fine to skip.
-		if errors.IsNotFound(err) {
-			return nil
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("could not fetch statefulset for pod fact collection %s %w", sc.Name, err)
 		}
-		return fmt.Errorf("could not fetch statefulset for pod fact collection %s %w", sc.Name, err)
-	}
-	maxStsSize := sc.Size
-	if *sts.Spec.Replicas > maxStsSize {
-		maxStsSize = *sts.Spec.Replicas
+	} else {
+		if *sts.Spec.Replicas > maxStsSize {
+			maxStsSize = *sts.Spec.Replicas
+		}
 	}
 
 	for i := int32(0); i < maxStsSize; i++ {
-		if err := p.collectPodByStsIndex(ctx, vdb, sc, i); err != nil {
+		if err := p.collectPodByStsIndex(ctx, vdb, sc, sts, i); err != nil {
 			return err
 		}
 	}
@@ -164,7 +169,8 @@ func (p *PodFacts) collectSubcluster(ctx context.Context, vdb *vapi.VerticaDB, s
 }
 
 // collectPodByStsIndex will collect facts about a single pod in a subcluster
-func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) error {
+func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB, sc *vapi.Subcluster,
+	sts *appsv1.StatefulSet, podIndex int32) error {
 	pf := PodFact{
 		name:       names.GenPodName(vdb, sc, podIndex),
 		subcluster: sc.Name,
@@ -179,6 +185,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		return err
 	}
 	pf.exists = true // Success from the Get() implies pod exists in API server
+	pf.managedByParent = podIndex < *sts.Spec.Replicas
 	pf.isPodRunning = pod.Status.Phase == corev1.PodRunning
 	pf.dnsName = pod.Spec.Hostname + "." + pod.Spec.Subdomain
 	pf.podIP = pod.Status.PodIP
@@ -502,7 +509,7 @@ func (p *PodFacts) filterPods(filterFunc func(p *PodFact) bool) []*PodFact {
 // and none of the pods have an installation.
 func (p *PodFacts) areAllPodsRunningAndZeroInstalled() bool {
 	for _, v := range p.Detail {
-		if !v.exists || !v.isPodRunning || v.isInstalled.IsTrue() {
+		if ((!v.exists || !v.isPodRunning) && v.managedByParent) || v.isInstalled.IsTrue() {
 			return false
 		}
 	}
@@ -531,7 +538,9 @@ func (p *PodFacts) countRunningAndInstalled() int {
 // countNotRunning returns number of pods that aren't running yet
 func (p *PodFacts) countNotRunning() int {
 	return p.countPods(func(v *PodFact) int {
-		if !v.isPodRunning {
+		// We don't count non-running pods that aren't yet managed by the parent
+		// sts.  The sts needs to be created or sized first.
+		if !v.isPodRunning && v.managedByParent {
 			return 1
 		}
 		return 0

--- a/pkg/controllers/restart_reconcile.go
+++ b/pkg/controllers/restart_reconcile.go
@@ -171,7 +171,7 @@ func (r *RestartReconciler) reconcileNodes(ctx context.Context) (ctrl.Result, er
 	// didn't originate the install.  So we will skip the rest if running in
 	// that mode.
 	if r.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: r.shouldRequeueIfPodsNotRunning()}, nil
 	}
 
 	// Find any pods that need to have their IP updated.  These are nodes that
@@ -182,10 +182,12 @@ func (r *RestartReconciler) reconcileNodes(ctx context.Context) (ctrl.Result, er
 			r.Log.Info("No pod found to run admintools from. Requeue reconciliation.")
 			return ctrl.Result{Requeue: true}, nil
 		}
-		return r.reipNodes(ctx, reIPPods)
+		if res, err := r.reipNodes(ctx, reIPPods); res.Requeue || err != nil {
+			return res, err
+		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{Requeue: r.shouldRequeueIfPodsNotRunning()}, nil
 }
 
 // restartPods restart the down pods using admintools
@@ -557,4 +559,15 @@ func (r *RestartReconciler) setATPod() bool {
 		r.ATPod = atPod.name
 	}
 	return true
+}
+
+// shouldRequeueIfPodsNotRunning is a helper function that will determine
+// whether a requeue of the reconcile is necessary because some pods are not yet
+// running.
+func (r *RestartReconciler) shouldRequeueIfPodsNotRunning() bool {
+	if r.PFacts.countNotRunning() > 0 {
+		r.Log.Info("Requeue.  Some pods are not yet running.")
+		return true
+	}
+	return false
 }

--- a/tests/e2e/revivedb-failures/08-delete-clean-s3-pod.yaml
+++ b/tests/e2e/revivedb-failures/08-delete-clean-s3-pod.yaml
@@ -16,5 +16,4 @@ kind: TestStep
 delete:
   - apiVersion: v1
     kind: Pod
-    metadata:
-      name: clean-s3-bucket
+    name: clean-s3-bucket

--- a/tests/e2e/vdb-gen/08-delete-clean-s3-pod.yaml
+++ b/tests/e2e/vdb-gen/08-delete-clean-s3-pod.yaml
@@ -16,5 +16,4 @@ kind: TestStep
 delete:
   - apiVersion: v1
     kind: Pod
-    metadata:
-      name: clean-s3-bucket
+    name: clean-s3-bucket


### PR DESCRIPTION
This addresses two scenarios related to the restart reconciler:
- Saw an issue during restart where it wouldn't do the restart as part of the image change reconcile.  The image change reconciler would skip the entire restart, and so it wouldn't happen until the restart reconciler.  Functionally, there is no issue here.  It just looks a bit weird in the events because it claimed the image change was successful then proceeds to restart Vertica after that.
- If some pods are not running, the restart reconciler should requeue.  Prior to this change it was possible for it to exit cleanly.  This could leave the operator in a state where it wouldn't restart a down pod.