### PR TITLE
Bump version and fix generation of operator image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.0
+VERSION ?= 1.1.0
 
 SHELL:=$(shell which bash)
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,9 +8,3 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: controller
-  newName: verticadb-operator
-  newTag: kind

--- a/helm-charts/verticadb-operator/Chart.yaml
+++ b/helm-charts/verticadb-operator/Chart.yaml
@@ -15,4 +15,4 @@ name: verticadb-operator
 description: An operator that can deploy and manage Vertica clusters
 type: application
 # Versions follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0

--- a/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
+++ b/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
@@ -5,10 +5,10 @@ tests:
   - it: allows the operator image and tag to be specified
     set:
       image:
-        name: verticadb-operator:kind
+        name: something:tag
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].image
       - equal:
           path: spec.template.spec.containers[0].image
-          value: verticadb-operator:kind
+          value: something:tag

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -18,7 +18,7 @@
 
 
 image:
-  name: vertica/verticadb-operator:1.0.0
+  name: vertica/verticadb-operator:1.1.0
 
 webhook:
   # The webhook requires a TLS certficate to work.  By default we rely on


### PR DESCRIPTION
To get ready for the October release, this bumps the version to 1.1.0.  There is also a fix in here to ensure we generate the proper operator image name -- both for helm and olm.