### PR TITLE
Allow any deploy method with client-access

### DIFF
--- a/scripts/kind.sh
+++ b/scripts/kind.sh
@@ -19,10 +19,6 @@ set -e
 
 UPLOAD_IMAGES=
 TAG=latest
-if [[ -n $KUBECONFIG ]]
-then
-    KUBECONFIG=$HOME/.kube/config
-fi
 KUBEVER=1.21.1
 IP_FAMILY=ipv4
 LISTEN_ALL_INTERFACES=N

--- a/tests/e2e/client-access/00-deploy-operator.yaml
+++ b/tests/e2e/client-access/00-deploy-operator.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE DEPLOY_WITH=olm"
+  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"


### PR DESCRIPTION
client-access was previously overriding the deploy method to be OLM.  This change will allow us to run the entire e2e suite with OLM if need be.