### PR TITLE
Handle 'admintools -t stop_db' when a password is required

### DIFF
--- a/pkg/cmds/exec.go
+++ b/pkg/cmds/exec.go
@@ -160,6 +160,7 @@ func getSupportingPasswdSlice() []string {
 	return []string{
 		"db_add_node", "db_add_subcluster", "db_remove_node",
 		"db_remove_subcluster", "create_db", "restart_node", "start_db",
+		"stop_db",
 	}
 }
 

--- a/pkg/controllers/imagechange_reconcile.go
+++ b/pkg/controllers/imagechange_reconcile.go
@@ -185,8 +185,8 @@ func (u *ImageChangeReconciler) stopCluster(ctx context.Context) (ctrl.Result, e
 	u.VRec.EVRec.Event(u.Vdb, corev1.EventTypeNormal, events.ClusterShutdownStarted,
 		"Calling 'admintools -t stop_db'")
 
-	_, _, err := u.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer,
-		"/opt/vertica/bin/admintools", "-t", "stop_db", "-F", "-d", u.Vdb.Spec.DBName)
+	_, _, err := u.PRunner.ExecAdmintools(ctx, pf.name, names.ServerContainer,
+		"-t", "stop_db", "-F", "-d", u.Vdb.Spec.DBName)
 	if err != nil {
 		u.VRec.EVRec.Event(u.Vdb, corev1.EventTypeWarning, events.ClusterShutdownFailed,
 			"Failed to shutdown the cluster")

--- a/scripts/kind.sh
+++ b/scripts/kind.sh
@@ -19,10 +19,6 @@ set -e
 
 UPLOAD_IMAGES=
 TAG=latest
-if [[ -n $KUBECONFIG ]]
-then
-    KUBECONFIG=$HOME/.kube/config
-fi
 KUBEVER=1.21.1
 IP_FAMILY=ipv4
 LISTEN_ALL_INTERFACES=N

--- a/tests/e2e/upgrade-vertica/04-assert.yaml
+++ b/tests/e2e/upgrade-vertica/04-assert.yaml
@@ -11,28 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Secret
 metadata:
-  name: v-upgrade-vertica
-spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
-  imagePullPolicy: IfNotPresent
-  superuserPasswordSecret: su-passwd
-  communal:
-    path: "s3://upgrade-vertica"
-    endpoint: kustomize-s3-endpoint
-    credentialSecret:  s3-creds
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  dbName: vd
-  shardCount: 17
-  kSafety: "0"
-  subclusters:
-    - name: defsc
-      size: 2
-  # Set requeueTime to prevent the exponential backoff kicking in, which can
-  # cause the test to timeout.
-  requeueTime: 5
-  certSecrets: []
+  name: su-passwd
+type: Opaque
+data:
+  password: c3VwZXJ1c2Vy

--- a/tests/e2e/upgrade-vertica/04-password-secret.yaml
+++ b/tests/e2e/upgrade-vertica/04-password-secret.yaml
@@ -11,28 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Secret
 metadata:
-  name: v-upgrade-vertica
-spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
-  imagePullPolicy: IfNotPresent
-  superuserPasswordSecret: su-passwd
-  communal:
-    path: "s3://upgrade-vertica"
-    endpoint: kustomize-s3-endpoint
-    credentialSecret:  s3-creds
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  dbName: vd
-  shardCount: 17
-  kSafety: "0"
-  subclusters:
-    - name: defsc
-      size: 2
-  # Set requeueTime to prevent the exponential backoff kicking in, which can
-  # cause the test to timeout.
-  requeueTime: 5
-  certSecrets: []
+  name: su-passwd
+type: Opaque
+data:
+  ## Password for superuser, base64 encoded (echo -n 'superuser' | base64)
+  password: c3VwZXJ1c2Vy


### PR DESCRIPTION
This is a bug fix for upgrade reconciler.  It has to shut down the cluster with 'admintools -t stop_db'.  It wasn't able to stop the cluster if a superuser password was set.  This fix will pass the password on if required. 