### PR TITLE
kind.sh term to delete registry by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,12 @@ export VERTICA_IMG
 # Image URL to use for the logger sidecar
 VLOGGER_IMG ?= vertica-logger:$(TAG)
 export VLOGGER_IMG
+# The port number for the local registry
+REG_PORT ?= 5000
 # Image URL to use for the bundle.  We special case kind because to use it with
 # kind it must be pushed to a local registry.
 ifeq ($(shell $(KIND_CHECK)), 1)
-BUNDLE_IMG ?= localhost:5000/verticadb-operator-bundle:$(TAG)
+BUNDLE_IMG ?= localhost:$(REG_PORT)/verticadb-operator-bundle:$(TAG)
 else
 # BUNDLE_IMG defines the image:tag used for the bundle. 
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -82,7 +84,7 @@ endif
 export BUNDLE_IMG
 # Image URL for the OLM catalog.  This is for testing purposes only.
 ifeq ($(shell $(KIND_CHECK)), 1)
-OLM_CATALOG_IMG ?= localhost:5000/olm-catalog:$(TAG)
+OLM_CATALOG_IMG ?= localhost:$(REG_PORT)/olm-catalog:$(TAG)
 else
 OLM_CATALOG_IMG ?= olm-catalog:$(TAG)
 endif

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ export E2E_PARALLELISM
 # Specify how to deploy the operator.  Allowable values are 'helm', 'olm' or 'random'.
 # When deploying with olm, it is expected that `make setup-olm` has been run
 # already.  When deploying with random, it will randomly pick between olm and helm.
-DEPLOY_WITH?=random
+DEPLOY_WITH?=helm
 # Name of the test OLM catalog that we will create and deploy with in e2e tests
 OLM_TEST_CATALOG_SOURCE=e2e-test-catalog
 

--- a/scripts/kind.sh
+++ b/scripts/kind.sh
@@ -30,7 +30,7 @@ REG_NAME='kind-registry'
 REG_PORT='5000'
 TERM_REGISTRY=1
 
-while getopts "ut:k:i:ap:x" opt
+while getopts "ut:k:i:ap:xr:" opt
 do
     case $opt in
         u) UPLOAD_IMAGES=1;;
@@ -39,13 +39,14 @@ do
         p) PORT=$OPTARG;;
         i) IP_FAMILY=$OPTARG;;
         a) LISTEN_ALL_INTERFACES="Y";;
+        r) REG_PORT=$OPTARG;;
         x) TERM_REGISTRY=;;
     esac
 done
 
 if [ $(( $# - $OPTIND )) -lt 1 ]
 then
-    echo "usage: kind.sh [-uax] [-t <tag>] [-k <ver>] [-p <port>] [-i <ip-family>] (init|term) <name>"
+    echo "usage: kind.sh [-uax] [-t <tag>] [-k <ver>] [-p <port>] [-i <ip-family>] [-r <port>] (init|term) <name>"
     echo
     echo "Options:"
     echo "  -u     Upload the images to kind after creating the cluster."
@@ -57,6 +58,7 @@ then
     echo "         the range of 30000-32767.  This option is used if you want"
     echo "         to use NodePort.  The given port is the port number you use"
     echo "         in the vdb manifest."
+    echo "  -r     Use port number for the registry.  Defaults to: $REG_PORT"
     echo "  -x     When terminating kind, skip killing of the registry."
     echo
     echo "Positional Arguments:"

--- a/scripts/kind.sh
+++ b/scripts/kind.sh
@@ -28,7 +28,7 @@ REPO_DIR=$(dirname $SCRIPT_DIR)
 KIND=$REPO_DIR/bin/kind
 REG_NAME='kind-registry'
 REG_PORT='5000'
-TERM_REGISTRY=
+TERM_REGISTRY=1
 
 while getopts "ut:k:i:ap:x" opt
 do
@@ -39,7 +39,7 @@ do
         p) PORT=$OPTARG;;
         i) IP_FAMILY=$OPTARG;;
         a) LISTEN_ALL_INTERFACES="Y";;
-        x) TERM_REGISTRY=1;;
+        x) TERM_REGISTRY=;;
     esac
 done
 
@@ -57,7 +57,7 @@ then
     echo "         the range of 30000-32767.  This option is used if you want"
     echo "         to use NodePort.  The given port is the port number you use"
     echo "         in the vdb manifest."
-    echo "  -x     When terminating kind, kill the registry also."
+    echo "  -x     When terminating kind, skip killing of the registry."
     echo
     echo "Positional Arguments:"
     echo " <name>  Name to give the cluster"

--- a/scripts/push-to-kind.sh
+++ b/scripts/push-to-kind.sh
@@ -23,6 +23,9 @@ function setImageWithTag() {
 }
 
 TAG=kind
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_DIR=$(dirname $SCRIPT_DIR)
+KIND=$REPO_DIR/bin/kind
 setImageWithTag $TAG
 
 function usage() {
@@ -99,5 +102,5 @@ do
       docker pull $imageName
     fi
 
-    kind load docker-image --name ${CLUSTER_NAME} ${imageName}
+    ${KIND} load docker-image --name ${CLUSTER_NAME} ${imageName}
 done

--- a/scripts/run-k8s-int-tests.sh
+++ b/scripts/run-k8s-int-tests.sh
@@ -74,6 +74,7 @@ export VERTICA_IMG=vertica-k8s:$TAG
 export OPERATOR_IMG=verticadb-operator:$TAG
 export VLOGGER_IMG=vertica-logger:$TAG
 export PATH=$PATH:$HOME/.krew/bin
+export DEPLOY_WITH=random  # Randomly pick between helm and OLM
 
 # cleanup the deployed k8s cluster
 function cleanup {


### PR DESCRIPTION
The -x option in kind.sh will now be used to skip killing of the registry.

Also changed the default deployment method for e2e tests to be helm.  When running the e2e tests in the CI it will randomly pick between helm and olm.