### PR TITLE
Remove changelog entry for ScheduleOnly initPolicy

### DIFF
--- a/changes/unreleased/Added-20210920-171923.yaml
+++ b/changes/unreleased/Added-20210920-171923.yaml
@@ -1,7 +1,0 @@
-kind: Added
-body: New initPolicy called ScheduleOnly.  The bootstrap of the database, either
-  create_db or revive_db, is not handled.  Use this policy when you have a vertica
-  cluster running outside of Kubernetes and you want to provision new nodes to run
-  inside Kubernetes.  Most of the automation is disabled when running in this mode.
-custom:
-  Issue: 59


### PR DESCRIPTION
We aren't going to externalize the ScheduleOnly initPolicy in the upcoming release, so removing it from the changelog.