### PR TITLE
Allow custom mount points to be added to vertica

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -17,8 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"regexp"
 
+	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -181,11 +183,21 @@ type VerticaDBSpec struct {
 	Sidecars []corev1.Container `json:"sidecars,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// Custom volumes that are added to sidecars.  Each sidecar must include
-	// the volume in the volumeMounts for it to appear in the container.  It
-	// accepts any valid volume type.  A unique name must be given for each
+	// Custom volumes that are added to sidecars and the Vertica container.
+	// For these volumes to be visible in either container, they must have a
+	// corresonding volumeMounts entry.  For sidecars, this is included in
+	// `spec.sidecars[*].volumeMounts`.  For the Vertica container, it is
+	// included in `spec.volumeMounts`.
+	//
+	// This accepts any valid volume type.  A unique name must be given for each
 	// volume and it cannot conflict with any of the internally generated volumes.
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// Additional volume mounts to include in the Vertica container.  These
+	// reference volumes that are in the Volumes list.  The mount path must not
+	// conflict with a mount path that the operator adds internally.
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// Secrets that will be mounted in the vertica container.  The purpose of
@@ -620,4 +632,38 @@ func IsValidSubclusterName(scName string) bool {
 func (v *VerticaDB) GetVerticaVersion() (string, bool) {
 	ver, ok := v.ObjectMeta.Annotations[VersionAnnotation]
 	return ver, ok
+}
+
+// GenInstallerIndicatorFileName returns the name of the installer indicator file.
+// Valid only for the current instance of the vdb.
+func (v *VerticaDB) GenInstallerIndicatorFileName() string {
+	return paths.InstallerIndicatorFile + string(v.UID)
+}
+
+// GetPVSubPath returns the subpath in the local data PV.
+// We use the UID so that we create unique paths in the PV.  If the PV is reused
+// for a new vdb, the UID will be different.
+func (v *VerticaDB) GetPVSubPath(subPath string) string {
+	return fmt.Sprintf("%s/%s", v.UID, subPath)
+}
+
+// GetDBDataPath get the data path for the current database
+func (v *VerticaDB) GetDBDataPath() string {
+	return fmt.Sprintf("%s/%s", v.Spec.Local.DataPath, v.Spec.DBName)
+}
+
+// GetCommunalPath returns the path to use for communal storage
+func (v *VerticaDB) GetCommunalPath() string {
+	// We include the UID in the communal path to generate a unique path for
+	// each new instance of vdb. This means we can't use the same base path for
+	// different databases and we don't require any cleanup if the vdb was
+	// recreated.
+	if !v.Spec.Communal.IncludeUIDInPath {
+		return v.Spec.Communal.Path
+	}
+	return fmt.Sprintf("%s/%s", v.Spec.Communal.Path, v.UID)
+}
+
+func (v *VerticaDB) GetDepotPath() string {
+	return fmt.Sprintf("%s/%s", v.Spec.Local.DepotPath, v.Spec.DBName)
 }

--- a/api/v1beta1/verticadb_types_test.go
+++ b/api/v1beta1/verticadb_types_test.go
@@ -13,39 +13,27 @@
  limitations under the License.
 */
 
-package paths
+package v1beta1
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
 
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"paths Suite",
-		[]Reporter{printer.NewlineReporter{}})
-}
-
-var _ = Describe("paths", func() {
+var _ = Describe("verticadb_types", func() {
 	const FakeUID = "abcdef"
 
 	It("should include UID in path if IncludeUIDInPath is set", func() {
-		vdb := vapi.MakeVDB()
+		vdb := MakeVDB()
 		vdb.ObjectMeta.UID = FakeUID
 		vdb.Spec.Communal.IncludeUIDInPath = true
-		Expect(GetCommunalPath(vdb)).Should(ContainSubstring(string(vdb.ObjectMeta.UID)))
+		Expect(vdb.GetCommunalPath()).Should(ContainSubstring(string(vdb.ObjectMeta.UID)))
 	})
 
 	It("should not include UID in path if IncludeUIDInPath is not set", func() {
-		vdb := vapi.MakeVDB()
+		vdb := MakeVDB()
 		vdb.ObjectMeta.UID = FakeUID
 		vdb.Spec.Communal.IncludeUIDInPath = false
-		Expect(GetCommunalPath(vdb)).ShouldNot(ContainSubstring(string(vdb.ObjectMeta.UID)))
+		Expect(vdb.GetCommunalPath()).ShouldNot(ContainSubstring(string(vdb.ObjectMeta.UID)))
 	})
 })

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -16,8 +16,11 @@
 package v1beta1
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -284,6 +287,22 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Communal.Endpoint = ""
 		vdb.Default()
 		Expect(vdb.Spec.Communal.Endpoint).Should(Equal(DefaultGCloudEndpoint))
+	})
+
+	It("should prevent volumeMount paths to use same path as internal mount points", func() {
+		vdb := createVDBHelper()
+		vdb.Spec.VolumeMounts = []v1.VolumeMount{
+			{MountPath: paths.LogPath}}
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.VolumeMounts = []v1.VolumeMount{
+			{MountPath: vdb.Spec.Local.DataPath}}
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.VolumeMounts = []v1.VolumeMount{
+			{MountPath: fmt.Sprintf("%s/my.cert", paths.CertsRoot)}}
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.VolumeMounts = []v1.VolumeMount{
+			{MountPath: "/good/path"}}
+		validateSpecValuesHaveErr(vdb, false)
 	})
 })
 

--- a/changes/unreleased/Added-20211029-083036.yaml
+++ b/changes/unreleased/Added-20211029-083036.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Added the ability to speciy custom volume mounts for use within the Vertica
+  container.
+time: 2021-10-29T08:30:36.097279509-04:00
+custom:
+  Issue: "89"

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -75,10 +75,10 @@ func buildHlSvc(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.Service {
 func buildVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 	volMnts := []corev1.VolumeMount{
 		{Name: vapi.LocalDataPVC, MountPath: paths.LocalDataPath},
-		{Name: vapi.LocalDataPVC, SubPath: paths.GetPVSubPath(vdb, "config"), MountPath: paths.ConfigPath},
-		{Name: vapi.LocalDataPVC, SubPath: paths.GetPVSubPath(vdb, "log"), MountPath: paths.LogPath},
-		{Name: vapi.LocalDataPVC, SubPath: paths.GetPVSubPath(vdb, "data"), MountPath: vdb.Spec.Local.DataPath},
-		{Name: vapi.LocalDataPVC, SubPath: paths.GetPVSubPath(vdb, "depot"), MountPath: vdb.Spec.Local.DepotPath},
+		{Name: vapi.LocalDataPVC, SubPath: vdb.GetPVSubPath("config"), MountPath: paths.ConfigPath},
+		{Name: vapi.LocalDataPVC, SubPath: vdb.GetPVSubPath("log"), MountPath: paths.LogPath},
+		{Name: vapi.LocalDataPVC, SubPath: vdb.GetPVSubPath("data"), MountPath: vdb.Spec.Local.DataPath},
+		{Name: vapi.LocalDataPVC, SubPath: vdb.GetPVSubPath("depot"), MountPath: vdb.Spec.Local.DepotPath},
 		{Name: vapi.PodInfoMountName, MountPath: paths.PodInfoPath},
 	}
 
@@ -97,6 +97,7 @@ func buildVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 	}
 
 	volMnts = append(volMnts, buildCertSecretVolumeMounts(vdb)...)
+	volMnts = append(volMnts, vdb.Spec.VolumeMounts...)
 
 	return volMnts
 }
@@ -291,7 +292,7 @@ func makeContainers(vdb *vapi.VerticaDB, sc *vapi.Subcluster) []corev1.Container
 		// prior to the creation of the VerticaDB.
 		c.VolumeMounts = append(c.VolumeMounts, buildVolumeMounts(vdb)...)
 		// As a convenience, add the database path as an environment variable.
-		c.Env = append(c.Env, corev1.EnvVar{Name: "DBPATH", Value: paths.GetDBDataPath(vdb)})
+		c.Env = append(c.Env, corev1.EnvVar{Name: "DBPATH", Value: vdb.GetDBDataPath()})
 		cnts = append(cnts, c)
 	}
 	return cnts

--- a/pkg/controllers/createdb_reconcile.go
+++ b/pkg/controllers/createdb_reconcile.go
@@ -92,12 +92,12 @@ func (c *CreateDBReconciler) execCmd(ctx context.Context, atPod types.Namespaced
 
 		case isBucketNotExistError(stdout):
 			c.VRec.EVRec.Eventf(c.Vdb, corev1.EventTypeWarning, events.S3BucketDoesNotExist,
-				"The bucket in the S3 path '%s' does not exist", paths.GetCommunalPath(c.Vdb))
+				"The bucket in the S3 path '%s' does not exist", c.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil
 
 		case isCommunalPathNotEmpty(stdout):
 			c.VRec.EVRec.Eventf(c.Vdb, corev1.EventTypeWarning, events.CommunalPathIsNotEmpty,
-				"The communal path '%s' is not empty", paths.GetCommunalPath(c.Vdb))
+				"The communal path '%s' is not empty", c.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil
 
 		case isWrongRegion(stdout):
@@ -198,7 +198,7 @@ func (c *CreateDBReconciler) genCmd(ctx context.Context, hostList []string) ([]s
 		"-t", "create_db",
 		"--skip-fs-checks",
 		"--hosts=" + strings.Join(hostList, ","),
-		"--communal-storage-location=" + paths.GetCommunalPath(c.Vdb),
+		"--communal-storage-location=" + c.Vdb.GetCommunalPath(),
 		"--communal-storage-params=" + paths.AuthParmsFile,
 		"--sql=" + PostDBCreateSQLFile,
 		fmt.Sprintf("--shard-count=%d", c.Vdb.Spec.ShardCount),

--- a/pkg/controllers/install_reconcile.go
+++ b/pkg/controllers/install_reconcile.go
@@ -242,7 +242,7 @@ func (d *InstallReconciler) fetchCompat21NodeNum(ctx context.Context, pf *PodFac
 func (d *InstallReconciler) genCmdCreateInstallIndicator(compat21Node string) []string {
 	// The install indicator file has the UID of the vdb. This allows us to know
 	// that we are working with a different life in the vdb is ever recreated.
-	return []string{"bash", "-c", fmt.Sprintf("echo %s > %s", compat21Node, paths.GenInstallerIndicatorFileName(d.Vdb))}
+	return []string{"bash", "-c", fmt.Sprintf("echo %s > %s", compat21Node, d.Vdb.GenInstallerIndicatorFileName())}
 }
 
 // genCmdRemoveOldConfig generates the command to remove the old admintools.conf file

--- a/pkg/controllers/install_reconcile_test.go
+++ b/pkg/controllers/install_reconcile_test.go
@@ -59,7 +59,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{
 			names.GenPodName(vdb, sc, 0): []cmds.CmdResult{{}},
 			names.GenPodName(vdb, sc, 1): []cmds.CmdResult{
-				{Stderr: "cat: " + paths.GenInstallerIndicatorFileName(vdb) + ": No such file or directory",
+				{Stderr: "cat: " + vdb.GenInstallerIndicatorFileName() + ": No such file or directory",
 					Err: errors.New("command terminated with exit code 1")},
 			},
 			names.GenPodName(vdb, sc, 2): []cmds.CmdResult{{}},
@@ -94,10 +94,10 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{
 			names.GenPodName(vdb, sc, 0): []cmds.CmdResult{{}},
 			names.GenPodName(vdb, sc, 1): []cmds.CmdResult{{
-				Stderr: "cat: " + paths.GenInstallerIndicatorFileName(vdb) + ": No such file or directory",
+				Stderr: "cat: " + vdb.GenInstallerIndicatorFileName() + ": No such file or directory",
 				Err:    errors.New("command terminated with exit code 1")}},
 			names.GenPodName(vdb, sc, 2): []cmds.CmdResult{{
-				Stderr: "cat: " + paths.GenInstallerIndicatorFileName(vdb) + ": No such file or directory",
+				Stderr: "cat: " + vdb.GenInstallerIndicatorFileName() + ": No such file or directory",
 				Err:    errors.New("command terminated with exit code 1")}},
 		}}
 

--- a/pkg/controllers/paths.go
+++ b/pkg/controllers/paths.go
@@ -32,7 +32,7 @@ import (
 // This step is necessary because of a lack of cleanup in admintools if any of
 // these commands fail.
 func cleanupLocalFiles(ctx context.Context, vdb *vapi.VerticaDB, prunner cmds.PodRunner, podName types.NamespacedName) error {
-	locPaths := []string{paths.GetDBDataPath(vdb), paths.GetDepotPath(vdb)}
+	locPaths := []string{vdb.GetDBDataPath(), vdb.GetDepotPath()}
 	for _, path := range locPaths {
 		cmd := []string{"rm", "-r", path}
 
@@ -72,7 +72,7 @@ func debugDumpAdmintoolsConfForPods(ctx context.Context, prunner cmds.PodRunner,
 // handle the depot directory.
 func changeDepotPermissions(ctx context.Context, vdb *vapi.VerticaDB, prunner cmds.PodRunner, podList []*PodFact) error {
 	cmd := []string{
-		"sudo", "chown", "dbadmin:verticadba", "-R", fmt.Sprintf("%s/%s", paths.LocalDataPath, paths.GetPVSubPath(vdb, "depot")),
+		"sudo", "chown", "dbadmin:verticadba", "-R", fmt.Sprintf("%s/%s", paths.LocalDataPath, vdb.GetPVSubPath("depot")),
 	}
 	for _, pod := range podList {
 		if _, _, err := prunner.ExecInPod(ctx, pod.name, names.ServerContainer, cmd...); err != nil {

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -236,7 +236,7 @@ func (p *PodFacts) checkIsInstalled(ctx context.Context, vdb *vapi.VerticaDB, pf
 		return nil
 	}
 
-	fn := paths.GenInstallerIndicatorFileName(vdb)
+	fn := vdb.GenInstallerIndicatorFileName()
 	if stdout, stderr, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "cat", fn); err != nil {
 		if !strings.Contains(stderr, "cat: "+fn+": No such file or directory") {
 			return err
@@ -316,7 +316,7 @@ func (p *PodFacts) checkIsDBCreated(ctx context.Context, vdb *vapi.VerticaDB, pf
 	cmd := []string{
 		"bash",
 		"-c",
-		fmt.Sprintf("ls -d %s/v_%s_node????_data", paths.GetDBDataPath(vdb), vdb.Spec.DBName),
+		fmt.Sprintf("ls -d %s/v_%s_node????_data", vdb.GetDBDataPath(), vdb.Spec.DBName),
 	}
 	if stdout, stderr, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, cmd...); err != nil {
 		if !strings.Contains(stderr, "No such file or directory") {

--- a/pkg/controllers/podfacts_test.go
+++ b/pkg/controllers/podfacts_test.go
@@ -24,7 +24,6 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
-	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"yunion.io/x/pkg/tristate"
@@ -51,7 +50,7 @@ var _ = Describe("podfacts", func() {
 		defer deletePods(ctx, vdb)
 
 		sc := &vdb.Spec.Subclusters[0]
-		installIndFn := paths.GenInstallerIndicatorFileName(vdb)
+		installIndFn := vdb.GenInstallerIndicatorFileName()
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{
 			names.GenPodName(vdb, sc, 0): []cmds.CmdResult{
 				{Stderr: "cat: " + installIndFn + ": No such file or directory", Err: errors.New("file not found")},

--- a/pkg/controllers/revivedb_reconcile.go
+++ b/pkg/controllers/revivedb_reconcile.go
@@ -80,12 +80,12 @@ func (r *ReviveDBReconciler) execCmd(ctx context.Context, atPod types.Namespaced
 		case isClusterLeaseNotExpired(stdout):
 			r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.ReviveDBClusterInUse,
 				"revive_db failed because the cluster lease has not expired for '%s'",
-				paths.GetCommunalPath(r.Vdb))
+				r.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil
 
 		case isBucketNotExistError(stdout):
 			r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.S3BucketDoesNotExist,
-				"The bucket in the S3 path '%s' does not exist", paths.GetCommunalPath(r.Vdb))
+				"The bucket in the S3 path '%s' does not exist", r.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil
 
 		case isEndpointBadError(stdout):
@@ -96,7 +96,7 @@ func (r *ReviveDBReconciler) execCmd(ctx context.Context, atPod types.Namespaced
 		case isDatabaseNotFound(stdout):
 			r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.ReviveDBNotFound,
 				"revive_db failed because the database '%s' could not be found in the communal path '%s'",
-				r.Vdb.Spec.DBName, paths.GetCommunalPath(r.Vdb))
+				r.Vdb.Spec.DBName, r.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil
 
 		case isPermissionDeniedError(stdout):
@@ -226,7 +226,7 @@ func (r *ReviveDBReconciler) genCmd(ctx context.Context, hostList []string) ([]s
 	cmd := []string{
 		"-t", "revive_db",
 		"--hosts=" + strings.Join(hostList, ","),
-		"--communal-storage-location=" + paths.GetCommunalPath(r.Vdb),
+		"--communal-storage-location=" + r.Vdb.GetCommunalPath(),
 		"--communal-storage-params=" + paths.AuthParmsFile,
 		"--database", r.Vdb.Spec.DBName,
 	}

--- a/pkg/controllers/uninstall_reconcile.go
+++ b/pkg/controllers/uninstall_reconcile.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/atconf"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
-	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -181,5 +180,5 @@ func (s *UninstallReconciler) findPodsSuitableForScaleDown(sc *vapi.Subcluster, 
 
 // genCmdRemoveInstallIndicator will generate the command to get rid of the installer indicator file
 func (s *UninstallReconciler) genCmdRemoveInstallIndicator() []string {
-	return []string{"rm", paths.GenInstallerIndicatorFileName(s.Vdb)}
+	return []string{"rm", s.Vdb.GenInstallerIndicatorFileName()}
 }

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -15,12 +15,6 @@
 
 package paths
 
-import (
-	"fmt"
-
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-)
-
 const (
 	// A file to denote the /config dir has been setup.  Note, we don't call
 	// update_vertica anymore, but it is kept in the name for backwards
@@ -42,36 +36,8 @@ const (
 	CertsRoot              = "/certs"
 )
 
-// GenInstallerIndicatorFileName returns the name of the installer indicator file.
-// Valid only for the current instance of the vdb.
-func GenInstallerIndicatorFileName(vdb *vapi.VerticaDB) string {
-	return InstallerIndicatorFile + string(vdb.UID)
-}
-
-// GetPVSubPath returns the subpath in the local data PV.
-// We use the UID so that we create unique paths in the PV.  If the PV is reused
-// for a new vdb, the UID will be different.
-func GetPVSubPath(vdb *vapi.VerticaDB, subPath string) string {
-	return fmt.Sprintf("%s/%s", vdb.UID, subPath)
-}
-
-// GetDBDataPath get the data path for the current database
-func GetDBDataPath(vdb *vapi.VerticaDB) string {
-	return fmt.Sprintf("%s/%s", vdb.Spec.Local.DataPath, vdb.Spec.DBName)
-}
-
-// GetCommunalPath returns the path to use for communal storage
-func GetCommunalPath(vdb *vapi.VerticaDB) string {
-	// We include the UID in the communal path to generate a unique path for
-	// each new instance of vdb. This means we can't use the same base path for
-	// different databases and we don't require any cleanup if the vdb was
-	// recreated.
-	if !vdb.Spec.Communal.IncludeUIDInPath {
-		return vdb.Spec.Communal.Path
-	}
-	return fmt.Sprintf("%s/%s", vdb.Spec.Communal.Path, vdb.UID)
-}
-
-func GetDepotPath(vdb *vapi.VerticaDB) string {
-	return fmt.Sprintf("%s/%s", vdb.Spec.Local.DepotPath, vdb.Spec.DBName)
-}
+// MountPaths lists all of the paths for internally generated mounts.
+var MountPaths = []string{LocalDataPath, CELicensePath, MountedLicensePath,
+	HadoopConfPath, ConfigPath, ConfigSharePath, ConfigLogrotatePath,
+	LogPath, PodInfoPath, AdminToolsConf, AuthParmsFile, EulaAcceptanceFile,
+	EulaAcceptanceScript, CertsRoot}

--- a/tests/e2e/create-and-del-crd/02-custom-volume-mounts.yaml
+++ b/tests/e2e/create-and-del-crd/02-custom-volume-mounts.yaml
@@ -15,3 +15,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c vlogger -n $NAMESPACE -- touch mymountpath/emptyfile"
+  - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c server -n $NAMESPACE -- test -f /tenants/emptyfile"
+  - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c server -n $NAMESPACE -- sh -c 'echo hello > /tenants/ack'"
+  - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c vlogger -n $NAMESPACE -- cat mymountpath/ack | grep hello"

--- a/tests/e2e/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
@@ -30,6 +30,9 @@ spec:
   volumes:
     - name: my-extra-vol1
       emptyDir: {}
+  volumeMounts:
+    - mountPath: /tenants
+      name: my-extra-vol1
   subclusters:
     - name: defaultsubcluster
   certSecrets: []


### PR DESCRIPTION
This adds the ability to add custom volume mounts to the Vertica container.  A new `spec.volumeMounts` parameter was added to achieve this.  It works alongside the `spec.volumes` parameter.

Here is an example that mounts the path /tenants in the Vertica container using an existing PVC.  

```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: verticadb-sample
spec:
  communal:
    ...
  subclusters:
  - name: sc1
  volumeMounts:
  - mountPath: /tenants
    name: tenants
  volumes:
  - name: tenants
    persistentVolumeClaim:
      claimName: vertica-pvc
```
      
The volumeMounts parameter takes the standard set of options for volume mounts (e.g. same as pod.spec.containers.volumeMounts).
 
The mount path for the new volume mount cannot conflict with any existing.  The webhook was updated to detect any conflicts.
 
To avoid a circular dependency with the imports, I had to move a few helper functions in the paths package to api/v1beta1.