### PR TITLE
Remove the Kerberos initContainer hack

### DIFF
--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -33,22 +33,21 @@ import (
 )
 
 const (
-	invalidDBNameChars      = "$=<>`" + `'^\".@*?#&/-:;{}()[] \~!%+|,`
-	dbNameLengthLimit       = 30
-	KSafety0MinHosts        = 1
-	KSafety0MaxHosts        = 3
-	KSafety1MinHosts        = 3
-	portLowerBound          = 30000
-	portUpperBound          = 32767
-	LocalDataPVC            = "local-data"
-	PodInfoMountName        = "podinfo"
-	LicensingMountName      = "licensing"
-	HadoopConfigMountName   = "hadoop-conf"
-	Krb5SecretMountName     = "krb5"
-	Krb5KeytabCopyMountName = "krb5-keytab-copy"
-	S3Prefix                = "s3://"
-	GCloudPrefix            = "gs://"
-	AzurePrefix             = "azb://"
+	invalidDBNameChars    = "$=<>`" + `'^\".@*?#&/-:;{}()[] \~!%+|,`
+	dbNameLengthLimit     = 30
+	KSafety0MinHosts      = 1
+	KSafety0MaxHosts      = 3
+	KSafety1MinHosts      = 3
+	portLowerBound        = 30000
+	portUpperBound        = 32767
+	LocalDataPVC          = "local-data"
+	PodInfoMountName      = "podinfo"
+	LicensingMountName    = "licensing"
+	HadoopConfigMountName = "hadoop-conf"
+	Krb5SecretMountName   = "krb5"
+	S3Prefix              = "s3://"
+	GCloudPrefix          = "gs://"
+	AzurePrefix           = "azb://"
 )
 
 // hdfsPrefixes are prefixes for an HDFS path.

--- a/pkg/controllers/init_db.go
+++ b/pkg/controllers/init_db.go
@@ -515,7 +515,7 @@ func (g *GenericDatabaseInitializer) hasCompatibleVersionForKerberos() ctrl.Resu
 	if !ok || ok && vinf.IsEqualOrNewer(DefaultKerberosSupportedVersion) {
 		return ctrl.Result{}
 	}
-	g.VRec.EVRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.KerberosOldEngineVerError,
+	g.VRec.EVRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.UnsupportedVerticaVersion,
 		"The engine (%s) doesn't have the required change to setup Kerberos in "+
 			"the container.  You must be on version %s or greater",
 		vinf.VdbVer, DefaultKerberosSupportedVersion)

--- a/pkg/controllers/init_db.go
+++ b/pkg/controllers/init_db.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/status"
+	"github.com/vertica/vertica-kubernetes/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -199,6 +200,9 @@ func (g *GenericDatabaseInitializer) ConstructAuthParms(ctx context.Context, atP
 	}
 
 	if g.Vdb.HasKerberosConfig() {
+		if res = g.hasCompatibleVersionForKerberos(); res.Requeue {
+			return res, nil
+		}
 		content = dedent.Dedent(fmt.Sprintf(`
 			%s
 			%s`, content, g.getKerberosAuthParmsContent()))
@@ -500,4 +504,20 @@ func (g *GenericDatabaseInitializer) getHadoopConfDir() string {
 		return fmt.Sprintf(`HadoopConfDir = %s`, paths.HadoopConfPath)
 	}
 	return ""
+}
+
+// hasCompatibleVersionForKerberos checks whether it has the required engine fix
+// to run with a Kerberos config.  If it doesn't the ctrl.Result will have the
+// requeue bool set.
+func (g *GenericDatabaseInitializer) hasCompatibleVersionForKerberos() ctrl.Result {
+	vinf, ok := version.MakeInfo(g.Vdb)
+	const DefaultKerberosSupportedVersion = "v11.0.2"
+	if !ok || ok && vinf.IsEqualOrNewer(DefaultKerberosSupportedVersion) {
+		return ctrl.Result{}
+	}
+	g.VRec.EVRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.KerberosOldEngineVerError,
+		"The engine (%s) doesn't have the required change to setup Kerberos in "+
+			"the container.  You must be on version %s or greater",
+		vinf.VdbVer, DefaultKerberosSupportedVersion)
+	return ctrl.Result{Requeue: true}
 }

--- a/pkg/controllers/init_db.go
+++ b/pkg/controllers/init_db.go
@@ -250,12 +250,16 @@ func (g *GenericDatabaseInitializer) getHDFSAuthParmsContent(ctx context.Context
 // getKerberosAuthParmsContent constructs a string for Kerberos related auth
 // parms if that is setup.  Must have Kerberos config in the Vdb.
 func (g *GenericDatabaseInitializer) getKerberosAuthParmsContent() string {
-	return fmt.Sprintf(`
+	// We disable KerberosEnableKeytabPermissionCheck, otherwise the engine will
+	// complain that the keytab file doesn't have read/write permissions from
+	// dbadmin only.
+	return dedent.Dedent(fmt.Sprintf(`
 			KerberosServiceName = %s
 			KerberosRealm = %s
-			KerberosKeytabFile = %s/%s
+			KerberosKeytabFile = %s
+			KerberosEnableKeytabPermissionCheck = 0
 	`, g.Vdb.Spec.Communal.KerberosServiceName,
-		g.Vdb.Spec.Communal.KerberosRealm, paths.Krb5KeytabCopyDir, paths.Krb5Keytab)
+		g.Vdb.Spec.Communal.KerberosRealm, paths.Krb5Keytab))
 }
 
 // getGCloudAuthParmsContent will get the content for the auth parms when we are

--- a/pkg/controllers/obj_reconcile.go
+++ b/pkg/controllers/obj_reconcile.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -117,7 +118,7 @@ func (o *ObjReconciler) checkMountedObjs(ctx context.Context) (ctrl.Result, erro
 			return res, err
 		}
 
-		keyNames := []string{paths.Krb5Conf, paths.Krb5Keytab}
+		keyNames := []string{filepath.Base(paths.Krb5Conf), filepath.Base(paths.Krb5Keytab)}
 		for _, key := range keyNames {
 			if _, ok := secret.Data[key]; !ok {
 				o.VRec.EVRec.Eventf(o.Vdb, corev1.EventTypeWarning, events.MissingSecretKeys,

--- a/pkg/controllers/obj_reconcile_test.go
+++ b/pkg/controllers/obj_reconcile_test.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -482,8 +483,8 @@ var _ = Describe("obj_reconcile", func() {
 			vdb := vapi.MakeVDB()
 			vdb.Spec.KerberosSecret = "my-secret-v1"
 			secret := buildKerberosSecretBase(vdb)
-			secret.Data[paths.Krb5Keytab] = []byte("keytab")
-			secret.Data[paths.Krb5Conf] = []byte("conf")
+			secret.Data[filepath.Base(paths.Krb5Keytab)] = []byte("keytab")
+			secret.Data[filepath.Base(paths.Krb5Conf)] = []byte("conf")
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 			defer deleteSecret(ctx, vdb, vdb.Spec.KerberosSecret)
 			createCrd(vdb, false)
@@ -496,7 +497,7 @@ var _ = Describe("obj_reconcile", func() {
 			vdb := vapi.MakeVDB()
 			vdb.Spec.KerberosSecret = "my-secret-v2"
 			secret := buildKerberosSecretBase(vdb)
-			secret.Data[paths.Krb5Conf] = []byte("conf") // Only the krb5.conf
+			secret.Data[filepath.Base(paths.Krb5Conf)] = []byte("conf") // Only the krb5.conf
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 			defer deleteSecret(ctx, vdb, vdb.Spec.KerberosSecret)
 			createCrd(vdb, false)

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -60,4 +60,5 @@ const (
 	ReipFailed                      = "ReipFailed"
 	MissingSecretKeys               = "MissingSecretKeys"
 	KerberosAuthError               = "KerberosAuthError"
+	KerberosOldEngineVerError       = "KerberosOldEngineVerError"
 )

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -60,5 +60,4 @@ const (
 	ReipFailed                      = "ReipFailed"
 	MissingSecretKeys               = "MissingSecretKeys"
 	KerberosAuthError               = "KerberosAuthError"
-	KerberosOldEngineVerError       = "KerberosOldEngineVerError"
 )

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -26,7 +26,6 @@ import (
 const (
 	ServerContainer      = "server"
 	ServerContainerIndex = 0
-	Krb5KeytabContainer  = "krb5-copy-keytab"
 )
 
 // GenNamespacedName will take any name and make it a namespace name that uses

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -34,14 +34,12 @@ const (
 	EulaAcceptanceFile     = "/opt/vertica/config/d5415f948449e9d4c421b568f2411140.dat"
 	EulaAcceptanceScript   = "/opt/vertica/config/accept_eula.py"
 	CertsRoot              = "/certs"
-	Krb5Root               = "/etc"
-	Krb5Conf               = "krb5.conf"
-	Krb5Keytab             = "krb5.keytab"
-	Krb5KeytabCopyDir      = "/home/dbadmin/keytabs"
+	Krb5Conf               = "/etc/krb5.conf"
+	Krb5Keytab             = "/etc/krb5/krb5.keytab"
 )
 
 // MountPaths lists all of the paths for internally generated mounts.
 var MountPaths = []string{LocalDataPath, CELicensePath, MountedLicensePath,
 	HadoopConfPath, ConfigPath, ConfigSharePath, ConfigLogrotatePath,
 	LogPath, PodInfoPath, AdminToolsConf, AuthParmsFile, EulaAcceptanceFile,
-	EulaAcceptanceScript, CertsRoot, Krb5Root}
+	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab}

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -763,8 +764,8 @@ func (d *DBGenerator) setKrb5Secret(ctx context.Context) error {
 	d.Objs.KerberosSecret.TypeMeta.Kind = SecretKindName
 	d.Objs.KerberosSecret.ObjectMeta.Name = fmt.Sprintf("%s-krb5", d.Opts.VdbName)
 	d.Objs.KerberosSecret.Data = map[string][]byte{
-		paths.Krb5Conf:   d.Krb5ConfData,
-		paths.Krb5Keytab: d.Krb5KeytabData,
+		filepath.Base(paths.Krb5Conf):   d.Krb5ConfData,
+		filepath.Base(paths.Krb5Keytab): d.Krb5KeytabData,
 	}
 	d.Objs.Vdb.Spec.KerberosSecret = d.Objs.KerberosSecret.ObjectMeta.Name
 


### PR DESCRIPTION
The Vertica engine has very specific requirements for the Kerberos keytab: it must have read/write permissions for dbadmin and no one else.  It isn't possible to mount a file in k8s with specific requirements.  I originally added a hack that created an initContainer and copied the keytab so that the permissions could be set.  I'm removing that here as we now have a config knob in the engine to relax the check.  We just have to set `KerberosEnableKeytabPermissionCheck = 0`, and the engine won't care about keytab permissions.  This also means we don't need to restart the pod whenever the keytab changes as the change will get automatically picked up whenever the Secret changes.  Since this relies on an engine change, I put in a version check that Kerberos cannot be used except on 11.0.2.