### PR TITLE
Add ability to specify custom ssh keys

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -219,8 +219,8 @@ type VerticaDBSpec struct {
 	// +kubebuilder:validation:Optional
 	// An optional secret that has the files for /home/dbadmin/.ssh.  If this is
 	// omitted, the ssh files from the image are used.  You can this option if
-	// you have a cluster that talks to Vertica notes outside of Kubernetes, so
-	// it needs the public keys to be able to ssh to those nodes.  It must have
+	// you have a cluster that talks to Vertica notes outside of Kubernetes, as
+	// it has the public keys to be able to ssh to those nodes.  It must have
 	// the following keys present: id_rsa, id_rsa.pub and authorized_keys.
 	SSHSecret string `json:"sshSecret,omitempty"`
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -215,6 +215,14 @@ type VerticaDBSpec struct {
 	// These files will be mounted in /etc.  We use the same keytab file on each
 	// host, so it must contain all of the Vertica principals.
 	KerberosSecret string `json:"kerberosSecret,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// An optional secret that has the files for /home/dbadmin/.ssh.  If this is
+	// omitted, the ssh files from the image are used.  You can this option if
+	// you have a cluster that talks to Vertica notes outside of Kubernetes, so
+	// it needs the public keys to be able to ssh to those nodes.  It must have
+	// the following keys present: id_rsa, id_rsa.pub and authorized_keys.
+	SSHSecret string `json:"sshSecret,omitempty"`
 }
 
 type CommunalInitPolicy string

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -45,7 +45,6 @@ const (
 	LicensingMountName    = "licensing"
 	HadoopConfigMountName = "hadoop-conf"
 	Krb5SecretMountName   = "krb5"
-	SSHCopyMountName      = "ssh-copy"
 	SSHMountName          = "ssh"
 	S3Prefix              = "s3://"
 	GCloudPrefix          = "gs://"

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -45,6 +45,8 @@ const (
 	LicensingMountName    = "licensing"
 	HadoopConfigMountName = "hadoop-conf"
 	Krb5SecretMountName   = "krb5"
+	SSHCopyMountName      = "ssh-copy"
+	SSHMountName          = "ssh"
 	S3Prefix              = "s3://"
 	GCloudPrefix          = "gs://"
 	AzurePrefix           = "azb://"

--- a/changes/unreleased/Added-20211122-155946.yaml
+++ b/changes/unreleased/Added-20211122-155946.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Ability to specify custom ssh keys
+time: 2021-11-22T15:59:46.319372681-04:00
+custom:
+  Issue: "94"

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -324,8 +324,6 @@ func buildSSHVolumes(vdb *vapi.VerticaDB) []corev1.Volume {
 // buildPodSpec creates a PodSpec for the statefulset
 func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.PodSpec {
 	termGracePeriod := int64(0)
-	const VerticaDBAGID = 5000
-	fsGroup := int64(VerticaDBAGID)
 	return corev1.PodSpec{
 		NodeSelector:                  sc.NodeSelector,
 		Affinity:                      sc.Affinity,
@@ -334,9 +332,6 @@ func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.PodSpec {
 		Containers:                    makeContainers(vdb, sc),
 		Volumes:                       buildVolumes(vdb),
 		TerminationGracePeriodSeconds: &termGracePeriod,
-		SecurityContext: &corev1.PodSecurityContext{
-			FSGroup: &fsGroup,
-		},
 	}
 }
 

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -133,7 +133,7 @@ func buildKerberosVolumeMounts() []corev1.VolumeMount {
 
 func buildSSHVolumeMounts() []corev1.VolumeMount {
 	mnts := []corev1.VolumeMount{}
-	for _, p := range []string{"id_rsa", "id_rsa.pub", "authorized_keys"} {
+	for _, p := range paths.SSHKeyPaths {
 		mnts = append(mnts, corev1.VolumeMount{
 			Name:      vapi.SSHMountName,
 			MountPath: fmt.Sprintf("%s/%s", paths.SSHPath, p),
@@ -503,6 +503,12 @@ func buildAzureSASCommunalCredSecret(vdb *vapi.VerticaDB, blobEndpoint, sas stri
 // Kerberos secret.  The caller's responsibility to add the necessary data.
 func buildKerberosSecretBase(vdb *vapi.VerticaDB) *corev1.Secret {
 	nm := names.GenNamespacedName(vdb, vdb.Spec.KerberosSecret)
+	return buildSecretBase(nm)
+}
+
+// buildSecretBase is a test helper that creates a Secret base with a specific
+// name.  The caller is responsible to add data elemets and create it.
+func buildSecretBase(nm types.NamespacedName) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nm.Name,

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -309,15 +309,12 @@ func buildKerberosVolume(vdb *vapi.VerticaDB) corev1.Volume {
 }
 
 func buildSSHVolumes(vdb *vapi.VerticaDB) []corev1.Volume {
-	const O700 = 448
-	o700 := int32(O700)
 	return []corev1.Volume{
 		{
 			Name: vapi.SSHMountName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName:  vdb.Spec.SSHSecret,
-					DefaultMode: &o700,
+					SecretName: vdb.Spec.SSHSecret,
 				},
 			},
 		},

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -26,6 +26,7 @@ import (
 const (
 	ServerContainer      = "server"
 	ServerContainerIndex = 0
+	SSHSetupContainer    = "ssh-setup"
 )
 
 // GenNamespacedName will take any name and make it a namespace name that uses

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -26,7 +26,6 @@ import (
 const (
 	ServerContainer      = "server"
 	ServerContainerIndex = 0
-	SSHSetupContainer    = "ssh-setup"
 )
 
 // GenNamespacedName will take any name and make it a namespace name that uses

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -44,3 +44,6 @@ var MountPaths = []string{LocalDataPath, CELicensePath, MountedLicensePath,
 	HadoopConfPath, ConfigPath, ConfigSharePath, ConfigLogrotatePath,
 	LogPath, PodInfoPath, AdminToolsConf, AuthParmsFile, EulaAcceptanceFile,
 	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, SSHPath}
+
+// SSHKeyPaths is a list of keys that must exist in the SSHSecret
+var SSHKeyPaths = []string{"id_rsa", "id_rsa.pub", "authorized_keys"}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -36,13 +36,11 @@ const (
 	CertsRoot              = "/certs"
 	Krb5Conf               = "/etc/krb5.conf"
 	Krb5Keytab             = "/etc/krb5/krb5.keytab"
-	// SPILLY - be consistent with this next path setup or copy or secret??
-	SSHSecretPath = "/ssh-secret"
-	SSHPath       = "/home/dbadmin/.ssh"
+	SSHPath                = "/home/dbadmin/.ssh"
 )
 
 // MountPaths lists all of the paths for internally generated mounts.
 var MountPaths = []string{LocalDataPath, CELicensePath, MountedLicensePath,
 	HadoopConfPath, ConfigPath, ConfigSharePath, ConfigLogrotatePath,
 	LogPath, PodInfoPath, AdminToolsConf, AuthParmsFile, EulaAcceptanceFile,
-	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, SSHSecretPath, SSHPath}
+	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, SSHPath}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -36,10 +36,13 @@ const (
 	CertsRoot              = "/certs"
 	Krb5Conf               = "/etc/krb5.conf"
 	Krb5Keytab             = "/etc/krb5/krb5.keytab"
+	// SPILLY - be consistent with this next path setup or copy or secret??
+	SSHSecretPath = "/ssh-secret"
+	SSHPath       = "/home/dbadmin/.ssh"
 )
 
 // MountPaths lists all of the paths for internally generated mounts.
 var MountPaths = []string{LocalDataPath, CELicensePath, MountedLicensePath,
 	HadoopConfPath, ConfigPath, ConfigSharePath, ConfigLogrotatePath,
 	LogPath, PodInfoPath, AdminToolsConf, AuthParmsFile, EulaAcceptanceFile,
-	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab}
+	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, SSHSecretPath, SSHPath}

--- a/tests/e2e/k-safety-0-scaling/.gitignore
+++ b/tests/e2e/k-safety-0-scaling/.gitignore
@@ -1,0 +1,1 @@
+ssh-keys/

--- a/tests/e2e/k-safety-0-scaling/08-create-ssh-keys.yaml
+++ b/tests/e2e/k-safety-0-scaling/08-create-ssh-keys.yaml
@@ -11,22 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-k-safety-0-scaling
-spec:
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  sshSecret: ssh-keys
-  communal:
-    includeUIDInPath: false
-  local:
-    requestSize: 100Mi
-  subclusters:
-    - name: sc1
-      size: 1
-  kSafety: "0"
-  certSecrets: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "mkdir -p ssh-keys && rm -f ssh-keys/* && ssh-keygen -q -t rsa -N '' -f ssh-keys/id_rsa && cp ssh-keys/id_rsa.pub ssh-keys/authorized_keys"
+  - script: "kubectl delete secret -n $NAMESPACE ssh-keys || :"
+  - script: "kubectl create secret -n $NAMESPACE generic ssh-keys --from-file=ssh-keys"


### PR DESCRIPTION
This adds the ability to specify a custom ssh keys in the container.  The keys, stored in a Secret, will get mounted in /home/dbadmin/.ssh.  If this Secret is omitted, the ssh files from the image are used.  You can this option if you have a cluster that talks to Vertica notes outside of Kubernetes, as it has the public keys to be able to ssh to those nodes.  

The secret can be installed in the CR like this:
```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: v
spec:
  communal:
    ...
  subclusters:
    - name: sc1
  sshSecret: ssh-key  
```

It must have the following keys present: id_rsa, id_rsa.pub and authorized_keys.