### PR TITLE
Add security context to enable ssh on Openshift

### DIFF
--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -340,6 +340,12 @@ func makeServerContainer(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.Contai
 				},
 			},
 		},
+		// Is needed to run sshd on Openshift
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"SYS_CHROOT", "AUDIT_WRITE"},
+			},
+		},
 		Env: []corev1.EnvVar{
 			{Name: "POD_IP", ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}},


### PR DESCRIPTION
Deploy a multi nodes cluster on Openshift fail because nodes cannot ssh each other.
This security context is added to enable that.