### PR TITLE
Add serviceaccount to run pods with

### DIFF
--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -318,6 +318,7 @@ func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.PodSpec {
 		Containers:                    makeContainers(vdb, sc),
 		Volumes:                       buildVolumes(vdb),
 		TerminationGracePeriodSeconds: &termGracePeriod,
+		ServiceAccountName:            "verticadb-operator-controller-manager",
 	}
 }
 


### PR DESCRIPTION
With the security context added to enable ssh on pods on Openshift, it is necessary to have pods associated to privileged scc.
For that, instead of running them with default serviceaccount, we reference the operator serviceaccount which of course is to be associated to a privileged scc in the CSV. This will not break helm install as among the manifests generated in the chart there is already a service account with the same name.