### PR TITLE
Handle concurrent updates to rbac during e2e tests

### DIFF
--- a/tests/e2e-extra/revivedb-multi-sc/01-assert.yaml
+++ b/tests/e2e-extra/revivedb-multi-sc/01-assert.yaml
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
-    ignoreFailure: true
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-extra/vdb-gen/53-assert.yaml
+++ b/tests/e2e-extra/vdb-gen/53-assert.yaml
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
-    ignoreFailure: true
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-extra/vdb-gen/53-rbac.yaml
+++ b/tests/e2e-extra/vdb-gen/53-rbac.yaml
@@ -15,3 +15,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e/client-access/20-assert.yaml
+++ b/tests/e2e/client-access/20-assert.yaml
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
-    ignoreFailure: true
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e/client-access/20-rbac.yaml
+++ b/tests/e2e/client-access/20-rbac.yaml
@@ -15,3 +15,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e/mount-certs/23-assert.yaml
+++ b/tests/e2e/mount-certs/23-assert.yaml
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
-    ignoreFailure: true
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e/mount-certs/23-rbac.yaml
+++ b/tests/e2e/mount-certs/23-rbac.yaml
@@ -15,3 +15,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e/multi-sc/17-assert.yaml
+++ b/tests/e2e/multi-sc/17-assert.yaml
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
-    ignoreFailure: true
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e/multi-sc/17-rbac.yaml
+++ b/tests/e2e/multi-sc/17-rbac.yaml
@@ -15,3 +15,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e/schedule-only/30-assert.yaml
+++ b/tests/e2e/schedule-only/30-assert.yaml
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
-    ignoreFailure: true
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e/schedule-only/30-rbac.yaml
+++ b/tests/e2e/schedule-only/30-rbac.yaml
@@ -15,3 +15,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e/update-strategy/01-assert.yaml
+++ b/tests/e2e/update-strategy/01-assert.yaml
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
-    ignoreFailure: true
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e/update-strategy/01-rbac.yaml
+++ b/tests/e2e/update-strategy/01-rbac.yaml
@@ -15,3 +15,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true


### PR DESCRIPTION
This closes a timing scenario with e2e when creating common cluster scoped objects, like a ClusterRole.  If two tests create the objects at the same time (via kubectl apply), it is possible to get a failure.  

```
    logger.go:42: 12:51:31 | vdb-gen/53-rbac | starting test step 53-rbac
    logger.go:42: 12:51:31 | vdb-gen/53-rbac | running command: [sh -c kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml]
=== CONT  kuttl/harness/revivedb-multi-sc
    logger.go:42: 12:51:31 | revivedb-multi-sc/0-deploy-operator | test step completed 0-deploy-operator
    logger.go:42: 12:51:31 | revivedb-multi-sc/1-rbac | starting test step 1-rbac
    logger.go:42: 12:51:31 | revivedb-multi-sc/1-rbac | running command: [sh -c kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml]
=== CONT  kuttl/harness/vdb-gen
    logger.go:42: 12:51:32 | vdb-gen/53-rbac | clusterrole.rbac.authorization.k8s.io/integration-test-role created
    logger.go:42: 12:51:32 | vdb-gen/53-rbac | rolebinding.rbac.authorization.k8s.io/integration-test-rb created
=== CONT  kuttl/harness/revivedb-multi-sc
    logger.go:42: 12:51:32 | revivedb-multi-sc/1-rbac | rolebinding.rbac.authorization.k8s.io/integration-test-rb created
    logger.go:42: 12:51:32 | revivedb-multi-sc/1-rbac | Error from server (AlreadyExists): error when creating "../../manifests/rbac/base/rbac.yaml": clusterroles.rbac.authorization.k8s.io "integration-test-role" already exists
=== CONT  kuttl/harness/vdb-gen
    logger.go:42: 12:51:33 | vdb-gen/53-rbac | test step completed 53-rbac
    logger.go:42: 12:51:33 | vdb-gen/55-verify-subclusters | starting test step 55-verify-subclusters
=== CONT  kuttl/harness/revivedb-multi-sc
    case.go:361: failed in step 1-rbac
    case.go:363: exit status 1
```

The solution was to ignore any failures when creating rbac and check the results via an assert.