### PR TITLE
Image change can be marked complete before restart of the pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,6 @@ docker-build-bundle: bundle ## Build the bundle image
 docker-push-bundle: ## Push the bundle image
 	docker push $(BUNDLE_IMG)
 
-OLM_CATALOG_BASE?=quay.io/operatorhubio/catalog:latest
 docker-build-olm-catalog: opm ## Build an OLM catalog that includes our bundle (testing purposes only)
 	$(OPM) index add --bundles $(BUNDLE_IMG) --tag $(OLM_CATALOG_IMG) --build-tool docker --skip-tls
 

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ docker-push-bundle: ## Push the bundle image
 
 OLM_CATALOG_BASE?=quay.io/operatorhubio/catalog:latest
 docker-build-olm-catalog: opm ## Build an OLM catalog that includes our bundle (testing purposes only)
-	$(OPM) index add --bundles $(BUNDLE_IMG) --from-index $(OLM_CATALOG_BASE) --tag $(OLM_CATALOG_IMG) --build-tool docker --skip-tls
+	$(OPM) index add --bundles $(BUNDLE_IMG) --tag $(OLM_CATALOG_IMG) --build-tool docker --skip-tls
 
 docker-push-olm-catalog:
 	docker push $(OLM_CATALOG_IMG)

--- a/changes/unreleased/Fixed-20211126-104134.yaml
+++ b/changes/unreleased/Fixed-20211126-104134.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: The image change can be marked complete before we finish the restart of the
+  pods.
+time: 2021-11-26T10:41:34.063761924-04:00
+custom:
+  Issue: "101"


### PR DESCRIPTION
This closes a timing window during upgrade where we can indicate the image change has finished before completing the restart of the pods.  There is a check during the restart portion that calls `areAllPodsRunningAndZeroInstalled`.  This returns true if none of the pods exist yet, which is not correct.  State that the function uses was being set after checking if the pod exists.  If the pod doesn't exist, the state was left unset.  The timing hole is closed now that the state is being set correctly.