### PR TITLE
Change vertica image version

### DIFF
--- a/tests/e2e/labels-annotations/04-delete-crd.yaml
+++ b/tests/e2e/labels-annotations/04-delete-crd.yaml
@@ -16,3 +16,5 @@ kind: TestStep
 delete:
   - apiVersion: vertica.com/v1beta1
     kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim

--- a/tests/e2e/upgrade-vertica-ks-0/15-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/15-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,4 +25,4 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal

--- a/tests/e2e/upgrade-vertica-ks-0/20-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/20-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e/upgrade-vertica-ks-0/20-upgrade-vertica.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/20-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal

--- a/tests/e2e/upgrade-vertica-ks-0/35-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/35-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-defsc-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e/upgrade-vertica-ks-0/35-upgrade-and-scale-up.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/35-upgrade-and-scale-up.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal
   subclusters:
   - name: defsc
     size: 3

--- a/tests/e2e/upgrade-vertica-ks-0/40-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/40-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e/upgrade-vertica-ks-0/40-upgrade-and-scale-down.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/40-upgrade-and-scale-down.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal
   subclusters:
   - name: defsc
     size: 1

--- a/tests/e2e/upgrade-vertica-ks-0/50-upgrade-vertica.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/50-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal

--- a/tests/e2e/upgrade-vertica-ks-0/55-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/55-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e/upgrade-vertica-ks-0/70-upgrade-vertica.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/70-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal

--- a/tests/e2e/upgrade-vertica-ks-0/75-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/75-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e/upgrade-vertica-ks-0/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal
   imagePullPolicy: IfNotPresent
   superuserPasswordSecret: su-passwd
   communal:

--- a/tests/e2e/upgrade-vertica-ks-1/25-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-1/25-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-sc1-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-sc1-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e/upgrade-vertica-ks-1/35-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-1/35-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-sc1-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-sc1-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.0.0-0-minimal
+    - image: vertica/vertica-k8s:11.0.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e/upgrade-vertica-ks-1/35-upgrade-vertica.yaml
+++ b/tests/e2e/upgrade-vertica-ks-1/35-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal

--- a/tests/e2e/upgrade-vertica-ks-1/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/upgrade-vertica-ks-1/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal
   imagePullPolicy: IfNotPresent
   communal:
     includeUIDInPath: true

--- a/tests/external-images.txt
+++ b/tests/external-images.txt
@@ -5,7 +5,7 @@
 # nodes.
 #    scripts/push-to-kind.sh -f tests/external-images.txt
 #
-vertica/vertica-k8s:11.0.0-0-minimal
+vertica/vertica-k8s:11.0.1-0-minimal
 minio/minio:RELEASE.2021-09-03T03-56-13Z
 amazon/aws-cli:2.2.24
 quay.io/helmpack/chart-testing:v3.3.1

--- a/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
+++ b/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
@@ -16,4 +16,4 @@ kind: ConfigMap
 metadata:
   name: upgrade-vertica-1
 data:
-  image: vertica/vertica-k8s:11.0.0-0-minimal
+  image: vertica/vertica-k8s:11.0.1-0-minimal


### PR DESCRIPTION
upgrade-vertica-ks-0/1 fail because of the use of the version 11.0.0 of the vertica image. We replaced it with version 11.0.1 and updated all related files.