### PR TITLE
Reduce space requirements when running e2e in CI

### DIFF
--- a/kuttl-soak-test-iteration-0.yaml
+++ b/kuttl-soak-test-iteration-0.yaml
@@ -35,7 +35,7 @@ commands:
   # Create minio tenant and the vdb
   - command: kubectl krew update
   - command: kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/95d35f73fd3c57465c837bed2cf9ad2d933328b2/plugins/minio.yaml
-  # If these images ever change, they must be updated in tests/external-images.txt
+  # If these images ever change, they must be updated in tests/external-images-common-ci.txt
   - command: kubectl minio init --console-image minio/console:v0.6.3 --image minio/operator:v4.0.2
   - command: bash -c "bin/kustomize build tests/manifests/soak-setup/overlay | kubectl -n soak apply -f -"
 

--- a/scripts/run-k8s-int-tests.sh
+++ b/scripts/run-k8s-int-tests.sh
@@ -117,7 +117,7 @@ function push {
     echo "Pushing the images to the kind cluster"
     make  docker-push
     echo "Pushing the external images to the kind cluster"
-    scripts/push-to-kind.sh -f tests/external-images.txt
+    scripts/push-to-kind.sh -f tests/external-images-common-ci.txt
     if [ -n "$EXTRA_EXTERNAL_IMAGE_FILE" ]
     then
         scripts/push-to-kind.sh -f $EXTRA_EXTERNAL_IMAGE_FILE

--- a/scripts/setup-minio.sh
+++ b/scripts/setup-minio.sh
@@ -59,7 +59,7 @@ set -o xtrace
 # First setup the operator
 kubectl krew update
 kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/9ee1af89f729b999bcd37f90484c4d74c70a1df2/plugins/minio.yaml
-# If these images ever change, they must be updated in tests/external-images.txt
+# If these images ever change, they must be updated in tests/external-images-common-ci.txt
 kubectl minio init --console-image minio/console:v0.9.8 --image minio/operator:v4.2.7
 
 # Early exit if the operator was the only thing that needed to be setup.

--- a/scripts/setup-olm.sh
+++ b/scripts/setup-olm.sh
@@ -81,7 +81,7 @@ if ! $SCRIPT_DIR/is-openshift.sh
 then
     if ! kubectl get -n $OLM_NS deployment olm-operator
     then
-        # When changing the olm version, update the digest in tests/external-images.txt
+        # When changing the olm version, update the image in tests/external-images-build.txt
         $OPERATOR_SDK olm install --version 0.18.3
 
         # Delete the default catalog that OLM ships with to avoid a lot of duplicates entries.

--- a/tests/external-images-build.txt
+++ b/tests/external-images-build.txt
@@ -1,6 +1,6 @@
-# This file contains images that are requried for the build and setup of the
-e2e tests.  These images aren't used during the run of the e2e tests
-themselves.
+# This file contains images that are required for the build and setup of the
+# e2e tests.  These images aren't used during the run of the e2e tests
+# themselves.
 
 # Images that are used as the base in our containers
 centos:centos7.9.2009

--- a/tests/external-images-build.txt
+++ b/tests/external-images-build.txt
@@ -1,0 +1,16 @@
+# This file contains images that are requried for the build and setup of the
+e2e tests.  These images aren't used during the run of the e2e tests
+themselves.
+
+# Images that are used as the base in our containers
+centos:centos7.9.2009
+golang:1.15
+gcr.io/distroless/static:nonroot
+alpine:3.13
+
+# Images needed for setting up the kind cluster for e2e testing
+kindest/node:v1.21.1
+registry:2
+
+# Images needed to setup for olm deployments
+quay.io/operator-framework/olm:v0.18.3

--- a/tests/external-images-common-ci.txt
+++ b/tests/external-images-common-ci.txt
@@ -3,7 +3,7 @@
 # To avoid pull issues during the test runs in kind, you can use
 # this file with push-to-kind.sh to ensure they are in the kind
 # nodes.
-#    scripts/push-to-kind.sh -f tests/external-images.txt
+#    scripts/push-to-kind.sh -f tests/external-images-common-ci.txt
 #
 vertica/vertica-k8s:11.0.0-0-minimal
 minio/minio:RELEASE.2021-09-03T03-56-13Z
@@ -14,19 +14,3 @@ minio/operator:v4.2.7
 minio/console:v0.9.8
 rancher/local-path-provisioner:v0.0.19
 gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-
-# Images that are used as the base in our containers
-centos:centos7.9.2009
-golang:1.15
-gcr.io/distroless/static:nonroot
-alpine:3.13
-
-# Images needed for testing in CI
-kindest/node:v1.21.1
-registry:2
-
-# Images needed for olm
-quay.io/operator-framework/olm:v0.18.3
-
-# Images needed if testing gcloud
-# google/cloud-sdk:360.0.0-alpine

--- a/tests/external-images-gc-ci.txt
+++ b/tests/external-images-gc-ci.txt
@@ -1,0 +1,4 @@
+# List of additional images that are needed to run the CI against a Google
+Cloud endpoint in CI.
+# These are pushed to kind in run-k8s-int-tests.sh.
+google/cloud-sdk:360.0.0-alpine

--- a/tests/external-images-gc-ci.txt
+++ b/tests/external-images-gc-ci.txt
@@ -1,4 +1,4 @@
 # List of additional images that are needed to run the CI against a Google
-Cloud endpoint in CI.
+# Cloud endpoint in CI.
 # These are pushed to kind in run-k8s-int-tests.sh.
 google/cloud-sdk:360.0.0-alpine


### PR DESCRIPTION
Some of the CI tests are failing because we run out of disk space on the machines that run CI.  This reduces the number of images we need to push into the kind cluster prior to the e2e run.  There were some images that weren't needed for e2e.  Just needed for setup of the kind cluster itself.  So this PR moves some of those images into a new file external-images-build.txt.