### PR TITLE
Fixes for kuttl when VERTICA_IMG env not set

### DIFF
--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -74,10 +74,10 @@ then
 fi
 
 if [ -z "${VERTICA_IMG}" ]; then
-    VERTICA_IMG=$DEF_VERTICA_IMG
+    VERTICA_IMG=$(cd $REPO_DIR && make echo-images | grep VERTICA_IMG | cut -d'=' -f2)
 fi
 if [ -z "${VLOGGER_IMG}" ]; then
-    VLOGGER_IMG=$DEF_VLOGGER_IMG
+    VLOGGER_IMG=$(cd $REPO_DIR && make echo-images | grep VLOGGER_IMG | cut -d'=' -f2)
 fi
 
 # Name of the secret that contains the cert to use for communal access
@@ -416,8 +416,8 @@ kind: ConfigMap
 metadata:
   name: e2e
 data:
-  verticaImage: ${VERTICA_IMG:-$DEF_VERTICA_IMG}
-  vloggerImage: ${VLOGGER_IMG:-$DEF_VLOGGER_IMG}
+  verticaImage: ${VERTICA_IMG}
+  vloggerImage: ${VLOGGER_IMG}
 EOF
 
     # If a cert was specified for communal endpoint access, include a datapoint

--- a/tests/kustomize-defaults.cfg
+++ b/tests/kustomize-defaults.cfg
@@ -21,12 +21,6 @@
 # We have a set of default images to use in case the image environment
 # variables are not set.
 
-# The vertica image to use.  VERTICA_IMG always overrides this.
-DEF_VERTICA_IMG="vertica/vertica-k8s:latest"
-
-# The vertica logger image to use.  VLOGGER_IMG always overrides this.
-DEF_VLOGGER_IMG="vertica-logger:kind"
-
 # If specified, this contains a license secret to be patched into the
 # kustomization.yaml file.  The secret must already exist.
 LICENSE_SECRET=


### PR DESCRIPTION
When running kuttl without setting VERTICA_IMG, it was using
vertica/vertica-k8s:latest as the image.  There was also some config
setting to set the default image to use if one isn't set.  We will now
use the image that `make echo-images` reports if the env. variable isn't
set.