### PR TITLE
Bump vlogger base image

### DIFF
--- a/docker-vlogger/Dockerfile
+++ b/docker-vlogger/Dockerfile
@@ -14,7 +14,7 @@
 # A docker container that will tail the vertica.log.  This allows vertica to
 # follow the idiomatic way in Kubernetes of logging to stdout.
 
-FROM alpine:3.13
+FROM alpine:3.15
 
 # Tini - A tiny but valid init for containers
 RUN apk add --no-cache tini


### PR DESCRIPTION
This will increase the base image of the vlogger image to solve security vulnerabilities.  After I changed the base, the snyk scan didn't find any vulnerabilities.