### PR TITLE
Add clusterPermissions to CSV to run pods in priviledged mode

### DIFF
--- a/config/clusterpermissions/cluster_role.yaml
+++ b/config/clusterpermissions/cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-cluster-role
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames: 
+  - privileged
+  verbs:
+  - use

--- a/config/clusterpermissions/cluster_role_binding.yaml
+++ b/config/clusterpermissions/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-cluster-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system
+roleRef:
+  kind: ClusterRole
+  name: openshift-cluster-role
+  apiGroup: rbac.authorization.k8s.io

--- a/config/clusterpermissions/kustomization.yaml
+++ b/config/clusterpermissions/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- cluster_role.yaml
+- cluster_role_binding.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
 - ../rbac
 - ../manager
 - ../webhook
+- ../clusterpermissions
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.

--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -458,6 +458,9 @@ spec:
       - description: This is set to true if /opt/vertica/config has been bootstrapped.
         displayName: Installed
         path: subclusters[0].detail[0].installed
+      - description: True means the vertica process on this pod is in read-only state
+        displayName: Read Only
+        path: subclusters[0].detail[0].readOnly
       - description: True means the vertica process is running on this pod and it
           can accept connections on port 5433.
         displayName: Up Node
@@ -473,6 +476,10 @@ spec:
       - description: Name of the subcluster
         displayName: Name
         path: subclusters[0].name
+      - description: A count of the number of pods that are in read-only state in
+          this subcluster.
+        displayName: Read Only Count
+        path: subclusters[0].readOnlyCount
       - description: A count of the number of pods that have a running vertica process
           in this subcluster.
         displayName: Up Node Count


### PR DESCRIPTION
This uses clusterRole and clusterRoleBinding files to add and populate clusterPermissions field in the CSV. In the CSV we will something like this:

```
clusterPermissions:
      - rules:
        - apiGroups:
          - security.openshift.io
          resourceNames:
          - privileged
          resources:
          - securitycontextconstraints
          verbs:
          - use
        serviceAccountName: verticadb-operator-controller-manager
```