### PR TITLE
Online image change: handling of the standby subcluster

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -798,7 +798,7 @@ func MakeVDB() *VerticaDB {
 			DBName:     "db",
 			ShardCount: 12,
 			Subclusters: []Subcluster{
-				{Name: "defaultsubcluster", Size: 3, ServiceType: corev1.ServiceTypeClusterIP},
+				{Name: "defaultsubcluster", Size: 3, ServiceType: corev1.ServiceTypeClusterIP, IsPrimary: true},
 			},
 		},
 	}

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -512,6 +512,13 @@ type Subcluster struct {
 	// for.  This is state internally managed for online image change.
 	StandbyParent string `json:"standbyParent,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// This allows a different image to be used for the subcluster than the one
+	// in VerticaDB.  This is intended to be used internally by the online image
+	// change process.
+	ImageOverride string `json:"imageOverride,omitempty"`
+
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// A map of label keys and values to restrict Vertica node scheduling to workers
 	// with matching labels.

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -508,8 +508,9 @@ type Subcluster struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
-	// If a standby, this is the name of the primary subcluster it is a standby
-	// for.  This is state internally managed for online image change.
+	// If this is a standby subcluster, this is the name of the primary
+	// subcluster it was created for.  This is state internally managed for an
+	// online image change.
 	StandbyParent string `json:"standbyParent,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -632,8 +632,12 @@ const (
 	AutoRestartVertica VerticaDBConditionType = "AutoRestartVertica"
 	// DBInitialized indicates the database has been created or revived
 	DBInitialized VerticaDBConditionType = "DBInitialized"
-	// ImageChangeInProgress indicates if the vertica server is in the process of having its image change
-	ImageChangeInProgress VerticaDBConditionType = "ImageChangeInProgress"
+	// ImageChangeInProgress indicates if the vertica server is in the process
+	// of having its image change.  We have two additional conditions to
+	// distinguish between online and offline image change.
+	ImageChangeInProgress        VerticaDBConditionType = "ImageChangeInProgress"
+	OfflineImageChangeInProgress VerticaDBConditionType = "OfflineImageChangeInProgress"
+	OnlineImageChangeInProgress  VerticaDBConditionType = "OnlineImageChangeInProgress"
 )
 
 // Fixed index entries for each condition.
@@ -641,22 +645,28 @@ const (
 	AutoRestartVerticaIndex = iota
 	DBInitializedIndex
 	ImageChangeInProgressIndex
+	OfflineImageChangeInProgressIndex
+	OnlineImageChangeInProgressIndex
 )
 
 // VerticaDBConditionIndexMap is a map of the VerticaDBConditionType to its
 // index in the condition array
 var VerticaDBConditionIndexMap = map[VerticaDBConditionType]int{
-	AutoRestartVertica:    AutoRestartVerticaIndex,
-	DBInitialized:         DBInitializedIndex,
-	ImageChangeInProgress: ImageChangeInProgressIndex,
+	AutoRestartVertica:           AutoRestartVerticaIndex,
+	DBInitialized:                DBInitializedIndex,
+	ImageChangeInProgress:        ImageChangeInProgressIndex,
+	OfflineImageChangeInProgress: OfflineImageChangeInProgressIndex,
+	OnlineImageChangeInProgress:  OnlineImageChangeInProgressIndex,
 }
 
 // VerticaDBConditionNameMap is the reverse of VerticaDBConditionIndexMap.  It
 // maps an index to the condition name.
 var VerticaDBConditionNameMap = map[int]VerticaDBConditionType{
-	AutoRestartVerticaIndex:    AutoRestartVertica,
-	DBInitializedIndex:         DBInitialized,
-	ImageChangeInProgressIndex: ImageChangeInProgress,
+	AutoRestartVerticaIndex:           AutoRestartVertica,
+	DBInitializedIndex:                DBInitialized,
+	ImageChangeInProgressIndex:        ImageChangeInProgress,
+	OfflineImageChangeInProgressIndex: OfflineImageChangeInProgress,
+	OnlineImageChangeInProgressIndex:  OnlineImageChangeInProgress,
 }
 
 // VerticaDBCondition defines condition for VerticaDB

--- a/api/v1beta1/verticadb_types_test.go
+++ b/api/v1beta1/verticadb_types_test.go
@@ -36,4 +36,19 @@ var _ = Describe("verticadb_types", func() {
 		vdb.Spec.Communal.IncludeUIDInPath = false
 		Expect(vdb.GetCommunalPath()).ShouldNot(ContainSubstring(string(vdb.ObjectMeta.UID)))
 	})
+
+	It("should generate map of standbys", func() {
+		vdb := MakeVDB()
+		vdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1", IsPrimary: true},
+			{Name: "sc1-standby", IsPrimary: false, IsStandby: true, StandbyParent: "sc1"},
+			{Name: "sc2", IsPrimary: false},
+			{Name: "sc3", IsPrimary: true},
+			{Name: "sc3-standby", IsPrimary: false, IsStandby: true, StandbyParent: "sc3"},
+		}
+		m := vdb.GenSubclusterStandbyMap()
+		Expect(m["sc1"]).Should(Equal("sc1-standby"))
+		Expect(m["sc3"]).Should(Equal("sc3-standby"))
+		Expect(m["sc2"]).Should(Equal(""))
+	})
 })

--- a/pkg/controllers/imagechange_test.go
+++ b/pkg/controllers/imagechange_test.go
@@ -70,7 +70,8 @@ var _ = Describe("imagechange", func() {
 		createPods(ctx, vdb, AllPodsRunning)
 		defer deletePods(ctx, vdb)
 
-		mgr := MakeImageChangeManager(vrec, logger, vdb, func(vdb *vapi.VerticaDB) bool { return true })
+		mgr := MakeImageChangeManager(vrec, logger, vdb, vapi.OnlineImageChangeInProgress,
+			func(vdb *vapi.VerticaDB) bool { return true })
 		Expect(mgr.IsImageChangeNeeded(ctx)).Should(Equal(false))
 	})
 
@@ -90,7 +91,8 @@ var _ = Describe("imagechange", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 
-		mgr := MakeImageChangeManager(vrec, logger, vdb, func(vdb *vapi.VerticaDB) bool { return true })
+		mgr := MakeImageChangeManager(vrec, logger, vdb, vapi.OfflineImageChangeInProgress,
+			func(vdb *vapi.VerticaDB) bool { return true })
 		Expect(mgr.IsImageChangeNeeded(ctx)).Should(Equal(true))
 		stsChange, res, err := mgr.updateImageInStatefulSets(ctx, true, false)
 		Expect(err).Should(Succeed())

--- a/pkg/controllers/imagechange_test.go
+++ b/pkg/controllers/imagechange_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -117,5 +118,34 @@ var _ = Describe("imagechange", func() {
 		Expect(sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image).Should(Equal(NewImage1))
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[1]), sts)).Should(Succeed())
 		Expect(sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image).Should(Equal(NewImage2))
+	})
+
+	It("should delete pods of primaries only", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "sc1", Size: 1, IsPrimary: true},
+			{Name: "sc2", Size: 1, IsPrimary: false},
+		}
+		createPods(ctx, vdb, AllPodsRunning)
+		defer deletePods(ctx, vdb)
+		vdb.Spec.Image = "new-image" // Change image to force pod deletion
+
+		mgr := MakeImageChangeManager(vrec, logger, vdb, vapi.OfflineImageChangeInProgress,
+			func(vdb *vapi.VerticaDB) bool { return true })
+		numPodsDeleted, res, err := mgr.deletePodsRunningOldImage(ctx, false) // pods from primaries only
+		Expect(err).Should(Succeed())
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(numPodsDeleted).Should(Equal(1))
+
+		pod := &corev1.Pod{}
+		Expect(k8sClient.Get(ctx, names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0), pod)).ShouldNot(Succeed())
+		Expect(k8sClient.Get(ctx, names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0), pod)).Should(Succeed())
+
+		numPodsDeleted, res, err = mgr.deletePodsRunningOldImage(ctx, true) // pods from secondary and primaries
+		Expect(err).Should(Succeed())
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(numPodsDeleted).Should(Equal(1))
+
+		Expect(k8sClient.Get(ctx, names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0), pod)).ShouldNot(Succeed())
 	})
 })

--- a/pkg/controllers/labels_annotations.go
+++ b/pkg/controllers/labels_annotations.go
@@ -28,10 +28,10 @@ const (
 )
 
 // makeSubclusterLabels returns the labels added for the subcluster
-func makeSubclusterLabels(sc *SubclusterHandle) map[string]string {
+func makeSubclusterLabels(sc *vapi.Subcluster) map[string]string {
 	return map[string]string{
 		SubclusterNameLabel: sc.Name,
-		SubclusterTypeLabel: sc.GetSubclusterType(),
+		SubclusterTypeLabel: sc.GetType(),
 	}
 }
 
@@ -48,7 +48,7 @@ func makeOperatorLabels(vdb *vapi.VerticaDB) map[string]string {
 }
 
 // makeCommonLabels returns the labels that are common to all objects.
-func makeCommonLabels(vdb *vapi.VerticaDB, sc *SubclusterHandle) map[string]string {
+func makeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
 	labels := makeOperatorLabels(vdb)
 
 	// Remaining labels are for objects that are subcluster specific
@@ -64,7 +64,7 @@ func makeCommonLabels(vdb *vapi.VerticaDB, sc *SubclusterHandle) map[string]stri
 }
 
 // makeLabelsForObjects constructs the labels for a new k8s object
-func makeLabelsForObject(vdb *vapi.VerticaDB, sc *SubclusterHandle) map[string]string {
+func makeLabelsForObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
 	labels := makeCommonLabels(vdb, sc)
 
 	// Add any custom labels that were in the spec.
@@ -76,7 +76,7 @@ func makeLabelsForObject(vdb *vapi.VerticaDB, sc *SubclusterHandle) map[string]s
 }
 
 // makeLabelsForSvcObject will create the set of labels for use with service objects
-func makeLabelsForSvcObject(vdb *vapi.VerticaDB, sc *SubclusterHandle, svcType string) map[string]string {
+func makeLabelsForSvcObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, svcType string) map[string]string {
 	labels := makeLabelsForObject(vdb, sc)
 	labels[SvcTypeLabel] = svcType
 	return labels
@@ -93,7 +93,7 @@ func makeAnnotationsForObject(vdb *vapi.VerticaDB) map[string]string {
 }
 
 // makeSvcSelectorLabels returns the labels that are used for selectors in service objects.
-func makeSvcSelectorLabels(vdb *vapi.VerticaDB, sc *SubclusterHandle) map[string]string {
+func makeSvcSelectorLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
 	// The selector will simply use the common labels for all objects.
 	return makeCommonLabels(vdb, sc)
 }

--- a/pkg/controllers/offlineimagechange_reconcile.go
+++ b/pkg/controllers/offlineimagechange_reconcile.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -140,37 +139,11 @@ func (o *OfflineImageChangeReconciler) stopCluster(ctx context.Context) (ctrl.Re
 // Since there will be processing after to delete the pods so that they come up
 // with the new image.
 func (o *OfflineImageChangeReconciler) updateImageInStatefulSets(ctx context.Context) (ctrl.Result, error) {
-	// We use FindExisting for the finder because we only want to work with sts
-	// that already exist.  This is necessary incase the image change was paired
-	// with a scaling operation.  The pod change due to the scaling operation
-	// doesn't take affect until after the image change.
-	stss, err := o.Finder.FindStatefulSets(ctx, FindExisting)
-	if err != nil {
-		return ctrl.Result{}, err
+	numStsChanged, res, err := o.Manager.updateImageInStatefulSets(ctx, true, true)
+	if numStsChanged > 0 {
+		o.PFacts.Invalidate()
 	}
-	for i := range stss.Items {
-		sts := &stss.Items[i]
-		// Skip the statefulset if it already has the proper image.
-		if sts.Spec.Template.Spec.Containers[names.ServerContainerIndex].Image != o.Vdb.Spec.Image {
-			o.Log.Info("Updating image in old statefulset", "name", sts.ObjectMeta.Name)
-			err = o.Manager.setImageChangeStatus(ctx, "Rescheduling pods with new image name")
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			sts.Spec.Template.Spec.Containers[names.ServerContainerIndex].Image = o.Vdb.Spec.Image
-			// We change the update strategy to OnDelete.  We don't want the k8s
-			// sts controller to interphere and do a rolling update after the
-			// update has completed.  We don't explicitly change this back.  The
-			// ObjReconciler will handle it for us.
-			sts.Spec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
-			err = o.VRec.Client.Update(ctx, sts)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			o.PFacts.Invalidate()
-		}
-	}
-	return ctrl.Result{}, nil
+	return res, err
 }
 
 // deletePods will delete pods that are running the old image.  The assumption

--- a/pkg/controllers/offlineimagechange_reconcile.go
+++ b/pkg/controllers/offlineimagechange_reconcile.go
@@ -46,7 +46,7 @@ func MakeOfflineImageChangeReconciler(vdbrecon *VerticaDBReconciler, log logr.Lo
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &OfflineImageChangeReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts,
 		Finder:  MakeSubclusterFinder(vdbrecon.Client, vdb),
-		Manager: *MakeImageChangeManager(vdbrecon, log, vdb, offlineImageChangeAllowed),
+		Manager: *MakeImageChangeManager(vdbrecon, log, vdb, vapi.OfflineImageChangeInProgress, offlineImageChangeAllowed),
 	}
 }
 

--- a/pkg/controllers/onlineimagechange_reconcile_test.go
+++ b/pkg/controllers/onlineimagechange_reconcile_test.go
@@ -1,0 +1,83 @@
+/*
+ (c) Copyright [2021] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	appsv1 "k8s.io/api/apps/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("onlineimagechange_reconcile", func() {
+	ctx := context.Background()
+	const NewImageName = "different-image"
+
+	It("should properly report if primaries don't have matching image in vdb", func() {
+		vdb := vapi.MakeVDB()
+		createPods(ctx, vdb, AllPodsRunning)
+		defer deletePods(ctx, vdb)
+
+		r := createOnlineImageChangeReconciler(vdb)
+		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{}))
+		Expect(r.allPrimariesHaveNewImage()).Should(BeTrue())
+		vdb.Spec.Image = NewImageName
+		Expect(r.allPrimariesHaveNewImage()).Should(BeFalse())
+	})
+
+	It("should create and delete standby subclusters", func() {
+		vdb := vapi.MakeVDB()
+		scs := []vapi.Subcluster{
+			{Name: "sc1-primary", IsPrimary: true, Size: 5},
+			{Name: "sc2-secondary", IsPrimary: false, Size: 1},
+			{Name: "sc3-primary", IsPrimary: true, Size: 3},
+		}
+		vdb.Spec.Subclusters = scs
+		createVdb(ctx, vdb)
+		defer deleteVdb(ctx, vdb)
+		createPods(ctx, vdb, AllPodsRunning)
+		defer deletePods(ctx, vdb)
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+
+		r := createOnlineImageChangeReconciler(vdb)
+		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{}))
+		Expect(r.createStandbySubclusters(ctx)).Should(Equal(ctrl.Result{}))
+		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{})) // Pickup new subclusters
+		defer func() { Expect(r.deleteStandbySubclusters(ctx)).Should(Equal(ctrl.Result{})) }()
+
+		sts := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[0]), sts)).Should(Succeed())
+		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[1]), sts)).ShouldNot(Succeed())
+		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[2]), sts)).Should(Succeed())
+		Expect(r.deleteStandbySubclusters(ctx)).Should(Equal(ctrl.Result{}))
+		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[0]), sts)).ShouldNot(Succeed())
+		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[1]), sts)).ShouldNot(Succeed())
+		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[2]), sts)).ShouldNot(Succeed())
+	})
+})
+
+// createOnlineImageChangeReconciler is a helper to run the OnlineImageChangeReconciler.
+func createOnlineImageChangeReconciler(vdb *vapi.VerticaDB) *OnlineImageChangeReconciler {
+	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
+	pfacts := MakePodFacts(k8sClient, fpr)
+	actor := MakeOnlineImageChangeReconciler(vrec, logger, vdb, fpr, &pfacts)
+	return actor.(*OnlineImageChangeReconciler)
+}

--- a/pkg/controllers/onlineimagechange_reconcile_test.go
+++ b/pkg/controllers/onlineimagechange_reconcile_test.go
@@ -59,15 +59,15 @@ var _ = Describe("onlineimagechange_reconcile", func() {
 
 		r := createOnlineImageChangeReconciler(vdb)
 		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{}))
-		Expect(r.createStandbySubclusters(ctx)).Should(Equal(ctrl.Result{}))
+		Expect(r.createStandbySts(ctx)).Should(Equal(ctrl.Result{}))
 		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{})) // Pickup new subclusters
-		defer func() { Expect(r.deleteStandbySubclusters(ctx)).Should(Equal(ctrl.Result{})) }()
+		defer func() { Expect(r.deleteStandbySts(ctx)).Should(Equal(ctrl.Result{})) }()
 
 		sts := &appsv1.StatefulSet{}
 		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[0]), sts)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[1]), sts)).ShouldNot(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[2]), sts)).Should(Succeed())
-		Expect(r.deleteStandbySubclusters(ctx)).Should(Equal(ctrl.Result{}))
+		Expect(r.deleteStandbySts(ctx)).Should(Equal(ctrl.Result{}))
 		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[0]), sts)).ShouldNot(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[1]), sts)).ShouldNot(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenStandbyStsName(vdb, &scs[2]), sts)).ShouldNot(Succeed())

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -65,9 +65,10 @@ func (o *OnlineImageChangeReconciler) Reconcile(ctx context.Context, req *ctrl.R
 		// Load up state that is used for the subsequent steps
 		o.loadSubclusterState,
 		// Setup a secondary standby subcluster for each primary
-		o.createStandbySubclusters,
-		o.installVerticaOnStandbySubclusters,
-		o.addNodesOnStandbySubclusters,
+		o.createStandbySts,
+		o.installStandbyNodes,
+		o.addStandbySubclusters,
+		o.addStandbyNodes,
 		// Reroute all traffic from primary subclusters to their standby's
 		o.rerouteClientTrafficToStandby,
 		// Drain all connections from the primary subcluster.  This waits for
@@ -83,8 +84,11 @@ func (o *OnlineImageChangeReconciler) Reconcile(ctx context.Context, req *ctrl.R
 		// Drain all connections from the standby subclusters to prepare them
 		// for being removed.
 		o.drainStandbys,
-		// Will delete the standby subclusters now that the primaries are back up.
-		o.deleteStandbySubclusters,
+		// Will cleanup the standby subclusters now that the primaries are back up.
+		o.removeStandbySubclusters,
+		o.removeStandbyNodes,
+		o.uninstallStandbyNodes,
+		o.deleteStandbySts,
 		// With the primaries back up, we can do a "rolling upgrade" style of
 		// update for the secondary subclusters.
 		o.startRollingUpgradeOfSecondarySubclusters,
@@ -116,11 +120,11 @@ func (o *OnlineImageChangeReconciler) loadSubclusterState(ctx context.Context) (
 	return ctrl.Result{}, nil
 }
 
-// createStandbySubclusters this will create a secondary subcluster to accept
+// createStandbySts this will create a secondary subcluster to accept
 // traffic from the primaries when they are down.  These subclusters are scalled
 // standby and are transient since they only exist for the life of the image
 // change.
-func (o *OnlineImageChangeReconciler) createStandbySubclusters(ctx context.Context) (ctrl.Result, error) {
+func (o *OnlineImageChangeReconciler) createStandbySts(ctx context.Context) (ctrl.Result, error) {
 	if o.skipStandbySetup() {
 		return ctrl.Result{}, nil
 	}
@@ -141,28 +145,40 @@ func (o *OnlineImageChangeReconciler) createStandbySubclusters(ctx context.Conte
 			}
 		}
 	}
-	// SPILLY - need to handle install and add node
+
 	return ctrl.Result{}, nil
 }
 
-// installVerticaOnStandbySubclusters will ensure we have installed vertica on
+// installStandbyNodes will ensure we have installed vertica on
 // each of the standby nodes.
-func (o *OnlineImageChangeReconciler) installVerticaOnStandbySubclusters(ctx context.Context) (ctrl.Result, error) {
+func (o *OnlineImageChangeReconciler) installStandbyNodes(ctx context.Context) (ctrl.Result, error) {
 	if o.skipStandbySetup() {
 		return ctrl.Result{}, nil
 	}
 
-	return ctrl.Result{}, nil
+	actor := MakeInstallReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
-// addNodesOnStandbySubclusters will ensure nodes on the standby's have been
-// added to the cluster.
-func (o *OnlineImageChangeReconciler) addNodesOnStandbySubclusters(ctx context.Context) (ctrl.Result, error) {
+// addStandbySubclusters will register new standby subclusters with Vertica
+func (o *OnlineImageChangeReconciler) addStandbySubclusters(ctx context.Context) (ctrl.Result, error) {
 	if o.skipStandbySetup() {
 		return ctrl.Result{}, nil
 	}
 
-	return ctrl.Result{}, nil
+	actor := MakeDBAddSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	return actor.Reconcile(ctx, &ctrl.Request{})
+}
+
+// addStandbyNodes will ensure nodes on the standby's have been
+// added to the cluster.
+func (o *OnlineImageChangeReconciler) addStandbyNodes(ctx context.Context) (ctrl.Result, error) {
+	if o.skipStandbySetup() {
+		return ctrl.Result{}, nil
+	}
+
+	actor := MakeDBAddNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
 // rerouteClientTrafficToStandby will update the service objects for each of the
@@ -184,7 +200,11 @@ func (o *OnlineImageChangeReconciler) drainPrimaries(ctx context.Context) (ctrl.
 // mode as all of the pods in the primary will be rescheduled with the new
 // image.
 func (o *OnlineImageChangeReconciler) changeImageInPrimaries(ctx context.Context) (ctrl.Result, error) {
-	return ctrl.Result{}, nil
+	numStsChanged, res, err := o.Manager.updateImageInStatefulSets(ctx, true, false)
+	if numStsChanged > 0 {
+		o.PFacts.Invalidate()
+	}
+	return res, err
 }
 
 // restartPrimaries will restart all of the pods in the primary subclusters.
@@ -206,8 +226,31 @@ func (o *OnlineImageChangeReconciler) drainStandbys(ctx context.Context) (ctrl.R
 	return ctrl.Result{}, nil
 }
 
-// deleteStandbySubclusters will delete any standby subclusters that were created for the image change.
-func (o *OnlineImageChangeReconciler) deleteStandbySubclusters(ctx context.Context) (ctrl.Result, error) {
+// removeStandbySubclusters will drive subcluster removal of any standbys
+func (o *OnlineImageChangeReconciler) removeStandbySubclusters(ctx context.Context) (ctrl.Result, error) {
+	act := MakeDBRemoveSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	return act.Reconcile(ctx, &ctrl.Request{})
+}
+
+// removeNodesOnStandybSubclusters will remove any vertica nodes from the
+// database for standby subclusters.  This is part of the tear down of the
+// standby's.
+func (o *OnlineImageChangeReconciler) removeStandbyNodes(ctx context.Context) (ctrl.Result, error) {
+	act := MakeDBRemoveNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	return act.Reconcile(ctx, &ctrl.Request{})
+	// SPILLY - need subcluster add and removal.
+	// SPILLY - Also, should we have a single function for a log of these?  Maybe a setup function and teardown function?
+}
+
+// uninstallStandbyNodes will drive uninstall logic for any
+// standby nodes.
+func (o *OnlineImageChangeReconciler) uninstallStandbyNodes(ctx context.Context) (ctrl.Result, error) {
+	act := MakeDBRemoveNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	return act.Reconcile(ctx, &ctrl.Request{})
+}
+
+// deleteStandbySts will delete any standby subclusters that were created for the image change.
+func (o *OnlineImageChangeReconciler) deleteStandbySts(ctx context.Context) (ctrl.Result, error) {
 	for i := range o.Subclusters {
 		sc := o.Subclusters[i]
 		if sc.IsStandby {

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -44,7 +44,7 @@ func MakeOnlineImageChangeReconciler(vdbrecon *VerticaDBReconciler, log logr.Log
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
 	return &OnlineImageChangeReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts,
 		Finder:  MakeSubclusterFinder(vdbrecon.Client, vdb),
-		Manager: *MakeImageChangeManager(vdbrecon, log, vdb, onlineImageChangeAllowed),
+		Manager: *MakeImageChangeManager(vdbrecon, log, vdb, vapi.OnlineImageChangeInProgress, onlineImageChangeAllowed),
 	}
 }
 

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -84,7 +84,6 @@ func (o *OnlineImageChangeReconciler) Reconcile(ctx context.Context, req *ctrl.R
 		o.drainStandbys,
 		// Will cleanup the standby subclusters now that the primaries are back up.
 		o.removeStandbySubclusters,
-		o.removeStandbyNodes,
 		o.uninstallStandbyNodes,
 		o.deleteStandbySts,
 		// With the primaries back up, we can do a "rolling upgrade" style of
@@ -237,19 +236,10 @@ func (o *OnlineImageChangeReconciler) removeStandbySubclusters(ctx context.Conte
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
-// removeNodesOnStandybSubclusters will remove any vertica nodes from the
-// database for standby subclusters.  This is part of the tear down of the
-// standby's.
-func (o *OnlineImageChangeReconciler) removeStandbyNodes(ctx context.Context) (ctrl.Result, error) {
-	actor := MakeDBRemoveNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
-	o.traceActorReconcile(actor)
-	return actor.Reconcile(ctx, &ctrl.Request{})
-}
-
 // uninstallStandbyNodes will drive uninstall logic for any
 // standby nodes.
 func (o *OnlineImageChangeReconciler) uninstallStandbyNodes(ctx context.Context) (ctrl.Result, error) {
-	actor := MakeDBRemoveNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	actor := MakeUninstallReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
 	o.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -532,11 +532,13 @@ func (p *PodFacts) findRunningPod() (*PodFact, bool) {
 
 // findRestartablePods returns a list of pod facts that can be restarted.
 // An empty list implies there are no pods that need to be restarted.
-// We treat read-only nodes as being restartable because they are in the
-// read-only state due to losing of cluster quorum.
-func (p *PodFacts) findRestartablePods() []*PodFact {
+// We allow read-only nodes to be treated as being restartable because they are
+// in the read-only state due to losing of cluster quorum.  This is an option
+// for online upgrade, which want to keep the read-only up to keep the cluster
+// accessible.
+func (p *PodFacts) findRestartablePods(restartReadOnly bool) []*PodFact {
 	return p.filterPods(func(v *PodFact) bool {
-		return (!v.upNode || v.readOnly) && v.dbExists.IsTrue() && v.isPodRunning
+		return (!v.upNode || (restartReadOnly && v.readOnly)) && v.dbExists.IsTrue() && v.isPodRunning
 	})
 }
 

--- a/pkg/controllers/subcluster_handle.go
+++ b/pkg/controllers/subcluster_handle.go
@@ -28,10 +28,6 @@ import (
 type SubclusterHandle struct {
 	vapi.Subcluster
 
-	// Indicates whether this subcluster is a transient standby that is created
-	// for online upgrade.
-	IsStandby bool
-
 	// The name of the image that is currently being run in this subcluster.  If
 	// the corresponding sts doesn't exist, then this will be left blank.
 	Image string
@@ -64,24 +60,6 @@ func (s *SubclusterHandle) SetIsAcceptingTraffic(svcLabels map[string]string) er
 	// labels from the service.
 	s.IsAcceptingTraffic = svcLabels[SubclusterTypeLabel] == s.GetSubclusterType()
 	return nil
-}
-
-// makeSubclusterHandle will form a SubclusterHandle from a Subcluster object
-// found in the VerticaDB
-func makeSubclusterHandle(sc *vapi.Subcluster) *SubclusterHandle {
-	return &SubclusterHandle{
-		Subcluster: *sc,
-		IsStandby:  false, // Assume not a standby since it is from VerticaDB
-	}
-}
-
-// makeStandbySubclusterHandle will form a SubclusterHandle for a standby subcluster
-func makeStandbySubclusterHandle(sc *vapi.Subcluster) *SubclusterHandle {
-	// SPILLY - need to adjust the size of the sub
-	return &SubclusterHandle{
-		Subcluster: *sc,
-		IsStandby:  true,
-	}
 }
 
 // makeSubclusterHandleFromSts will form a SubclusterHandle from a StatefulSet

--- a/pkg/controllers/subcluster_handle.go
+++ b/pkg/controllers/subcluster_handle.go
@@ -75,6 +75,15 @@ func makeSubclusterHandle(sc *vapi.Subcluster) *SubclusterHandle {
 	}
 }
 
+// makeStandbySubclusterHandle will form a SubclusterHandle for a standby subcluster
+func makeStandbySubclusterHandle(sc *vapi.Subcluster) *SubclusterHandle {
+	// SPILLY - need to adjust the size of the sub
+	return &SubclusterHandle{
+		Subcluster: *sc,
+		IsStandby:  true,
+	}
+}
+
 // makeSubclusterHandleFromSts will form a SubclusterHandle from a StatefulSet
 // object.
 func makeSubclusterHandleFromSts(sts *appsv1.StatefulSet, svcMap map[string]corev1.Service) *SubclusterHandle {

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -279,12 +279,14 @@ func createPodFactsWithInstallNeeded(ctx context.Context, vdb *vapi.VerticaDB, f
 }
 
 func createPodFactsWithRestartNeeded(ctx context.Context, vdb *vapi.VerticaDB, sc *vapi.Subcluster,
-	fpr *cmds.FakePodRunner, podsDownByIndex []int32) *PodFacts {
+	fpr *cmds.FakePodRunner, podsDownByIndex []int32, readOnly bool) *PodFacts {
 	pfacts := MakePodFacts(k8sClient, fpr)
 	ExpectWithOffset(1, pfacts.Collect(ctx, vdb)).Should(Succeed())
 	for _, podIndex := range podsDownByIndex {
 		downPodNm := names.GenPodName(vdb, sc, podIndex)
-		pfacts.Detail[downPodNm].upNode = false
+		// If readOnly is true, pod will be up and running.
+		pfacts.Detail[downPodNm].upNode = readOnly
+		pfacts.Detail[downPodNm].readOnly = readOnly
 	}
 	return &pfacts
 }

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -108,13 +108,18 @@ const (
 func createPods(ctx context.Context, vdb *vapi.VerticaDB, podRunningState PodRunningState) {
 	for i := range vdb.Spec.Subclusters {
 		sc := &vdb.Spec.Subclusters[i]
-		sch := makeSubclusterHandle(sc)
-		sts := buildStsSpec(names.GenStsName(vdb, sc), vdb, sch)
-		ExpectWithOffset(1, k8sClient.Create(ctx, sts)).Should(Succeed())
+		sts := &appsv1.StatefulSet{}
+		if err := k8sClient.Get(ctx, names.GenStsName(vdb, sc), sts); kerrors.IsNotFound(err) {
+			sts = buildStsSpec(names.GenStsName(vdb, sc), vdb, sc)
+			ExpectWithOffset(1, k8sClient.Create(ctx, sts)).Should(Succeed())
+		}
 		for j := int32(0); j < sc.Size; j++ {
-			pod := buildPod(vdb, sc, j)
-			ExpectWithOffset(1, k8sClient.Create(ctx, pod)).Should(Succeed())
-			setPodStatusHelper(ctx, 2 /* funcOffset */, names.GenPodName(vdb, sc, j), int32(i), j, podRunningState, false)
+			pod := &corev1.Pod{}
+			if err := k8sClient.Get(ctx, names.GenPodName(vdb, sc, j), pod); kerrors.IsNotFound(err) {
+				pod = buildPod(vdb, sc, j)
+				ExpectWithOffset(1, k8sClient.Create(ctx, pod)).Should(Succeed())
+				setPodStatusHelper(ctx, 2 /* funcOffset */, names.GenPodName(vdb, sc, j), int32(i), j, podRunningState, false)
+			}
 		}
 		// Update the status in the sts to reflect the number of pods we created
 		sts.Status.Replicas = sc.Size
@@ -175,8 +180,10 @@ func deletePods(ctx context.Context, vdb *vapi.VerticaDB) {
 			}
 		}
 		sts := &appsv1.StatefulSet{}
-		ExpectWithOffset(1, k8sClient.Get(ctx, names.GenStsName(vdb, sc), sts)).Should(Succeed())
-		ExpectWithOffset(1, k8sClient.Delete(ctx, sts)).Should(Succeed())
+		err := k8sClient.Get(ctx, names.GenStsName(vdb, sc), sts)
+		if !kerrors.IsNotFound(err) {
+			ExpectWithOffset(1, k8sClient.Delete(ctx, sts)).Should(Succeed())
+		}
 	}
 }
 

--- a/pkg/controllers/verticadb_controller.go
+++ b/pkg/controllers/verticadb_controller.go
@@ -106,7 +106,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Always start with a status reconcile in case the prior reconcile failed.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, &pfacts),
 		// Handles vertica server upgrade (i.e., when spec.image changes)
-		// MakeOfflineImageChangeReconciler(r, log, vdb, prunner, &pfacts), SPILLY need some state to know that we started an online image change
+		MakeOfflineImageChangeReconciler(r, log, vdb, prunner, &pfacts),
 		MakeOnlineImageChangeReconciler(r, log, vdb, prunner, &pfacts),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, &pfacts),

--- a/pkg/controllers/verticadb_controller.go
+++ b/pkg/controllers/verticadb_controller.go
@@ -106,7 +106,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Always start with a status reconcile in case the prior reconcile failed.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, &pfacts),
 		// Handles vertica server upgrade (i.e., when spec.image changes)
-		MakeOfflineImageChangeReconciler(r, log, vdb, prunner, &pfacts),
+		// MakeOfflineImageChangeReconciler(r, log, vdb, prunner, &pfacts), SPILLY need some state to know that we started an online image change
 		MakeOnlineImageChangeReconciler(r, log, vdb, prunner, &pfacts),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, &pfacts),

--- a/pkg/controllers/verticadb_controller.go
+++ b/pkg/controllers/verticadb_controller.go
@@ -109,7 +109,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		MakeOfflineImageChangeReconciler(r, log, vdb, prunner, &pfacts),
 		MakeOnlineImageChangeReconciler(r, log, vdb, prunner, &pfacts),
 		// Handles restart + re_ip of vertica
-		MakeRestartReconciler(r, log, vdb, prunner, &pfacts),
+		MakeRestartReconciler(r, log, vdb, prunner, &pfacts, true),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, &pfacts),
 		// Handles calls to admintools -t db_remove_subcluster
 		MakeDBRemoveSubclusterReconciler(r, log, vdb, prunner, &pfacts),

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -52,11 +52,6 @@ func GenStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
 	return GenNamespacedName(vdb, vdb.Name+"-"+sc.Name)
 }
 
-// GenStandbyStsName returns the name of the standby stateful object
-func GenStandbyStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s", vdb.Name, sc.Name, "standby"))
-}
-
 // GenCommunalCredSecretName returns the name of the secret that has the credentials to access s3
 func GenCommunalCredSecretName(vdb *vapi.VerticaDB) types.NamespacedName {
 	return GenNamespacedName(vdb, vdb.Spec.Communal.CredentialSecret)

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -52,6 +52,11 @@ func GenStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
 	return GenNamespacedName(vdb, vdb.Name+"-"+sc.Name)
 }
 
+// GenStandbyStsName returns the name of the standby stateful object
+func GenStandbyStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s", vdb.Name, sc.Name, "standby"))
+}
+
 // GenCommunalCredSecretName returns the name of the secret that has the credentials to access s3
 func GenCommunalCredSecretName(vdb *vapi.VerticaDB) types.NamespacedName {
 	return GenNamespacedName(vdb, vdb.Spec.Communal.CredentialSecret)

--- a/tests/e2e/upgrade-vertica-ks-0/75-assert.yaml
+++ b/tests/e2e/upgrade-vertica-ks-0/75-assert.yaml
@@ -40,3 +40,5 @@ status:
         status: "False"
       - type: ImageChangeInProgress
         status: "False"
+      - type: OfflineImageChangeInProgress
+        status: "False"


### PR DESCRIPTION
This is another PR for online-upgrade.  It will handle creation and removal of the standby subcluster during the online-image change process.

- new state was added to the vapi.Subcluster for this.  Originally, I was planning to keep most of this in the SubclusterHandle struct, but we already pass around vapi.Subcluster so it made it easier to have it their
- new status conditions for offline and online image change.  These are intended to be used by the operator to know what image change to continue with once an image change has started
- filled out more of the logic in onlineimagechange_reconciler.go.  It will scale-out a new standby subcluster for each primary, then scale them down when we are finishing the image change.
- moved more logic into imagechange.go that is common between online and offline image change
- restart logic was changed to allow option to restart read-only nodes.  When restarting for online, we will skip the read-only modes.  Offline restarts everything.