### PR TITLE
Online image change: manage client traffic over multiple subclusters

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -914,10 +914,10 @@ const (
 // GetType returns the type of the subcluster in string form
 func (s *Subcluster) GetType() string {
 	if s.IsPrimary {
-		if s.IsStandby {
-			return StandbySubclusterType
-		}
 		return PrimarySubclusterType
+	}
+	if s.IsStandby {
+		return StandbySubclusterType
 	}
 	return SecondarySubclusterType
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -563,6 +563,17 @@ type Subcluster struct {
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	// Identifies the name of the service object that will serve this
+	// subcluster.  If multiple subclusters share the same service name then
+	// they all share the same service object.  This allows for a single service
+	// object to round robin between multiple subclusters.  If this is left
+	// blank, a service object matching the subcluster name is used.  The actual
+	// name of the service object is always prefixed with the name of the owning
+	// VerticaDB.
+	ServiceName string `json:"serviceName,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number"
 	// When setting serviceType to NodePort, this parameter allows you to define the
 	// port that is opened at each node. If using NodePort and this is omitted,
@@ -920,4 +931,13 @@ func (s *Subcluster) GetType() string {
 		return StandbySubclusterType
 	}
 	return SecondarySubclusterType
+}
+
+// GetServiceName returns the name of the service object that route traffic to
+// this subcluster.
+func (s *Subcluster) GetServiceName() string {
+	if s.ServiceName == "" {
+		return s.Name
+	}
+	return s.ServiceName
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -508,13 +508,6 @@ type Subcluster struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
-	// If this is a standby subcluster, this is the name of the primary
-	// subcluster it was created for.  This is state internally managed for an
-	// online image change.
-	StandbyParent string `json:"standbyParent,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	// This allows a different image to be used for the subcluster than the one
 	// in VerticaDB.  This is intended to be used internally by the online image
 	// change process.
@@ -854,19 +847,6 @@ func (v *VerticaDB) GenSubclusterMap() map[string]*Subcluster {
 		scMap[sc.Name] = sc
 	}
 	return scMap
-}
-
-// GenSubclusterStandbyMap will create a map of primary subclusters to their
-// standby subcluster.  It returns an empty map if there are no standbys.
-func (v *VerticaDB) GenSubclusterStandbyMap() map[string]string {
-	m := map[string]string{}
-	for i := range v.Spec.Subclusters {
-		sc := &v.Spec.Subclusters[i]
-		if sc.IsStandby {
-			m[sc.StandbyParent] = sc.Name
-		}
-	}
-	return m
 }
 
 // IsValidSubclusterName validates the subcluster name is valid.  We have rules

--- a/api/v1beta1/verticadb_types_test.go
+++ b/api/v1beta1/verticadb_types_test.go
@@ -36,19 +36,4 @@ var _ = Describe("verticadb_types", func() {
 		vdb.Spec.Communal.IncludeUIDInPath = false
 		Expect(vdb.GetCommunalPath()).ShouldNot(ContainSubstring(string(vdb.ObjectMeta.UID)))
 	})
-
-	It("should generate map of standbys", func() {
-		vdb := MakeVDB()
-		vdb.Spec.Subclusters = []Subcluster{
-			{Name: "sc1", IsPrimary: true},
-			{Name: "sc1-standby", IsPrimary: false, IsStandby: true, StandbyParent: "sc1"},
-			{Name: "sc2", IsPrimary: false},
-			{Name: "sc3", IsPrimary: true},
-			{Name: "sc3-standby", IsPrimary: false, IsStandby: true, StandbyParent: "sc3"},
-		}
-		m := vdb.GenSubclusterStandbyMap()
-		Expect(m["sc1"]).Should(Equal("sc1-standby"))
-		Expect(m["sc3"]).Should(Equal("sc3-standby"))
-		Expect(m["sc2"]).Should(Equal(""))
-	})
 })

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -587,7 +587,6 @@ func buildStandby(sc *vapi.Subcluster, imageOverride string) *vapi.Subcluster {
 		Name:              fmt.Sprintf("%s-standby", sc.Name),
 		Size:              1,
 		IsStandby:         true,
-		StandbyParent:     sc.Name,
 		ImageOverride:     imageOverride,
 		IsPrimary:         false,
 		NodeSelector:      sc.NodeSelector,

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -596,6 +596,7 @@ func buildStandby(sc *vapi.Subcluster, imageOverride string) *vapi.Subcluster {
 		Tolerations:       sc.Tolerations,
 		Resources:         sc.Resources,
 		ServiceType:       sc.ServiceType,
+		ServiceName:       sc.GetServiceName(),
 		NodePort:          sc.NodePort,
 		ExternalIPs:       sc.ExternalIPs,
 	}

--- a/pkg/controllers/obj_reconcile.go
+++ b/pkg/controllers/obj_reconcile.go
@@ -238,6 +238,13 @@ func (o ObjReconciler) reconcileExtSvc(ctx context.Context, sc *vapi.Subcluster)
 		updated = true
 		curSvc.Spec.ExternalIPs = expSvc.Spec.ExternalIPs
 	}
+
+	// Check if the selectors are changing
+	if !reflect.DeepEqual(expSvc.Spec.Selector, curSvc.Spec.Selector) {
+		curSvc.Spec.Selector = expSvc.Spec.Selector
+		updated = true
+	}
+
 	if updated {
 		o.Log.Info("updating svc", "Name", svcName)
 		return o.VRec.Client.Update(ctx, curSvc)

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -321,14 +321,15 @@ func (o *OnlineImageChangeReconciler) addStandbysToVdb(ctx context.Context) erro
 		}
 
 		// Figure out if any standbys need to be added
-		standbyMap := o.Vdb.GenSubclusterStandbyMap()
+		scMap := o.Vdb.GenSubclusterMap()
 		standbys := []vapi.Subcluster{}
 		for i := range o.Vdb.Spec.Subclusters {
 			sc := &o.Vdb.Spec.Subclusters[i]
 			if sc.IsPrimary {
-				_, ok := standbyMap[sc.Name]
+				standby := buildStandby(sc, oldImage)
+				_, ok := scMap[standby.Name]
 				if !ok {
-					standbys = append(standbys, *buildStandby(sc, oldImage))
+					standbys = append(standbys, *standby)
 				}
 			}
 		}

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -174,7 +174,13 @@ func (o *OnlineImageChangeReconciler) addStandbyNodes(ctx context.Context) (ctrl
 // rerouteClientTrafficToStandby will update the service objects for each of the
 // primary subclusters so that they are routed to the standby subclusters.
 func (o *OnlineImageChangeReconciler) rerouteClientTrafficToStandby(ctx context.Context) (ctrl.Result, error) {
-	return ctrl.Result{}, nil
+	if o.skipStandbySetup() {
+		return ctrl.Result{}, nil
+	}
+
+	o.Log.Info("starting client traffic routing to standby")
+	err := o.routeClientTraffic(ctx, func(sc *vapi.Subcluster) bool { return sc.IsStandby })
+	return ctrl.Result{}, err
 }
 
 // drainPrimaries will only succeed if the primary subclusters are already down
@@ -219,7 +225,9 @@ func (o *OnlineImageChangeReconciler) restartPrimaries(ctx context.Context) (ctr
 // subclusters so that traffic is not routed to the standby's anymore but back
 // to te primary subclusters.
 func (o *OnlineImageChangeReconciler) rerouteClientTrafficToPrimary(ctx context.Context) (ctrl.Result, error) {
-	return ctrl.Result{}, nil
+	o.Log.Info("starting client traffic routing to primary")
+	err := o.routeClientTraffic(ctx, func(sc *vapi.Subcluster) bool { return sc.IsPrimary })
+	return ctrl.Result{}, err
 }
 
 // drainStandbys will wait for all active connections in the standby subclusters
@@ -364,4 +372,23 @@ func (o *OnlineImageChangeReconciler) removeStandbysFromVdb(ctx context.Context)
 
 func (o *OnlineImageChangeReconciler) traceActorReconcile(actor ReconcileActor) {
 	o.Log.Info("starting actor for online image change", "name", fmt.Sprintf("%T", actor))
+}
+
+// routeClientTraffic will update service objects to route to either the primary
+// or standby.  The subcluster picked is determined by the scCheckFunc the
+// caller provides.  If it returns true for a given subcluster, traffic will be
+// routed to that.
+func (o *OnlineImageChangeReconciler) routeClientTraffic(ctx context.Context, scCheckFunc func(sc *vapi.Subcluster) bool) error {
+	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts)
+	objRec := actor.(*ObjReconciler)
+
+	for i := range o.Vdb.Spec.Subclusters {
+		sc := &o.Vdb.Spec.Subclusters[i]
+		if scCheckFunc(sc) {
+			if err := objRec.reconcileExtSvc(ctx, sc); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/controllers/sc_finder.go
+++ b/pkg/controllers/sc_finder.go
@@ -78,28 +78,6 @@ func (m *SubclusterFinder) FindServices(ctx context.Context, flags FindFlags) (*
 	return svcs, nil
 }
 
-// FindServicesMap will find services for subclusters.  It returns the output in
-// a map with the subcluster name as the key to the map.
-func (m *SubclusterFinder) FindServicesMap(ctx context.Context, flags FindFlags) (map[string]corev1.Service, error) {
-	svcs, err := m.FindServices(ctx, flags)
-	if err != nil {
-		return nil, err
-	}
-	// Convert the found services to a map, where the key is the name of the
-	// subcluster.
-	svcMap := map[string]corev1.Service{}
-	for i := range svcs.Items {
-		// Skip if object is not subcluster specific as there is no way to
-		// include it in the map.
-		nm, ok := svcs.Items[i].Labels[SubclusterNameLabel]
-		if !ok {
-			continue
-		}
-		svcMap[nm] = svcs.Items[i]
-	}
-	return svcMap, nil
-}
-
 // FindPods returns pod objects that are are used to run Vertica.  It limits the
 // pods that were created by the VerticaDB object.
 func (m *SubclusterFinder) FindPods(ctx context.Context, flags FindFlags) (*corev1.PodList, error) {
@@ -153,13 +131,8 @@ func (m *SubclusterFinder) FindSubclusterHandles(ctx context.Context, flags Find
 		return nil, err
 	}
 
-	svcMap, err := m.FindServicesMap(ctx, flags)
-	if err != nil {
-		return nil, err
-	}
-
 	for i := range stss.Items {
-		subclusters = append(subclusters, makeSubclusterHandleFromSts(&stss.Items[i], svcMap))
+		subclusters = append(subclusters, makeSubclusterHandleFromSts(&stss.Items[i]))
 	}
 
 	return subclusters, nil

--- a/pkg/controllers/sc_finder_test.go
+++ b/pkg/controllers/sc_finder_test.go
@@ -137,11 +137,9 @@ var _ = Describe("sc_finder", func() {
 		Expect(schs[0].Name).Should(Equal(vdb.Spec.Subclusters[0].Name))
 		Expect(schs[0].IsPrimary).Should(Equal(vdb.Spec.Subclusters[0].IsPrimary))
 		Expect(schs[0].Image).Should(Equal(RunningImage))
-		Expect(schs[0].IsAcceptingTraffic).Should(Equal(true))
 		Expect(schs[1].Name).Should(Equal(vdb.Spec.Subclusters[1].Name))
 		Expect(schs[1].IsPrimary).Should(Equal(vdb.Spec.Subclusters[1].IsPrimary))
 		Expect(schs[1].Image).Should(Equal(RunningImage))
-		Expect(schs[1].IsAcceptingTraffic).Should(Equal(true))
 	})
 
 	It("should find all pods that exist in k8s for the VerticaDB", func() {

--- a/pkg/controllers/subcluster_handle.go
+++ b/pkg/controllers/subcluster_handle.go
@@ -18,7 +18,6 @@ package controllers
 import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // SubclusterHandle is a runtime object that has meta-data for a subcluster.  It
@@ -31,11 +30,6 @@ type SubclusterHandle struct {
 	// The name of the image that is currently being run in this subcluster.  If
 	// the corresponding sts doesn't exist, then this will be left blank.
 	Image string
-
-	// Indicates whether a service object is currently routing traffic to this
-	// subcluster.  When dealing with primary and standby subclusters pairs,
-	// only one will have traffic routed to it.
-	IsAcceptingTraffic bool
 }
 
 const (
@@ -55,28 +49,13 @@ func (s *SubclusterHandle) GetSubclusterType() string {
 	return SecondarySubclusterType
 }
 
-func (s *SubclusterHandle) SetIsAcceptingTraffic(svcLabels map[string]string) error {
-	// We determine if traffic is routed to the subcluster by checking the
-	// labels from the service.
-	s.IsAcceptingTraffic = svcLabels[SubclusterTypeLabel] == s.GetSubclusterType()
-	return nil
-}
-
 // makeSubclusterHandleFromSts will form a SubclusterHandle from a StatefulSet
 // object.
-func makeSubclusterHandleFromSts(sts *appsv1.StatefulSet, svcMap map[string]corev1.Service) *SubclusterHandle {
+func makeSubclusterHandleFromSts(sts *appsv1.StatefulSet) *SubclusterHandle {
 	sc := &SubclusterHandle{}
 	sc.Name = sts.Labels[SubclusterNameLabel]
 	sc.IsPrimary = sts.Labels[SubclusterTypeLabel] == PrimarySubclusterType
 	sc.IsStandby = sts.Labels[SubclusterTypeLabel] == StandbySubclusterType
 	sc.Image = sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image
-
-	// We check the service object to see if traffic is currently being routed
-	// to the subcluster.
-	svc, ok := svcMap[sc.Name]
-	if ok {
-		sc.IsAcceptingTraffic = svc.Spec.Selector[SubclusterTypeLabel] == sc.GetSubclusterType()
-	}
-
 	return sc
 }

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -39,11 +39,7 @@ func GenNamespacedName(vdb *vapi.VerticaDB, name string) types.NamespacedName {
 
 // GenExtSvcName returns the name of the external service object.
 func GenExtSvcName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
-	// Primary and its standby share the same service object.
-	if sc.IsStandby {
-		return GenNamespacedName(vdb, vdb.Name+"-"+sc.StandbyParent)
-	}
-	return GenNamespacedName(vdb, vdb.Name+"-"+sc.Name)
+	return GenNamespacedName(vdb, vdb.Name+"-"+sc.GetServiceName())
 }
 
 // GenHlSvcName returns the name of the headless service object.

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -39,6 +39,10 @@ func GenNamespacedName(vdb *vapi.VerticaDB, name string) types.NamespacedName {
 
 // GenExtSvcName returns the name of the external service object.
 func GenExtSvcName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
+	// Primary and its standby share the same service object.
+	if sc.IsStandby {
+		return GenNamespacedName(vdb, vdb.Name+"-"+sc.StandbyParent)
+	}
 	return GenNamespacedName(vdb, vdb.Name+"-"+sc.Name)
 }
 

--- a/scripts/kind.sh
+++ b/scripts/kind.sh
@@ -108,6 +108,8 @@ EOF
   extraPortMappings:
     - containerPort: $PORT
       hostPort: $VSQL_PORT
+    - containerPort: $(( $PORT + 1 ))
+      hostPort: $(( $VSQL_PORT + 1 ))
 EOF
     fi
     cat $tmpfile

--- a/tests/e2e/labels-annotations/02-assert.yaml
+++ b/tests/e2e/labels-annotations/02-assert.yaml
@@ -27,6 +27,8 @@ metadata:
     vertica.com/database: vdb
     vertica.com/subcluster-name: cluster1
     vertica.com/subcluster-type: primary
+    vertica.com/subcluster-svc: cluster1
+    vertica.com/subcluster-standby: "False"
 status:
   phase: Running
 ---
@@ -46,6 +48,8 @@ metadata:
     vertica.com/database: vdb
     vertica.com/subcluster-name: cluster1
     vertica.com/subcluster-type: primary
+    vertica.com/subcluster-svc: cluster1
+    vertica.com/subcluster-standby: "False"
 ---
 apiVersion: v1
 kind: Service
@@ -63,6 +67,8 @@ metadata:
     vertica.com/database: vdb
     vertica.com/subcluster-name: cluster1
     vertica.com/subcluster-type: primary
+    vertica.com/subcluster-svc: cluster1
+    vertica.com/subcluster-standby: "False"
 ---
 apiVersion: v1
 kind: Service
@@ -73,8 +79,7 @@ metadata:
   labels:
     app: kuttl
     ver: 0.7.2
-    app.kubernetes.io/component: database
     app.kubernetes.io/instance: vdb-label-ant
-    app.kubernetes.io/managed-by: verticadb-operator
-    app.kubernetes.io/name: vertica
     vertica.com/database: vdb
+    vertica.com/subcluster-svc: cluster1
+    vertica.com/subcluster-standby: "False"

--- a/tests/e2e/labels-annotations/02-assert.yaml
+++ b/tests/e2e/labels-annotations/02-assert.yaml
@@ -28,7 +28,7 @@ metadata:
     vertica.com/subcluster-name: cluster1
     vertica.com/subcluster-type: primary
     vertica.com/subcluster-svc: cluster1
-    vertica.com/subcluster-standby: "False"
+    vertica.com/subcluster-standby: "false"
 status:
   phase: Running
 ---
@@ -49,7 +49,7 @@ metadata:
     vertica.com/subcluster-name: cluster1
     vertica.com/subcluster-type: primary
     vertica.com/subcluster-svc: cluster1
-    vertica.com/subcluster-standby: "False"
+    vertica.com/subcluster-standby: "false"
 ---
 apiVersion: v1
 kind: Service
@@ -68,7 +68,7 @@ metadata:
     vertica.com/subcluster-name: cluster1
     vertica.com/subcluster-type: primary
     vertica.com/subcluster-svc: cluster1
-    vertica.com/subcluster-standby: "False"
+    vertica.com/subcluster-standby: "false"
 ---
 apiVersion: v1
 kind: Service
@@ -80,6 +80,3 @@ metadata:
     app: kuttl
     ver: 0.7.2
     app.kubernetes.io/instance: vdb-label-ant
-    vertica.com/database: vdb
-    vertica.com/subcluster-svc: cluster1
-    vertica.com/subcluster-standby: "False"


### PR DESCRIPTION
This adds manipulating of the service objects during an online image change.  It will route client traffic to the standby when we are upgrading, then reroute the traffic back to the original subclusters when completing the upgrade.

As a side affect this also adds the ability for multiple subclusters to share the same service object.  This has benefits outside of the online image change process.