### PR TITLE
Online image change: route to temporary subcluster to keep online

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -147,14 +147,6 @@ type VerticaDBSpec struct {
 	ImageChangePolicy ImageChangePolicyType `json:"imageChangePolicy"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
-	// When doing an online image change, we utilize a transient subcluster to
-	// serve traffic while one of the other subclusters restart.  This is the
-	// size of that subcluster.  This subcluster is created at the beginning of
-	// the online image change and is removed when that process cleans up.
-	TransientSubclusterSize int `json:"transientSubclusterSize,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:initPolicy:Revive","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	// This specifies the order of nodes when doing a revive.  Each entry
 	// contains an index to a subcluster, which is an index in Subclusters[],
@@ -198,6 +190,15 @@ type VerticaDBSpec struct {
 
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	Subclusters []Subcluster `json:"subclusters"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// When doing an online image change, we utilize a transient subcluster to
+	// serve traffic while one of the other subclusters restart.  This is the
+	// template to create that subcluster.  This subcluster is created at the
+	// beginning of the online image change and is removed when that process
+	// cleans up.
+	TransientSubclusterTemplate Subcluster `json:"transientSubclusterTemplate,omitempty"`
 
 	// +kubebuilder:default:="1"
 	// +kubebuilder:validation:Optional

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -605,6 +605,7 @@ func buildTransientSubcluster(vdb *vapi.VerticaDB, sc *vapi.Subcluster, imageOve
 	}
 }
 
+// transientSuclusterName returns the name of the transient subcluster
 func transientSubclusterName(vdb *vapi.VerticaDB) string {
 	if vdb.Spec.TransientSubclusterTemplate.Name == "" {
 		return DefaultTransientSubclusterName
@@ -612,6 +613,7 @@ func transientSubclusterName(vdb *vapi.VerticaDB) string {
 	return vdb.Spec.TransientSubclusterTemplate.Name
 }
 
+// transientSubclusterSize returns the size of the transient subcluster.
 func transientSubclusterSize(vdb *vapi.VerticaDB) int32 {
 	if vdb.Spec.TransientSubclusterTemplate.Size > 0 {
 		return vdb.Spec.TransientSubclusterTemplate.Size

--- a/pkg/controllers/obj_reconcile_test.go
+++ b/pkg/controllers/obj_reconcile_test.go
@@ -565,7 +565,7 @@ var _ = Describe("obj_reconcile", func() {
 			svc1 := &corev1.Service{}
 			Expect(k8sClient.Get(ctx, nm, svc1)).Should(Succeed())
 
-			standby := buildTransientSubcluster(sc, "")
+			standby := buildTransientSubcluster(vdb, sc, "")
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
 			actor := MakeObjReconciler(vrec, logger, vdb, &pfacts)
 			objr := actor.(*ObjReconciler)

--- a/pkg/controllers/offlineimagechange_reconcile.go
+++ b/pkg/controllers/offlineimagechange_reconcile.go
@@ -139,7 +139,7 @@ func (o *OfflineImageChangeReconciler) stopCluster(ctx context.Context) (ctrl.Re
 // Since there will be processing after to delete the pods so that they come up
 // with the new image.
 func (o *OfflineImageChangeReconciler) updateImageInStatefulSets(ctx context.Context) (ctrl.Result, error) {
-	numStsChanged, res, err := o.Manager.updateImageInStatefulSets(ctx, true, true)
+	numStsChanged, res, err := o.Manager.updateImageInStatefulSets(ctx)
 	if numStsChanged > 0 {
 		o.PFacts.Invalidate()
 	}
@@ -151,7 +151,7 @@ func (o *OfflineImageChangeReconciler) updateImageInStatefulSets(ctx context.Con
 // the sts is OnDelete.  Deleting the pods ensures they get rescheduled with the
 // new image.
 func (o *OfflineImageChangeReconciler) deletePods(ctx context.Context) (ctrl.Result, error) {
-	numPodsDeleted, err := o.Manager.deletePodsRunningOldImage(ctx, true, "")
+	numPodsDeleted, err := o.Manager.deletePodsRunningOldImage(ctx, "")
 	if numPodsDeleted > 0 {
 		o.PFacts.Invalidate()
 	}

--- a/pkg/controllers/offlineimagechange_reconcile.go
+++ b/pkg/controllers/offlineimagechange_reconcile.go
@@ -151,11 +151,11 @@ func (o *OfflineImageChangeReconciler) updateImageInStatefulSets(ctx context.Con
 // the sts is OnDelete.  Deleting the pods ensures they get rescheduled with the
 // new image.
 func (o *OfflineImageChangeReconciler) deletePods(ctx context.Context) (ctrl.Result, error) {
-	numPodsDeleted, res, err := o.Manager.deletePodsRunningOldImage(ctx, true)
+	numPodsDeleted, err := o.Manager.deletePodsRunningOldImage(ctx, true, "")
 	if numPodsDeleted > 0 {
 		o.PFacts.Invalidate()
 	}
-	return res, err
+	return ctrl.Result{}, err
 }
 
 // checkForNewPods will check to ensure at least one pod exists with the new image.

--- a/pkg/controllers/onlineimagechange_reconcile_test.go
+++ b/pkg/controllers/onlineimagechange_reconcile_test.go
@@ -71,7 +71,7 @@ var _ = Describe("onlineimagechange_reconcile", func() {
 
 		fscs := fetchVdb.Spec.Subclusters
 		Expect(len(fscs)).Should(Equal(4)) // orig + 1 transient
-		Expect(fscs[3].Name).Should(Equal(TransientSubclusterName))
+		Expect(fscs[3].Name).Should(Equal(DefaultTransientSubclusterName))
 
 		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{})) // Collect state again for new pods/sts
 

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -256,7 +256,7 @@ func (o *OnlineImageChangeReconciler) takeSubclusterOffline(ctx context.Context,
 		o.PFacts.Invalidate()
 	}
 
-	podsDeleted, err := o.Manager.deletePodsRunningOldImage(ctx, true, scName)
+	podsDeleted, err := o.Manager.deletePodsRunningOldImage(ctx, scName)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -333,7 +333,7 @@ func (o *OnlineImageChangeReconciler) addTransientToVdb(ctx context.Context) err
 		for i := range o.Vdb.Spec.Subclusters {
 			sc := &o.Vdb.Spec.Subclusters[i]
 			if sc.IsPrimary {
-				transient := buildTransientSubcluster(sc, oldImage)
+				transient := buildTransientSubcluster(o.Vdb, sc, oldImage)
 				_, ok := scMap[transient.Name]
 				if !ok {
 					if err := o.Manager.setImageChangeStatus(ctx, "Creating transient subcluster"); err != nil {

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -504,8 +504,15 @@ func (p *PodFacts) findPodToRunVsql() (*PodFact, bool) {
 // order to run admintools
 // Will return false for second parameter if no pod could be found.
 func (p *PodFacts) findPodToRunAdmintools() (*PodFact, bool) {
-	// We prefer to pick a pod that is up.  But failing that, we will pick one
-	// with vertica installed.
+	// Our preference for the pod is as follows:
+	// - up and not read-only
+	// - up and read-only
+	// - has vertica installation
+	for _, v := range p.Detail {
+		if v.upNode && !v.readOnly {
+			return v, true
+		}
+	}
 	for _, v := range p.Detail {
 		if v.upNode {
 			return v, true


### PR DESCRIPTION
This is the next set of changes for online image change.  It will route to a temporary subcluster, called a transient, so that client connections connect to an up node.  It will automatically route back to the original subcluster once the subcluster is back up.  It will also process secondary subclusters that they are brought back up.

This includes some rework in the onlineimagechange_reconciler to cut down on the amount of code duplication.

Added the ability to specify a template for the transient cluster.  This will get created when the image change starts and will get cleanup up when the image change is done.

