### PR TITLE
Online image change: allow reuse of existing sc for temporary routing

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -197,7 +197,7 @@ type VerticaDBSpec struct {
 	// accept traffic while the other subclusters restart.  The designated
 	// subcluster is specified here.  The name of the subcluster can refer to an
 	// existing one or an entirely new subcluster.  If the subcluster is new, it
-	// will be exist only for the duration of the image change.
+	// will exist only for the duration of the image change.
 	TemporarySubclusterRouting SubclusterSelection `json:"temporarySubclusterRouting,omitempty"`
 
 	// +kubebuilder:default:="1"
@@ -304,7 +304,10 @@ type SubclusterSelection struct {
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:validation:Optional
-	// A new subcluster will be created using this as a template.
+	// A new subcluster will be created using this as a template.  This
+	// subcluster will only exist for the life of the online image change.  It
+	// will accept client traffic for a subcluster that are in the process of
+	// being restarted.
 	Template Subcluster `json:"template,omitempty"`
 }
 
@@ -937,6 +940,8 @@ func (s *Subcluster) GetServiceName() string {
 // RequiresTransientSubcluster checks if an online image change requires a
 // transient subcluster.  A transient subcluster exists if the template is
 // filled out or the name of the temporary routing subcluster doesn't exist.
+// The intention of this latter check is to default to creating a transient if
+// all of the subclusters specified don't actually exist.
 func (v *VerticaDB) RequiresTransientSubcluster() bool {
 	scMap := v.GenSubclusterMap()
 	for i := range v.Spec.TemporarySubclusterRouting.Names {

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -193,13 +193,12 @@ type VerticaDBSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// When doing an online image change, we designate a secondary subcluster to
+	// When doing an online image change, we designate a subcluster to
 	// accept traffic while the other subclusters restart.  The designated
 	// subcluster is specified here.  The name of the subcluster can refer to an
 	// existing one or an entirely new subcluster.  If the subcluster is new, it
 	// will be exist only for the duration of the image change.
-	// SPILLY - what subcluster is in the list?  We don't always update it.  So should it be there?
-	TemporaryRoutingSubcluster SubclusterSelection `json:"temporaryRoutingSubcluster,omitempty"`
+	TemporarySubclusterRouting SubclusterSelection `json:"temporarySubclusterRouting,omitempty"`
 
 	// +kubebuilder:default:="1"
 	// +kubebuilder:validation:Optional
@@ -940,8 +939,8 @@ func (s *Subcluster) GetServiceName() string {
 // filled out or the name of the temporary routing subcluster doesn't exist.
 func (v *VerticaDB) RequiresTransientSubcluster() bool {
 	scMap := v.GenSubclusterMap()
-	for i := range v.Spec.TemporaryRoutingSubcluster.Names {
-		if _, ok := scMap[v.Spec.TemporaryRoutingSubcluster.Names[i]]; ok {
+	for i := range v.Spec.TemporarySubclusterRouting.Names {
+		if _, ok := scMap[v.Spec.TemporarySubclusterRouting.Names[i]]; ok {
 			return false
 		}
 	}

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -132,8 +132,8 @@ type VerticaDBSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:Auto","urn:alm:descriptor:com.tectonic.ui:select:Online","urn:alm:descriptor:com.tectonic.ui:select:Offline"}
 	// +kubebuilder:default:=Auto
-	// How will image changes be managed?  Available values are: Offline, Online
-	// and Auto.
+	// Defines how image change will be managed.  Available values are: Offline,
+	// Online and Auto.
 	// - Offline: means we take down the entire cluster then bring it back up
 	// with the new image.
 	// - Online: will keep the cluster up when the image change occurs.  The

--- a/api/v1beta1/verticadb_types_test.go
+++ b/api/v1beta1/verticadb_types_test.go
@@ -43,9 +43,9 @@ var _ = Describe("verticadb_types", func() {
 			{Name: "sc1"},
 			{Name: "sc2"},
 		}
-		vdb.Spec.TemporaryRoutingSubcluster.Names = []string{"transient"}
+		vdb.Spec.TemporarySubclusterRouting.Names = []string{"transient"}
 		Expect(vdb.RequiresTransientSubcluster()).Should(BeTrue())
-		vdb.Spec.TemporaryRoutingSubcluster.Names = []string{"sc1"}
+		vdb.Spec.TemporarySubclusterRouting.Names = []string{"sc1"}
 		Expect(vdb.RequiresTransientSubcluster()).Should(BeFalse())
 	})
 })

--- a/api/v1beta1/verticadb_types_test.go
+++ b/api/v1beta1/verticadb_types_test.go
@@ -36,4 +36,16 @@ var _ = Describe("verticadb_types", func() {
 		vdb.Spec.Communal.IncludeUIDInPath = false
 		Expect(vdb.GetCommunalPath()).ShouldNot(ContainSubstring(string(vdb.ObjectMeta.UID)))
 	})
+
+	It("should require a transient subcluster", func() {
+		vdb := MakeVDB()
+		vdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1"},
+			{Name: "sc2"},
+		}
+		vdb.Spec.TemporaryRoutingSubcluster.Names = []string{"transient"}
+		Expect(vdb.RequiresTransientSubcluster()).Should(BeTrue())
+		vdb.Spec.TemporaryRoutingSubcluster.Names = []string{"sc1"}
+		Expect(vdb.RequiresTransientSubcluster()).Should(BeFalse())
+	})
 })

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -594,11 +594,11 @@ func buildTransientSubcluster(vdb *vapi.VerticaDB, sc *vapi.Subcluster, imageOve
 		IsTransient:       true,
 		ImageOverride:     imageOverride,
 		IsPrimary:         false,
-		NodeSelector:      vdb.Spec.TemporaryRoutingSubcluster.Template.NodeSelector,
-		Affinity:          vdb.Spec.TemporaryRoutingSubcluster.Template.Affinity,
-		PriorityClassName: vdb.Spec.TemporaryRoutingSubcluster.Template.PriorityClassName,
-		Tolerations:       vdb.Spec.TemporaryRoutingSubcluster.Template.Tolerations,
-		Resources:         vdb.Spec.TemporaryRoutingSubcluster.Template.Resources,
+		NodeSelector:      vdb.Spec.TemporarySubclusterRouting.Template.NodeSelector,
+		Affinity:          vdb.Spec.TemporarySubclusterRouting.Template.Affinity,
+		PriorityClassName: vdb.Spec.TemporarySubclusterRouting.Template.PriorityClassName,
+		Tolerations:       vdb.Spec.TemporarySubclusterRouting.Template.Tolerations,
+		Resources:         vdb.Spec.TemporarySubclusterRouting.Template.Resources,
 		ServiceType:       sc.ServiceType,
 		ServiceName:       sc.GetServiceName(),
 		NodePort:          sc.NodePort,
@@ -608,16 +608,16 @@ func buildTransientSubcluster(vdb *vapi.VerticaDB, sc *vapi.Subcluster, imageOve
 
 // transientSuclusterName returns the name of the transient subcluster
 func transientSubclusterName(vdb *vapi.VerticaDB) string {
-	if vdb.Spec.TemporaryRoutingSubcluster.Template.Name == "" {
+	if vdb.Spec.TemporarySubclusterRouting.Template.Name == "" {
 		return DefaultTransientSubclusterName
 	}
-	return vdb.Spec.TemporaryRoutingSubcluster.Template.Name
+	return vdb.Spec.TemporarySubclusterRouting.Template.Name
 }
 
 // transientSubclusterSize returns the size of the transient subcluster.
 func transientSubclusterSize(vdb *vapi.VerticaDB) int32 {
-	if vdb.Spec.TemporaryRoutingSubcluster.Template.Size > 0 {
-		return vdb.Spec.TemporaryRoutingSubcluster.Template.Size
+	if vdb.Spec.TemporarySubclusterRouting.Template.Size > 0 {
+		return vdb.Spec.TemporarySubclusterRouting.Template.Size
 	}
 	return 1
 }

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -593,11 +593,11 @@ func buildTransientSubcluster(vdb *vapi.VerticaDB, sc *vapi.Subcluster, imageOve
 		IsTransient:       true,
 		ImageOverride:     imageOverride,
 		IsPrimary:         false,
-		NodeSelector:      vdb.Spec.TransientSubclusterTemplate.NodeSelector,
-		Affinity:          vdb.Spec.TransientSubclusterTemplate.Affinity,
-		PriorityClassName: vdb.Spec.TransientSubclusterTemplate.PriorityClassName,
-		Tolerations:       vdb.Spec.TransientSubclusterTemplate.Tolerations,
-		Resources:         vdb.Spec.TransientSubclusterTemplate.Resources,
+		NodeSelector:      vdb.Spec.TemporaryRoutingSubcluster.Template.NodeSelector,
+		Affinity:          vdb.Spec.TemporaryRoutingSubcluster.Template.Affinity,
+		PriorityClassName: vdb.Spec.TemporaryRoutingSubcluster.Template.PriorityClassName,
+		Tolerations:       vdb.Spec.TemporaryRoutingSubcluster.Template.Tolerations,
+		Resources:         vdb.Spec.TemporaryRoutingSubcluster.Template.Resources,
 		ServiceType:       sc.ServiceType,
 		ServiceName:       sc.GetServiceName(),
 		NodePort:          sc.NodePort,
@@ -607,16 +607,16 @@ func buildTransientSubcluster(vdb *vapi.VerticaDB, sc *vapi.Subcluster, imageOve
 
 // transientSuclusterName returns the name of the transient subcluster
 func transientSubclusterName(vdb *vapi.VerticaDB) string {
-	if vdb.Spec.TransientSubclusterTemplate.Name == "" {
+	if vdb.Spec.TemporaryRoutingSubcluster.Template.Name == "" {
 		return DefaultTransientSubclusterName
 	}
-	return vdb.Spec.TransientSubclusterTemplate.Name
+	return vdb.Spec.TemporaryRoutingSubcluster.Template.Name
 }
 
 // transientSubclusterSize returns the size of the transient subcluster.
 func transientSubclusterSize(vdb *vapi.VerticaDB) int32 {
-	if vdb.Spec.TransientSubclusterTemplate.Size > 0 {
-		return vdb.Spec.TransientSubclusterTemplate.Size
+	if vdb.Spec.TemporaryRoutingSubcluster.Template.Size > 0 {
+		return vdb.Spec.TemporaryRoutingSubcluster.Template.Size
 	}
 	return 1
 }

--- a/pkg/controllers/obj_reconcile.go
+++ b/pkg/controllers/obj_reconcile.go
@@ -150,7 +150,8 @@ func (o *ObjReconciler) checkForCreatedSubcluster(ctx context.Context, sc *vapi.
 	// Transient subclusters never have their own service objects.  They always
 	// reuse ones we have for other primary/secondary subclusters.
 	if !sc.IsTransient {
-		if err := o.reconcileExtSvc(ctx, sc); err != nil {
+		svcName := names.GenExtSvcName(o.Vdb, sc)
+		if err := o.reconcileExtSvc(ctx, svcName, sc); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -200,9 +201,8 @@ func (o *ObjReconciler) checkForDeletedSubcluster(ctx context.Context) (ctrl.Res
 }
 
 // reconcileExtSvc verifies the external service objects exists and creates it if necessary.
-func (o ObjReconciler) reconcileExtSvc(ctx context.Context, sc *vapi.Subcluster) error {
+func (o ObjReconciler) reconcileExtSvc(ctx context.Context, svcName types.NamespacedName, sc *vapi.Subcluster) error {
 	curSvc := &corev1.Service{}
-	svcName := names.GenExtSvcName(o.Vdb, sc)
 	expSvc := buildExtSvc(svcName, o.Vdb, sc)
 	err := o.VRec.Client.Get(ctx, svcName, curSvc)
 	if err != nil && errors.IsNotFound(err) {

--- a/pkg/controllers/obj_reconcile_test.go
+++ b/pkg/controllers/obj_reconcile_test.go
@@ -569,9 +569,10 @@ var _ = Describe("obj_reconcile", func() {
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
 			actor := MakeObjReconciler(vrec, logger, vdb, &pfacts)
 			objr := actor.(*ObjReconciler)
-			// Force a label change to reconcile with the standby subcluster
+			// Force a label change to reconcile with the transient subcluster
 			svcName := names.GenExtSvcName(vdb, sc)
-			Expect(objr.reconcileExtSvc(ctx, svcName, standby)).Should(Succeed())
+			expSvc := buildExtSvc(svcName, vdb, sc, makeSvcSelectorLabelsForSubclusterNameRouting)
+			Expect(objr.reconcileExtSvc(ctx, expSvc, standby)).Should(Succeed())
 
 			// Fetch the service object again.  The selectors should be different.
 			svc2 := &corev1.Service{}

--- a/pkg/controllers/obj_reconcile_test.go
+++ b/pkg/controllers/obj_reconcile_test.go
@@ -570,7 +570,8 @@ var _ = Describe("obj_reconcile", func() {
 			actor := MakeObjReconciler(vrec, logger, vdb, &pfacts)
 			objr := actor.(*ObjReconciler)
 			// Force a label change to reconcile with the standby subcluster
-			Expect(objr.reconcileExtSvc(ctx, standby)).Should(Succeed())
+			svcName := names.GenExtSvcName(vdb, sc)
+			Expect(objr.reconcileExtSvc(ctx, svcName, standby)).Should(Succeed())
 
 			// Fetch the service object again.  The selectors should be different.
 			svc2 := &corev1.Service{}

--- a/pkg/controllers/onlineimagechange_reconcile_test.go
+++ b/pkg/controllers/onlineimagechange_reconcile_test.go
@@ -113,7 +113,7 @@ var _ = Describe("onlineimagechange_reconcile", func() {
 			{Name: ScName, IsPrimary: true},
 		}
 		sc := &vdb.Spec.Subclusters[0]
-		vdb.Spec.TemporaryRoutingSubcluster.Template.Name = TransientScName
+		vdb.Spec.TemporarySubclusterRouting.Template.Name = TransientScName
 		vdb.Spec.Image = OldImage
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
@@ -145,7 +145,7 @@ var _ = Describe("onlineimagechange_reconcile", func() {
 			{Name: PriScName, IsPrimary: true},
 			{Name: SecScName, IsPrimary: true},
 		}
-		vdb.Spec.TemporaryRoutingSubcluster.Names = []string{"dummy-non-existent", SecScName, PriScName}
+		vdb.Spec.TemporarySubclusterRouting.Names = []string{"dummy-non-existent", SecScName, PriScName}
 		vdb.Spec.Image = OldImage
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)

--- a/pkg/controllers/onlineimagechange_reconciler.go
+++ b/pkg/controllers/onlineimagechange_reconciler.go
@@ -473,8 +473,8 @@ func (o *OnlineImageChangeReconciler) routeClientTraffic(ctx context.Context,
 	// defined in the vdb.
 	if setTemporaryRouting {
 		foundRoutingSubcluster := false
-		for i := range o.Vdb.Spec.TemporaryRoutingSubcluster.Names {
-			routeName := o.Vdb.Spec.TemporaryRoutingSubcluster.Names[i]
+		for i := range o.Vdb.Spec.TemporarySubclusterRouting.Names {
+			routeName := o.Vdb.Spec.TemporarySubclusterRouting.Names[i]
 			// Don't route to the subcluster that we are taking offline
 			if routeName == scName {
 				continue

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -192,7 +192,7 @@ func createSvcs(ctx context.Context, vdb *vapi.VerticaDB) {
 	ExpectWithOffset(1, k8sClient.Create(ctx, svc)).Should(Succeed())
 	for i := range vdb.Spec.Subclusters {
 		sc := &vdb.Spec.Subclusters[i]
-		svc := buildExtSvc(names.GenExtSvcName(vdb, sc), vdb, sc)
+		svc := buildExtSvc(names.GenExtSvcName(vdb, sc), vdb, sc, makeSvcSelectorLabelsForServiceNameRouting)
 		ExpectWithOffset(1, k8sClient.Create(ctx, svc)).Should(Succeed())
 	}
 }


### PR DESCRIPTION
This is the next set of changes for online image change.  The CR parm TransientSubclusterTemplate was renamed to TemporarySubclusterRouting.  The parm can be used to provide a template of a subcluster to use for temporary routing while subclusters are down.  Or the parm can also be used to specify an existing subcluster.  This later option may be useful to those that want to just reuse existing subclusters.

This PR also cleans up how we route traffic to the subclusters.  We previously had relied on a 'transient' label.  But now we route to service name or subcluster name.