### PR TITLE
Add Changie entry for OpenShift

### DIFF
--- a/changes/unreleased/Added-20220112-124418.yaml
+++ b/changes/unreleased/Added-20220112-124418.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Support for RedHat OpenShift 4.8+
+time: 2022-01-12T12:44:18.8725699+01:00
+custom:
+  Issue: "81"


### PR DESCRIPTION
Following up issue [81](https://github.com/vertica/vertica-kubernetes/issues/81), OpenShift support has been spread over many many PR. This PR concludes that by adding a changie entry for OpenShift.