### PR TITLE
Online image change: changes for new admintools options in 11.1.0

### DIFF
--- a/pkg/controllers/dbaddnode_reconcile.go
+++ b/pkg/controllers/dbaddnode_reconcile.go
@@ -83,7 +83,7 @@ func (d *DBAddNodeReconciler) reconcileSubcluster(ctx context.Context, sc *vapi.
 			}
 		}
 		if unknownState {
-			d.Log.Info("Requeue due to some pods were not running")
+			d.Log.Info("Requeue because some pods were not running")
 		}
 		return ctrl.Result{Requeue: unknownState}, nil
 	}

--- a/pkg/controllers/dbaddsubcluster_reconcile.go
+++ b/pkg/controllers/dbaddsubcluster_reconcile.go
@@ -64,7 +64,7 @@ func (d *DBAddSubclusterReconciler) Reconcile(ctx context.Context, req *ctrl.Req
 
 // addMissingSubclusters will compare subclusters passed in and create any missing ones
 func (d *DBAddSubclusterReconciler) addMissingSubclusters(ctx context.Context, scs []vapi.Subcluster) (ctrl.Result, error) {
-	atPod, ok := d.PFacts.findPodToRunAdmintools()
+	atPod, ok := d.PFacts.findPodToRunAdmintoolsOnline()
 	if !ok || !atPod.upNode {
 		d.Log.Info("No pod found to run admintools from. Requeue reconciliation.")
 		return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/dbaddsubcluster_reconcile.go
+++ b/pkg/controllers/dbaddsubcluster_reconcile.go
@@ -64,7 +64,7 @@ func (d *DBAddSubclusterReconciler) Reconcile(ctx context.Context, req *ctrl.Req
 
 // addMissingSubclusters will compare subclusters passed in and create any missing ones
 func (d *DBAddSubclusterReconciler) addMissingSubclusters(ctx context.Context, scs []vapi.Subcluster) (ctrl.Result, error) {
-	atPod, ok := d.PFacts.findPodToRunAdmintoolsOnline()
+	atPod, ok := d.PFacts.findPodToRunAdmintoolsAny()
 	if !ok || !atPod.upNode {
 		d.Log.Info("No pod found to run admintools from. Requeue reconciliation.")
 		return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/dbremovenode_reconcile.go
+++ b/pkg/controllers/dbremovenode_reconcile.go
@@ -110,7 +110,7 @@ func (d *DBRemoveNodeReconciler) removeNodesInSubcluster(ctx context.Context, sc
 	podsToRemove, requeueNeeded := d.findPodsSuitableForScaleDown(sc, startPodIndex, endPodIndex)
 	if len(podsToRemove) > 0 {
 		cmd := d.genCmdRemoveNode(podsToRemove)
-		atPod, ok := d.PFacts.findPodToRunAdmintoolsOnline()
+		atPod, ok := d.PFacts.findPodToRunAdmintoolsAny()
 		if !ok {
 			// Requeue since we couldn't find a running pod
 			d.Log.Info("Requeue since we could not find a pod to run admintools")

--- a/pkg/controllers/dbremovenode_reconcile.go
+++ b/pkg/controllers/dbremovenode_reconcile.go
@@ -110,7 +110,7 @@ func (d *DBRemoveNodeReconciler) removeNodesInSubcluster(ctx context.Context, sc
 	podsToRemove, requeueNeeded := d.findPodsSuitableForScaleDown(sc, startPodIndex, endPodIndex)
 	if len(podsToRemove) > 0 {
 		cmd := d.genCmdRemoveNode(podsToRemove)
-		atPod, ok := d.PFacts.findPodToRunAdmintools()
+		atPod, ok := d.PFacts.findPodToRunAdmintoolsOnline()
 		if !ok {
 			// Requeue since we couldn't find a running pod
 			d.Log.Info("Requeue since we could not find a pod to run admintools")

--- a/pkg/controllers/dbremovesubcluster_reconcile.go
+++ b/pkg/controllers/dbremovesubcluster_reconcile.go
@@ -70,7 +70,7 @@ func (d *DBRemoveSubclusterReconciler) removeExtraSubclusters(ctx context.Contex
 	}
 
 	if len(subclusters) > 0 {
-		atPod, ok := d.PFacts.findPodToRunAdmintoolsOnline()
+		atPod, ok := d.PFacts.findPodToRunAdmintoolsAny()
 		if !ok || !atPod.upNode {
 			d.Log.Info("No pod found to run admintools from. Requeue reconciliation.")
 			return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/dbremovesubcluster_reconcile.go
+++ b/pkg/controllers/dbremovesubcluster_reconcile.go
@@ -70,7 +70,7 @@ func (d *DBRemoveSubclusterReconciler) removeExtraSubclusters(ctx context.Contex
 	}
 
 	if len(subclusters) > 0 {
-		atPod, ok := d.PFacts.findPodToRunAdmintools()
+		atPod, ok := d.PFacts.findPodToRunAdmintoolsOnline()
 		if !ok || !atPod.upNode {
 			d.Log.Info("No pod found to run admintools from. Requeue reconciliation.")
 			return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/init_db.go
+++ b/pkg/controllers/init_db.go
@@ -78,7 +78,7 @@ func (g *GenericDatabaseInitializer) checkAndRunInit(ctx context.Context) (ctrl.
 // runInit will physically setup the database.
 // Depending on g.initializer, this will either do create_db or revive_db.
 func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, error) {
-	atPodFact, ok := g.PFacts.findPodToRunAdmintools()
+	atPodFact, ok := g.PFacts.findPodToRunAdmintoolsOffline()
 	if !ok {
 		// Could not find a runable pod to run from.
 		return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -507,10 +507,23 @@ func (p *PodFacts) findPodToRunVsql() (*PodFact, bool) {
 }
 
 // findPodToRunAdmintoolsAny returns the name of the pod we will exec into into
-// order to run admintools.  To checking is done regarding whether the pod has a
-// running vertica instance.
+// order to run admintools.
 // Will return false for second parameter if no pod could be found.
 func (p *PodFacts) findPodToRunAdmintoolsAny() (*PodFact, bool) {
+	// Our preference for the pod is as follows:
+	// - up and not read-only
+	// - up and read-only
+	// - has vertica installation
+	for _, v := range p.Detail {
+		if v.upNode && !v.readOnly {
+			return v, true
+		}
+	}
+	for _, v := range p.Detail {
+		if v.upNode {
+			return v, true
+		}
+	}
 	for _, v := range p.Detail {
 		if v.isInstalled.IsTrue() && v.isPodRunning {
 			return v, true

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -506,13 +506,13 @@ func (p *PodFacts) findPodToRunVsql() (*PodFact, bool) {
 	return &PodFact{}, false
 }
 
-// findPodToRunAdmintoolsOnline returns the name of the pod we will exec into into
-// order to run admintools.  This version will pick a pod to run an admintools
-// command that is meant to be run on at an online node.
+// findPodToRunAdmintoolsAny returns the name of the pod we will exec into into
+// order to run admintools.  To checking is done regarding whether the pod has a
+// running vertica instance.
 // Will return false for second parameter if no pod could be found.
-func (p *PodFacts) findPodToRunAdmintoolsOnline() (*PodFact, bool) {
+func (p *PodFacts) findPodToRunAdmintoolsAny() (*PodFact, bool) {
 	for _, v := range p.Detail {
-		if v.upNode && !v.readOnly {
+		if v.isInstalled.IsTrue() && v.isPodRunning {
 			return v, true
 		}
 	}

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -506,26 +506,24 @@ func (p *PodFacts) findPodToRunVsql() (*PodFact, bool) {
 	return &PodFact{}, false
 }
 
-// findPodToRunAdmintools returns the name of the pod we will exec into into
-// order to run admintools
+// findPodToRunAdmintoolsOnline returns the name of the pod we will exec into into
+// order to run admintools.  This version will pick a pod to run an admintools
+// command that is meant to be run on at an online node.
 // Will return false for second parameter if no pod could be found.
-func (p *PodFacts) findPodToRunAdmintools() (*PodFact, bool) {
-	// Our preference for the pod is as follows:
-	// - up and not read-only
-	// - up and read-only
-	// - has vertica installation
+func (p *PodFacts) findPodToRunAdmintoolsOnline() (*PodFact, bool) {
 	for _, v := range p.Detail {
 		if v.upNode && !v.readOnly {
 			return v, true
 		}
 	}
+	return &PodFact{}, false
+}
+
+// findPodToRunAdmintoolsOffline will return a pod to run an offline admintools
+// command.  If nothing is found, the second parameter returned will be false.
+func (p *PodFacts) findPodToRunAdmintoolsOffline() (*PodFact, bool) {
 	for _, v := range p.Detail {
-		if v.upNode {
-			return v, true
-		}
-	}
-	for _, v := range p.Detail {
-		if v.isInstalled.IsTrue() && v.isPodRunning {
+		if v.isInstalled.IsTrue() && v.isPodRunning && !v.upNode {
 			return v, true
 		}
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -38,6 +38,10 @@ const (
 	NodesHaveReadOnlyStateVersion = "v11.0.2"
 	// The minimum version that allows for online image change.
 	OnlineImageChangeVersion = "v11.1.0"
+	// The version that added the --force option to reip to handle up nodes
+	ReIPAllowedWithUpNodesVersion = "v11.1.0"
+	// The version that added support a for --host list to start_db command
+	StartDBAcceptsHostListVersion = "v11.0.1"
 )
 
 // MakeInfo will construct an Info struct by extracting the version from the


### PR DESCRIPTION
- when running AT start_db, we need to run from one of the primary nodes.  It won't work if we try from a read-only node that isn't being restarted.
- when calling re_ip, use the --force option.  This option is new in 11.1.0, so we needed conditional logic to know when we could use this.
- when calling start_db, we use the host list.  This option exists first in 11.0.1, so like reip, we needed conditional logic to know when we can use that option

One thing that isn't related to the title of this PR is some new logic needed in DBAddNodeReconicler.  That reconciler will now requeue if some pods aren't yet ready.  This was needed so that the upgrade properly waits for the transient subcluster to scale out.  Prior to this change, it was possible that the image change went ahead and restarted the primaries before the transient was up.  This should be solved now.