### PR TITLE
Online image change: temporarySubclusterRouting to default to existing subclusters

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -206,7 +206,8 @@ type VerticaDBSpec struct {
 	// accept traffic while the other subclusters restart.  The designated
 	// subcluster is specified here.  The name of the subcluster can refer to an
 	// existing one or an entirely new subcluster.  If the subcluster is new, it
-	// will exist only for the duration of the image change.
+	// will exist only for the duration of the image change.  If this struct is
+	// left empty the operator will default to picking existing subclusters.
 	TemporarySubclusterRouting SubclusterSelection `json:"temporarySubclusterRouting,omitempty"`
 
 	// +kubebuilder:default:="1"
@@ -949,17 +950,10 @@ func (s *Subcluster) GetServiceName() string {
 
 // RequiresTransientSubcluster checks if an online image change requires a
 // transient subcluster.  A transient subcluster exists if the template is
-// filled out or the name of the temporary routing subcluster doesn't exist.
-// The intention of this latter check is to default to creating a transient if
-// all of the subclusters specified don't actually exist.
+// filled out.
 func (v *VerticaDB) RequiresTransientSubcluster() bool {
-	scMap := v.GenSubclusterMap()
-	for i := range v.Spec.TemporarySubclusterRouting.Names {
-		if _, ok := scMap[v.Spec.TemporarySubclusterRouting.Names[i]]; ok {
-			return false
-		}
-	}
-	return true
+	return v.Spec.TemporarySubclusterRouting.Template.Name != "" &&
+		v.Spec.TemporarySubclusterRouting.Template.Size > 0
 }
 
 // IsOnlineImageChangeInProgress returns true if an online image change is in progress

--- a/api/v1beta1/verticadb_types_test.go
+++ b/api/v1beta1/verticadb_types_test.go
@@ -43,9 +43,15 @@ var _ = Describe("verticadb_types", func() {
 			{Name: "sc1"},
 			{Name: "sc2"},
 		}
-		vdb.Spec.TemporarySubclusterRouting.Names = []string{"transient"}
-		Expect(vdb.RequiresTransientSubcluster()).Should(BeTrue())
+		// Transient is only required if specified
+		Expect(vdb.RequiresTransientSubcluster()).Should(BeFalse())
 		vdb.Spec.TemporarySubclusterRouting.Names = []string{"sc1"}
 		Expect(vdb.RequiresTransientSubcluster()).Should(BeFalse())
+		vdb.Spec.TemporarySubclusterRouting.Template = Subcluster{
+			Name:      "the-transient-sc-name",
+			Size:      1,
+			IsPrimary: false,
+		}
+		Expect(vdb.RequiresTransientSubcluster()).Should(BeTrue())
 	})
 })

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -632,6 +632,12 @@ func (v *VerticaDB) hasValidTemporarySubclusterRouting(allErrs field.ErrorList) 
 			allErrs = append(allErrs, err)
 		}
 	}
+	if len(v.Spec.TemporarySubclusterRouting.Names) > 0 && v.RequiresTransientSubcluster() {
+		err := field.Invalid(fieldPrefix,
+			v.Spec.TemporarySubclusterRouting,
+			"cannot use a template and a list of subcluster names at the same time")
+		allErrs = append(allErrs, err)
+	}
 	return allErrs
 }
 

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -358,6 +358,15 @@ var _ = Describe("verticadb_webhook", func() {
 		validateSpecValuesHaveErr(vdb, false)
 	})
 
+	It("should fail setting template and names in temporary routing", func() {
+		vdb := createVDBHelper()
+		vdb.Spec.TemporarySubclusterRouting.Template.Name = "my-transient-sc"
+		vdb.Spec.TemporarySubclusterRouting.Template.Size = 1
+		vdb.Spec.TemporarySubclusterRouting.Template.IsPrimary = false
+		vdb.Spec.TemporarySubclusterRouting.Names = []string{vdb.Spec.Subclusters[0].Name}
+		validateSpecValuesHaveErr(vdb, true)
+	})
+
 	It("should fail if temporary routing to a subcluster doesn't exist", func() {
 		vdb := createVDBHelper()
 		const ValidScName = "sc1"

--- a/pkg/controllers/builder.go
+++ b/pkg/controllers/builder.go
@@ -29,8 +29,7 @@ import (
 )
 
 const (
-	SuperuserPasswordPath          = "superuser-passwd"
-	DefaultTransientSubclusterName = "transient"
+	SuperuserPasswordPath = "superuser-passwd"
 )
 
 // buildExtSvc creates desired spec for the external service.
@@ -589,8 +588,8 @@ func getK8sAffinity(a vapi.Affinity) *corev1.Affinity {
 // existing subcluster
 func buildTransientSubcluster(vdb *vapi.VerticaDB, imageOverride string) *vapi.Subcluster {
 	return &vapi.Subcluster{
-		Name:              transientSubclusterName(vdb),
-		Size:              transientSubclusterSize(vdb),
+		Name:              vdb.Spec.TemporarySubclusterRouting.Template.Name,
+		Size:              vdb.Spec.TemporarySubclusterRouting.Template.Size,
 		IsTransient:       true,
 		ImageOverride:     imageOverride,
 		IsPrimary:         false,
@@ -603,20 +602,4 @@ func buildTransientSubcluster(vdb *vapi.VerticaDB, imageOverride string) *vapi.S
 		// object.  These are ignored since transient don't have their own
 		// service objects.
 	}
-}
-
-// transientSuclusterName returns the name of the transient subcluster
-func transientSubclusterName(vdb *vapi.VerticaDB) string {
-	if vdb.Spec.TemporarySubclusterRouting.Template.Name == "" {
-		return DefaultTransientSubclusterName
-	}
-	return vdb.Spec.TemporarySubclusterRouting.Template.Name
-}
-
-// transientSubclusterSize returns the size of the transient subcluster.
-func transientSubclusterSize(vdb *vapi.VerticaDB) int32 {
-	if vdb.Spec.TemporarySubclusterRouting.Template.Size > 0 {
-		return vdb.Spec.TemporarySubclusterRouting.Template.Size
-	}
-	return 1
 }

--- a/pkg/controllers/restart_reconciler_test.go
+++ b/pkg/controllers/restart_reconciler_test.go
@@ -548,6 +548,11 @@ var _ = Describe("restart_reconciler", func() {
 	It("should skip restart_node of transient nodes", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 1
+		vdb.Spec.TemporarySubclusterRouting.Template = vapi.Subcluster{
+			Name:      "the-transient-sc",
+			Size:      1,
+			IsPrimary: false,
+		}
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		createPods(ctx, vdb, AllPodsRunning)

--- a/tests/e2e-11.1/online-upgrade-no-transient-1-sc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-11.1/online-upgrade-no-transient-1-sc/setup-vdb/base/setup-vdb.yaml
@@ -27,7 +27,9 @@ spec:
     - name: pri
       size: 3
       isPrimary: true
-  temporarySubclusterRouting:
-    names:
-      - pri
+  # Intentionally leaving out temporarySubclusterRouting to test the
+  # default.  Leaving the default in as comments.
+  # temporarySubclusterRouting:
+  #   names:
+  #     - pri
   certSecrets: []


### PR DESCRIPTION
This changes the default behaviour for temporarySubclusterRouting.  It now defaults to picking existing subclusters rather than creating a transient subcluster.