### PR TITLE
Fallback to offline upgrade if server incompatible

### DIFF
--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -408,6 +408,10 @@ func (p *PodFacts) queryNodeStatus(ctx context.Context, pf *PodFact) error {
 // parseNodeStateAndReadOnly will parse query output to determine if a node is
 // up and read-only.
 func parseNodeStateAndReadOnly(stdout string) (upNode, readOnly bool, err error) {
+	// For testing purposes we early out with no error if there is no output
+	if stdout == "" {
+		return
+	}
 	// The stdout comes in the form like this:
 	// UP|t
 	// This means upNode is true and readOnly is true.

--- a/pkg/controllers/podfacts_test.go
+++ b/pkg/controllers/podfacts_test.go
@@ -280,7 +280,7 @@ var _ = Describe("podfacts", func() {
 		Expect(readOnly2).Should(BeFalse())
 
 		_, _, err = parseNodeStateAndReadOnly("")
-		Expect(err).ShouldNot(Succeed())
+		Expect(err).Should(Succeed())
 
 		_, _, err = parseNodeStateAndReadOnly("UP|z|garbage")
 		Expect(err).ShouldNot(Succeed())

--- a/pkg/controllers/upgrade.go
+++ b/pkg/controllers/upgrade.go
@@ -286,13 +286,15 @@ func onlineUpgradeAllowed(vdb *vapi.VerticaDB) bool {
 		if (vdb.RequiresTransientSubcluster() && vdb.Spec.LicenseSecret == "") || vdb.Spec.KSafety == vapi.KSafety0 {
 			return false
 		}
-		vinf, ok := version.MakeInfoFromVdb(vdb)
-		if ok && vinf.IsEqualOrNewer(version.OnlineUpgradeVersion) {
-			return true
-		}
-		return false
 	}
-	return true
+	// Online upgrade can only be done if we are already on a server version
+	// that supports it.  It we are on an older version, we will fallback to
+	// offline even though online may have been specified in the vdb.
+	vinf, ok := version.MakeInfoFromVdb(vdb)
+	if ok && vinf.IsEqualOrNewer(version.OnlineUpgradeVersion) {
+		return true
+	}
+	return false
 }
 
 // offlineUpgradeAllowed returns true if upgrade must be done offline

--- a/pkg/controllers/upgrade_test.go
+++ b/pkg/controllers/upgrade_test.go
@@ -41,14 +41,15 @@ var _ = Describe("upgrade", func() {
 			IsPrimary: false,
 		}
 
+		// No version -- always pick offline
 		vdb.Spec.UpgradePolicy = vapi.OfflineUpgrade
 		Expect(onlineUpgradeAllowed(vdb)).Should(Equal(false))
 		Expect(offlineUpgradeAllowed(vdb)).Should(Equal(true))
 		vdb.Spec.UpgradePolicy = vapi.OnlineUpgrade
-		Expect(onlineUpgradeAllowed(vdb)).Should(Equal(true))
-		Expect(offlineUpgradeAllowed(vdb)).Should(Equal(false))
+		Expect(onlineUpgradeAllowed(vdb)).Should(Equal(false))
+		Expect(offlineUpgradeAllowed(vdb)).Should(Equal(true))
 
-		// No version -- offline
+		// auto will pick offline because of no version
 		vdb.Spec.UpgradePolicy = vapi.AutoUpgrade
 		vdb.Spec.LicenseSecret = "license"
 		vdb.Spec.KSafety = vapi.KSafety1
@@ -70,6 +71,11 @@ var _ = Describe("upgrade", func() {
 
 		// k-safety 0
 		vdb.Spec.KSafety = vapi.KSafety0
+		Expect(offlineUpgradeAllowed(vdb)).Should(Equal(true))
+
+		// Old version and online requested
+		vdb.ObjectMeta.Annotations[vapi.VersionAnnotation] = "v11.0.2"
+		vdb.Spec.UpgradePolicy = vapi.OnlineUpgrade
 		Expect(offlineUpgradeAllowed(vdb)).Should(Equal(true))
 	})
 

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -54,6 +54,7 @@ const (
 	AuthParmsCopyFailed             = "AuthParmsCopyFailed"
 	UpgradeStart                    = "UpgradeStart"
 	UpgradeSucceeded                = "UpgradeSucceeded"
+	IncompatibleOnlineUpgrade       = "IncompatibleOnlineUpgrade"
 	ClusterShutdownStarted          = "ClusterShutdownStarted"
 	ClusterShutdownFailed           = "ClusterShutdownFailed"
 	ClusterShutdownSucceeded        = "ClusterShutdownSucceeded"

--- a/scripts/patch-image-in-vdb.sh
+++ b/scripts/patch-image-in-vdb.sh
@@ -62,7 +62,7 @@ IMAGE=$2
 
 if [ -z "$IMAGE" ]
 then
-    IMAGE=$(cd $REPO_DIR && make echo-images | grep VERTICA_IMG | cut -d= -f2)
+    IMAGE=$(cd $REPO_DIR && make echo-images | grep ^VERTICA_IMG= | cut -d= -f2)
 fi
 
 tmpfile=$(mktemp /tmp/patch-XXXXXX.yaml)

--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -74,7 +74,10 @@ then
 fi
 
 if [ -z "${VERTICA_IMG}" ]; then
-    VERTICA_IMG=$(cd $REPO_DIR && make echo-images | grep VERTICA_IMG | cut -d'=' -f2)
+    VERTICA_IMG=$(cd $REPO_DIR && make echo-images | grep ^VERTICA_IMG= | cut -d'=' -f2)
+fi
+if [ -z "${BASE_VERTICA_IMG}" ]; then
+    BASE_VERTICA_IMG=$(cd $REPO_DIR && make echo-images | grep ^BASE_VERTICA_IMG= | cut -d'=' -f2)
 fi
 if [ -z "${VLOGGER_IMG}" ]; then
     VLOGGER_IMG=$(cd $REPO_DIR && make echo-images | grep VLOGGER_IMG | cut -d'=' -f2)
@@ -429,7 +432,7 @@ metadata:
 data:
   verticaImage: ${VERTICA_IMG}
   vloggerImage: ${VLOGGER_IMG}
-  baseVerticaImage: ${BASE_VERTICA_IMG:-"<not-set>"}
+  baseVerticaImage: ${BASE_VERTICA_IMG}
 EOF
 
     # If a cert was specified for communal endpoint access, include a datapoint

--- a/tests/e2e-extra/vdb-gen/45-run-vdbgen.yaml
+++ b/tests/e2e-extra/vdb-gen/45-run-vdbgen.yaml
@@ -21,7 +21,7 @@ commands:
   - command: kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- chmod +x /tmp/vdb-gen
   - command: kubectl -n $NAMESPACE cp run-vdb-gen.sh v-vdb-gen-sc1-0:/tmp/run-vdb-gen.sh
   - command: kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- chmod +x /tmp/run-vdb-gen.sh
-  - script: sh -c "kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- sh -c \"/tmp/run-vdb-gen.sh $NAMESPACE $(cd ../../.. && make echo-images | grep VERTICA_IMG | cut -d'=' -f2) $(kubectl get cm e2e -n $NAMESPACE -o jsonpath='{.data.caFileSecretName}')\" > /tmp/$NAMESPACE-vdb-gen.yaml"
+  - script: sh -c "kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- sh -c \"/tmp/run-vdb-gen.sh $NAMESPACE $(cd ../../.. && make echo-images | grep ^VERTICA_IMG= | cut -d'=' -f2) $(kubectl get cm e2e -n $NAMESPACE -o jsonpath='{.data.caFileSecretName}')\" > /tmp/$NAMESPACE-vdb-gen.yaml"
   - command: cat /tmp/$NAMESPACE-vdb-gen.yaml
   # Apply the generated CR
   - command: kubectl -n $NAMESPACE apply -f /tmp/$NAMESPACE-vdb-gen.yaml

--- a/tests/kustomize-defaults.cfg
+++ b/tests/kustomize-defaults.cfg
@@ -32,16 +32,6 @@ ACCESSKEY=minio
 SECRETKEY=minio123
 REGION=us-east-1
 
-# This is the base image to use for some upgrade tests.  We will always
-# upgrade to VERTICA_IMG, so BASE_VERTICA_IMG must be some image from a
-# version earlier than VERTICA_IMG.
-# Note, not all upgrade tests use this.  Some upgrade between one of the
-# official vertica images and a bad-image.
-#
-# There is no default value for this image.  Any test will fail that requires
-# this but it isn't set.
-BASE_VERTICA_IMG=
-
 # Credentials for setting up for Azure Blob Storage.
 #
 # Identify the azure container name.


### PR DESCRIPTION
An online upgrade can only be used if upgrading from Vertica version 11.1+.  I'm reverting back to offline upgrade if we aren't on the correct version.