### PR TITLE
Webhook to account for empty serviceName in checks

### DIFF
--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -667,12 +667,12 @@ func (v *VerticaDB) matchingServiceNamesAreConsistent(allErrs field.ErrorList) f
 
 	for i := range v.Spec.Subclusters {
 		sc := &v.Spec.Subclusters[i]
-		if _, ok := processedServiceName[sc.ServiceName]; ok {
+		if _, ok := processedServiceName[sc.GetServiceName()]; ok {
 			continue
 		}
 		for j := i + 1; j < len(v.Spec.Subclusters); j++ {
 			osc := &v.Spec.Subclusters[j]
-			if sc.ServiceName == osc.ServiceName {
+			if sc.GetServiceName() == osc.GetServiceName() {
 				fieldPrefix := field.NewPath("spec").Child("subclusters").Index(j)
 				if !reflect.DeepEqual(sc.ExternalIPs, osc.ExternalIPs) {
 					err := field.Invalid(fieldPrefix.Child("externalIPs").Index(i),
@@ -695,7 +695,7 @@ func (v *VerticaDB) matchingServiceNamesAreConsistent(allErrs field.ErrorList) f
 			}
 		}
 		// Set a flag so that we don't process this service name in another subcluster
-		processedServiceName[sc.ServiceName] = true
+		processedServiceName[sc.GetServiceName()] = true
 	}
 	return allErrs
 }

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -434,6 +434,27 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Subclusters[1].ExternalIPs[1] = vdb.Spec.Subclusters[0].ExternalIPs[1]
 		validateSpecValuesHaveErr(vdb, false)
 	})
+
+	It("should allow different serviceTypes if the serviceName isn't filled in", func() {
+		vdb := createVDBHelper()
+		vdb.Spec.Subclusters = []Subcluster{
+			{
+				Name:        "sc1",
+				Size:        2,
+				IsPrimary:   true,
+				ServiceType: "NodePort",
+				NodePort:    30008,
+			},
+			{
+				Name:        "sc2",
+				Size:        1,
+				IsPrimary:   false,
+				ServiceType: "ClusterIP",
+			},
+		}
+		validateSpecValuesHaveErr(vdb, false)
+	})
+
 })
 
 func createVDBHelper() *VerticaDB {


### PR DESCRIPTION
The webhook makes sure that two subclusters that share the same service
name have similar service specific settings (serviceType, nodePort,
etc.).  It didn't account for subclusters that don't fill in the
serviceName.  A blank service name will just use the subcluster name.
So two subclusters that have a blank service name will have different
service objects.  Using the GetServiceName() fixes this bug.