### PR TITLE
Skip step in online upgrade if not using transient

### DIFF
--- a/pkg/controllers/onlineupgrade_reconciler.go
+++ b/pkg/controllers/onlineupgrade_reconciler.go
@@ -225,6 +225,10 @@ func (o *OnlineUpgradeReconciler) addTransientNodes(ctx context.Context) (ctrl.R
 // This is done so that when we direct traffic to the transient subcluster the
 // service object has a pod to route too.
 func (o *OnlineUpgradeReconciler) waitForReadyTransientPod(ctx context.Context) (ctrl.Result, error) {
+	if o.skipTransientSetup() {
+		return ctrl.Result{}, nil
+	}
+
 	pod := &corev1.Pod{}
 	sc := buildTransientSubcluster(o.Vdb, "")
 	// We only check the first pod is ready


### PR DESCRIPTION
We weren't skipping waitForReadyTransientPod if we are driving online
upgrade without a transient.  It isn't a major problem as we would error
out looking for the transient pod. But it does add some noise to the
operator log.