### PR TITLE
Batch 'admintools -t db_add_node' for faster scale up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ kubeconfig
 run.out
 local-soak.cfg
 local-kustomize*.cfg
+.envrc
 
 # Generated files from create-kustomize-overlay.sh
 overlay/

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -22,7 +22,7 @@ This guide explains how to set up an environment to develop and test the Vertica
 Prior to developing, the following software needs to be installed manually.  There is other software that needed, but it is downloaded through make targets in the repo's bin directory.
 
 - [docker](https://docs.docker.com/get-docker/)
-- [go](https://golang.org/doc/install) (version 1.16.2)
+- [go](https://golang.org/doc/install) (version 1.17.3)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (version 1.20.1)
 - [helm](https://helm.sh/docs/intro/install/) (version 3.5.0)
 - [kubectx](https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubectx) (version 0.9.1)

--- a/changes/unreleased/Changed-20220308-080716.yaml
+++ b/changes/unreleased/Changed-20220308-080716.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Batch 'admintools -t db_add_node' for faster scale up
+time: 2022-03-08T08:07:16.768837381-04:00
+custom:
+  Issue: "166"

--- a/pkg/controllers/dbaddnode_reconcile.go
+++ b/pkg/controllers/dbaddnode_reconcile.go
@@ -75,30 +75,27 @@ func (d *DBAddNodeReconciler) Reconcile(ctx context.Context, req *ctrl.Request) 
 // reconcileSubcluster will reconcile a single subcluster.  Add node will be
 // triggered if we determine that it hasn't been run.
 func (d *DBAddNodeReconciler) reconcileSubcluster(ctx context.Context, sc *vapi.Subcluster) (ctrl.Result, error) {
-	if missingDB, unknownState := d.PFacts.anyPodsMissingDB(sc.Name); missingDB || unknownState {
-		if missingDB {
-			res, err := d.runAddNode(ctx, sc)
-			if err != nil || res.Requeue {
-				return res, err
-			}
-		}
-		if unknownState {
-			d.Log.Info("Requeue because some pods were not running")
-		}
-		return ctrl.Result{Requeue: unknownState}, nil
+	addNodePods, unknownState := d.PFacts.findPodsWithMissingDB(sc.Name)
+
+	// We want to group all of the add nodes in a single admintools call.
+	// Doing so limits the impact on any running queries.  So if there is at
+	// least one pod with unknown state, we requeue until that pod is
+	// running before we proceed with the admintools call.
+	if unknownState {
+		d.Log.Info("Requeue add node because some pods were not running")
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if len(addNodePods) > 0 {
+		res, err := d.runAddNode(ctx, sc, addNodePods)
+		return res, err
 	}
 	return ctrl.Result{}, nil
 }
 
 // runAddNode will add nodes to the given subcluster
-func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, sc *vapi.Subcluster) (ctrl.Result, error) {
-	pods := d.PFacts.findPodsWithMissingDB(sc.Name)
-	// The pods that are missing the db might not be running, so we requeue the
-	// reconciliation so we don't miss this pod
-	if len(pods) == 0 {
-		return ctrl.Result{Requeue: true}, nil
-	}
-
+// SPILLY
+// nolint:unparam
+func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, sc *vapi.Subcluster, pods []*PodFact) (ctrl.Result, error) {
 	atPod, ok := d.PFacts.findPodToRunVsql(false, "")
 	if !ok {
 		d.Log.Info("No pod found to run vsql and admintools from. Requeue reconciliation.")
@@ -116,36 +113,42 @@ func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, sc *vapi.Subcluste
 		if err := cleanupLocalFiles(ctx, d.Vdb, d.PRunner, pod.name); err != nil {
 			return ctrl.Result{}, err
 		}
-
-		debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
-
-		if stdout, err := d.runAddNodeForPod(ctx, pod, atPod); err != nil {
-			// If we reached the node limit according to the license, end this
-			// reconcile successfully. We don't want to fail and requeue because
-			// this isn't going to get fixed until someone manually adds a new
-			// license.
-			if isLicenseLimitError(stdout) {
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{}, err
-		}
-
-		debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
-
-		// Invalidate the cached pod facts now that some pods have a DB now.
-		d.PFacts.Invalidate()
 	}
-	err := d.rebalanceShards(ctx, atPod, sc.Name)
-	return ctrl.Result{}, err
+
+	debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
+
+	if stdout, err := d.runAddNodeForPod(ctx, pods, atPod); err != nil {
+		// If we reached the node limit according to the license, end this
+		// reconcile successfully. We don't want to fail and requeue because
+		// this isn't going to get fixed until someone manually adds a new
+		// license.
+		if isLicenseLimitError(stdout) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
+
+	// Invalidate the cached pod facts now that some pods have a DB now.
+	d.PFacts.Invalidate()
+
+	// SPILLY create a separate reconciler for this.  Add to podfacts some query
+	// from node_subscriptions.  We need to do this for the node_name.
+
+	// SPILLY do this separately based on whether there are nodes without subscriptions
+	// err := d.rebalanceShards(ctx, atPod, sc.Name)
+	return ctrl.Result{}, nil
 }
 
 // runAddNodeForPod will execute the command to add a single node to the cluster
 // Returns the stdout from the command.
-func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pod, atPod *PodFact) (string, error) {
+func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pods []*PodFact, atPod *PodFact) (string, error) {
+	podNames := genPodNames(pods)
 	d.VRec.EVRec.Eventf(d.Vdb, corev1.EventTypeNormal, events.AddNodeStart,
-		"Calling 'admintools -t db_add_node' for pod '%s'", pod.name.Name)
+		"Calling 'admintools -t db_add_node' for pod(s) '%s'", podNames)
 	start := time.Now()
-	cmd := d.genAddNodeCommand(pod)
+	cmd := d.genAddNodeCommand(pods)
 	stdout, _, err := d.PRunner.ExecAdmintools(ctx, atPod.name, names.ServerContainer, cmd...)
 	if err != nil {
 		switch {
@@ -154,7 +157,7 @@ func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pod, atPod *
 				"You cannot add more nodes to the database.  You have reached the limit allowed by your license.")
 		default:
 			d.VRec.EVRec.Eventf(d.Vdb, corev1.EventTypeWarning, events.AddNodeFailed,
-				"Failed when calling 'admintools -t db_add_node' from pod %s", pod.name.Name)
+				"Failed when calling 'admintools -t db_add_node' for pod(s) '%s'", podNames)
 		}
 	} else {
 		d.VRec.EVRec.Eventf(d.Vdb, corev1.EventTypeNormal, events.AddNodeSucceeded,
@@ -170,6 +173,8 @@ func isLicenseLimitError(stdout string) bool {
 
 // rebalanceShards will execute the command to rebalance the shards
 // between all the nodes(old and new)
+// SPILLY
+// nolint:unused
 func (d *DBAddNodeReconciler) rebalanceShards(ctx context.Context, atPod *PodFact, scName string) error {
 	podName := atPod.name
 	selectCmd := fmt.Sprintf("select rebalance_shards('%s')", scName)
@@ -185,12 +190,17 @@ func (d *DBAddNodeReconciler) rebalanceShards(ctx context.Context, atPod *PodFac
 }
 
 // genAddNodeCommand returns the command to run to add nodes to the cluster.
-func (d *DBAddNodeReconciler) genAddNodeCommand(pod *PodFact) []string {
+func (d *DBAddNodeReconciler) genAddNodeCommand(pods []*PodFact) []string {
+	hostNames := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		hostNames = append(hostNames, pod.dnsName)
+	}
+
 	return []string{
 		"-t", "db_add_node",
-		"--hosts", pod.podIP,
+		"--hosts", strings.Join(hostNames, ","),
 		"--database", d.Vdb.Spec.DBName,
-		"--subcluster", pod.subcluster,
+		"--subcluster", pods[0].subcluster,
 		"--noprompt",
 	}
 }

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -320,7 +320,9 @@ func (p *PodFacts) checkThatConfigShareExists(ctx context.Context, vdb *vapi.Ver
 // checkShardSubscriptions will cound the number of shards that are subscribed
 // to the current node
 func (p *PodFacts) checkShardSubscriptions(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
-	if !pf.isPodRunning {
+	// This check depends on the vnode, which is only present if the pod is
+	// running and the database exists at the node.
+	if !pf.isPodRunning || pf.dbExists != tristate.True {
 		return nil
 	}
 	cmd := []string{

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -317,7 +317,7 @@ func (p *PodFacts) checkThatConfigShareExists(ctx context.Context, vdb *vapi.Ver
 	return nil
 }
 
-// checkShardSubscriptions will cound the number of shards that are subscribed
+// checkShardSubscriptions will count the number of shards that are subscribed
 // to the current node
 func (p *PodFacts) checkShardSubscriptions(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
 	// This check depends on the vnode, which is only present if the pod is

--- a/pkg/controllers/podfacts_test.go
+++ b/pkg/controllers/podfacts_test.go
@@ -285,4 +285,10 @@ var _ = Describe("podfacts", func() {
 		_, _, err = parseNodeStateAndReadOnly("UP|z|garbage")
 		Expect(err).ShouldNot(Succeed())
 	})
+
+	It("should parse node subscriptions output", func() {
+		pf := &PodFact{}
+		Expect(setShardSubscription("3\n", pf)).Should(Succeed())
+		Expect(pf.shardSubscriptions).Should(Equal(3))
+	})
 })

--- a/pkg/controllers/podfacts_test.go
+++ b/pkg/controllers/podfacts_test.go
@@ -126,23 +126,23 @@ var _ = Describe("podfacts", func() {
 		Expect(pf.doesDBExist()).Should(Equal(tristate.True))
 	})
 
-	It("should verify anyPodsMissingDB return codes", func() {
+	It("should verify findPodsWithMissingDB return codes", func() {
 		pf := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{dbExists: tristate.True, subcluster: "sc1"}
-		missingDB, unknownState := pf.anyPodsMissingDB("sc1")
-		Expect(missingDB).Should(Equal(false))
+		pods, unknownState := pf.findPodsWithMissingDB("sc1")
+		Expect(len(pods)).Should(Equal(0))
 		Expect(unknownState).Should(Equal(false))
 		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{dbExists: tristate.None, subcluster: "sc1"}
-		missingDB, unknownState = pf.anyPodsMissingDB("sc1")
-		Expect(missingDB).Should(Equal(false))
+		pods, unknownState = pf.findPodsWithMissingDB("sc1")
+		Expect(len(pods)).Should(Equal(0))
 		Expect(unknownState).Should(Equal(true))
 		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{dbExists: tristate.False, subcluster: "sc1"}
-		missingDB, unknownState = pf.anyPodsMissingDB("sc1")
-		Expect(missingDB).Should(Equal(true))
+		pods, unknownState = pf.findPodsWithMissingDB("sc1")
+		Expect(len(pods)).Should(Equal(1))
 		Expect(unknownState).Should(Equal(true))
 		pf.Detail[types.NamespacedName{Name: "p4"}] = &PodFact{dbExists: tristate.False, subcluster: "sc2"}
-		missingDB, unknownState = pf.anyPodsMissingDB("sc2")
-		Expect(missingDB).Should(Equal(true))
+		pods, unknownState = pf.findPodsWithMissingDB("sc2")
+		Expect(len(pods)).Should(Equal(1))
 		Expect(unknownState).Should(Equal(false))
 	})
 
@@ -152,21 +152,21 @@ var _ = Describe("podfacts", func() {
 			dnsName: "p1", subcluster: "sc1", dbExists: tristate.True,
 		}
 		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
-			dnsName: "p2", subcluster: "sc1", dbExists: tristate.False, isPodRunning: true,
+			dnsName: "p2", subcluster: "sc1", dbExists: tristate.False,
 		}
 		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
-			dnsName: "p3", subcluster: "sc1", dbExists: tristate.False, isPodRunning: false,
+			dnsName: "p3", subcluster: "sc1", dbExists: tristate.False,
 		}
 		pf.Detail[types.NamespacedName{Name: "p4"}] = &PodFact{
-			dnsName: "p4", subcluster: "sc2", dbExists: tristate.False, isPodRunning: true,
+			dnsName: "p4", subcluster: "sc2", dbExists: tristate.False,
 		}
 		pf.Detail[types.NamespacedName{Name: "p5"}] = &PodFact{
-			dnsName: "p5", subcluster: "sc2", dbExists: tristate.False, isPodRunning: true,
+			dnsName: "p5", subcluster: "sc2", dbExists: tristate.False,
 		}
-		pods := pf.findPodsWithMissingDB("sc1")
-		Expect(len(pods)).Should(Equal(1))
+		pods, _ := pf.findPodsWithMissingDB("sc1")
+		Expect(len(pods)).Should(Equal(2))
 		Expect(pods[0].dnsName).Should(Equal("p2"))
-		pods = pf.findPodsWithMissingDB("sc2")
+		pods, _ = pf.findPodsWithMissingDB("sc2")
 		Expect(len(pods)).Should(Equal(2))
 		Expect(pods[0].dnsName).Should(Equal("p4"))
 		Expect(pods[1].dnsName).Should(Equal("p5"))

--- a/pkg/controllers/rebalanceshards_reconcile.go
+++ b/pkg/controllers/rebalanceshards_reconcile.go
@@ -1,0 +1,105 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// RebalanceShardsReconciler will ensure each node has at least one shard subscription
+type RebalanceShardsReconciler struct {
+	VRec    *VerticaDBReconciler
+	Log     logr.Logger
+	Vdb     *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	PRunner cmds.PodRunner
+	PFacts  *PodFacts
+}
+
+// MakeRebalanceShardsReconciler will build a RebalanceShardsReconciler object
+func MakeRebalanceShardsReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
+	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) ReconcileActor {
+	return &RebalanceShardsReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
+}
+
+// Reconcile will ensure each node has at least one shard subscription
+func (s *RebalanceShardsReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if err := s.PFacts.Collect(ctx, s.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	scToRebalance := s.findShardsToRebalance()
+	if len(scToRebalance) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	atPod, ok := s.PFacts.findPodToRunVsql(false, "")
+	if !ok {
+		s.Log.Info("No pod found to run vsql from. Requeue reconciliation.")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	for i := range scToRebalance {
+		if err := s.rebalanceShards(ctx, atPod, scToRebalance[i]); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// findShardsToRebalance will populate the scToRebalance slice with subclusters
+// that need a rebalance
+func (s *RebalanceShardsReconciler) findShardsToRebalance() []string {
+	scRebalanceMap := map[string]bool{}
+	scToRebalance := []string{}
+
+	for _, pf := range s.PFacts.Detail {
+		if pf.isPodRunning && pf.upNode && pf.shardSubscriptions == 0 {
+			_, ok := scRebalanceMap[pf.subcluster]
+			if !ok {
+				scToRebalance = append(scToRebalance, pf.subcluster)
+				scRebalanceMap[pf.subcluster] = true
+			}
+		}
+	}
+	return scToRebalance
+}
+
+// rebalanceShards will run rebalance_shards for the given subcluster
+func (s *RebalanceShardsReconciler) rebalanceShards(ctx context.Context, atPod *PodFact, scName string) error {
+	podName := atPod.name
+	selectCmd := fmt.Sprintf("select rebalance_shards('%s')", scName)
+	cmd := []string{
+		"-tAc", selectCmd,
+	}
+	_, _, err := s.PRunner.ExecVSQL(ctx, podName, names.ServerContainer, cmd...)
+	if err != nil {
+		return err
+	}
+	s.VRec.EVRec.Eventf(s.Vdb, corev1.EventTypeNormal, events.RebalanceShards,
+		"Successfully called 'rebalance_shards' for '%s'", scName)
+
+	return nil
+}

--- a/pkg/controllers/rebalanceshards_reconciler_test.go
+++ b/pkg/controllers/rebalanceshards_reconciler_test.go
@@ -1,0 +1,57 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("rebalanceshards_reconcile", func() {
+	ctx := context.Background()
+
+	It("should rebalance shards if one pod doesn't have any subscriptions", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "sc1", Size: 1},
+			{Name: "sc2", Size: 1},
+		}
+		createPods(ctx, vdb, AllPodsRunning)
+		defer deletePods(ctx, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := MakePodFacts(k8sClient, fpr)
+		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
+		pfn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		pfacts.Detail[pfn].upNode = true
+		pfacts.Detail[pfn].shardSubscriptions = 0
+		pfn = names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0)
+		pfacts.Detail[pfn].shardSubscriptions = 3
+		pfacts.Detail[pfn].upNode = true
+		r := MakeRebalanceShardsReconciler(vrec, logger, vdb, fpr, &pfacts)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		atCmd := fpr.FindCommands("select rebalance_shards('sc1')")
+		Expect(len(atCmd)).Should(Equal(1))
+		atCmd = fpr.FindCommands("select rebalance_shards('sc2')")
+		Expect(len(atCmd)).Should(Equal(0))
+	})
+})

--- a/pkg/controllers/verticadb_controller.go
+++ b/pkg/controllers/verticadb_controller.go
@@ -144,6 +144,8 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Handle calls to admintools -t db_add_node
 		MakeDBAddNodeReconciler(r, log, vdb, prunner, &pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, &pfacts),
+		// Handle calls to rebalance_shards
+		MakeRebalanceShardsReconciler(r, log, vdb, prunner, &pfacts),
 	}
 
 	for _, act := range actors {

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -63,4 +63,5 @@ const (
 	KerberosAuthError               = "KerberosAuthError"
 	OperatorUpgrade                 = "OperatorUpgrade"
 	InvalidUpgradePath              = "InvalidUpgradePath"
+	RebalanceShards                 = "RebalanceShards"
 )

--- a/tests/e2e/k-safety-0-scaling/35-assert.yaml
+++ b/tests/e2e/k-safety-0-scaling/35-assert.yaml
@@ -16,6 +16,14 @@ kind: StatefulSet
 metadata:
   name: v-k-safety-0-scaling-sc1
 status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-k-safety-0-scaling-sc2
+status:
   currentReplicas: 2
   readyReplicas: 2
 ---
@@ -24,6 +32,5 @@ kind: VerticaDB
 metadata:
   name: v-k-safety-0-scaling
 status:
-  subclusters:
-    - installCount: 2
-      addedToDBCount: 2
+  installCount: 3
+  addedToDBCount: 3

--- a/tests/e2e/k-safety-0-scaling/35-scale-up-to-3.yaml
+++ b/tests/e2e/k-safety-0-scaling/35-scale-up-to-3.yaml
@@ -18,4 +18,8 @@ metadata:
 spec:
   subclusters:
     - name: sc1
+      size: 1
+      isPrimary: true
+    - name: sc2
       size: 2
+      isPrimary: false

--- a/tests/e2e/k-safety-0-scaling/40-assert.yaml
+++ b/tests/e2e/k-safety-0-scaling/40-assert.yaml
@@ -11,22 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
+apiVersion: v1
+kind: Event
+reason: AddNodeStart
+message: Calling 'admintools -t db_add_node' for pod(s) 'v-k-safety-0-scaling-sc2-0, v-k-safety-0-scaling-sc2-1'
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
   name: v-k-safety-0-scaling
-spec:
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  sshSecret: ssh-keys
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  subclusters:
-    - name: sc1
-      size: 1
-  kSafety: "0"
-  certSecrets: []

--- a/tests/e2e/k-safety-0-scaling/40-check-rebalance-shards.yaml
+++ b/tests/e2e/k-safety-0-scaling/40-check-rebalance-shards.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-k-safety-0-scaling
-spec:
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  sshSecret: ssh-keys
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  subclusters:
-    - name: sc1
-      size: 1
-  kSafety: "0"
-  certSecrets: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: n=$(kubectl exec -n $NAMESPACE v-k-safety-0-scaling-sc1-0 -- vsql -tAc "select node_name from nodes where node_name not in (select distinct(node_name) from node_subscriptions)" | wc -l) && exit $n

--- a/tests/external-images-build.txt
+++ b/tests/external-images-build.txt
@@ -4,7 +4,7 @@
 
 # Images that are used as the base in our containers
 centos:centos7.9.2009
-golang:1.15
+golang:1.17
 gcr.io/distroless/static:nonroot
 alpine:3.15
 


### PR DESCRIPTION
Prior to this PR we did 'admintools -t db_add_node' one at a time.  So if you were adding 3 nodes to a subcluster we would call admintools 3 times.  We now batch that into a single call.  This greatly speeds up the time to do scale up.  I have seen it take about 52 seconds to add 3 nodes, where previously we did 3 calls to admintools that took about 40 seconds each.

Shard rebalance is always done after add node.  I moved this to a separate reconciler now.  This allows for better error handling and better separation of concerns.