### PR TITLE
Refactor of controllers package

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -958,3 +958,23 @@ func (v *VerticaDB) IsOnlineUpgradeInProgress() bool {
 	inx := OnlineUpgradeInProgressIndex
 	return inx < len(v.Status.Conditions) && v.Status.Conditions[inx].Status == corev1.ConditionTrue
 }
+
+// buildTransientSubcluster creates a temporary read-only subcluster based on an
+// existing subcluster
+func (v *VerticaDB) BuildTransientSubcluster(imageOverride string) *Subcluster {
+	return &Subcluster{
+		Name:              v.Spec.TemporarySubclusterRouting.Template.Name,
+		Size:              v.Spec.TemporarySubclusterRouting.Template.Size,
+		IsTransient:       true,
+		ImageOverride:     imageOverride,
+		IsPrimary:         false,
+		NodeSelector:      v.Spec.TemporarySubclusterRouting.Template.NodeSelector,
+		Affinity:          v.Spec.TemporarySubclusterRouting.Template.Affinity,
+		PriorityClassName: v.Spec.TemporarySubclusterRouting.Template.PriorityClassName,
+		Tolerations:       v.Spec.TemporarySubclusterRouting.Template.Tolerations,
+		Resources:         v.Spec.TemporarySubclusterRouting.Template.Resources,
+		// We ignore any parameter that is specific to the subclusters service
+		// object.  These are ignored since transient don't have their own
+		// service objects.
+	}
+}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	verticacomv1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	//+kubebuilder:scaffold:imports
 )
@@ -272,7 +273,7 @@ func main() {
 		Log:    ctrl.Log.WithName("controllers").WithName("VerticaDB"),
 		Scheme: mgr.GetScheme(),
 		Cfg:    restCfg,
-		EVRec:  mgr.GetEventRecorderFor(controllers.OperatorName),
+		EVRec:  mgr.GetEventRecorderFor(builder.OperatorName),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VerticaDB")
 		os.Exit(1)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-package controllers
+package builder
 
 import (
 	"fmt"
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cloud"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,15 +36,15 @@ const (
 	SuperuserPasswordPath = "superuser-passwd"
 )
 
-// buildExtSvc creates desired spec for the external service.
-func buildExtSvc(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster,
+// BuildExtSvc creates desired spec for the external service.
+func BuildExtSvc(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster,
 	selectorLabelCreator func(*vapi.VerticaDB, *vapi.Subcluster) map[string]string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      makeLabelsForSvcObject(vdb, sc, "external"),
-			Annotations: makeAnnotationsForObject(vdb),
+			Labels:      MakeLabelsForSvcObject(vdb, sc, "external"),
+			Annotations: MakeAnnotationsForObject(vdb),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: selectorLabelCreator(vdb, sc),
@@ -57,17 +58,17 @@ func buildExtSvc(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclust
 	}
 }
 
-// buildHlSvc creates the desired spec for the headless service.
-func buildHlSvc(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.Service {
+// BuildHlSvc creates the desired spec for the headless service.
+func BuildHlSvc(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      makeLabelsForSvcObject(vdb, nil, "headless"),
-			Annotations: makeAnnotationsForObject(vdb),
+			Labels:      MakeLabelsForSvcObject(vdb, nil, "headless"),
+			Annotations: MakeAnnotationsForObject(vdb),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector:                 makeBaseSvcSelectorLabels(vdb),
+			Selector:                 MakeBaseSvcSelectorLabels(vdb),
 			ClusterIP:                "None",
 			Type:                     "ClusterIP",
 			PublishNotReadyAddresses: true,
@@ -318,9 +319,9 @@ func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.PodSpec {
 	termGracePeriod := int64(0)
 	return corev1.PodSpec{
 		NodeSelector:                  sc.NodeSelector,
-		Affinity:                      getK8sAffinity(sc.Affinity),
+		Affinity:                      GetK8sAffinity(sc.Affinity),
 		Tolerations:                   sc.Tolerations,
-		ImagePullSecrets:              getK8sLocalObjectReferenceArray(vdb.Spec.ImagePullSecrets),
+		ImagePullSecrets:              GetK8sLocalObjectReferenceArray(vdb.Spec.ImagePullSecrets),
 		Containers:                    makeContainers(vdb, sc),
 		Volumes:                       buildVolumes(vdb),
 		TerminationGracePeriodSeconds: &termGracePeriod,
@@ -430,25 +431,25 @@ func getStorageClassName(vdb *vapi.VerticaDB) *string {
 	return &vdb.Spec.Local.StorageClass
 }
 
-// buildStsSpec builds manifest for a subclusters statefulset
-func buildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster) *appsv1.StatefulSet {
+// BuildStsSpec builds manifest for a subclusters statefulset
+func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      makeLabelsForObject(vdb, sc),
-			Annotations: makeAnnotationsForObject(vdb),
+			Labels:      MakeLabelsForObject(vdb, sc),
+			Annotations: MakeAnnotationsForObject(vdb),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: makeSvcSelectorLabelsForSubclusterNameRouting(vdb, sc),
+				MatchLabels: MakeSvcSelectorLabelsForSubclusterNameRouting(vdb, sc),
 			},
 			ServiceName: names.GenHlSvcName(vdb).Name,
 			Replicas:    &sc.Size,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      makeLabelsForObject(vdb, sc),
-					Annotations: makeAnnotationsForObject(vdb),
+					Labels:      MakeLabelsForObject(vdb, sc),
+					Annotations: MakeAnnotationsForObject(vdb),
 				},
 				Spec: buildPodSpec(vdb, sc),
 			},
@@ -477,14 +478,14 @@ func buildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 // buildPod will construct a spec for a pod.
 // This is only here for testing purposes when we need to construct the pods ourselves.  This
 // bit is typically handled by the statefulset controller.
-func buildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.Pod {
+func BuildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.Pod {
 	nm := names.GenPodName(vdb, sc, podIndex)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      makeLabelsForObject(vdb, sc),
-			Annotations: makeAnnotationsForObject(vdb),
+			Labels:      MakeLabelsForObject(vdb, sc),
+			Annotations: MakeAnnotationsForObject(vdb),
 		},
 		Spec: buildPodSpec(vdb, sc),
 	}
@@ -504,8 +505,8 @@ func buildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.
 	return pod
 }
 
-// buildS3CommunalCredSecret is a test helper to build up the Secret spec to store communal credentials
-func buildS3CommunalCredSecret(vdb *vapi.VerticaDB, accessKey, secretKey string) *corev1.Secret {
+// BuildS3CommunalCredSecret is a test helper to build up the Secret spec to store communal credentials
+func BuildS3CommunalCredSecret(vdb *vapi.VerticaDB, accessKey, secretKey string) *corev1.Secret {
 	nm := names.GenCommunalCredSecretName(vdb)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -513,16 +514,16 @@ func buildS3CommunalCredSecret(vdb *vapi.VerticaDB, accessKey, secretKey string)
 			Namespace: nm.Namespace,
 		},
 		Data: map[string][]byte{
-			CommunalAccessKeyName: []byte(accessKey),
-			CommunalSecretKeyName: []byte(secretKey),
+			cloud.CommunalAccessKeyName: []byte(accessKey),
+			cloud.CommunalSecretKeyName: []byte(secretKey),
 		},
 	}
 	return secret
 }
 
-// buildAzureAccountKeyCommunalCredSecret builds a secret that is setup for
+// BuildAzureAccountKeyCommunalCredSecret builds a secret that is setup for
 // Azure using an account key.
-func buildAzureAccountKeyCommunalCredSecret(vdb *vapi.VerticaDB, accountName, accountKey string) *corev1.Secret {
+func BuildAzureAccountKeyCommunalCredSecret(vdb *vapi.VerticaDB, accountName, accountKey string) *corev1.Secret {
 	nm := names.GenCommunalCredSecretName(vdb)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -530,16 +531,16 @@ func buildAzureAccountKeyCommunalCredSecret(vdb *vapi.VerticaDB, accountName, ac
 			Namespace: nm.Namespace,
 		},
 		Data: map[string][]byte{
-			AzureAccountName: []byte(accountName),
-			AzureAccountKey:  []byte(accountKey),
+			cloud.AzureAccountName: []byte(accountName),
+			cloud.AzureAccountKey:  []byte(accountKey),
 		},
 	}
 	return secret
 }
 
-// buildAzureSASCommunalCredSecret builds a secret that is setup for Azure using
+// BuildAzureSASCommunalCredSecret builds a secret that is setup for Azure using
 // shared access signature.
-func buildAzureSASCommunalCredSecret(vdb *vapi.VerticaDB, blobEndpoint, sas string) *corev1.Secret {
+func BuildAzureSASCommunalCredSecret(vdb *vapi.VerticaDB, blobEndpoint, sas string) *corev1.Secret {
 	nm := names.GenCommunalCredSecretName(vdb)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -547,23 +548,23 @@ func buildAzureSASCommunalCredSecret(vdb *vapi.VerticaDB, blobEndpoint, sas stri
 			Namespace: nm.Namespace,
 		},
 		Data: map[string][]byte{
-			AzureBlobEndpoint:          []byte(blobEndpoint),
-			AzureSharedAccessSignature: []byte(sas),
+			cloud.AzureBlobEndpoint:          []byte(blobEndpoint),
+			cloud.AzureSharedAccessSignature: []byte(sas),
 		},
 	}
 	return secret
 }
 
-// buildKerberosSecretBase is a test helper that creates the skeleton of a
+// BuildKerberosSecretBase is a test helper that creates the skeleton of a
 // Kerberos secret.  The caller's responsibility to add the necessary data.
-func buildKerberosSecretBase(vdb *vapi.VerticaDB) *corev1.Secret {
+func BuildKerberosSecretBase(vdb *vapi.VerticaDB) *corev1.Secret {
 	nm := names.GenNamespacedName(vdb, vdb.Spec.KerberosSecret)
-	return buildSecretBase(nm)
+	return BuildSecretBase(nm)
 }
 
-// buildSecretBase is a test helper that creates a Secret base with a specific
+// BuildSecretBase is a test helper that creates a Secret base with a specific
 // name.  The caller is responsible to add data elemets and create it.
-func buildSecretBase(nm types.NamespacedName) *corev1.Secret {
+func BuildSecretBase(nm types.NamespacedName) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nm.Name,
@@ -599,9 +600,9 @@ func buildReadinessProbeSQL(vdb *vapi.VerticaDB) string {
 	return fmt.Sprintf("vsql %s -c 'select 1'", passwd)
 }
 
-// getK8sLocalObjectReferenceArray returns a k8s LocalObjecReference array
+// GetK8sLocalObjectReferenceArray returns a k8s LocalObjecReference array
 // from a vapi.LocalObjectReference array
-func getK8sLocalObjectReferenceArray(lors []vapi.LocalObjectReference) []corev1.LocalObjectReference {
+func GetK8sLocalObjectReferenceArray(lors []vapi.LocalObjectReference) []corev1.LocalObjectReference {
 	localObjectReferences := []corev1.LocalObjectReference{}
 	for i := range lors {
 		l := corev1.LocalObjectReference{Name: lors[i].Name}
@@ -610,31 +611,11 @@ func getK8sLocalObjectReferenceArray(lors []vapi.LocalObjectReference) []corev1.
 	return localObjectReferences
 }
 
-// getK8sAffinity returns a K8s Affinity object from a vapi.Affinity object
-func getK8sAffinity(a vapi.Affinity) *corev1.Affinity {
+// GetK8sAffinity returns a K8s Affinity object from a vapi.Affinity object
+func GetK8sAffinity(a vapi.Affinity) *corev1.Affinity {
 	return &corev1.Affinity{
 		NodeAffinity:    a.NodeAffinity,
 		PodAffinity:     a.PodAffinity,
 		PodAntiAffinity: a.PodAntiAffinity,
-	}
-}
-
-// buildTransientSubcluster creates a temporary read-only subcluster based on an
-// existing subcluster
-func buildTransientSubcluster(vdb *vapi.VerticaDB, imageOverride string) *vapi.Subcluster {
-	return &vapi.Subcluster{
-		Name:              vdb.Spec.TemporarySubclusterRouting.Template.Name,
-		Size:              vdb.Spec.TemporarySubclusterRouting.Template.Size,
-		IsTransient:       true,
-		ImageOverride:     imageOverride,
-		IsPrimary:         false,
-		NodeSelector:      vdb.Spec.TemporarySubclusterRouting.Template.NodeSelector,
-		Affinity:          vdb.Spec.TemporarySubclusterRouting.Template.Affinity,
-		PriorityClassName: vdb.Spec.TemporarySubclusterRouting.Template.PriorityClassName,
-		Tolerations:       vdb.Spec.TemporarySubclusterRouting.Template.Tolerations,
-		Resources:         vdb.Spec.TemporarySubclusterRouting.Template.Resources,
-		// We ignore any parameter that is specific to the subclusters service
-		// object.  These are ignored since transient don't have their own
-		// service objects.
 	}
 }

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-package controllers
+package builder
 
 import (
 	"reflect"

--- a/pkg/builder/su-passwd.go
+++ b/pkg/builder/su-passwd.go
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-package controllers
+package builder
 
 const (
 	// The name of the key in the superuser password secret that holds the password

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-package controllers
+package cloud
 
 const (
 	// Key names in the communal credentials for Azure blob storage endpoints.

--- a/pkg/cloud/s3.go
+++ b/pkg/cloud/s3.go
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-package controllers
+package cloud
 
 import "strings"
 
@@ -24,12 +24,12 @@ const (
 	CommunalSecretKeyName = "secretkey"
 )
 
-// isEndpointBadError returns true if the given message text has the message aboud a bad endpoint
-func isEndpointBadError(op string) bool {
+// IsEndpointBadError returns true if the given message text has the message aboud a bad endpoint
+func IsEndpointBadError(op string) bool {
 	return strings.Contains(op, "Unable to connect to endpoint")
 }
 
-// isBucketNotExistError returns true if the given message text has the message about a bad bucket
-func isBucketNotExistError(op string) bool {
+// IsBucketNotExistError returns true if the given message text has the message about a bad bucket
+func IsBucketNotExistError(op string) bool {
 	return strings.Contains(op, "The specified bucket does not exist")
 }

--- a/pkg/controllers/at_test.go
+++ b/pkg/controllers/at_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 )
 
 var _ = Describe("at", func() {
@@ -35,8 +36,8 @@ var _ = Describe("at", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		const ScSize = 3
 		sc.Size = ScSize
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pf := createPodFactsWithInstallNeeded(ctx, vdb, fpr)

--- a/pkg/controllers/createdb_reconcile.go
+++ b/pkg/controllers/createdb_reconcile.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cloud"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/license"
@@ -85,12 +86,12 @@ func (c *CreateDBReconciler) execCmd(ctx context.Context, atPod types.Namespaced
 	stdout, _, err := c.PRunner.ExecAdmintools(ctx, atPod, names.ServerContainer, cmd...)
 	if err != nil {
 		switch {
-		case isEndpointBadError(stdout):
+		case cloud.IsEndpointBadError(stdout):
 			c.VRec.EVRec.Eventf(c.Vdb, corev1.EventTypeWarning, events.S3EndpointIssue,
 				"Unable to write to the bucket in the S3 endpoint '%s'", c.Vdb.Spec.Communal.Endpoint)
 			return ctrl.Result{Requeue: true}, nil
 
-		case isBucketNotExistError(stdout):
+		case cloud.IsBucketNotExistError(stdout):
 			c.VRec.EVRec.Eventf(c.Vdb, corev1.EventTypeWarning, events.S3BucketDoesNotExist,
 				"The bucket in the S3 path '%s' does not exist", c.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/createdb_reconcile_test.go
+++ b/pkg/controllers/createdb_reconcile_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -34,8 +35,8 @@ var _ = Describe("createdb_reconciler", func() {
 	It("should not call create_db if db already exists", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 		createS3CredSecret(ctx, vdb)
 		defer deleteCommunalCredSecret(ctx, vdb)
 
@@ -52,8 +53,8 @@ var _ = Describe("createdb_reconciler", func() {
 		vdb.Spec.Subclusters[0].Size = 3
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 		createS3CredSecret(ctx, vdb)
 		defer deleteCommunalCredSecret(ctx, vdb)
 
@@ -71,8 +72,8 @@ var _ = Describe("createdb_reconciler", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 1
 		vdb.Spec.Subclusters = append(vdb.Spec.Subclusters, vapi.Subcluster{Name: "secondary", Size: 2})
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
@@ -158,8 +159,8 @@ func createMultiPodSubclusterForKsafe(ctx context.Context, ksafe vapi.KSafetyTyp
 	vdb.Spec.Subclusters[0].Size = firstScSize
 	vdb.Spec.KSafety = ksafe
 	vdb.Spec.Subclusters = append(vdb.Spec.Subclusters, vapi.Subcluster{Name: "secondary", Size: 2})
-	createPods(ctx, vdb, AllPodsRunning)
-	defer deletePods(ctx, vdb)
+	test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+	defer test.DeletePods(ctx, k8sClient, vdb)
 
 	fpr := &cmds.FakePodRunner{}
 	pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)

--- a/pkg/controllers/dbaddnode_reconcile_test.go
+++ b/pkg/controllers/dbaddnode_reconcile_test.go
@@ -24,6 +24,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"yunion.io/x/pkg/tristate"
 )
@@ -34,8 +35,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should not call db_add_node if db already exists everywhere", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -48,8 +49,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should not call db_add_node if no db exists anywhere", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 3)
@@ -62,8 +63,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should call db_add_node if db exists but is missing at one running pod", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
@@ -77,8 +78,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should succeed if we try to add a node and hit the limit", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -108,8 +109,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should rebalance shards if we scale out", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
@@ -122,8 +123,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should not call select rebalance_shards() if no node has been added", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -138,8 +139,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should not add node and requeue if one pod is missing db and another pod isn't running", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -160,8 +161,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 	It("should have a single add node call if multi pods are missing db", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 2)

--- a/pkg/controllers/dbaddsubcluster_reconcile_test.go
+++ b/pkg/controllers/dbaddsubcluster_reconcile_test.go
@@ -23,6 +23,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -32,8 +33,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 	It("should parse subcluster from vsql output", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -61,8 +62,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 			Name: "sc2",
 			Size: 0,
 		})
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -87,8 +88,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 	It("should use the proper subcluster type switch for v10.1.1 versions", func() {
 		vdb := vapi.MakeVDB()
 		vdb.ObjectMeta.Annotations[vapi.VersionAnnotation] = "v10.1.1-0"
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)

--- a/pkg/controllers/dbremovenode_reconcile.go
+++ b/pkg/controllers/dbremovenode_reconcile.go
@@ -25,6 +25,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -80,8 +81,8 @@ func (d *DBRemoveNodeReconciler) Reconcile(ctx context.Context, req *ctrl.Reques
 	// Use the finder so that we check only the subclusters that are in the vdb.
 	// Any nodes that are in subclusters that we are removing are handled by the
 	// DBRemoveSubcusterReconciler.
-	finder := MakeSubclusterFinder(d.VRec.Client, d.Vdb)
-	subclusters, err := finder.FindSubclusters(ctx, FindInVdb)
+	finder := iter.MakeSubclusterFinder(d.VRec.Client, d.Vdb)
+	subclusters, err := finder.FindSubclusters(ctx, iter.FindInVdb)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/dbremovenode_reconcile_test.go
+++ b/pkg/controllers/dbremovenode_reconcile_test.go
@@ -21,8 +21,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"yunion.io/x/pkg/tristate"
@@ -44,10 +46,10 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
-		uninstallPod := buildPod(vdb, sc, 1)
+		uninstallPod := builder.BuildPod(vdb, sc, 1)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -69,8 +71,8 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 3
 		vdbCopy := vdb.DeepCopy() // Take a copy so that we cleanup with the original size
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdbCopy)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdbCopy)
 		sc.Size = 1 // mimic a pending db_remove_node
 
 		uninstallPods := []types.NamespacedName{names.GenPodName(vdb, sc, 1), names.GenPodName(vdb, sc, 2)}
@@ -94,8 +96,8 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		vdbCopy := vdb.DeepCopy() // Take a copy so that we cleanup with the original size
-		createPods(ctx, vdb, AllPodsNotRunning)
-		defer deletePods(ctx, vdbCopy)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdbCopy)
 		sc.Size = sc.Size - 1 // mimic a pending db_remove_node
 
 		fpr := &cmds.FakePodRunner{}
@@ -112,8 +114,8 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 3
 		vdbCopy := vdb.DeepCopy() // Take a copy so that we cleanup with the original size
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdbCopy)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdbCopy)
 		sc.Size = 2 // Set to 2 to mimic a pending uninstall of the last pod
 
 		fpr := &cmds.FakePodRunner{}

--- a/pkg/controllers/dbremovesubcluster_reconcile_test.go
+++ b/pkg/controllers/dbremovesubcluster_reconcile_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -45,10 +46,10 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 			{Name: scNames[0], Size: scSizes[0]},
 			{Name: scNames[1], Size: scSizes[1]},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
-		createSvcs(ctx, vdb)
-		defer deleteSvcs(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		test.CreateSvcs(ctx, k8sClient, vdb)
+		defer test.DeleteSvcs(ctx, k8sClient, vdb)
 
 		// We create a second vdb without one of the subclusters.  We then use
 		// the finder to discover this additional subcluster.

--- a/pkg/controllers/install_reconcile_test.go
+++ b/pkg/controllers/install_reconcile_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"yunion.io/x/pkg/tristate"
 )
@@ -36,8 +37,8 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 
 	It("should detect no install is needed", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, true)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, true)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		sc := &vdb.Spec.Subclusters[0]
 		fpr := &cmds.FakePodRunner{}
@@ -52,8 +53,8 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 
 	It("should detect one pod that needs to be installed", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		sc := &vdb.Spec.Subclusters[0]
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{
@@ -87,8 +88,8 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 
 	It("should try install if a pod has not run the installer yet", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		sc := &vdb.Spec.Subclusters[0]
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{
@@ -132,8 +133,8 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 	It("should skip call exec on a pod if is not yet running", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 1
-		createPods(ctx, vdb, AllPodsNotRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
 		pfact := MakePodFacts(k8sClient, fpr)
@@ -151,11 +152,11 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		const ScIndex = 0
 		sc := &vdb.Spec.Subclusters[ScIndex]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsNotRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 		// Make only pod -1 runable.
 		const PodIndex = 1
-		setPodStatus(ctx, 1 /* funcOffset */, names.GenPodName(vdb, sc, 1), ScIndex, PodIndex, AllPodsRunning)
+		test.SetPodStatus(ctx, k8sClient, 1 /* funcOffset */, names.GenPodName(vdb, sc, 1), ScIndex, PodIndex, test.AllPodsRunning)
 
 		fpr := &cmds.FakePodRunner{}
 		pfact := MakePodFacts(k8sClient, fpr)
@@ -171,8 +172,8 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		const ScIndex = 0
 		sc := &vdb.Spec.Subclusters[ScIndex]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfact := createPodFactsWithInstallNeeded(ctx, vdb, fpr)

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -24,7 +24,9 @@ import (
 	"strings"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/version"
@@ -134,8 +136,8 @@ func (p *PodFacts) Collect(ctx context.Context, vdb *vapi.VerticaDB) error {
 	// Find all of the subclusters to collect facts for.  We want to include all
 	// subclusters, even ones that are scheduled to be deleted -- we keep
 	// collecting facts for those until the statefulsets are gone.
-	finder := MakeSubclusterFinder(p.Client, vdb)
-	subclusters, err := finder.FindSubclusters(ctx, FindAll)
+	finder := iter.MakeSubclusterFinder(p.Client, vdb)
+	subclusters, err := finder.FindSubclusters(ctx, iter.FindAll)
 	if err != nil {
 		return nil
 	}
@@ -201,7 +203,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 	pf.isPodRunning = pod.Status.Phase == corev1.PodRunning
 	pf.dnsName = pod.Spec.Hostname + "." + pod.Spec.Subdomain
 	pf.podIP = pod.Status.PodIP
-	pf.isTransient, _ = strconv.ParseBool(pod.Labels[SubclusterTransientLabel])
+	pf.isTransient, _ = strconv.ParseBool(pod.Labels[builder.SubclusterTransientLabel])
 
 	fns := []func(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error{
 		p.checkIsInstalled,

--- a/pkg/controllers/podfacts_test.go
+++ b/pkg/controllers/podfacts_test.go
@@ -24,6 +24,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,8 +48,8 @@ var _ = Describe("podfacts", func() {
 
 	It("should detect that there is a stale admintools.conf", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		sc := &vdb.Spec.Subclusters[0]
 		installIndFn := vdb.GenInstallerIndicatorFileName()
@@ -82,8 +83,8 @@ var _ = Describe("podfacts", func() {
 
 	It("should never indicate db exists if pods not running", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsNotRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr := &cmds.FakePodRunner{}
@@ -97,8 +98,8 @@ var _ = Describe("podfacts", func() {
 
 	It("should not indicate db exists if db directory is not there", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{
@@ -251,8 +252,8 @@ var _ = Describe("podfacts", func() {
 
 	It("should parse out the compat21 node name from install indicator file", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{

--- a/pkg/controllers/rebalanceshards_reconciler_test.go
+++ b/pkg/controllers/rebalanceshards_reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -35,8 +36,8 @@ var _ = Describe("rebalanceshards_reconcile", func() {
 			{Name: "sc1", Size: 1},
 			{Name: "sc2", Size: 1},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)

--- a/pkg/controllers/restart_reconciler_test.go
+++ b/pkg/controllers/restart_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,8 +61,8 @@ var _ = Describe("restart_reconciler", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		sc := &vdb.Spec.Subclusters[0]
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{1}, PodNotReadOnly)
@@ -88,8 +89,8 @@ var _ = Describe("restart_reconciler", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		sc := &vdb.Spec.Subclusters[0]
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		nm := types.NamespacedName{
 			Name:      vdb.Name,
@@ -122,8 +123,8 @@ var _ = Describe("restart_reconciler", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		sc := &vdb.Spec.Subclusters[0]
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{1, 4}, PodNotReadOnly)
@@ -174,8 +175,8 @@ var _ = Describe("restart_reconciler", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1, 2}, PodNotReadOnly)
@@ -190,9 +191,9 @@ var _ = Describe("restart_reconciler", func() {
 		Expect(ok).Should(BeTrue())
 		Expect(ipChanging).Should(BeTrue())
 		Expect(mapFileContents).Should(ContainElements(
-			fmt.Sprintf("%s %s", Node1OldIP, fakeIPForPod(0, 0)),
-			fmt.Sprintf("%s %s", Node2OldIP, fakeIPForPod(0, 1)),
-			fmt.Sprintf("%s %s", Node3OldIP, fakeIPForPod(0, 2)),
+			fmt.Sprintf("%s %s", Node1OldIP, test.FakeIPForPod(0, 0)),
+			fmt.Sprintf("%s %s", Node2OldIP, test.FakeIPForPod(0, 1)),
+			fmt.Sprintf("%s %s", Node3OldIP, test.FakeIPForPod(0, 2)),
 		))
 	})
 
@@ -201,8 +202,8 @@ var _ = Describe("restart_reconciler", func() {
 		const ScIndex = 0
 		sc := &vdb.Spec.Subclusters[ScIndex]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsNotRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1}, PodNotReadOnly)
@@ -220,8 +221,8 @@ var _ = Describe("restart_reconciler", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1}, PodNotReadOnly)
@@ -244,7 +245,7 @@ var _ = Describe("restart_reconciler", func() {
 		Expect(ipChanging).Should(BeTrue())
 		Expect(len(mapFileContents)).Should(Equal(1))
 		Expect(mapFileContents).Should(ContainElement(
-			"10.10.2.1 " + fakeIPForPod(0, 0),
+			"10.10.2.1 " + test.FakeIPForPod(0, 0),
 		))
 	})
 
@@ -252,8 +253,8 @@ var _ = Describe("restart_reconciler", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 3
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		atPod := names.GenPodName(vdb, sc, 0)
 		fpr := &cmds.FakePodRunner{}
@@ -272,9 +273,9 @@ var _ = Describe("restart_reconciler", func() {
 		Expect(ok).Should(BeTrue())
 		Expect(ipChanging).Should(BeTrue())
 		Expect(mapFileContents).Should(ContainElements(
-			"10.10.2.1 "+fakeIPForPod(0, 0),
-			"10.10.2.2 "+fakeIPForPod(0, 1),
-			"10.10.2.3 "+fakeIPForPod(0, 2),
+			"10.10.2.1 "+test.FakeIPForPod(0, 0),
+			"10.10.2.2 "+test.FakeIPForPod(0, 1),
+			"10.10.2.3 "+test.FakeIPForPod(0, 2),
 		))
 	})
 
@@ -282,8 +283,8 @@ var _ = Describe("restart_reconciler", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		atPod := names.GenPodName(vdb, sc, 0)
 		fpr := &cmds.FakePodRunner{}
@@ -293,7 +294,7 @@ var _ = Describe("restart_reconciler", func() {
 		r := act.(*RestartReconciler)
 		fpr.Results = cmds.CmdResults{
 			atPod: []cmds.CmdResult{
-				{Stdout: fmt.Sprintf("node0001 = %s,/d/d\nnode0002 = %s,/d,/d\n", fakeIPForPod(0, 0), fakeIPForPod(0, 1))},
+				{Stdout: fmt.Sprintf("node0001 = %s,/d/d\nnode0002 = %s,/d,/d\n", test.FakeIPForPod(0, 0), test.FakeIPForPod(0, 1))},
 			},
 		}
 		oldIPs, err := r.fetchOldIPsFromNode(ctx, atPod)
@@ -310,8 +311,8 @@ var _ = Describe("restart_reconciler", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		sc := &vdb.Spec.Subclusters[0]
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1}, PodNotReadOnly)
@@ -330,7 +331,7 @@ var _ = Describe("restart_reconciler", func() {
 		r.ATPod = atPod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// Check the command history.
-		upload := fpr.FindCommands("4.4.4.4", fakeIPForPod(0, 0)) // Verify we upload the map file
+		upload := fpr.FindCommands("4.4.4.4", test.FakeIPForPod(0, 0)) // Verify we upload the map file
 		Expect(len(upload)).Should(Equal(1))
 		reip := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "re_ip")
 		Expect(len(reip)).Should(Equal(1))
@@ -368,8 +369,8 @@ var _ = Describe("restart_reconciler", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		sc := &vdb.Spec.Subclusters[0]
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -395,8 +396,8 @@ var _ = Describe("restart_reconciler", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		sc := &vdb.Spec.Subclusters[0]
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		const DownPodIndex = 0
@@ -427,8 +428,8 @@ var _ = Describe("restart_reconciler", func() {
 		vdb.Spec.RestartTimeout = 500
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1}, PodNotReadOnly)
@@ -449,8 +450,8 @@ var _ = Describe("restart_reconciler", func() {
 		vdb.Spec.RestartTimeout = 800
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0}, PodNotReadOnly)
@@ -470,8 +471,8 @@ var _ = Describe("restart_reconciler", func() {
 		sc.Size = ScSize
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
@@ -507,11 +508,11 @@ var _ = Describe("restart_reconciler", func() {
 		sc.Size = ScSize
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
-		createPods(ctx, vdb, AllPodsNotRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		// Pod -0 is running and pod -1 is not running.
-		setPodStatusHelper(ctx, 1, names.GenPodName(vdb, sc, 0), 0, 0, AllPodsRunning, false)
+		test.SetPodStatus(ctx, k8sClient, 1, names.GenPodName(vdb, sc, 0), 0, 0, test.AllPodsRunning)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		const DownPodIndex = 1
@@ -527,8 +528,8 @@ var _ = Describe("restart_reconciler", func() {
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
 		sc := &vdb.Spec.Subclusters[0]
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		const DownPodIndex = 0
@@ -555,11 +556,11 @@ var _ = Describe("restart_reconciler", func() {
 		}
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
-		transientSc := buildTransientSubcluster(vdb, "")
-		createSts(ctx, vdb, transientSc, 1, 0, AllPodsRunning)
-		defer deleteSts(ctx, vdb, transientSc, 1)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		transientSc := vdb.BuildTransientSubcluster("")
+		test.CreateSts(ctx, k8sClient, vdb, transientSc, 1, 0, test.AllPodsRunning)
+		defer test.DeleteSts(ctx, k8sClient, vdb, transientSc, 1)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		const DownPodIndex = 0

--- a/pkg/controllers/revivedb_reconcile.go
+++ b/pkg/controllers/revivedb_reconcile.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cloud"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
@@ -83,12 +84,12 @@ func (r *ReviveDBReconciler) execCmd(ctx context.Context, atPod types.Namespaced
 				r.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil
 
-		case isBucketNotExistError(stdout):
+		case cloud.IsBucketNotExistError(stdout):
 			r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.S3BucketDoesNotExist,
 				"The bucket in the S3 path '%s' does not exist", r.Vdb.GetCommunalPath())
 			return ctrl.Result{Requeue: true}, nil
 
-		case isEndpointBadError(stdout):
+		case cloud.IsEndpointBadError(stdout):
 			r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.S3EndpointIssue,
 				"Unable to connect to S3 endpoint '%s'", r.Vdb.Spec.Communal.Endpoint)
 			return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/revivedb_reconcile_test.go
+++ b/pkg/controllers/revivedb_reconcile_test.go
@@ -24,6 +24,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -46,8 +47,8 @@ var _ = Describe("revivedb_reconcile", func() {
 		vdb.Spec.InitPolicy = vapi.CommunalInitPolicyRevive
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -65,8 +66,8 @@ var _ = Describe("revivedb_reconcile", func() {
 		sc.Size = ScSize
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 		createS3CredSecret(ctx, vdb)
 		defer deleteCommunalCredSecret(ctx, vdb)
 
@@ -157,8 +158,8 @@ var _ = Describe("revivedb_reconcile", func() {
 			{SubclusterIndex: 2, PodCount: 2},
 			{SubclusterIndex: 0, PodCount: 1},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -185,8 +186,8 @@ var _ = Describe("revivedb_reconcile", func() {
 			{SubclusterIndex: 2, PodCount: 5}, // Will only pick 3 from this subcluster
 			{SubclusterIndex: 1, PodCount: 0}, // Will include entire subcluster
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -204,8 +205,8 @@ var _ = Describe("revivedb_reconcile", func() {
 
 	It("will fail to generate host list if reviveOrder is bad", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)

--- a/pkg/controllers/status_reconcile.go
+++ b/pkg/controllers/status_reconcile.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/status"
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,8 +55,8 @@ func (s *StatusReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ct
 
 	// Use all subclusters, even ones that are scheduled for removal.  We keep
 	// reporting status on the deleted ones until the statefulsets are gone.
-	finder := MakeSubclusterFinder(s.Client, s.Vdb)
-	subclusters, err := finder.FindSubclusters(ctx, FindAll)
+	finder := iter.MakeSubclusterFinder(s.Client, s.Vdb)
+	subclusters, err := finder.FindSubclusters(ctx, iter.FindAll)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -25,12 +25,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -80,7 +78,7 @@ var _ = BeforeSuite(func() {
 		Log:    logger,
 		Scheme: scheme.Scheme,
 		Cfg:    restCfg,
-		EVRec:  mgr.GetEventRecorderFor(OperatorName),
+		EVRec:  mgr.GetEventRecorderFor(builder.OperatorName),
 	}
 }, 60)
 
@@ -96,149 +94,6 @@ func TestAPIs(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"K8s Suite",
 		[]Reporter{printer.NewlineReporter{}})
-}
-
-type PodRunningState bool
-
-const (
-	AllPodsRunning    PodRunningState = true
-	AllPodsNotRunning PodRunningState = false
-)
-
-func createPods(ctx context.Context, vdb *vapi.VerticaDB, podRunningState PodRunningState) {
-	for i := range vdb.Spec.Subclusters {
-		sc := &vdb.Spec.Subclusters[i]
-		createSts(ctx, vdb, sc, 2, int32(i), podRunningState)
-	}
-}
-
-func createSts(ctx context.Context, vdb *vapi.VerticaDB, sc *vapi.Subcluster, offset int, scIndex int32, podRunningState PodRunningState) {
-	sts := &appsv1.StatefulSet{}
-	if err := k8sClient.Get(ctx, names.GenStsName(vdb, sc), sts); kerrors.IsNotFound(err) {
-		sts = buildStsSpec(names.GenStsName(vdb, sc), vdb, sc)
-		ExpectWithOffset(offset, k8sClient.Create(ctx, sts)).Should(Succeed())
-	}
-	for j := int32(0); j < sc.Size; j++ {
-		pod := &corev1.Pod{}
-		if err := k8sClient.Get(ctx, names.GenPodName(vdb, sc, j), pod); kerrors.IsNotFound(err) {
-			pod = buildPod(vdb, sc, j)
-			ExpectWithOffset(offset, k8sClient.Create(ctx, pod)).Should(Succeed())
-			setPodStatusHelper(ctx, offset+1, names.GenPodName(vdb, sc, j), scIndex, j, podRunningState, false)
-		}
-	}
-	// Update the status in the sts to reflect the number of pods we created
-	sts.Status.Replicas = sc.Size
-	sts.Status.ReadyReplicas = sc.Size
-	ExpectWithOffset(offset, k8sClient.Status().Update(ctx, sts))
-}
-
-func fakeIPv6ForPod(scIndex, podIndex int32) string {
-	return fmt.Sprintf("fdf8:f535:82e4::%x", scIndex*100+podIndex)
-}
-
-func fakeIPForPod(scIndex, podIndex int32) string {
-	return fmt.Sprintf("192.168.%d.%d", scIndex, podIndex)
-}
-
-func setPodStatusHelper(ctx context.Context, funcOffset int, podName types.NamespacedName,
-	scIndex, podIndex int32, podRunningState PodRunningState, ipv6 bool) {
-	pod := &corev1.Pod{}
-	ExpectWithOffset(funcOffset, k8sClient.Get(ctx, podName, pod)).Should(Succeed())
-
-	// Since we using a fake kubernetes cluster, none of the pods we
-	// create will actually be changed to run. Some testcases depend
-	// on that, so we will update the pod status to show that they
-	// are running.
-	if podRunningState {
-		pod.Status.Phase = corev1.PodRunning
-		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Ready: true}}
-	}
-	// We assign a fake IP that is deterministic so that it is easily
-	// identifiable in a test.
-	if ipv6 {
-		pod.Status.PodIP = fakeIPv6ForPod(scIndex, podIndex)
-	} else {
-		pod.Status.PodIP = fakeIPForPod(scIndex, podIndex)
-	}
-
-	ExpectWithOffset(funcOffset, k8sClient.Status().Update(ctx, pod))
-	if podRunningState {
-		ExpectWithOffset(funcOffset, k8sClient.Get(ctx, podName, pod)).Should(Succeed())
-		ExpectWithOffset(funcOffset, pod.Status.Phase).Should(Equal(corev1.PodRunning))
-	}
-}
-
-func setPodStatus(ctx context.Context, funcOffset int, podName types.NamespacedName,
-	scIndex, podIndex int32, podRunningState PodRunningState) {
-	setPodStatusHelper(ctx, funcOffset, podName, scIndex, podIndex, podRunningState, false)
-}
-
-func deletePods(ctx context.Context, vdb *vapi.VerticaDB) {
-	for i := range vdb.Spec.Subclusters {
-		sc := &vdb.Spec.Subclusters[i]
-		deleteSts(ctx, vdb, sc, 2)
-	}
-}
-
-func deleteSts(ctx context.Context, vdb *vapi.VerticaDB, sc *vapi.Subcluster, offset int) {
-	for j := int32(0); j < sc.Size; j++ {
-		pod := &corev1.Pod{}
-		err := k8sClient.Get(ctx, names.GenPodName(vdb, sc, j), pod)
-		if !kerrors.IsNotFound(err) {
-			ExpectWithOffset(offset, k8sClient.Delete(ctx, pod)).Should(Succeed())
-		}
-	}
-	sts := &appsv1.StatefulSet{}
-	err := k8sClient.Get(ctx, names.GenStsName(vdb, sc), sts)
-	if !kerrors.IsNotFound(err) {
-		ExpectWithOffset(offset, k8sClient.Delete(ctx, sts)).Should(Succeed())
-	}
-}
-
-func createSvcs(ctx context.Context, vdb *vapi.VerticaDB) {
-	svc := buildHlSvc(names.GenHlSvcName(vdb), vdb)
-	ExpectWithOffset(1, k8sClient.Create(ctx, svc)).Should(Succeed())
-	for i := range vdb.Spec.Subclusters {
-		sc := &vdb.Spec.Subclusters[i]
-		svc := buildExtSvc(names.GenExtSvcName(vdb, sc), vdb, sc, makeSvcSelectorLabelsForServiceNameRouting)
-		ExpectWithOffset(1, k8sClient.Create(ctx, svc)).Should(Succeed())
-	}
-}
-
-func deleteSvcs(ctx context.Context, vdb *vapi.VerticaDB) {
-	for i := range vdb.Spec.Subclusters {
-		sc := &vdb.Spec.Subclusters[i]
-		svc := &corev1.Service{}
-		err := k8sClient.Get(ctx, names.GenExtSvcName(vdb, sc), svc)
-		if !kerrors.IsNotFound(err) {
-			ExpectWithOffset(1, k8sClient.Delete(ctx, svc)).Should(Succeed())
-		}
-	}
-	svc := &corev1.Service{}
-	err := k8sClient.Get(ctx, names.GenHlSvcName(vdb), svc)
-	if !kerrors.IsNotFound(err) {
-		ExpectWithOffset(1, k8sClient.Delete(ctx, svc)).Should(Succeed())
-	}
-}
-
-func scaleDownSubcluster(ctx context.Context, vdb *vapi.VerticaDB, sc *vapi.Subcluster, newSize int32) {
-	ExpectWithOffset(1, sc.Size).Should(BeNumerically(">=", newSize))
-	for i := newSize; i < sc.Size; i++ {
-		pod := &corev1.Pod{}
-		ExpectWithOffset(1, k8sClient.Get(ctx, names.GenPodName(vdb, sc, i), pod)).Should(Succeed())
-		ExpectWithOffset(1, k8sClient.Delete(ctx, pod)).Should(Succeed())
-	}
-
-	// Update the status field of the sts
-	sts := &appsv1.StatefulSet{}
-	ExpectWithOffset(1, k8sClient.Get(ctx, names.GenStsName(vdb, sc), sts)).Should(Succeed())
-	sts.Status.Replicas = newSize
-	sts.Status.ReadyReplicas = newSize
-	ExpectWithOffset(1, k8sClient.Status().Update(ctx, sts))
-
-	// Update the subcluster size
-	sc.Size = newSize
-	ExpectWithOffset(1, k8sClient.Update(ctx, vdb)).Should(Succeed())
 }
 
 func createVdb(ctx context.Context, vdb *vapi.VerticaDB) {
@@ -303,17 +158,17 @@ const testAccessKey = "dummy"
 const testSecretKey = "dummy"
 
 func createS3CredSecret(ctx context.Context, vdb *vapi.VerticaDB) {
-	secret := buildS3CommunalCredSecret(vdb, testAccessKey, testSecretKey)
+	secret := builder.BuildS3CommunalCredSecret(vdb, testAccessKey, testSecretKey)
 	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 }
 
 func createAzureAccountKeyCredSecret(ctx context.Context, vdb *vapi.VerticaDB) {
-	secret := buildAzureAccountKeyCommunalCredSecret(vdb, "verticaAccountName", "secretKey")
+	secret := builder.BuildAzureAccountKeyCommunalCredSecret(vdb, "verticaAccountName", "secretKey")
 	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 }
 
 func createAzureSASCredSecret(ctx context.Context, vdb *vapi.VerticaDB) {
-	secret := buildAzureSASCommunalCredSecret(vdb, "blob.microsoft.net", "sharedAccessKey")
+	secret := builder.BuildAzureSASCommunalCredSecret(vdb, "blob.microsoft.net", "sharedAccessKey")
 	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 }
 

--- a/pkg/controllers/uninstall_reconcile.go
+++ b/pkg/controllers/uninstall_reconcile.go
@@ -24,6 +24,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/atconf"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -92,8 +93,8 @@ func (s *UninstallReconciler) Reconcile(ctx context.Context, req *ctrl.Request) 
 	// We need to use the finder so that we include subclusters that don't exist
 	// in the vdb.  We need to call uninstall for each pod that is part of a
 	// deleted subcluster.
-	finder := MakeSubclusterFinder(s.VRec.Client, s.Vdb)
-	subclusters, err := finder.FindSubclusters(ctx, FindAll)
+	finder := iter.MakeSubclusterFinder(s.VRec.Client, s.Vdb)
+	subclusters, err := finder.FindSubclusters(ctx, iter.FindAll)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/uninstall_reconcile_test.go
+++ b/pkg/controllers/uninstall_reconcile_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"yunion.io/x/pkg/tristate"
 )
@@ -46,8 +47,8 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -66,8 +67,8 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
 		vdbCopy := vdb.DeepCopy() // Take a copy so that cleanup with original size
-		createPods(ctx, vdb, AllPodsNotRunning)
-		defer deletePods(ctx, vdbCopy)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdbCopy)
 		sc.Size = 1 // Set to 1 to mimic a pending uninstall
 
 		fpr := &cmds.FakePodRunner{}
@@ -85,8 +86,8 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 3
 		vdbCopy := vdb.DeepCopy() // Take a copy so that we cleanup with the original size
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdbCopy)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdbCopy)
 		sc.Size = 1 // mimic a pending db_remove_node
 
 		fpr := &cmds.FakePodRunner{}
@@ -108,8 +109,8 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
 		vdbCopy := vdb.DeepCopy() // Take a copy so that we cleanup with the original size
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdbCopy)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdbCopy)
 		sc.Size = 1 // mimic a pending db_remove_node
 
 		fpr := &cmds.FakePodRunner{}

--- a/pkg/controllers/upgrade_test.go
+++ b/pkg/controllers/upgrade_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -81,8 +82,8 @@ var _ = Describe("upgrade", func() {
 
 	It("should not need an upgrade if images match in sts and vdb", func() {
 		vdb := vapi.MakeVDB()
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		mgr := MakeUpgradeManager(vrec, logger, vdb, vapi.OnlineUpgradeInProgress,
 			func(vdb *vapi.VerticaDB) bool { return true })
@@ -96,8 +97,8 @@ var _ = Describe("upgrade", func() {
 			{Name: "sc1", Size: 2, IsPrimary: true},
 			{Name: "sc2", Size: 3, IsPrimary: false},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 		vdb.Spec.Image = NewImage
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
@@ -123,8 +124,8 @@ var _ = Describe("upgrade", func() {
 			{Name: "sc1", Size: 1, IsPrimary: true},
 			{Name: "sc2", Size: 1, IsPrimary: false},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 		vdb.Spec.Image = NewImage // Change image to force pod deletion
 
 		mgr := MakeUpgradeManager(vrec, logger, vdb, vapi.OfflineUpgradeInProgress,
@@ -144,8 +145,8 @@ var _ = Describe("upgrade", func() {
 			{Name: "sc1", Size: 1, IsPrimary: false},
 			{Name: "sc2", Size: 1, IsPrimary: false},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 		vdb.Spec.Image = NewImage // Change image to force pod deletion
 
 		mgr := MakeUpgradeManager(vrec, logger, vdb, vapi.OfflineUpgradeInProgress,

--- a/pkg/controllers/upgradeoperator120_reconciler_test.go
+++ b/pkg/controllers/upgradeoperator120_reconciler_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -35,9 +36,9 @@ var _ = Describe("k8s/upgradeoperator120_reconciler", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		nm := names.GenStsName(vdb, sc)
-		sts := buildStsSpec(nm, vdb, sc)
+		sts := builder.BuildStsSpec(nm, vdb, sc)
 		// Set an old operator version to force the upgrade
-		sts.Labels[OperatorVersionLabel] = OperatorVersion110
+		sts.Labels[builder.OperatorVersionLabel] = builder.OperatorVersion110
 		Expect(k8sClient.Create(ctx, sts)).Should(Succeed())
 		defer func() {
 			delSts := &appsv1.StatefulSet{}

--- a/pkg/controllers/version_reconciler_test.go
+++ b/pkg/controllers/version_reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -34,8 +35,8 @@ var _ = Describe("k8s/version_reconcile", func() {
 		vdb.Spec.Subclusters[0].Size = 1
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
@@ -70,8 +71,8 @@ vertica(v11.1.0) built by @re-docker2 from tag@releases/VER_10_1_RELEASE_BUILD_1
 		vdb.Spec.Subclusters[0].Size = 1
 		createVdb(ctx, vdb)
 		defer deleteVdb(ctx, vdb)
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)

--- a/pkg/controllers/verticadb_controller.go
+++ b/pkg/controllers/verticadb_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
@@ -182,11 +183,11 @@ func (r *VerticaDBReconciler) GetSuperuserPassword(ctx context.Context, vdb *vap
 		}
 		return passwd, err
 	}
-	pwd, ok := secret.Data[SuperuserPasswordKey]
+	pwd, ok := secret.Data[builder.SuperuserPasswordKey]
 	if ok {
 		passwd = string(pwd)
 	} else {
-		log.Error(err, fmt.Sprintf("password not found, secret must have a key with name '%s'", SuperuserPasswordKey))
+		log.Error(err, fmt.Sprintf("password not found, secret must have a key with name '%s'", builder.SuperuserPasswordKey))
 	}
 	return passwd, nil
 }

--- a/pkg/iter/sc_finder_test.go
+++ b/pkg/iter/sc_finder_test.go
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-package controllers
+package iter
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 )
 
 var _ = Describe("sc_finder", func() {
@@ -56,8 +57,8 @@ var _ = Describe("sc_finder", func() {
 			{Name: scNames[0], Size: scSizes[0]},
 			{Name: scNames[1], Size: scSizes[1]},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		// We create a second vdb without one of the subclusters.  We then use
 		// the finder to discover this additional subcluster.
@@ -81,8 +82,8 @@ var _ = Describe("sc_finder", func() {
 			{Name: scNames[0], Size: scSizes[0]},
 			{Name: scNames[1], Size: scSizes[1]},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		// We create a second vdb without one of the subclusters.  We then use
 		// the finder to discover this additional subcluster.
@@ -106,11 +107,11 @@ var _ = Describe("sc_finder", func() {
 			{Name: scNames[0], Size: scSizes[0], IsPrimary: true},
 			{Name: scNames[1], Size: scSizes[1], IsPrimary: false},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		vdbCopy := *vdb // Make a copy for cleanup since we will mutate vdb
-		defer deletePods(ctx, &vdbCopy)
-		createSvcs(ctx, vdb)
-		defer deleteSvcs(ctx, vdb)
+		defer test.DeletePods(ctx, k8sClient, &vdbCopy)
+		test.CreateSvcs(ctx, k8sClient, vdb)
+		defer test.DeleteSvcs(ctx, k8sClient, vdb)
 
 		// Add another subcluster, but since we didn't create any k8s objects
 		// for it, it won't be returned by the finder.
@@ -141,8 +142,8 @@ var _ = Describe("sc_finder", func() {
 			{Name: scNames[0], Size: scSizes[0]},
 			{Name: scNames[1], Size: scSizes[1]},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		// When use the finder, pass in a Vdb that is entirely different then
 		// the one we used above.  It will be ignored anyway when using
@@ -156,8 +157,8 @@ var _ = Describe("sc_finder", func() {
 	It("should find service objects that exist in the vdb", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
-		createSvcs(ctx, vdb)
-		defer deleteSvcs(ctx, vdb)
+		test.CreateSvcs(ctx, k8sClient, vdb)
+		defer test.DeleteSvcs(ctx, k8sClient, vdb)
 
 		finder := MakeSubclusterFinder(k8sClient, vdb)
 		svcs, err := finder.FindServices(ctx, FindInVdb)
@@ -180,8 +181,8 @@ var _ = Describe("sc_finder", func() {
 			{Name: scNames[1]},
 		}
 		sc2 := &vdb.Spec.Subclusters[1]
-		createSvcs(ctx, vdb)
-		defer deleteSvcs(ctx, vdb)
+		test.CreateSvcs(ctx, k8sClient, vdb)
+		defer test.DeleteSvcs(ctx, k8sClient, vdb)
 
 		// Use a different vdb for the finder so that we can find the service
 		// objects missing from it.
@@ -208,8 +209,8 @@ var _ = Describe("sc_finder", func() {
 			{Name: scNames[0]},
 			{Name: scNames[1]},
 		}
-		createSvcs(ctx, vdb)
-		defer deleteSvcs(ctx, vdb)
+		test.CreateSvcs(ctx, k8sClient, vdb)
+		defer test.DeleteSvcs(ctx, k8sClient, vdb)
 
 		finder := MakeSubclusterFinder(k8sClient, vdb)
 		svcs, err := finder.FindServices(ctx, FindExisting|FindSorted)
@@ -225,8 +226,8 @@ var _ = Describe("sc_finder", func() {
 			{Name: scNames[0], Size: 2},
 			{Name: scNames[1], Size: 1},
 		}
-		createPods(ctx, vdb, AllPodsRunning)
-		defer deletePods(ctx, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		finder := MakeSubclusterFinder(k8sClient, vdb)
 		stss, err := finder.FindStatefulSets(ctx, FindExisting|FindSorted)

--- a/pkg/iter/suite_test.go
+++ b/pkg/iter/suite_test.go
@@ -1,0 +1,74 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package iter
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var logger logr.Logger
+var restCfg *rest.Config
+
+var _ = BeforeSuite(func() {
+	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(logger)
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, cfg).NotTo(BeNil())
+	restCfg = cfg
+
+	err = vapi.AddToScheme(scheme.Scheme)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+})
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"iter Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -1,0 +1,177 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/gomega" // nolint:revive,stylecheck
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type PodRunningState bool
+
+const (
+	AllPodsRunning    PodRunningState = true
+	AllPodsNotRunning PodRunningState = false
+)
+
+func CreatePods(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, podRunningState PodRunningState) {
+	for i := range vdb.Spec.Subclusters {
+		sc := &vdb.Spec.Subclusters[i]
+		const ExpectOffset = 2
+		CreateSts(ctx, c, vdb, sc, ExpectOffset, int32(i), podRunningState)
+	}
+}
+
+func CreateSts(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *vapi.Subcluster, offset int,
+	scIndex int32, podRunningState PodRunningState) {
+	sts := &appsv1.StatefulSet{}
+	if err := c.Get(ctx, names.GenStsName(vdb, sc), sts); kerrors.IsNotFound(err) {
+		sts = builder.BuildStsSpec(names.GenStsName(vdb, sc), vdb, sc)
+		ExpectWithOffset(offset, c.Create(ctx, sts)).Should(Succeed())
+	}
+	for j := int32(0); j < sc.Size; j++ {
+		pod := &corev1.Pod{}
+		if err := c.Get(ctx, names.GenPodName(vdb, sc, j), pod); kerrors.IsNotFound(err) {
+			pod = builder.BuildPod(vdb, sc, j)
+			ExpectWithOffset(offset, c.Create(ctx, pod)).Should(Succeed())
+			setPodStatusHelper(ctx, c, offset+1, names.GenPodName(vdb, sc, j), scIndex, j, podRunningState, false)
+		}
+	}
+	// Update the status in the sts to reflect the number of pods we created
+	sts.Status.Replicas = sc.Size
+	sts.Status.ReadyReplicas = sc.Size
+	ExpectWithOffset(offset, c.Status().Update(ctx, sts))
+}
+
+func ScaleDownSubcluster(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *vapi.Subcluster, newSize int32) {
+	ExpectWithOffset(1, sc.Size).Should(BeNumerically(">=", newSize))
+	for i := newSize; i < sc.Size; i++ {
+		pod := &corev1.Pod{}
+		ExpectWithOffset(1, c.Get(ctx, names.GenPodName(vdb, sc, i), pod)).Should(Succeed())
+		ExpectWithOffset(1, c.Delete(ctx, pod)).Should(Succeed())
+	}
+
+	// Update the status field of the sts
+	sts := &appsv1.StatefulSet{}
+	ExpectWithOffset(1, c.Get(ctx, names.GenStsName(vdb, sc), sts)).Should(Succeed())
+	sts.Status.Replicas = newSize
+	sts.Status.ReadyReplicas = newSize
+	ExpectWithOffset(1, c.Status().Update(ctx, sts))
+
+	// Update the subcluster size
+	sc.Size = newSize
+	ExpectWithOffset(1, c.Update(ctx, vdb)).Should(Succeed())
+}
+
+func FakeIPv6ForPod(scIndex, podIndex int32) string {
+	return fmt.Sprintf("fdf8:f535:82e4::%x", scIndex*100+podIndex)
+}
+
+func FakeIPForPod(scIndex, podIndex int32) string {
+	return fmt.Sprintf("192.168.%d.%d", scIndex, podIndex)
+}
+
+func setPodStatusHelper(ctx context.Context, c client.Client, funcOffset int, podName types.NamespacedName,
+	scIndex, podIndex int32, podRunningState PodRunningState, ipv6 bool) {
+	pod := &corev1.Pod{}
+	ExpectWithOffset(funcOffset, c.Get(ctx, podName, pod)).Should(Succeed())
+
+	// Since we using a fake kubernetes cluster, none of the pods we
+	// create will actually be changed to run. Some testcases depend
+	// on that, so we will update the pod status to show that they
+	// are running.
+	if podRunningState {
+		pod.Status.Phase = corev1.PodRunning
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Ready: true}}
+	}
+	// We assign a fake IP that is deterministic so that it is easily
+	// identifiable in a test.
+	if ipv6 {
+		pod.Status.PodIP = FakeIPv6ForPod(scIndex, podIndex)
+	} else {
+		pod.Status.PodIP = FakeIPForPod(scIndex, podIndex)
+	}
+
+	ExpectWithOffset(funcOffset, c.Status().Update(ctx, pod))
+	if podRunningState {
+		ExpectWithOffset(funcOffset, c.Get(ctx, podName, pod)).Should(Succeed())
+		ExpectWithOffset(funcOffset, pod.Status.Phase).Should(Equal(corev1.PodRunning))
+	}
+}
+
+func SetPodStatus(ctx context.Context, c client.Client, funcOffset int, podName types.NamespacedName,
+	scIndex, podIndex int32, podRunningState PodRunningState) {
+	setPodStatusHelper(ctx, c, funcOffset, podName, scIndex, podIndex, podRunningState, false)
+}
+
+func DeletePods(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
+	for i := range vdb.Spec.Subclusters {
+		sc := &vdb.Spec.Subclusters[i]
+		const ExpectOffset = 2
+		DeleteSts(ctx, c, vdb, sc, ExpectOffset)
+	}
+}
+
+func DeleteSts(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *vapi.Subcluster, offset int) {
+	for j := int32(0); j < sc.Size; j++ {
+		pod := &corev1.Pod{}
+		err := c.Get(ctx, names.GenPodName(vdb, sc, j), pod)
+		if !kerrors.IsNotFound(err) {
+			ExpectWithOffset(offset, c.Delete(ctx, pod)).Should(Succeed())
+		}
+	}
+	sts := &appsv1.StatefulSet{}
+	err := c.Get(ctx, names.GenStsName(vdb, sc), sts)
+	if !kerrors.IsNotFound(err) {
+		ExpectWithOffset(offset, c.Delete(ctx, sts)).Should(Succeed())
+	}
+}
+
+func CreateSvcs(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
+	svc := builder.BuildHlSvc(names.GenHlSvcName(vdb), vdb)
+	ExpectWithOffset(1, c.Create(ctx, svc)).Should(Succeed())
+	for i := range vdb.Spec.Subclusters {
+		sc := &vdb.Spec.Subclusters[i]
+		svc := builder.BuildExtSvc(names.GenExtSvcName(vdb, sc), vdb, sc, builder.MakeSvcSelectorLabelsForServiceNameRouting)
+		ExpectWithOffset(1, c.Create(ctx, svc)).Should(Succeed())
+	}
+}
+
+func DeleteSvcs(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
+	for i := range vdb.Spec.Subclusters {
+		sc := &vdb.Spec.Subclusters[i]
+		svc := &corev1.Service{}
+		err := c.Get(ctx, names.GenExtSvcName(vdb, sc), svc)
+		if !kerrors.IsNotFound(err) {
+			ExpectWithOffset(1, c.Delete(ctx, svc)).Should(Succeed())
+		}
+	}
+	svc := &corev1.Service{}
+	err := c.Get(ctx, names.GenHlSvcName(vdb), svc)
+	if !kerrors.IsNotFound(err) {
+		ExpectWithOffset(1, c.Delete(ctx, svc)).Should(Succeed())
+	}
+}

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/cloud"
 )
 
 var (
@@ -103,8 +103,8 @@ var _ = Describe("vdb", func() {
 		Expect(dbGen.fetchDatabaseConfig(ctx)).Should(Succeed())
 		Expect(dbGen.setCommunalEndpointAWS(ctx)).Should(Succeed())
 		Expect(dbGen.Objs.Vdb.Spec.Communal.Endpoint).Should(Equal("http://minio:30312"))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.CommunalAccessKeyName]).Should(Equal([]byte("minio")))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.CommunalSecretKeyName]).Should(Equal([]byte("minio123")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.CommunalAccessKeyName]).Should(Equal([]byte("minio")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.CommunalSecretKeyName]).Should(Equal([]byte("minio123")))
 
 		mock.ExpectQuery(Queries[DBCfgKey]).
 			WillReturnRows(sqlmock.NewRows([]string{"key", "value"}).
@@ -153,8 +153,8 @@ var _ = Describe("vdb", func() {
 					`[{"accountName": "devopsvertica","accountKey": "secretKey"}]`))
 		Expect(dbGen.fetchDatabaseConfig(ctx)).Should(Succeed())
 		Expect(dbGen.setCommunalEndpointAzure(ctx)).Should(Succeed())
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureAccountName]).Should(Equal([]byte("devopsvertica")))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureAccountKey]).Should(Equal([]byte("secretKey")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureAccountName]).Should(Equal([]byte("devopsvertica")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureAccountKey]).Should(Equal([]byte("secretKey")))
 
 		Expect(mock.ExpectationsWereMet()).Should(Succeed())
 	})
@@ -181,10 +181,10 @@ var _ = Describe("vdb", func() {
 
 		dbGen.Opts.AzureAccountName = "devopsvertica"
 		Expect(dbGen.setCommunalEndpointAzure(ctx)).Should(Succeed())
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureAccountName]).Should(Equal([]byte("devopsvertica")))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureBlobEndpoint]).Should(Equal([]byte("custom.endpoint")))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureAccountKey]).Should(Equal([]byte("")))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureSharedAccessSignature]).Should(Equal([]byte("secretSig")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureAccountName]).Should(Equal([]byte("devopsvertica")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureBlobEndpoint]).Should(Equal([]byte("custom.endpoint")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureAccountKey]).Should(Equal([]byte("")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureSharedAccessSignature]).Should(Equal([]byte("secretSig")))
 
 		Expect(mock.ExpectationsWereMet()).Should(Succeed())
 	})
@@ -205,9 +205,9 @@ var _ = Describe("vdb", func() {
 					`[{"accountName": "myacc","blobEndpoint": "azurite:10000","protocol": "http"}]`))
 		Expect(dbGen.fetchDatabaseConfig(ctx)).Should(Succeed())
 		Expect(dbGen.setCommunalEndpointAzure(ctx)).Should(Succeed())
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureAccountName]).Should(Equal([]byte("myacc")))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureBlobEndpoint]).Should(Equal([]byte("http://azurite:10000")))
-		Expect(dbGen.Objs.CredSecret.Data[controllers.AzureAccountKey]).Should(Equal([]byte("key")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureAccountName]).Should(Equal([]byte("myacc")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureBlobEndpoint]).Should(Equal([]byte("http://azurite:10000")))
+		Expect(dbGen.Objs.CredSecret.Data[cloud.AzureAccountKey]).Should(Equal([]byte("key")))
 
 		Expect(mock.ExpectationsWereMet()).Should(Succeed())
 	})


### PR DESCRIPTION
Main motivation here is that the controllers package is getting quite big, so I was looking at reducing its size.  There are some things I pulled out of it that can live in their own package.  Namely:

- sc_finder.go is moved to its own package called iter
- some cloud specific const, structs and helpers were moved to a cloud package
- a new builder package that handles constructing of the various k8s objects
- created a new test package that has common test helpers that can be used across packages