### PR TITLE
controller-manager: Configurable image repos + imagePullSecrets

### DIFF
--- a/changes/unreleased/Added-20220321-142806.yaml
+++ b/changes/unreleased/Added-20220321-142806.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Helm parameters to allow deployment of the operator from private registries
+time: 2022-03-21T14:28:06.364713612-03:00
+custom:
+  Issue: "170"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,6 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
+        # Update scripts/create-helm-charts.sh with changes to image
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/helm-charts/verticadb-operator/README.md
+++ b/helm-charts/verticadb-operator/README.md
@@ -3,6 +3,10 @@ This helm chart will install the operator and an admission controller webhook.  
 | Parameter Name | Description | Default Value |
 |----------------|-------------|---------------|
 | image.name | The name of image that runs the operator. | vertica/verticadb-operator:1.0.0 |
+| image.repo | Repo server hosting image.name | null (DockerHub) |
+| rbac_proxy_image.name | Image name of Kubernetes RBAC proxy. | kubebuilder/kube-rbac-proxy:v0.8.0 |
+| rbac_proxy_image.repo | Repo server hosting rbac_proxy_image.name | gcr.io |
+| imagePullSecrets | List of Secret names containing login credentials for above repos | null (pull images anonymously) |
 | webhook.caBundle | A PEM encoded CA bundle that will be used to validate the webhook's server certificate.  If unspecified, system trust roots on the apiserver are used. | |
 | webhook.tlsSecret | The webhook requires a TLS certficate to work.  By default we rely on cert-manager to be installed as we use it generate the cert.  If you don't want to use cert-manager, you need to specify your own cert, which you can do with this parameter.  When set, it is a name of a secret in the same namespace the chart is being installed in.  The secret must have the keys: tls.key, ca.crt, and tls.crt. | |
 | webhook.enable | If true, the webhook will be enabled and its configuration is setup by the helm chart. Setting this to false will disable the webhook. The webhook setup needs privileges to add validatingwebhookconfiguration and mutatingwebhookconfiguration, both are cluster scoped. If you do not have necessary privileges to add these configurations, then this option can be used to skip that and still deploy the operator. | true |

--- a/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
+++ b/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
@@ -1,4 +1,4 @@
-suite: test image:tag creation
+suite: image tests
 templates:
   - verticadb-operator-controller-manager-deployment.yaml
 tests:
@@ -12,3 +12,24 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: something:tag
+  - it: allows a custom image repo and image pull secrets to be set
+    set:
+      image:
+        repo: first-private-repo:5000
+        name: vertica/verticadb-operator:latest
+      rbac_proxy_image:
+        repo: second-private-repo:5000
+        name: my-rbac-proxy:v1
+      imagePullSecrets:
+        - name: image-pull-secrets
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: first-private-repo:5000/vertica/verticadb-operator:latest
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: second-private-repo:5000/my-rbac-proxy:v1
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: image-pull-secrets
+

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -18,7 +18,14 @@
 
 
 image:
+  repo: null # null = dockerhub
   name: vertica/verticadb-operator:1.3.1
+
+rbac_proxy_image:
+  repo: gcr.io
+  name: kubebuilder/kube-rbac-proxy:v0.8.0
+
+imagePullSecrets: null
 
 webhook:
   # The webhook requires a TLS certficate to work.  By default we rely on

--- a/scripts/create-helm-charts.sh
+++ b/scripts/create-helm-charts.sh
@@ -33,24 +33,32 @@ mv $TEMPLATE_DIR/verticadbs.vertica.com-crd.yaml $CRD_DIR
 # 1. Template the namespace
 sed -i 's/verticadb-operator-system/{{ .Release.Namespace }}/g' $TEMPLATE_DIR/*
 sed -i 's/verticadb-operator-.*-webhook-configuration/{{ .Release.Namespace }}-&/' $TEMPLATE_DIR/*
-# 2. Template the image name
-sed -i "s/image: controller/image: '{{ .Values.image.name }}'/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-# 3. Template the tls secret name
+# 2. Template image names
+sed -i "s|image: controller|image: '{{ with .Values.image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+sed -i "s|image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0|image: '{{ with .Values.rbac_proxy_image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+# 3. Append imagePullSecrets
+cat >>$TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml << END
+{{ if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ .Values.imagePullSecrets | toYaml | indent 8 }}
+{{ end }}
+END
+# 4. Template the tls secret name
 sed -i 's/secretName: webhook-server-cert/secretName: {{ default "webhook-server-cert" .Values.webhook.tlsSecret }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 for fn in verticadb-operator-selfsigned-issuer-issuer.yaml verticadb-operator-serving-cert-certificate.yaml
 do
   sed -i '1s/^/{{- if not .Values.webhook.tlsSecret }}\n/' $TEMPLATE_DIR/$fn
   echo "{{- end -}}" >> $TEMPLATE_DIR/$fn
 done
-# 4. Template the caBundle
+# 5. Template the caBundle
 for fn in $(ls $TEMPLATE_DIR/*webhookconfiguration.yaml)
 do
   sed -i 's/clientConfig:/clientConfig:\n    caBundle: {{ .Values.webhook.caBundle }}/' $fn
 done
-# 5. Template the resource limits and requests
+# 6. Template the resource limits and requests
 sed -i 's/resources: template-placeholder/resources:\n          {{- toYaml .Values.resources | nindent 10 }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 
-# 6.  Template the logging
+# 7.  Template the logging
 sed -i "s/--filepath=.*/--filepath={{ .Values.logging.filePath }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 sed -i "s/--maxfilesize=.*/--maxfilesize={{ .Values.logging.maxFileSize }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 sed -i "s/--maxfileage=.*/--maxfileage={{ .Values.logging.maxFileAge }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
@@ -58,7 +66,7 @@ sed -i "s/--maxfilerotation=.*/--maxfilerotation={{ .Values.logging.maxFileRotat
 sed -i "s/--level=.*/--level={{ .Values.logging.level }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 sed -i "s/--dev=.*/--dev={{ .Values.logging.dev }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 
-# 7.  Template the serviceaccount, roles and rolebindings
+# 8.  Template the serviceaccount, roles and rolebindings
 sed -i 's/serviceAccountName: verticadb-operator-controller-manager/serviceAccountName: {{ default "verticadb-operator-controller-manager" .Values.serviceAccountNameOverride }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 sed -i 's/--service-account-name=.*/--service-account-name={{ default "verticadb-operator-controller-manager" .Values.serviceAccountNameOverride }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 sed -i '1s/^/{{- if not .Values.serviceAccountNameOverride -}}\n/' $TEMPLATE_DIR/verticadb-operator-controller-manager-sa.yaml
@@ -72,7 +80,7 @@ echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-leader-election-role-role.
 sed -i '1s/^/{{- if not .Values.serviceAccountNameOverride -}}\n/' $TEMPLATE_DIR/verticadb-operator-leader-election-rolebinding-rb.yaml
 echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-leader-election-rolebinding-rb.yaml
 
-# 8.  Template the webhook access enablement
+# 9.  Template the webhook access enablement
 sed -i '1s/^/{{- if .Values.webhook.enable -}}\n/' $TEMPLATE_DIR/verticadb-operator-validating-webhook-configuration-validatingwebhookconfiguration.yaml 
 echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-validating-webhook-configuration-validatingwebhookconfiguration.yaml
 sed -i '1s/^/{{- if .Values.webhook.enable -}}\n/' $TEMPLATE_DIR/verticadb-operator-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml


### PR DESCRIPTION
Add config option for kube-rbac-proxy image instead of a hard
coded name, so that the controller-manager can be depoloyed
from a 3rd party registry (e.g. air gapped cluster, caching proxy).

Add image.repo config options to allow specifying a different
repository without changing name or version, for convenience.

Add imagePullSecrets so that images can be pulled from private repos.
