### PR TITLE
Use a helper function to set UpgradeRequeueTime in the test

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -20,6 +20,7 @@ package v1beta1
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	corev1 "k8s.io/api/core/v1"
@@ -970,12 +971,12 @@ func (v *VerticaDB) IsOnlineUpgradeInProgress() bool {
 	return inx < len(v.Status.Conditions) && v.Status.Conditions[inx].Status == corev1.ConditionTrue
 }
 
-// GetUpgradeRequeueTime returns default if not set in the CRD
-func (v *VerticaDB) GetUpgradeRequeueTime() int {
+// GetUpgradeRequeueTime returns default upgrade requeue time if not set in the CRD
+func (v *VerticaDB) GetUpgradeRequeueTime() time.Duration {
 	if v.Spec.UpgradeRequeueTime == 0 {
-		return URTime
+		return time.Second * time.Duration(URTime)
 	}
-	return v.Spec.UpgradeRequeueTime
+	return time.Second * time.Duration(v.Spec.UpgradeRequeueTime)
 }
 
 // buildTransientSubcluster creates a temporary read-only sc based on an existing subcluster

--- a/pkg/controllers/offlineupgrade_reconcile.go
+++ b/pkg/controllers/offlineupgrade_reconcile.go
@@ -104,7 +104,7 @@ func (o *OfflineUpgradeReconciler) Reconcile(ctx context.Context, req *ctrl.Requ
 			// If Reconcile was aborted with a requeue, set the RequeueAfter interval to prevent exponential backoff
 			if err == nil {
 				res.Requeue = false
-				res.RequeueAfter = time.Second * time.Duration(o.Vdb.GetUpgradeRequeueTime())
+				res.RequeueAfter = o.Vdb.GetUpgradeRequeueTime()
 			}
 			return res, err
 		}

--- a/pkg/controllers/offlineupgrade_reconcile_test.go
+++ b/pkg/controllers/offlineupgrade_reconcile_test.go
@@ -18,7 +18,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -42,7 +41,6 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		const NewImage = "vertica-k8s:newimage"
-		UpgradeRequeueTime := time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 
 		sts := &appsv1.StatefulSet{}
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[0]), sts)).Should(Succeed())
@@ -51,7 +49,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, NewImage)
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[0]), sts)).Should(Succeed())
 		Expect(sts.Spec.Template.Spec.Containers[names.ServerContainerIndex].Image).Should(Equal(NewImage))
@@ -66,10 +64,9 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		updateVdbToCauseUpgrade(ctx, vdb, "container1:newimage")
-		UpgradeRequeueTime := time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 
 		r, fpr, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 		h := fpr.FindCommands("admintools -t stop_db")
 		Expect(len(h)).Should(Equal(1))
 	})
@@ -82,16 +79,15 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		updateVdbToCauseUpgrade(ctx, vdb, "container2:newimage")
-		UpgradeRequeueTime := time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 		// Delete the sts in preparation of recrating everything with the new
 		// image.  Pods will come up not running to force a requeue by the
 		// restart reconciler.
 		test.DeletePods(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 	})
 
 	It("should delete pods during an upgrade", func() {
@@ -102,10 +98,9 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		updateVdbToCauseUpgrade(ctx, vdb, "container2:newimage")
-		UpgradeRequeueTime := time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 
 		finder := iter.MakeSubclusterFinder(k8sClient, vdb)
 		pods, err := finder.FindPods(ctx, iter.FindExisting)
@@ -122,11 +117,10 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		updateVdbToCauseUpgrade(ctx, vdb, "container2:newimage")
-		UpgradeRequeueTime := time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 		r, fpr, pfacts := createOfflineUpgradeReconciler(vdb)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)].upNode = false
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 		h := fpr.FindCommands("admintools -t stop_db")
 		Expect(len(h)).Should(Equal(0))
 	})
@@ -141,7 +135,6 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		updateVdbToCauseUpgrade(ctx, vdb, "container3:newimage")
-		UpgradeRequeueTime := time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 		r, fpr, pfacts := createOfflineUpgradeReconciler(vdb)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 
@@ -156,7 +149,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		// Read the latest vdb to get status conditions, etc.
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), vdb)).Should(Succeed())
 
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 		Expect(r.Manager.ContinuingUpgrade).Should(Equal(true))
 	})
 })

--- a/pkg/controllers/offlineupgrade_reconcile_test.go
+++ b/pkg/controllers/offlineupgrade_reconcile_test.go
@@ -49,7 +49,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, NewImage)
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[0]), sts)).Should(Succeed())
 		Expect(sts.Spec.Template.Spec.Containers[names.ServerContainerIndex].Image).Should(Equal(NewImage))
@@ -66,7 +66,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, "container1:newimage")
 
 		r, fpr, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 		h := fpr.FindCommands("admintools -t stop_db")
 		Expect(len(h)).Should(Equal(1))
 	})
@@ -81,13 +81,13 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, "container2:newimage")
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 		// Delete the sts in preparation of recrating everything with the new
 		// image.  Pods will come up not running to force a requeue by the
 		// restart reconciler.
 		test.DeletePods(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 	})
 
 	It("should delete pods during an upgrade", func() {
@@ -100,7 +100,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, "container2:newimage")
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 
 		finder := iter.MakeSubclusterFinder(k8sClient, vdb)
 		pods, err := finder.FindPods(ctx, iter.FindExisting)
@@ -120,7 +120,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		r, fpr, pfacts := createOfflineUpgradeReconciler(vdb)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)].upNode = false
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 		h := fpr.FindCommands("admintools -t stop_db")
 		Expect(len(h)).Should(Equal(0))
 	})
@@ -149,7 +149,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		// Read the latest vdb to get status conditions, etc.
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), vdb)).Should(Succeed())
 
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 		Expect(r.Manager.ContinuingUpgrade).Should(Equal(true))
 	})
 })

--- a/pkg/controllers/onlineupgrade_reconcile_test.go
+++ b/pkg/controllers/onlineupgrade_reconcile_test.go
@@ -320,11 +320,11 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		vdb.Spec.Image = NewImageName // Trigger an upgrade
-		UpgradeRequeueTime := time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
+
 		Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		r := createOnlineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: UpgradeRequeueTime}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
 		Expect(vdb.Status.UpgradeStatus).Should(Equal("Checking if new version is compatible"))
 	})
 

--- a/pkg/controllers/onlineupgrade_reconcile_test.go
+++ b/pkg/controllers/onlineupgrade_reconcile_test.go
@@ -324,7 +324,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		r := createOnlineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: test.GetURTime(vdb)}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
 		Expect(vdb.Status.UpgradeStatus).Should(Equal("Checking if new version is compatible"))
 	})
 

--- a/pkg/controllers/onlineupgrade_reconciler.go
+++ b/pkg/controllers/onlineupgrade_reconciler.go
@@ -99,7 +99,7 @@ func (o *OnlineUpgradeReconciler) Reconcile(ctx context.Context, req *ctrl.Reque
 			// If Reconcile was aborted with a requeue, set the RequeueAfter interval to prevent exponential backoff
 			if err == nil {
 				res.Requeue = false
-				res.RequeueAfter = time.Second * time.Duration(o.Vdb.GetUpgradeRequeueTime())
+				res.RequeueAfter = o.Vdb.GetUpgradeRequeueTime()
 			}
 			return res, err
 		}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -18,6 +18,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/gomega" // nolint:revive,stylecheck
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
@@ -174,4 +175,9 @@ func DeleteSvcs(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
 	if !kerrors.IsNotFound(err) {
 		ExpectWithOffset(1, c.Delete(ctx, svc)).Should(Succeed())
 	}
+}
+
+// GetURTime is a helper function that returns the upgrade requeue time for the test to assert.
+func GetURTime(vdb *vapi.VerticaDB) time.Duration {
+	return time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 }

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -18,7 +18,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/gomega" // nolint:revive,stylecheck
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
@@ -175,9 +174,4 @@ func DeleteSvcs(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
 	if !kerrors.IsNotFound(err) {
 		ExpectWithOffset(1, c.Delete(ctx, svc)).Should(Succeed())
 	}
-}
-
-// GetURTime is a helper function that returns the upgrade requeue time for the test to assert.
-func GetURTime(vdb *vapi.VerticaDB) time.Duration {
-	return time.Second * time.Duration(vdb.GetUpgradeRequeueTime())
 }


### PR DESCRIPTION
Instead of defining the UpgraderequeueTime for each test, use a helper function GetURTime()