### PR TITLE
Minor test refactor

### DIFF
--- a/pkg/controllers/at_test.go
+++ b/pkg/controllers/at_test.go
@@ -46,7 +46,7 @@ var _ = Describe("at", func() {
 				{Err: fmt.Errorf("failed to copy file")},
 			},
 		}
-		Expect(distributeAdmintoolsConf(ctx, vdb, vrec, pf, fpr, "at.conf.tmp")).ShouldNot(Succeed())
+		Expect(distributeAdmintoolsConf(ctx, vdb, vdbRec, pf, fpr, "at.conf.tmp")).ShouldNot(Succeed())
 		cmds := fpr.FindCommands(fmt.Sprintf("sh -c cat > %s", paths.AdminToolsConf))
 		Expect(len(cmds)).Should(Equal(ScSize))
 	})

--- a/pkg/controllers/dbaddnode_reconcile_test.go
+++ b/pkg/controllers/dbaddnode_reconcile_test.go
@@ -40,7 +40,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.Histories[len(fpr.Histories)-1]
 		Expect(lastCall.Command).ShouldNot(ContainElements("/opt/vertica/bin/admintools", "db_add_node"))
@@ -54,7 +54,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 3)
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		lastCall := fpr.Histories[len(fpr.Histories)-1]
 		Expect(lastCall.Command).ShouldNot(ContainElements("/opt/vertica/bin/admintools", "db_add_node"))
@@ -68,7 +68,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("db_add_node")
 		Expect(len(atCmd)).Should(Equal(1))
@@ -100,7 +100,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 					"already contains 3 node(s), Sqlstate: V2001",
 			},
 		}
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
 		Expect(len(lastCall)).Should(Equal(1))
@@ -114,7 +114,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("select rebalance_shards('defaultsubcluster')")
 		Expect(len(atCmd)).Should(Equal(0))
@@ -128,7 +128,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
 		Expect(len(atCmd)).Should(Equal(0))
@@ -152,7 +152,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		// Make a specific pod as having an unknown state
 		podInUnknownState := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 2)
 		pfacts.Detail[podInUnknownState].dbExists = tristate.None
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
 		Expect(len(lastCall)).Should(Equal(0))
@@ -167,7 +167,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 2)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
-		r := MakeDBAddNodeReconciler(vrec, logger, vdb, fpr, pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
 		Expect(len(lastCall)).Should(Equal(1))

--- a/pkg/controllers/dbaddsubcluster_reconcile_test.go
+++ b/pkg/controllers/dbaddsubcluster_reconcile_test.go
@@ -38,7 +38,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		a := MakeDBAddSubclusterReconciler(vrec, logger, vdb, fpr, &pfacts)
+		a := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		r := a.(*DBAddSubclusterReconciler)
 		subclusters := r.parseFetchSubclusterVsql(
 			" sc1\n" +
@@ -76,7 +76,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 				{Stdout: " sc1\n"},
 			},
 		}
-		r := MakeDBAddSubclusterReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// Last command should be AT -t db_add_subcluster
 		atCmdHistory := fpr.Histories[len(fpr.Histories)-1]
@@ -93,7 +93,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		act := MakeDBAddSubclusterReconciler(vrec, logger, vdb, fpr, &pfacts)
+		act := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		r := act.(*DBAddSubclusterReconciler)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		r.ATPod = pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)]

--- a/pkg/controllers/dbremovenode_reconcile_test.go
+++ b/pkg/controllers/dbremovenode_reconcile_test.go
@@ -38,7 +38,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		recon := MakeDBRemoveNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		recon := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
 
@@ -53,7 +53,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		actor := MakeDBRemoveNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		actor := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		recon := actor.(*DBRemoveNodeReconciler)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		fpr.Histories = make([]cmds.CmdHistory, 0) // reset the calls so the first one is admintools
@@ -79,7 +79,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		r := MakeDBRemoveNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
 		Expect(res.Requeue).Should(BeFalse())
@@ -102,7 +102,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		r := MakeDBRemoveNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
 		Expect(res.Requeue).Should(BeTrue())
@@ -123,7 +123,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		removePod := names.GenPodName(vdb, sc, 2)
 		pfacts.Detail[removePod].dbExists = tristate.False
-		r := MakeDBRemoveNodeReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
 		Expect(res.Requeue).Should(BeFalse())

--- a/pkg/controllers/dbremovesubcluster_reconcile_test.go
+++ b/pkg/controllers/dbremovesubcluster_reconcile_test.go
@@ -34,7 +34,7 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		r := MakeDBRemoveSubclusterReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
 
@@ -58,7 +58,7 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		r := MakeDBRemoveSubclusterReconciler(vrec, logger, lookupVdb, fpr, &pfacts)
+		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, lookupVdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// One command should be AT -t db_remove_subcluster and one should be
 		// changing the default subcluster

--- a/pkg/controllers/init_db_test.go
+++ b/pkg/controllers/init_db_test.go
@@ -40,7 +40,7 @@ var _ = Describe("init_db", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		g := GenericDatabaseInitializer{
-			VRec:    vrec,
+			VRec:    vdbRec,
 			Log:     logger,
 			Vdb:     vdb,
 			PRunner: fpr,
@@ -54,7 +54,7 @@ var _ = Describe("init_db", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		g := GenericDatabaseInitializer{
-			VRec:    vrec,
+			VRec:    vdbRec,
 			Log:     logger,
 			Vdb:     vdb,
 			PRunner: fpr,
@@ -91,7 +91,7 @@ var _ = Describe("init_db", func() {
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, ScSize)
 
 		g := GenericDatabaseInitializer{
-			VRec:    vrec,
+			VRec:    vdbRec,
 			Log:     logger,
 			Vdb:     vdb,
 			PRunner: fpr,
@@ -182,7 +182,7 @@ var _ = Describe("init_db", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		g := GenericDatabaseInitializer{
-			VRec:    vrec,
+			VRec:    vdbRec,
 			Log:     logger,
 			Vdb:     vdb,
 			PRunner: fpr,
@@ -218,7 +218,7 @@ var _ = Describe("init_db", func() {
 func contructAuthParmsHelper(ctx context.Context, vdb *vapi.VerticaDB, mustHaveCmd string) []cmds.CmdHistory {
 	fpr := &cmds.FakePodRunner{}
 	g := GenericDatabaseInitializer{
-		VRec:    vrec,
+		VRec:    vdbRec,
 		Log:     logger,
 		Vdb:     vdb,
 		PRunner: fpr,

--- a/pkg/controllers/install_reconcile_test.go
+++ b/pkg/controllers/install_reconcile_test.go
@@ -43,7 +43,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		fpr := &cmds.FakePodRunner{}
 		pfact := MakePodFacts(k8sClient, fpr)
-		actor := MakeInstallReconciler(vrec, logger, vdb, fpr, &pfact)
+		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, &pfact)
 		drecon := actor.(*InstallReconciler)
 		Expect(drecon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		for i := int32(0); i < 3; i++ {
@@ -77,7 +77,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 				{}, // Copy admintools.conf to the pod
 				{Stdout: "node0003 = 192.168.0.1,/d,/d\n"}}, // Get of compat21 node name
 		}
-		actor := MakeInstallReconciler(vrec, logger, vdb, fpr, &pfact)
+		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, &pfact)
 		drecon := actor.(*InstallReconciler)
 		drecon.ATWriter = &atconf.FakeWriter{}
 		Expect(drecon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -119,7 +119,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 				{}, // Copy admintools.conf to the pod
 				{Stdout: "node0003 = 192.168.0.2,/d,/d\n"}}, // Get of compat21 node name
 		}
-		actor := MakeInstallReconciler(vrec, logger, vdb, fpr, &pfact)
+		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, &pfact)
 		drecon := actor.(*InstallReconciler)
 		drecon.ATWriter = &atconf.FakeWriter{}
 		Expect(drecon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -138,7 +138,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
 		pfact := MakePodFacts(k8sClient, fpr)
-		actor := MakeInstallReconciler(vrec, logger, vdb, fpr, &pfact)
+		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, &pfact)
 		drecon := actor.(*InstallReconciler)
 		drecon.ATWriter = &atconf.FakeWriter{}
 		res, err := drecon.Reconcile(ctx, &ctrl.Request{})
@@ -160,7 +160,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfact := MakePodFacts(k8sClient, fpr)
-		actor := MakeInstallReconciler(vrec, logger, vdb, fpr, &pfact)
+		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, &pfact)
 		drecon := actor.(*InstallReconciler)
 		res, err := drecon.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
@@ -177,7 +177,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfact := createPodFactsWithInstallNeeded(ctx, vdb, fpr)
-		actor := MakeInstallReconciler(vrec, logger, vdb, fpr, pfact)
+		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, pfact)
 		drecon := actor.(*InstallReconciler)
 		res, err := drecon.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())

--- a/pkg/controllers/k8s_test.go
+++ b/pkg/controllers/k8s_test.go
@@ -45,7 +45,7 @@ var _ = Describe("k8s", func() {
 		Expect(k8sClient.Create(ctx, &secret)).Should(Succeed())
 		defer deleteSecret(ctx, vdb, nm.Name)
 
-		fetchSecret, res, err := getSecret(ctx, vrec, vdb, nm)
+		fetchSecret, res, err := getSecret(ctx, vdbRec, vdb, nm)
 		Expect(err).Should(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
 		Expect(fetchSecret.Data["Data1"]).Should(Equal([]byte("secret")))
@@ -67,7 +67,7 @@ var _ = Describe("k8s", func() {
 		Expect(k8sClient.Create(ctx, &cm)).Should(Succeed())
 		defer deleteConfigMap(ctx, vdb, nm.Name)
 
-		fetchCm, res, err := getConfigMap(ctx, vrec, vdb, nm)
+		fetchCm, res, err := getConfigMap(ctx, vdbRec, vdb, nm)
 		Expect(err).Should(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
 		Expect(fetchCm.Data["cmData1"]).Should(Equal("stuff"))

--- a/pkg/controllers/obj_reconcile_test.go
+++ b/pkg/controllers/obj_reconcile_test.go
@@ -46,7 +46,7 @@ var _ = Describe("obj_reconcile", func() {
 	runReconciler := func(vdb *vapi.VerticaDB, expResult ctrl.Result) {
 		// Create any dependent objects for the CRD.
 		pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-		objr := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+		objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 		Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(expResult))
 	}
 
@@ -160,7 +160,7 @@ var _ = Describe("obj_reconcile", func() {
 
 			// Refresh any dependent objects
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 			_, err := objr.Reconcile(ctx, &ctrl.Request{})
 			Expect(err).Should(Succeed())
 
@@ -379,7 +379,7 @@ var _ = Describe("obj_reconcile", func() {
 
 			// Refresh any dependent objects
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 			_, err := objr.Reconcile(ctx, &ctrl.Request{})
 			Expect(err).Should(Succeed())
 
@@ -456,7 +456,7 @@ var _ = Describe("obj_reconcile", func() {
 			defer deleteCrd(vdb)
 
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
 
@@ -467,7 +467,7 @@ var _ = Describe("obj_reconcile", func() {
 			defer deleteCrd(vdb)
 
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
 
@@ -478,7 +478,7 @@ var _ = Describe("obj_reconcile", func() {
 			defer deleteCrd(vdb)
 
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
 
@@ -542,7 +542,7 @@ var _ = Describe("obj_reconcile", func() {
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
 			pfacts.Detail[pn] = &PodFact{isInstalled: tristate.True, dbExists: tristate.False}
 
-			objr := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 
 			pfacts.Detail[pn] = &PodFact{isInstalled: tristate.False, dbExists: tristate.True}
@@ -568,7 +568,7 @@ var _ = Describe("obj_reconcile", func() {
 
 			standby := vdb.BuildTransientSubcluster("")
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			actor := MakeObjReconciler(vrec, logger, vdb, &pfacts)
+			actor := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
 			objr := actor.(*ObjReconciler)
 			// Force a label change to reconcile with the transient subcluster
 			svcName := names.GenExtSvcName(vdb, sc)

--- a/pkg/controllers/offlineupgrade_reconcile_test.go
+++ b/pkg/controllers/offlineupgrade_reconcile_test.go
@@ -35,8 +35,8 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 
 	It("should change image if image don't match between sts and vdb", func() {
 		vdb := vapi.MakeVDB()
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -58,8 +58,8 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 	It("should stop cluster during an upgrade", func() {
 		vdb := vapi.MakeVDB()
 
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -73,8 +73,8 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 
 	It("should requeue upgrade if pods aren't running", func() {
 		vdb := vapi.MakeVDB()
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -92,8 +92,8 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 
 	It("should delete pods during an upgrade", func() {
 		vdb := vapi.MakeVDB()
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -111,8 +111,8 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 	It("should avoid stop_db if vertica isn't running", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 1
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -129,8 +129,8 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 1
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -165,6 +165,6 @@ func updateVdbToCauseUpgrade(ctx context.Context, vdb *vapi.VerticaDB, newImage 
 func createOfflineUpgradeReconciler(vdb *vapi.VerticaDB) (*OfflineUpgradeReconciler, *cmds.FakePodRunner, *PodFacts) {
 	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
 	pfacts := MakePodFacts(k8sClient, fpr)
-	actor := MakeOfflineUpgradeReconciler(vrec, logger, vdb, fpr, &pfacts)
+	actor := MakeOfflineUpgradeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 	return actor.(*OfflineUpgradeReconciler), fpr, &pfacts
 }

--- a/pkg/controllers/onlineupgrade_reconcile_test.go
+++ b/pkg/controllers/onlineupgrade_reconcile_test.go
@@ -61,8 +61,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		}
 		vdb.Spec.Subclusters = scs
 		vdb.Spec.TemporarySubclusterRouting.Template = vapi.Subcluster{Name: "transient", Size: 1, IsPrimary: false}
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		defer test.DeleteSvcs(ctx, k8sClient, vdb)
@@ -96,8 +96,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 	It("should be able to figure out what the old image was", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Image = OldImage
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		vdb.Spec.Image = NewImageName // Trigger an upgrade
@@ -123,8 +123,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 			IsPrimary: false,
 		}
 		vdb.Spec.Image = OldImage
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		test.CreateSvcs(ctx, k8sClient, vdb)
@@ -162,8 +162,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 			IsPrimary: false,
 		}
 		vdb.Spec.Image = OldImage
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		test.CreateSvcs(ctx, k8sClient, vdb)
@@ -186,8 +186,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		}
 		vdb.Spec.TemporarySubclusterRouting.Template.Name = "wont-be-created"
 		vdb.Spec.Image = OldImage
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		test.CreateSvcs(ctx, k8sClient, vdb)
@@ -208,8 +208,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		}
 		vdb.Spec.TemporarySubclusterRouting.Names = []string{"dummy-non-existent", SecScName, PriScName}
 		vdb.Spec.Image = OldImage
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		test.CreateSvcs(ctx, k8sClient, vdb)
@@ -252,8 +252,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 			{Name: SecScName, IsPrimary: false},
 		}
 		vdb.Spec.Image = OldImage
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		vdb.Spec.Image = NewImageName // Trigger an upgrade
@@ -287,8 +287,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		vdb.Spec.UpgradePolicy = vapi.OnlineUpgrade
 		vdb.Spec.IgnoreUpgradePath = true
 		vdb.ObjectMeta.Annotations[vapi.VersionAnnotation] = version.OnlineUpgradeVersion
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -314,8 +314,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		vdb.Spec.Image = OldImage
 		vdb.Spec.UpgradePolicy = vapi.OnlineUpgrade
 		vdb.ObjectMeta.Annotations[vapi.VersionAnnotation] = version.OnlineUpgradeVersion
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -336,8 +336,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		vdb.Spec.Image = OldImage
 		vdb.Spec.UpgradePolicy = vapi.OnlineUpgrade
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -371,8 +371,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		vdb.Spec.UpgradeRequeueTime = 100 // Set a non-default UpgradeRequeueTime for the test
 		vdb.ObjectMeta.Annotations[vapi.VersionAnnotation] = version.OnlineUpgradeVersion
 
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -397,8 +397,8 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 			IsPrimary: false,
 		}
 		vdb.Spec.Image = OldImage
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		test.CreateSvcs(ctx, k8sClient, vdb)
@@ -463,6 +463,6 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 func createOnlineUpgradeReconciler(vdb *vapi.VerticaDB) *OnlineUpgradeReconciler {
 	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
 	pfacts := MakePodFacts(k8sClient, fpr)
-	actor := MakeOnlineUpgradeReconciler(vrec, logger, vdb, fpr, &pfacts)
+	actor := MakeOnlineUpgradeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 	return actor.(*OnlineUpgradeReconciler)
 }

--- a/pkg/controllers/rebalanceshards_reconciler_test.go
+++ b/pkg/controllers/rebalanceshards_reconciler_test.go
@@ -48,7 +48,7 @@ var _ = Describe("rebalanceshards_reconcile", func() {
 		pfn = names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0)
 		pfacts.Detail[pfn].shardSubscriptions = 3
 		pfacts.Detail[pfn].upNode = true
-		r := MakeRebalanceShardsReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeRebalanceShardsReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("select rebalance_shards('sc1')")
 		Expect(len(atCmd)).Should(Equal(1))

--- a/pkg/controllers/status_reconcile_test.go
+++ b/pkg/controllers/status_reconcile_test.go
@@ -34,8 +34,8 @@ var _ = Describe("status_reconcile", func() {
 	It("should update the installed count when all pods are installed", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -55,8 +55,8 @@ var _ = Describe("status_reconcile", func() {
 	It("should not fail if no objects exist yet in the crd", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		// We intentionally don't create the pods or sts
 
 		fpr := &cmds.FakePodRunner{}
@@ -75,8 +75,8 @@ var _ = Describe("status_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 1
 		vdb.Spec.Subclusters = append(vdb.Spec.Subclusters, vapi.Subcluster{Name: "other", Size: 4})
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -100,8 +100,8 @@ var _ = Describe("status_reconcile", func() {
 		const ScIndex = 0
 		sc := vdb.Spec.Subclusters[ScIndex]
 		sc.Size = 2
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		// Make only 1 pod running
@@ -124,8 +124,8 @@ var _ = Describe("status_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 5
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -44,7 +44,7 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 var logger logr.Logger
 var restCfg *rest.Config
-var vrec *VerticaDBReconciler
+var vdbRec *VerticaDBReconciler
 
 var _ = BeforeSuite(func() {
 	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	vrec = &VerticaDBReconciler{
+	vdbRec = &VerticaDBReconciler{
 		Client:             k8sClient,
 		Log:                logger,
 		Scheme:             scheme.Scheme,
@@ -95,14 +95,6 @@ func TestAPIs(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"K8s Suite",
 		[]Reporter{printer.NewlineReporter{}})
-}
-
-func createVdb(ctx context.Context, vdb *vapi.VerticaDB) {
-	ExpectWithOffset(1, k8sClient.Create(ctx, vdb)).Should(Succeed())
-}
-
-func deleteVdb(ctx context.Context, vdb *vapi.VerticaDB) {
-	ExpectWithOffset(1, k8sClient.Delete(ctx, vdb)).Should(Succeed())
 }
 
 func setVerticaNodeNameInPodFacts(vdb *vapi.VerticaDB, sc *vapi.Subcluster, pf *PodFacts) {

--- a/pkg/controllers/uninstall_reconcile_test.go
+++ b/pkg/controllers/uninstall_reconcile_test.go
@@ -39,7 +39,7 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
-		recon := MakeUninstallReconciler(vrec, logger, vdb, fpr, &pfacts)
+		recon := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
 
@@ -53,7 +53,7 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
 		updatePodFactsForUninstall(ctx, &pfacts, vdb, sc, 1, 1)
-		actor := MakeUninstallReconciler(vrec, logger, vdb, fpr, &pfacts)
+		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		recon := actor.(*UninstallReconciler)
 		recon.ATWriter = &atconf.FakeWriter{}
 		_, err := recon.uninstallPodsInSubcluster(ctx, sc, 1, 1)
@@ -74,7 +74,7 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(k8sClient, fpr)
 		updatePodFactsForUninstall(ctx, &pfacts, vdb, sc, 1, 1)
-		r := MakeUninstallReconciler(vrec, logger, vdb, fpr, &pfacts)
+		r := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
 		Expect(res.Requeue).Should(BeTrue())
@@ -94,7 +94,7 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		pfacts := MakePodFacts(k8sClient, fpr)
 		updatePodFactsForUninstall(ctx, &pfacts, vdb, sc, 1, 2)
 
-		actor := MakeUninstallReconciler(vrec, logger, vdb, fpr, &pfacts)
+		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		r := actor.(*UninstallReconciler)
 		r.ATWriter = &atconf.FakeWriter{}
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
@@ -119,7 +119,7 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		pn := names.GenPodName(vdb, sc, 1)
 		Expect(pfacts.Detail[pn].dbExists).Should(Equal(tristate.True))
 
-		actor := MakeUninstallReconciler(vrec, logger, vdb, fpr, &pfacts)
+		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		r := actor.(*UninstallReconciler)
 		r.ATWriter = &atconf.FakeWriter{}
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))

--- a/pkg/controllers/upgradeoperator120_reconciler_test.go
+++ b/pkg/controllers/upgradeoperator120_reconciler_test.go
@@ -51,7 +51,7 @@ var _ = Describe("k8s/upgradeoperator120_reconciler", func() {
 		fetchedSts := &appsv1.StatefulSet{}
 		Expect(k8sClient.Get(ctx, nm, fetchedSts)).Should(Succeed())
 
-		r := MakeUpgradeOperator120Reconciler(vrec, logger, vdb)
+		r := MakeUpgradeOperator120Reconciler(vdbRec, logger, vdb)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		// Reconcile should have deleted the sts because it was created by an

--- a/pkg/controllers/version_reconciler_test.go
+++ b/pkg/controllers/version_reconciler_test.go
@@ -33,8 +33,8 @@ var _ = Describe("k8s/version_reconcile", func() {
 	It("should update annotations in vdb since they differ", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 1
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -51,7 +51,7 @@ vertica(v11.1.0) built by @re-docker2 from tag@releases/VER_10_1_RELEASE_BUILD_1
 				},
 			},
 		}
-		r := MakeVersionReconciler(vrec, logger, vdb, fpr, &pfacts, false)
+		r := MakeVersionReconciler(vdbRec, logger, vdb, fpr, &pfacts, false)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -69,8 +69,8 @@ vertica(v11.1.0) built by @re-docker2 from tag@releases/VER_10_1_RELEASE_BUILD_1
 			vapi.VersionAnnotation: OrigVersion,
 		}
 		vdb.Spec.Subclusters[0].Size = 1
-		createVdb(ctx, vdb)
-		defer deleteVdb(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -87,7 +87,7 @@ vertica(v11.1.0) built by @re-docker2 from tag@releases/VER_10_1_RELEASE_BUILD_1
 				},
 			},
 		}
-		r := MakeVersionReconciler(vrec, logger, vdb, fpr, &pfacts, true)
+		r := MakeVersionReconciler(vdbRec, logger, vdb, fpr, &pfacts, true)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 
 		// Ensure we didn't update the vdb

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -175,3 +175,11 @@ func DeleteSvcs(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
 		ExpectWithOffset(1, c.Delete(ctx, svc)).Should(Succeed())
 	}
 }
+
+func CreateVDB(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
+	ExpectWithOffset(1, c.Create(ctx, vdb)).Should(Succeed())
+}
+
+func DeleteVDB(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
+	ExpectWithOffset(1, c.Delete(ctx, vdb)).Should(Succeed())
+}


### PR DESCRIPTION
This is a minor test refactor.  A few things I want to do based on some preliminary autoscaler work:
- in the test suite for the controller, rename `vrec` to `vdbRec`.  There is going to be another reconciler struct for the autoscaler, so calling it vrec isn't good enough to distinguish from the new one coming.
- moved test helpers createVdb and deleteVdb to the test package.  Now called CreateVDB and DeleteVDB.