### PR TITLE
Skip service packs in upgrade path detection

### DIFF
--- a/changes/unreleased/Fixed-20220315-110324.yaml
+++ b/changes/unreleased/Fixed-20220315-110324.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Upgrade path detection should allow skipping service packs
+time: 2022-03-15T11:03:24.512411223-03:00
+custom:
+  Issue: "176"

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -84,9 +84,11 @@ var _ = Describe("version", func() {
 		ok, _ = cur.IsValidUpgradePath("v10.1.1")
 		Expect(ok).Should(BeFalse())
 		ok, _ = cur.IsValidUpgradePath("v11.1.0")
-		Expect(ok).Should(BeFalse()) // We fail because we skip v11.0.2
+		Expect(ok).Should(BeTrue())
 		ok, _ = cur.IsValidUpgradePath("v11.0.2")
 		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v11.2.2")
+		Expect(ok).Should(BeFalse()) // Fail because it skips v11.1.x
 
 		cur, ok = MakeInfoFromStr("v15.1.1")
 		Expect(ok).Should(BeTrue())


### PR DESCRIPTION
The upgrade path detection that was added in v1.3.0 of the operator was too strict when it came to checking for service packs.  As per the Vertica docs, those can be skipped when doing upgrades.  This PR fixes that bug.