### PR TITLE
docker log <container> was showing errors

### DIFF
--- a/docker-vertica/docker-entrypoint.sh
+++ b/docker-vertica/docker-entrypoint.sh
@@ -10,12 +10,13 @@ start_cron(){
 # because we have a Persistent Volume that backs /opt/vertica/config, so
 # it starts up empty and must be populated
 copy_config_files() {
-    cp -r /home/dbadmin/logrotate/* /opt/vertica/config/
+    mkdir -p /opt/vertica/config/licensing
+
+    mv /home/dbadmin/logrotate/* /opt/vertica/config/ 2>/dev/null
     rm -rf /home/dbadmin/logrotate
 
-    mkdir -p /opt/vertica/config/licensing
-    cp -r /home/dbadmin/licensing/ce/* /opt/vertica/config/licensing
-    chmod -R 0755 /opt/vertica/config/licensing
+    cp -r /home/dbadmin/licensing/ce/* /opt/vertica/config/licensing 2>/dev/null
+    chmod -R ugo+r,u+rw /opt/vertica/config/licensing
 }
 
 # Ensure all PV paths are owned by dbadmin.  This is done for some PVs that

--- a/docker-vertica/docker-entrypoint.sh
+++ b/docker-vertica/docker-entrypoint.sh
@@ -12,10 +12,10 @@ start_cron(){
 copy_config_files() {
     mkdir -p /opt/vertica/config/licensing
 
-    mv /home/dbadmin/logrotate/* /opt/vertica/config/ 2>/dev/null
+    mv /home/dbadmin/logrotate/* /opt/vertica/config/ 2>/dev/null || true
     rm -rf /home/dbadmin/logrotate
 
-    cp -r /home/dbadmin/licensing/ce/* /opt/vertica/config/licensing 2>/dev/null
+    cp -r /home/dbadmin/licensing/ce/* /opt/vertica/config/licensing 2>/dev/null || true
     chmod -R ugo+r,u+rw /opt/vertica/config/licensing
 }
 

--- a/docker-vertica/docker-entrypoint.sh
+++ b/docker-vertica/docker-entrypoint.sh
@@ -13,7 +13,6 @@ copy_config_files() {
     mkdir -p /opt/vertica/config/licensing
 
     mv /home/dbadmin/logrotate/* /opt/vertica/config/ 2>/dev/null || true
-    rm -rf /home/dbadmin/logrotate
 
     cp -r /home/dbadmin/licensing/ce/* /opt/vertica/config/licensing 2>/dev/null || true
     chmod -R ugo+r,u+rw /opt/vertica/config/licensing


### PR DESCRIPTION
I'm pretty sure they were coming from these copy commands.  It's OK that
these logs don't exist, so I piped stderr to /dev/null.
And, "mv" can be more efficient than "cp;rm".
And, mkdir -p could create /opt/vertica/config, so move it before the mv
And, chmod 755 is wrong for non-executables.  Instead add 644 to perms