### PR TITLE
Prevent cluster restart after offline upgrade

### DIFF
--- a/changes/unreleased/Fixed-20220316-092618.yaml
+++ b/changes/unreleased/Fixed-20220316-092618.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Avoid a second cluster restart after offline upgrade has completed
+  successfully.
+time: 2022-03-16T09:26:18.133664698-03:00
+custom:
+  Issue: "178"

--- a/pkg/controllers/onlineupgrade_reconciler.go
+++ b/pkg/controllers/onlineupgrade_reconciler.go
@@ -129,6 +129,7 @@ func (o *OnlineUpgradeReconciler) precomputeStatusMsgs(ctx context.Context) (ctr
 		"Draining primary subclusters",
 		"Recreating pods for primary subclusters",
 		"Checking if new version is compatible",
+		"Waiting for secondary nodes to become read-only",
 		"Restarting vertica in primary subclusters",
 	}
 
@@ -299,6 +300,7 @@ func (o *OnlineUpgradeReconciler) restartPrimaries(ctx context.Context) (ctrl.Re
 		o.drainSubcluster,
 		o.recreateSubclusterWithNewImage,
 		o.checkVersion,
+		o.waitForReadOnly,
 		o.bringSubclusterOnline,
 	}
 	for i, fn := range funcs {
@@ -414,6 +416,21 @@ func (o *OnlineUpgradeReconciler) checkVersion(ctx context.Context, sts *appsv1.
 	return vr.Reconcile(ctx, &ctrl.Request{})
 }
 
+// waitForReadOnly will only succeed if all of the up pods running the old image
+// are in read-only state.  This wait is necessary so that we don't try to do a
+// 'AT -t restart_node' for the primary nodes when the cluster is in read-only.
+// We should always start those with 'AT -t start_db'.
+func (o *OnlineUpgradeReconciler) waitForReadOnly(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
+	newImage := sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image
+	// If all the pods that are running the old image are read-only we are done
+	// our wait.
+	if o.PFacts.countNotReadOnlyWithOldImage(newImage) == 0 {
+		return ctrl.Result{}, nil
+	}
+	o.Log.Info("Requeueing because at least 1 pod running the old image is still up and isn't considered read-only yet")
+	return ctrl.Result{Requeue: true}, nil
+}
+
 // bringSubclusterOnline will bring up a subcluster and reroute traffic back to the subcluster.
 func (o *OnlineUpgradeReconciler) bringSubclusterOnline(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
 	const DoNotRestartReadOnly = false
@@ -423,7 +440,6 @@ func (o *OnlineUpgradeReconciler) bringSubclusterOnline(ctx context.Context, sts
 	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
-	o.PFacts.Invalidate() // Status of the pods may have changed
 
 	scName := sts.Labels[builder.SubclusterNameLabel]
 	o.Log.Info("starting client traffic routing back to subcluster", "name", scName)

--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -52,6 +52,9 @@ type PodFact struct {
 	// Name of the subcluster the pod is part of
 	subcluster string
 
+	// The image that is currently running in the pod
+	image string
+
 	// true means the pod exists in k8s.  false means it hasn't been created yet.
 	exists bool
 
@@ -204,6 +207,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 	pf.dnsName = pod.Spec.Hostname + "." + pod.Spec.Subdomain
 	pf.podIP = pod.Status.PodIP
 	pf.isTransient, _ = strconv.ParseBool(pod.Labels[builder.SubclusterTransientLabel])
+	pf.image = pod.Spec.Containers[ServerContainerIndex].Image
 
 	fns := []func(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error{
 		p.checkIsInstalled,
@@ -673,6 +677,19 @@ func (p *PodFacts) countNotRunning() int {
 		// We don't count non-running pods that aren't yet managed by the parent
 		// sts.  The sts needs to be created or sized first.
 		if !v.isPodRunning && v.managedByParent {
+			return 1
+		}
+		return 0
+	})
+}
+
+// countNotReadOnlyWithOldImage will return a count of the number of pods that
+// are not read-only and are running an image different then newImage.  This is
+// used in online upgrade to wait until pods running the old image have gone
+// into read-only mode.
+func (p *PodFacts) countNotReadOnlyWithOldImage(newImage string) int {
+	return p.countPods(func(v *PodFact) int {
+		if v.isPodRunning && v.upNode && !v.readOnly && v.image != newImage {
 			return 1
 		}
 		return 0

--- a/pkg/controllers/podfacts_test.go
+++ b/pkg/controllers/podfacts_test.go
@@ -173,6 +173,33 @@ var _ = Describe("podfacts", func() {
 		Expect(pods[1].dnsName).Should(Equal("p5"))
 	})
 
+	It("should verify return of countNotReadOnlyWithOldImage", func() {
+		const OldImage = "image:v1"
+		const NewImage = "image:v2"
+		pf := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
+		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
+			isPodRunning: true,
+			upNode:       true,
+			readOnly:     false,
+			image:        OldImage,
+		}
+		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
+			isPodRunning: true,
+			upNode:       true,
+			readOnly:     true,
+			image:        OldImage,
+		}
+		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
+			isPodRunning: true,
+			upNode:       true,
+			readOnly:     false,
+			image:        NewImage,
+		}
+		Expect(pf.countNotReadOnlyWithOldImage(NewImage)).Should(Equal(1))
+		pf.Detail[types.NamespacedName{Name: "p1"}].readOnly = true
+		Expect(pf.countNotReadOnlyWithOldImage(NewImage)).Should(Equal(0))
+	})
+
 	It("should parse the vertica node name from the directory listing", func() {
 		Expect(parseVerticaNodeName("data/1b532ad7-42bf-4777-a6d1-fdae69fb94de/vertdb/v_vertdb_node0001_data/")).Should(
 			Equal("v_vertdb_node0001"))

--- a/pkg/controllers/restart_reconcile.go
+++ b/pkg/controllers/restart_reconcile.go
@@ -144,7 +144,14 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{}, nil
 	}
 
-	return r.restartCluster(ctx, downPods)
+	if res, err := r.restartCluster(ctx, downPods); verrors.IsReconcileAborted(res, err) {
+		return res, err
+	}
+
+	// Invalidate the cached pod facts now that some pods have restarted.
+	r.PFacts.Invalidate()
+
+	return ctrl.Result{}, nil
 }
 
 // reconcileNodes will handle a subset of the pods.  It will try to restart any

--- a/pkg/controllers/upgrade.go
+++ b/pkg/controllers/upgrade.go
@@ -136,6 +136,7 @@ func (i *UpgradeManager) finishUpgrade(ctx context.Context) (ctrl.Result, error)
 		return ctrl.Result{}, err
 	}
 
+	i.Log.Info("The upgrade has completed successfully")
 	i.VRec.EVRec.Eventf(i.Vdb, corev1.EventTypeNormal, events.UpgradeSucceeded,
 		"Vertica server upgrade has completed successfully")
 

--- a/pkg/controllers/upgrade.go
+++ b/pkg/controllers/upgrade.go
@@ -113,7 +113,8 @@ func (i *UpgradeManager) isVDBImageDifferent(ctx context.Context) (bool, error) 
 
 // startUpgrade handles condition status and event recording for start of an upgrade
 func (i *UpgradeManager) startUpgrade(ctx context.Context) (ctrl.Result, error) {
-	i.Log.Info("Starting upgrade for reconciliation iteration", "ContinuingUpgrade", i.ContinuingUpgrade)
+	i.Log.Info("Starting upgrade for reconciliation iteration", "ContinuingUpgrade", i.ContinuingUpgrade,
+		"New Image", i.Vdb.Spec.Image)
 	if err := i.toggleImageChangeInProgress(ctx, corev1.ConditionTrue); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -121,7 +122,7 @@ func (i *UpgradeManager) startUpgrade(ctx context.Context) (ctrl.Result, error) 
 	// We only log an event message the first time we begin an upgrade.
 	if !i.ContinuingUpgrade {
 		i.VRec.EVRec.Eventf(i.Vdb, corev1.EventTypeNormal, events.UpgradeStart,
-			"Vertica server upgrade has started.  New image is '%s'", i.Vdb.Spec.Image)
+			"Vertica server upgrade has started.")
 	}
 	return ctrl.Result{}, nil
 }
@@ -138,7 +139,7 @@ func (i *UpgradeManager) finishUpgrade(ctx context.Context) (ctrl.Result, error)
 
 	i.Log.Info("The upgrade has completed successfully")
 	i.VRec.EVRec.Eventf(i.Vdb, corev1.EventTypeNormal, events.UpgradeSucceeded,
-		"Vertica server upgrade has completed successfully")
+		"Vertica server upgrade has completed successfully.  New image is '%s'", i.Vdb.Spec.Image)
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
This fixes a bug that caused a second cluster restart to occur after a successful offline upgrade.  The cached pod facts weren't getting invalidated.  So after the upgrade, it will proceed to the restart reconciler and using the stale facts think that a cluster restart is needed.  Adding an invalidate to the restart reconciler fixed this problem.

Also fixing a minor issue with online upgrade.  We could try to restart the primaries with 'AT -t restart_node'.  This will fail because the cluster is read-only.  Added a wait mechanism so that we only proceed with the primary restart once the server moves the secondaries into read-only mode.  This last issue was minor, so I didn't bother adding a changie entry for it.