### PR TITLE
Clean up unnecessary files

### DIFF
--- a/docker-vertica/packages/cleanup.sh
+++ b/docker-vertica/packages/cleanup.sh
@@ -34,11 +34,17 @@ rm -r -f \
    /opt/vertica/examples \
    /opt/vertica/sdk \
    /opt/vertica/packages/*/examples \
-   /opt/vertica/oss/python3/lib/python3.7/test \
-   /opt/vertica/oss/python3/lib/python3.7/pip \
-   /opt/vertica/oss/python3/lib/python3.7/site-packages/pip \
-   /opt/vertica/oss/python3/lib/python3.7/config-3.7*
+   /opt/vertica/packages/kafka \
+   /opt/vertica/oss/python3/lib/python3.9/test \
+   /opt/vertica/oss/python3/lib/python3.9/unittest/test \
+   /opt/vertica/oss/python3/lib/python3.9/pip \
+   /opt/vertica/oss/python3/lib/python3.9/site-packages/pip \
+   /opt/vertica/oss/python3/lib/python3.9/config-3.9* \
+   /opt/vertica/oss/python3/lib/python3.9/tkinter \
+   /opt/vertica/oss/python3/lib/python3.9/idlelib 
 
+# cleanup many of the __pycache__ directories 
+find /opt/vertica/oss/python3/lib/python3.9/  -type d -name "__pycache__" -exec rm -rf {} +
    
 # many of these directories contain things that aren't binaries
 # thus divert error output to /dev/null

--- a/docker-vertica/packages/cleanup.sh
+++ b/docker-vertica/packages/cleanup.sh
@@ -34,30 +34,30 @@ rm -r -f \
    /opt/vertica/examples \
    /opt/vertica/sdk \
    /opt/vertica/packages/*/examples \
-   /opt/vertica/packages/kafka \
-   /opt/vertica/oss/python3/lib/python3.9/test \
-   /opt/vertica/oss/python3/lib/python3.9/unittest/test \
-   /opt/vertica/oss/python3/lib/python3.9/pip \
-   /opt/vertica/oss/python3/lib/python3.9/site-packages/pip \
-   /opt/vertica/oss/python3/lib/python3.9/config-3.9* \
-   /opt/vertica/oss/python3/lib/python3.9/tkinter \
-   /opt/vertica/oss/python3/lib/python3.9/idlelib 
+   /opt/vertica/packages/kafka `# Removing kafka because we don't have a java runtime installed ` \
+   /opt/vertica/oss/python*/lib/python*/test \
+   /opt/vertica/oss/python*/lib/python*/unittest/test \
+   /opt/vertica/oss/python*/lib/python*/pip \
+   /opt/vertica/oss/python*/lib/python*/site-packages/pip \
+   /opt/vertica/oss/python*/lib/python*/config-[0-9]* \
+   /opt/vertica/oss/python*/lib/python*/tkinter \
+   /opt/vertica/oss/python*/lib/python*/idlelib 
 
 # cleanup many of the __pycache__ directories 
-find /opt/vertica/oss/python3/lib/python3.9/  -type d -name "__pycache__" -exec rm -rf {} +
+find /opt/vertica/oss/ -type d -name "__pycache__" -exec rm -rf {} +
    
 # many of these directories contain things that aren't binaries
 # thus divert error output to /dev/null
 strip /opt/vertica/bin/* 2> /dev/null
 strip /opt/vertica/lib/*.so*
-strip /opt/vertica/oss/python3/bin/* 2> /dev/null
-strip /opt/vertica/oss/python3/lib/libpython*.a
-strip /opt/vertica/oss/python3/lib/python3.7/lib-dynload/*.so*
+strip /opt/vertica/oss/python*/bin/* 2> /dev/null
+strip /opt/vertica/oss/python*/lib/libpython*.a
+strip /opt/vertica/oss/python*/lib/python*/lib-dynload/*.so*
 
 # stripping the packages directory saves about 900MB, but...
 strip /opt/vertica/packages/*/lib/*.so* 2> /dev/null
 # it changes the checksums used to verify the libraries when loaded
-/opt/vertica/oss/python3/bin/python3 \
+/opt/vertica/oss/python*/bin/python[0-9] \
     /tmp/package-checksum-patcher.py /opt/vertica/packages/*
 
 # (optional) minimal images remove packages that aren't auto installed

--- a/docker-vertica/packages/cleanup.sh
+++ b/docker-vertica/packages/cleanup.sh
@@ -23,14 +23,6 @@
 #
 # wander around in the image looking for things you can remove
 rm -r -f \
-   /anaconda-post.log \
-   /usr/lib64/python2.7 \
-   /usr/lib/python2.7 \
-   /usr/bin/python2.7 \
-   /usr/include/python2.7 \
-   /usr/include/python2.7/pyconfig-64.h \
-   /usr/lib64/libpython2.7.so.1.0 \
-   /usr/share/systemtap/tapset/libpython2.7-64.stp \
    /opt/vertica/examples \
    /opt/vertica/sdk \
    /opt/vertica/packages/*/examples \

--- a/docker-vertica/packages/package-checksum-patcher.py
+++ b/docker-vertica/packages/package-checksum-patcher.py
@@ -111,7 +111,7 @@ def patch_file(fname, old_checksum, new_checksum):
     except FileNotFoundError:
         # the first time through, the file won't be found
         pass
-    os.rename(fname, file_backup)
+    os.remove(fname)
     os.rename(file_new, fname)
 
 def patch_dir(dir, old_checksum):


### PR DESCRIPTION
This is the 1st of 2 PR to decrease the size of the vertica-k8s image.
It adds more files to clean up, removes the backup files and some libraries.