### PR TITLE
Fix wrong upgradeStatus message

### DIFF
--- a/.github/workflows/e2e-azb.yml
+++ b/.github/workflows/e2e-azb.yml
@@ -32,6 +32,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       if: always()
+      continue-on-error: true
       with:
         name: logs-e2e-azb
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*

--- a/.github/workflows/e2e-hdfs.yml
+++ b/.github/workflows/e2e-hdfs.yml
@@ -32,6 +32,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       if: always()
+      continue-on-error: true
       with:
         name: logs-e2e-hdfs
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*

--- a/.github/workflows/e2e-online-upgrade.yml
+++ b/.github/workflows/e2e-online-upgrade.yml
@@ -33,6 +33,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       if: always()
+      continue-on-error: true
       with:
         name: logs-e2e-online-upgrade
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*

--- a/.github/workflows/e2e-operator-upgrade.yml
+++ b/.github/workflows/e2e-operator-upgrade.yml
@@ -29,6 +29,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       if: always()
+      continue-on-error: true
       with:
         name: logs-e2e-operator-upgrade
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*

--- a/.github/workflows/e2e-s3.yml
+++ b/.github/workflows/e2e-s3.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       if: always()
+      continue-on-error: true
       with:
         name: logs-e2e-s3
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*

--- a/pkg/controllers/upgrade.go
+++ b/pkg/controllers/upgrade.go
@@ -271,8 +271,15 @@ func (i *UpgradeManager) postNextStatusMsg(ctx context.Context, statusMsgs []str
 		return nil
 	}
 
-	if statusMsgs[msgIndex-1] == i.Vdb.Status.UpgradeStatus {
-		return i.setUpgradeStatus(ctx, statusMsgs[msgIndex])
+	// Compare with all status messages prior to msgIndex.  The current status
+	// in the vdb might not be the proceeding one if the vdb is stale.
+	for j := 0; j <= msgIndex-1; j++ {
+		if statusMsgs[j] == i.Vdb.Status.UpgradeStatus {
+			err := i.setUpgradeStatus(ctx, statusMsgs[msgIndex])
+			i.Log.Info("Status message after update", "msgIndex", msgIndex, "statusMsgs[msgIndex]", statusMsgs[msgIndex],
+				"UpgradeStatus", i.Vdb.Status.UpgradeStatus, "err", err)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controllers/upgrade_test.go
+++ b/pkg/controllers/upgrade_test.go
@@ -196,7 +196,7 @@ var _ = Describe("upgrade", func() {
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		vdb.Spec.Image = NewImage // Change image to force pod deletion
 
-		statusMsgs := []string{"msg1", "msg2", "msg3"}
+		statusMsgs := []string{"msg1", "msg2", "msg3", "msg4"}
 
 		mgr := MakeUpgradeManager(vdbRec, logger, vdb, vapi.OfflineUpgradeInProgress,
 			func(vdb *vapi.VerticaDB) bool { return true })
@@ -210,17 +210,18 @@ var _ = Describe("upgrade", func() {
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
 		Expect(fetchedVdb.Status.UpgradeStatus).Should(Equal(statusMsgs[0]))
 
-		Expect(mgr.postNextStatusMsg(ctx, statusMsgs, 2)).Should(Succeed()) // no change
-		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
-		Expect(fetchedVdb.Status.UpgradeStatus).Should(Equal(statusMsgs[0]))
-
-		Expect(mgr.postNextStatusMsg(ctx, statusMsgs, 1)).Should(Succeed())
-		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
-		Expect(fetchedVdb.Status.UpgradeStatus).Should(Equal(statusMsgs[1]))
-
+		// Skip msg2
 		Expect(mgr.postNextStatusMsg(ctx, statusMsgs, 2)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
 		Expect(fetchedVdb.Status.UpgradeStatus).Should(Equal(statusMsgs[2]))
+
+		Expect(mgr.postNextStatusMsg(ctx, statusMsgs, 2)).Should(Succeed()) // no change
+		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
+		Expect(fetchedVdb.Status.UpgradeStatus).Should(Equal(statusMsgs[2]))
+
+		Expect(mgr.postNextStatusMsg(ctx, statusMsgs, 3)).Should(Succeed())
+		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
+		Expect(fetchedVdb.Status.UpgradeStatus).Should(Equal(statusMsgs[3]))
 
 		Expect(mgr.postNextStatusMsg(ctx, statusMsgs, 9)).ShouldNot(Succeed()) // fail - out of bounds
 	})


### PR DESCRIPTION
I have noticed that on occasion the upgradeStatus message gets *stuck*
at a stage in the online upgrade.  The upgrade has gone past a stage,
but it will end up reporting the wrong upgradeStatus message.  One
test (online-upgrade-with-transient) is sensitive to this as it checks
the status message in its assertions.  I suspect this occurs because we
are using a stale copy of the VerticaDB when we update the message.  I
am fixing this by making that update more robust.