### PR TITLE
Fix timing in online-upgrade-drain

### DIFF
--- a/tests/e2e-online-upgrade/online-upgrade-drain/20-assert.yaml
+++ b/tests/e2e-online-upgrade/online-upgrade-drain/20-assert.yaml
@@ -26,3 +26,24 @@ status:
     - installCount: 1
       addedToDBCount: 1
       upNodeCount: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-base-upgrade-sec1-0
+  labels:
+    vertica.com/client-routing: "true"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-base-upgrade-pri1-0
+  labels:
+    vertica.com/client-routing: "true"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-base-upgrade-pri2-0
+  labels:
+    vertica.com/client-routing: "true"


### PR DESCRIPTION
The e2e testcase online-upgrade-drain can fail intermittently.  This
commit will fix that issue.  The issue it was hitting was that it would
try to connect to vertica through a service object for subcluster pri2.
Due to timing this subcluster might not be totally ready to accept
connections.  Adding a strict assertion that will only continue once
pods in that service object are ready.