### PR TITLE
Fix timing in restart-node-multi-sc testcase

### DIFF
--- a/.github/workflows/e2e-azb.yml
+++ b/.github/workflows/e2e-azb.yml
@@ -34,6 +34,6 @@ jobs:
       if: always()
       continue-on-error: true
       with:
-        name: logs-e2e-azb
+        name: logs-e2e-azb-${{ github.job_id }}
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
         

--- a/.github/workflows/e2e-azb.yml
+++ b/.github/workflows/e2e-azb.yml
@@ -31,9 +31,8 @@ jobs:
         scripts/run-k8s-int-tests.sh -e tests/external-images-azb-ci.txt
 
     - uses: actions/upload-artifact@v2
-      if: always()
-      continue-on-error: true
+      if: failure()
       with:
-        name: logs-e2e-azb-${{ github.job_id }}
+        name: logs-e2e-azb
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
         

--- a/.github/workflows/e2e-hdfs.yml
+++ b/.github/workflows/e2e-hdfs.yml
@@ -31,8 +31,7 @@ jobs:
         scripts/run-k8s-int-tests.sh -e tests/external-images-hdfs-ci.txt
 
     - uses: actions/upload-artifact@v2
-      if: always()
-      continue-on-error: true
+      if: failure()
       with:
-        name: logs-e2e-hdfs-${{ github.job_id }}
+        name: logs-e2e-hdfs
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*

--- a/.github/workflows/e2e-hdfs.yml
+++ b/.github/workflows/e2e-hdfs.yml
@@ -34,5 +34,5 @@ jobs:
       if: always()
       continue-on-error: true
       with:
-        name: logs-e2e-hdfs
+        name: logs-e2e-hdfs-${{ github.job_id }}
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*

--- a/.github/workflows/e2e-online-upgrade.yml
+++ b/.github/workflows/e2e-online-upgrade.yml
@@ -32,9 +32,8 @@ jobs:
         scripts/run-k8s-int-tests.sh
 
     - uses: actions/upload-artifact@v2
-      if: always()
-      continue-on-error: true
+      if: failure()
       with:
-        name: logs-e2e-online-upgrade-${{ github.job_id }}
+        name: logs-e2e-online-upgrade
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
 

--- a/.github/workflows/e2e-online-upgrade.yml
+++ b/.github/workflows/e2e-online-upgrade.yml
@@ -35,6 +35,6 @@ jobs:
       if: always()
       continue-on-error: true
       with:
-        name: logs-e2e-online-upgrade
+        name: logs-e2e-online-upgrade-${{ github.job_id }}
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
 

--- a/.github/workflows/e2e-operator-upgrade.yml
+++ b/.github/workflows/e2e-operator-upgrade.yml
@@ -31,6 +31,6 @@ jobs:
       if: always()
       continue-on-error: true
       with:
-        name: logs-e2e-operator-upgrade
+        name: logs-e2e-operator-upgrade-${{ github.job_id }}
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
 

--- a/.github/workflows/e2e-operator-upgrade.yml
+++ b/.github/workflows/e2e-operator-upgrade.yml
@@ -28,9 +28,8 @@ jobs:
         scripts/run-k8s-int-tests.sh
 
     - uses: actions/upload-artifact@v2
-      if: always()
-      continue-on-error: true
+      if: failure()
       with:
-        name: logs-e2e-operator-upgrade-${{ github.job_id }}
+        name: logs-e2e-operator-upgrade
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
 

--- a/.github/workflows/e2e-s3.yml
+++ b/.github/workflows/e2e-s3.yml
@@ -30,9 +30,8 @@ jobs:
         scripts/run-k8s-int-tests.sh
 
     - uses: actions/upload-artifact@v2
-      if: always()
-      continue-on-error: true
+      if: failure()
       with:
-        name: logs-e2e-s3-${{ github.job_id }}
+        name: logs-e2e-s3
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
 

--- a/.github/workflows/e2e-s3.yml
+++ b/.github/workflows/e2e-s3.yml
@@ -33,6 +33,6 @@ jobs:
       if: always()
       continue-on-error: true
       with:
-        name: logs-e2e-s3
+        name: logs-e2e-s3-${{ github.job_id }}
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/int-tests-output/*
 

--- a/changes/unreleased/Fixed-20220323-100220.yaml
+++ b/changes/unreleased/Fixed-20220323-100220.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Handle the scenario when restart is needed because the StatefulSets were deleted.  We
+  ensure the necessary k8s objects are created before driving restart.
+time: 2022-03-23T10:02:20.221254417-03:00
+custom:
+  Issue: "186"

--- a/pkg/controllers/obj_reconcile.go
+++ b/pkg/controllers/obj_reconcile.go
@@ -183,6 +183,11 @@ func (o *ObjReconciler) checkForCreatedSubcluster(ctx context.Context, sc *vapi.
 // checkForDeletedSubcluster will remove any objects that were created for
 // subclusters that don't exist anymore.
 func (o *ObjReconciler) checkForDeletedSubcluster(ctx context.Context) (ctrl.Result, error) {
+	if o.Mode == ObjReconcileModeIfNotFound {
+		// Bypass this check since we won't be doing any scale down with this reconcile
+		return ctrl.Result{}, nil
+	}
+
 	finder := iter.MakeSubclusterFinder(o.VRec.Client, o.Vdb)
 
 	// Find any statefulsets that need to be deleted

--- a/pkg/controllers/obj_reconcile_test.go
+++ b/pkg/controllers/obj_reconcile_test.go
@@ -43,10 +43,10 @@ import (
 var _ = Describe("obj_reconcile", func() {
 	ctx := context.Background()
 
-	runReconciler := func(vdb *vapi.VerticaDB, expResult ctrl.Result) {
+	runReconciler := func(vdb *vapi.VerticaDB, expResult ctrl.Result, mode ObjReconcileModeType) {
 		// Create any dependent objects for the CRD.
 		pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-		objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+		objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, mode)
 		Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(expResult))
 	}
 
@@ -58,7 +58,7 @@ var _ = Describe("obj_reconcile", func() {
 		Expect(k8sClient.Get(ctx, nameLookup, createdVdb)).Should(Succeed())
 
 		if doReconcile {
-			runReconciler(vdb, ctrl.Result{})
+			runReconciler(vdb, ctrl.Result{}, ObjReconcileModeAll)
 		}
 	}
 
@@ -160,7 +160,7 @@ var _ = Describe("obj_reconcile", func() {
 
 			// Refresh any dependent objects
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			_, err := objr.Reconcile(ctx, &ctrl.Request{})
 			Expect(err).Should(Succeed())
 
@@ -379,7 +379,7 @@ var _ = Describe("obj_reconcile", func() {
 
 			// Refresh any dependent objects
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			_, err := objr.Reconcile(ctx, &ctrl.Request{})
 			Expect(err).Should(Succeed())
 
@@ -456,7 +456,7 @@ var _ = Describe("obj_reconcile", func() {
 			defer deleteCrd(vdb)
 
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
 
@@ -467,7 +467,7 @@ var _ = Describe("obj_reconcile", func() {
 			defer deleteCrd(vdb)
 
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
 
@@ -478,7 +478,7 @@ var _ = Describe("obj_reconcile", func() {
 			defer deleteCrd(vdb)
 
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
 
@@ -493,7 +493,7 @@ var _ = Describe("obj_reconcile", func() {
 			createCrd(vdb, false)
 			defer deleteCrd(vdb)
 
-			runReconciler(vdb, ctrl.Result{})
+			runReconciler(vdb, ctrl.Result{}, ObjReconcileModeAll)
 		})
 
 		It("should requeue if the kerberos secret has a missing keytab", func() {
@@ -506,7 +506,7 @@ var _ = Describe("obj_reconcile", func() {
 			createCrd(vdb, false)
 			defer deleteCrd(vdb)
 
-			runReconciler(vdb, ctrl.Result{Requeue: true})
+			runReconciler(vdb, ctrl.Result{Requeue: true}, ObjReconcileModeAll)
 		})
 
 		It("should requeue if the ssh secret has a missing keys", func() {
@@ -520,7 +520,7 @@ var _ = Describe("obj_reconcile", func() {
 			createCrd(vdb, false)
 			defer deleteCrd(vdb)
 
-			runReconciler(vdb, ctrl.Result{Requeue: true})
+			runReconciler(vdb, ctrl.Result{Requeue: true}, ObjReconcileModeAll)
 		})
 
 		It("should not proceed with the scale down if uninstall or db_remove_node hasn't happened", func() {
@@ -542,7 +542,7 @@ var _ = Describe("obj_reconcile", func() {
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
 			pfacts.Detail[pn] = &PodFact{isInstalled: tristate.True, dbExists: tristate.False}
 
-			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 
 			pfacts.Detail[pn] = &PodFact{isInstalled: tristate.False, dbExists: tristate.True}
@@ -568,7 +568,7 @@ var _ = Describe("obj_reconcile", func() {
 
 			standby := vdb.BuildTransientSubcluster("")
 			pfacts := MakePodFacts(k8sClient, &cmds.FakePodRunner{})
-			actor := MakeObjReconciler(vdbRec, logger, vdb, &pfacts)
+			actor := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			objr := actor.(*ObjReconciler)
 			// Force a label change to reconcile with the transient subcluster
 			svcName := names.GenExtSvcName(vdb, sc)
@@ -579,6 +579,34 @@ var _ = Describe("obj_reconcile", func() {
 			svc2 := &corev1.Service{}
 			Expect(k8sClient.Get(ctx, nm, svc2)).Should(Succeed())
 			Expect(reflect.DeepEqual(svc1.Spec.Selector, svc2.Spec.Selector)).Should(BeFalse())
+		})
+
+		It("should only create new objects and not update existin if ObjReconcileModeIfNotExists is used", func() {
+			vdb := vapi.MakeVDB()
+			vdb.Spec.Subclusters = []vapi.Subcluster{
+				{Name: "sc1", Size: 1},
+				{Name: "sc2", Size: 1},
+			}
+			createCrd(vdb, true)
+			defer deleteCrd(vdb)
+
+			// Delete a statefulset and make a change that should cause a change
+			// in the other statefulset.  If we run with ObjReconcileModeIfNotExists
+			// we won't make the second change.  We'll only recreate the first sts.
+			sc1 := &vdb.Spec.Subclusters[0]
+			sc1StsName := names.GenStsName(vdb, sc1)
+			sts := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, sc1StsName, sts)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, sts)).Should(Succeed())
+			sc2 := &vdb.Spec.Subclusters[1]
+			sc2.Size = 2
+
+			runReconciler(vdb, ctrl.Result{}, ObjReconcileModeIfNotFound)
+
+			Expect(k8sClient.Get(ctx, sc1StsName, sts)).Should(Succeed())
+			sc2StsName := names.GenStsName(vdb, sc2)
+			Expect(k8sClient.Get(ctx, sc2StsName, sts)).Should(Succeed())
+			Expect(*sts.Spec.Replicas).Should(Equal(int32(1)))
 		})
 	})
 })

--- a/pkg/controllers/onlineupgrade_reconciler.go
+++ b/pkg/controllers/onlineupgrade_reconciler.go
@@ -230,7 +230,7 @@ func (o *OnlineUpgradeReconciler) createTransientSts(ctx context.Context) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts)
+	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, ObjReconcileModeAll)
 	o.traceActorReconcile(actor)
 	or := actor.(*ObjReconciler)
 
@@ -570,7 +570,7 @@ func (o *OnlineUpgradeReconciler) deleteTransientSts(ctx context.Context) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts)
+	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, ObjReconcileModeAll)
 	o.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
@@ -639,7 +639,7 @@ func (o *OnlineUpgradeReconciler) traceActorReconcile(actor ReconcileActor) {
 // routed to that.
 func (o *OnlineUpgradeReconciler) routeClientTraffic(ctx context.Context,
 	scName string, setTemporaryRouting bool) error {
-	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts)
+	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, ObjReconcileModeAll)
 	objRec := actor.(*ObjReconciler)
 
 	scMap := o.Vdb.GenSubclusterMap()

--- a/pkg/controllers/verticadb_controller.go
+++ b/pkg/controllers/verticadb_controller.go
@@ -143,6 +143,11 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Handles vertica server upgrade (i.e., when spec.image changes)
 		MakeOfflineUpgradeReconciler(r, log, vdb, prunner, pfacts),
 		MakeOnlineUpgradeReconciler(r, log, vdb, prunner, pfacts),
+		// Creates any missing k8s objects.  This doesn't update existing
+		// objects.  It is a special case for when restart is needed but the
+		// pods are missing.  We don't want to apply all updates as we may need
+		// to go through necessary admintools commands to handle a scale down.
+		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeIfNotFound),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
@@ -162,7 +167,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Creates or updates any k8s objects the CRD creates. This includes any
 		// statefulsets and service objects.
-		MakeObjReconciler(r, log, vdb, pfacts),
+		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeAll),
 		// Set version info in the annotations and check that it is the minimum
 		MakeVersionReconciler(r, log, vdb, prunner, pfacts, false),
 		// Handle calls to add hosts to admintools.conf

--- a/tests/e2e-extra/restart-kill-sts/05-create-communal-creds.yaml
+++ b/tests/e2e-extra/restart-kill-sts/05-create-communal-creds.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-extra/restart-kill-sts/10-assert.yaml
+++ b/tests/e2e-extra/restart-kill-sts/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-extra/restart-kill-sts/10-deploy-operator.yaml
+++ b/tests/e2e-extra/restart-kill-sts/10-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator WATCH_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/restart-kill-sts/15-assert.yaml
+++ b/tests/e2e-extra/restart-kill-sts/15-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-kill-sts
+status:
+  installCount: 3

--- a/tests/e2e-extra/restart-kill-sts/15-create-cr.yaml
+++ b/tests/e2e-extra/restart-kill-sts/15-create-cr.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/restart-kill-sts/20-assert.yaml
+++ b/tests/e2e-extra/restart-kill-sts/20-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-kill-sts
+status:
+  installCount: 3
+  addedToDBCount: 3
+  upNodeCount: 3
+  subclusterCount: 2

--- a/tests/e2e-extra/restart-kill-sts/20-wait-for-create-db.yaml
+++ b/tests/e2e-extra/restart-kill-sts/20-wait-for-create-db.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/restart-kill-sts/25-wait-for-steady-state.yaml
+++ b/tests/e2e-extra/restart-kill-sts/25-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -t 360"

--- a/tests/e2e-extra/restart-kill-sts/30-delete-sts.yaml
+++ b/tests/e2e-extra/restart-kill-sts/30-delete-sts.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete sts v-restart-kill-sts-pri1
+    namespaced: true

--- a/tests/e2e-extra/restart-kill-sts/35-assert.yaml
+++ b/tests/e2e-extra/restart-kill-sts/35-assert.yaml
@@ -1,0 +1,28 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-restart-kill-sts-pri1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-kill-sts-pri1-0
+status:
+  containerStatuses:
+  - ready: false
+    started: true
+    name: server
+

--- a/tests/e2e-extra/restart-kill-sts/35-wait-for-sts-creation.yaml
+++ b/tests/e2e-extra/restart-kill-sts/35-wait-for-sts-creation.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/restart-kill-sts/40-delete-sts.yaml
+++ b/tests/e2e-extra/restart-kill-sts/40-delete-sts.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete sts v-restart-kill-sts-pri1
+    namespaced: true

--- a/tests/e2e-extra/restart-kill-sts/45-assert.yaml
+++ b/tests/e2e-extra/restart-kill-sts/45-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-kill-sts
+status:
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1
+    - addedToDBCount: 2
+      upNodeCount: 2

--- a/tests/e2e-extra/restart-kill-sts/45-wait-for-restart.yaml
+++ b/tests/e2e-extra/restart-kill-sts/45-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/restart-kill-sts/95-assert.yaml
+++ b/tests/e2e-extra/restart-kill-sts/95-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-extra/restart-kill-sts/95-delete-crd.yaml
+++ b/tests/e2e-extra/restart-kill-sts/95-delete-crd.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/restart-kill-sts/95-errors.yaml
+++ b/tests/e2e-extra/restart-kill-sts/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-extra/restart-kill-sts/99-errors.yaml
+++ b/tests/e2e-extra/restart-kill-sts/99-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-extra/restart-kill-sts/99-uninstall-operator.yaml
+++ b/tests/e2e-extra/restart-kill-sts/99-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/restart-kill-sts/README.txt
+++ b/tests/e2e-extra/restart-kill-sts/README.txt
@@ -1,0 +1,3 @@
+This will drive restart by killing the primary statefulset.  This adds test
+coverage for the case when it needs to reform the cluster but the statefulset
+for the primary subcluster doesn't exist.

--- a/tests/e2e-extra/restart-kill-sts/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-extra/restart-kill-sts/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-extra/restart-kill-sts/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/restart-kill-sts/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-kill-sts
+spec:
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  dbName: vertica1
+  requeueTime: 5
+  subclusters:
+    - name: pri1
+      size: 1
+      isPrimary: true
+    - name: sec1
+      size: 2
+      isPrimary: false
+  certSecrets: []


### PR DESCRIPTION
This fixes a timing hole when deleting StatefulSet's.  This was hit
intermittently in the restart-node-multi-sc testcase.  A new testcase
was added to make it more likely to exercise this issue.

The restart reconciler runs before the object reconciler.  The object
reconciler will create the k8s objects but the restart reconciler
depends on those objects.  The reason why we had this order was because
of scale down.  The object reconciler will update the size of any
StatefulSet that are scaling down.  But we need to drive admintools
commands before we do that, which requires Vertica to be up.

We are going to inject a new call to the object reconciler ahead of the
restart reconciler to cover this case.  So that it doesn't do scale down
events, this new run of the object reconciler will only create missing
objects and won't update any.