### PR TITLE
New base image

### DIFF
--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -3,8 +3,9 @@
 # Copyright (c) 2021 Vertica
 #
 
-ARG OS_VERSION="7.9.2009"
-FROM centos:centos${OS_VERSION} as builder
+ARG BASE_OS_VERSION="focal-20220316"
+ARG BUILDER_OS_VERSION="7.9.2009"
+FROM centos:centos${BUILDER_OS_VERSION} as builder
 
 ARG VERTICA_RPM="vertica-x86_64.RHEL6.latest.rpm"
 ARG MINIMAL=""
@@ -87,7 +88,7 @@ RUN set -x \
   && chmod 777 -R /opt/vertica
 
 ##############################################################################################
-FROM centos:centos${OS_VERSION}
+FROM ubuntu:${BASE_OS_VERSION}
 
 ARG DBADMIN_GID=5000
 ARG DBADMIN_UID=5000
@@ -95,7 +96,6 @@ ARG DBADMIN_UID=5000
 COPY --from=builder /opt/vertica /opt/vertica
 COPY --from=builder /home/dbadmin /home/dbadmin
 COPY --from=builder /root/.ssh /root/.ssh
-COPY --from=builder /etc/ssh /etc/ssh
 COPY --from=builder /var/spool/cron /var/spool/cron
 
 ENV LANG en_US.utf8
@@ -104,6 +104,12 @@ ENV PATH "$PATH:/opt/vertica/bin:/opt/vertica/sbin"
 
 ADD ./packages/init.d.functions /etc/rc.d/init.d/functions
 
+
+# make the "en_US.UTF-8" locale so vertica will be utf-8 enabled by default
+RUN apt update && apt install -y locales && rm -rf /var/lib/apt/lists/* \
+	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+
 RUN set -x \
   # COPY may not preserve file permissions on older docker versions.  This is a
   # workaround for that.  This will cause the image to increase a bit, but there
@@ -111,35 +117,24 @@ RUN set -x \
   && chown -R $DBADMIN_UID:$DBADMIN_GID /home/dbadmin \
   # Update is needed to be confident that we're picking up
   # fixed libraries.  We depend on malware check of container afterwards 
-  && yum -q -y update \
-  && yum -y update --security \
-  # CentOS 8 - enable powertools to fix locales issue
-  && bash -c "if [ \"$(rpm -E %{rhel})\" == '8' ]; then yum install -q -y dnf-plugins-core glibc-locale-source; yum -q config-manager --set-enabled powertools; fi" \
-  && yum install -y \
-  cronie \
+  && apt-get -y update \
+  && apt-get install -y \
+  cron \
   dialog \
-  iproute \
-  krb5-workstation \
-  mcelog \
+  iproute2 \
+  krb5-user \
   logrotate \
+  openssh-client \
   openssh-server \
-  openssh-clients \
   openssl \
   sudo \
-  which \
-  # CentOS 8 - fixes - Unsupported locale character encoding: use a utf8 locale, not a ANSI_X3.4-1968 locale
-  && bash -c "if [ \"$(rpm -E %{rhel})\" == '8' ]; then localedef -i en_US -f UTF-8 en_US.UTF-8; fi" \
   && /usr/sbin/groupadd -r verticadba --gid ${DBADMIN_GID} \
   && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba --uid ${DBADMIN_UID} dbadmin \
   # Allow passwordless sudo access from dbadmin
   && echo "dbadmin ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers \
-  && yum clean all \
-  && /bin/rm -rf /var/cache/yum \
-  # Used by the agent to see if networking is enabled.  Empty file is okay
-  && touch /etc/sysconfig/network \
   # Permit ssh connections
   && rm -rf /run/nologin
-
+  
 ENTRYPOINT ["/opt/vertica/bin/docker-entrypoint.sh"]
 
 # vertica port
@@ -147,6 +142,6 @@ EXPOSE 5433
 # agent port
 EXPOSE 5444
 USER dbadmin
-LABEL os_family="centos"
+LABEL os_family="ubuntu"
 LABEL image_name="vertica_k8s"
 LABEL maintainer="K8 Team"

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -74,7 +74,6 @@ RUN set -x \
   && chmod a+x /opt/vertica/bin/docker-entrypoint.sh \
   && chown dbadmin:verticadba /home/dbadmin/.bash_profile \
   && chmod 600 /home/dbadmin/.bash_profile \
-  && ssh-keygen -q -A \
   && mkdir -p /root/.ssh \
   && cp -r /home/dbadmin/.ssh /root \
   && chmod 700 /root/.ssh \
@@ -101,12 +100,13 @@ COPY --from=builder /var/spool/cron /var/spool/cron
 ENV LANG en_US.utf8
 ENV TZ UTC
 ENV PATH "$PATH:/opt/vertica/bin:/opt/vertica/sbin"
+ENV DEBIAN_FRONTEND noninteractive
 
 ADD ./packages/init.d.functions /etc/rc.d/init.d/functions
 
 
 # make the "en_US.UTF-8" locale so vertica will be utf-8 enabled by default
-RUN apt update && apt install -y locales && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 
@@ -120,20 +120,31 @@ RUN set -x \
   && apt-get -y update \
   && apt-get install -y \
   cron \
+  sysstat \
+  ca-certificates \
+  ntp \
   dialog \
   iproute2 \
+  libkeyutils1\
+  procps \
   krb5-user \
   logrotate \
   openssh-client \
   openssh-server \
   openssl \
   sudo \
+  && ssh-keygen -q -A \
   && /usr/sbin/groupadd -r verticadba --gid ${DBADMIN_GID} \
   && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba --uid ${DBADMIN_UID} dbadmin \
+  && /etc/init.d/ssh start \
   # Allow passwordless sudo access from dbadmin
   && echo "dbadmin ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers \
+  && echo "dbadmin -       nofile  65536" >> /etc/security/limits.conf \
   # Permit ssh connections
-  && rm -rf /run/nologin
+  && rm -rf /run/nologin \
+  # Moving this because on Ubuntu crontab files are in /var/spool/cron/crontabs/
+  && mv /var/spool/cron/dbadmin /var/spool/cron/crontabs/ \
+  && apt remove --purge -y libpython2.7
   
 ENTRYPOINT ["/opt/vertica/bin/docker-entrypoint.sh"]
 

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -1,5 +1,6 @@
 VERTICA_RPM?=vertica-x86_64.RHEL6.latest.rpm
-OS_VERSION?=7.9.2009
+BUILDER_OS_VERSION?=7.9.2009
+BASE_OS_VERSION?=focal-20220316
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
@@ -11,9 +12,10 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 	docker build \
 		-f Dockerfile \
 		--label minimal=${MINIMAL_VERTICA_IMG} \
-		--label os_version=${OS_VERSION} \
+		--label os_version=${BASE_OS_VERSION} \
 		--label vertica_version=${VERTICA_VERSION} \
 		--build-arg MINIMAL=${MINIMAL_VERTICA_IMG} \
 		--build-arg VERTICA_RPM=${VERTICA_RPM} \
-		--build-arg OS_VERSION=${OS_VERSION} \
+		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
+		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
 		-t ${VERTICA_IMG} .

--- a/docker-vertica/docker-entrypoint.sh
+++ b/docker-vertica/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 start_cron(){
     # daemonizes, no need for &
-    sudo /usr/sbin/crond
+    sudo /usr/sbin/cron
 }
 
 # We copy back the files normally stored in /opt/vertica/config/.  We do this


### PR DESCRIPTION
This PR replace the base image of the vertica-k8s. It was CentOS 7 before and now it uses a recent ubuntu image. Some changes have been made mainly in the Dockerfile to have a valid and lighter image.