### PR TITLE
Set minimum TLS version of webhook to 1.3

### DIFF
--- a/changes/unreleased/Changed-20220325-102922.yaml
+++ b/changes/unreleased/Changed-20220325-102922.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Set the minimum TLS version of the webhook to TLS 1.3
+time: 2022-03-25T10:29:22.620758589-03:00
+custom:
+  Issue: "188"

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -285,6 +285,15 @@ func main() {
 	}
 
 	if getIsWebhookEnabled() {
+		// Set the minimum TLS version for the webhook.  By default it will use
+		// TLS 1.0, which has a lot of security flaws.  This is a hacky way to
+		// set this and should be removed once there is a supported way.
+		// There are numerous proposals to allow this to be configured from
+		// Manager -- based on most recent activity this one looks promising:
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/852
+		webhookServer := mgr.GetWebhookServer()
+		webhookServer.TLSMinVersion = "1.3"
+
 		if err = (&verticacomv1beta1.VerticaDB{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "VerticaDB")
 			os.Exit(1)


### PR DESCRIPTION
When configuring the webhook, this will set the minimum TLS version to 1.3.  This is a bit of a hacky way to do this, but it will suffice until the controller-runtime allows this setting to be configure through the Manager.  See #155 for more of a discussion on what changes we are waiting for in controller-runtime.

Fixes #155 