### PR TITLE
subcluster: Add loadBalancerIP and serviceAnnotations

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -619,6 +619,18 @@ type Subcluster struct {
 	// specify. If not set, the external IP list is left empty in the service object.
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
 	ExternalIPs []string `json:"externalIPs,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Specify IP address of LoadBalancer service for this subcluster.
+	// This field is ignored when serviceType != "LoadBalancer".
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// A map of key/value pairs appended to service metadata.annotations.
+	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 }
 
 // Affinity is used instead of corev1.Affinity and behaves the same.

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -681,6 +681,18 @@ func (v *VerticaDB) matchingServiceNamesAreConsistent(allErrs field.ErrorList) f
 						"externalIPs don't match other subcluster(s) sharing the same serviceName")
 					allErrs = append(allErrs, err)
 				}
+				if sc.LoadBalancerIP != osc.LoadBalancerIP {
+					err := field.Invalid(fieldPrefix.Child("loadBalancerIP").Index(i),
+						sc.LoadBalancerIP,
+						"loadBalancerIP doesn't match other subcluster(s) sharing the same serviceName")
+					allErrs = append(allErrs, err)
+				}
+				if !reflect.DeepEqual(sc.ServiceAnnotations, osc.ServiceAnnotations) {
+					err := field.Invalid(fieldPrefix.Child("serviceAnnotations").Index(i),
+						sc.ServiceAnnotations,
+						"serviceAnnotations don't match other subcluster(s) sharing the same serviceName")
+					allErrs = append(allErrs, err)
+				}
 				if sc.NodePort != osc.NodePort {
 					err := field.Invalid(fieldPrefix.Child("nodePort").Index(i),
 						sc.NodePort,

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -408,22 +408,26 @@ var _ = Describe("verticadb_webhook", func() {
 		const ServiceName = "main"
 		vdb.Spec.Subclusters = []Subcluster{
 			{
-				Name:        "sc1",
-				Size:        2,
-				IsPrimary:   true,
-				ServiceName: ServiceName,
-				ServiceType: "NodePort",
-				NodePort:    30008,
-				ExternalIPs: []string{"8.1.2.3", "8.2.4.6"},
+				Name:               "sc1",
+				Size:               2,
+				IsPrimary:          true,
+				ServiceName:        ServiceName,
+				ServiceType:        "NodePort",
+				NodePort:           30008,
+				ExternalIPs:        []string{"8.1.2.3", "8.2.4.6"},
+				LoadBalancerIP:     "9.0.1.2",
+				ServiceAnnotations: map[string]string{"foo": "bar", "dib": "dab"},
 			},
 			{
-				Name:        "sc2",
-				Size:        1,
-				IsPrimary:   false,
-				ServiceName: ServiceName,
-				ServiceType: "ClusterIP",
-				NodePort:    30009,
-				ExternalIPs: []string{"8.1.2.3", "7.2.4.6"},
+				Name:               "sc2",
+				Size:               1,
+				IsPrimary:          false,
+				ServiceName:        ServiceName,
+				ServiceType:        "ClusterIP",
+				NodePort:           30009,
+				ExternalIPs:        []string{"8.1.2.3", "7.2.4.6"},
+				LoadBalancerIP:     "9.3.4.5",
+				ServiceAnnotations: map[string]string{"foo": "bar", "dib": "baz"},
 			},
 		}
 		validateSpecValuesHaveErr(vdb, true)
@@ -432,6 +436,10 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Subclusters[1].NodePort = vdb.Spec.Subclusters[0].NodePort
 		validateSpecValuesHaveErr(vdb, true)
 		vdb.Spec.Subclusters[1].ExternalIPs[1] = vdb.Spec.Subclusters[0].ExternalIPs[1]
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.Subclusters[1].LoadBalancerIP = vdb.Spec.Subclusters[0].LoadBalancerIP
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.Subclusters[1].ServiceAnnotations = vdb.Spec.Subclusters[0].ServiceAnnotations
 		validateSpecValuesHaveErr(vdb, false)
 	})
 

--- a/changes/unreleased/Added-20220328-085611.yaml
+++ b/changes/unreleased/Added-20220328-085611.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Additional subcluster options to better customize network load balancers
+time: 2022-03-28T08:56:11.644437279-03:00
+custom:
+  Issue: "189"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -45,7 +45,7 @@ func BuildExtSvc(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclust
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
 			Labels:      MakeLabelsForSvcObject(vdb, sc, "external"),
-			Annotations: MakeAnnotationsForObject(vdb),
+			Annotations: MakeAnnotationsForSubclusterService(vdb, sc),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: selectorLabelCreator(vdb, sc),
@@ -54,7 +54,8 @@ func BuildExtSvc(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclust
 				{Port: 5433, Name: "vertica", NodePort: sc.NodePort},
 				{Port: 5444, Name: "agent"},
 			},
-			ExternalIPs: sc.ExternalIPs,
+			ExternalIPs:    sc.ExternalIPs,
+			LoadBalancerIP: sc.LoadBalancerIP,
 		},
 	}
 }

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -168,3 +168,13 @@ func MakeStsSelectorLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]
 	m[SubclusterNameLabel] = sc.Name
 	return m
 }
+
+// MakeAnnotationsForSubclusterService returns a map of annotations
+// for Subcluster sc's service under VerticaDB vdb.
+func MakeAnnotationsForSubclusterService(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
+	annotations := MakeAnnotationsForObject(vdb)
+	for k, v := range sc.ServiceAnnotations {
+		annotations[k] = v
+	}
+	return annotations
+}


### PR DESCRIPTION
Additional subcluster options to better customize network load
balancers, i.e. when subcluster.serviceType is "LoadBalancer".

loadBalancerIP: Specifies front-end IP address of services. This is
useful in baremetal K8s (e.g. using MetalLB) to assign static IPs [1].

serviceAnnotations: Additional annotations for implementation-specific
customization of services. Managed K8s (e.g. Amazon EKS) heavily
use annotations to configure NLBs [2]. This is useful for choosing a
VPC/subnet, enabling logging, and other configurations.

[1] https://metallb.universe.tf/usage/#requesting-specific-ips
[2] https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/

Example configuration:
```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: example
  namespace: example
spec:
  subclusters:
    - name: example
      serviceType: LoadBalancer
      loadBalancerIP: 192.168.1.2
      serviceAnnotations:
        service.beta.kubernetes.io/aws-load-balancer-foo: bar
```
