### PR TITLE
Allow uppercase dbName

### DIFF
--- a/pkg/controllers/podfacts.go
+++ b/pkg/controllers/podfacts.go
@@ -369,7 +369,7 @@ func (p *PodFacts) checkIsDBCreated(ctx context.Context, vdb *vapi.VerticaDB, pf
 	cmd := []string{
 		"bash",
 		"-c",
-		fmt.Sprintf("ls -d %s/v_%s_node????_data", vdb.GetDBDataPath(), vdb.Spec.DBName),
+		fmt.Sprintf("ls -d %s/v_%s_node????_data", vdb.GetDBDataPath(), strings.ToLower(vdb.Spec.DBName)),
 	}
 	if stdout, stderr, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, cmd...); err != nil {
 		if !strings.Contains(stderr, "No such file or directory") {

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -100,7 +101,7 @@ func TestAPIs(t *testing.T) {
 func setVerticaNodeNameInPodFacts(vdb *vapi.VerticaDB, sc *vapi.Subcluster, pf *PodFacts) {
 	for podIndex := int32(0); podIndex < sc.Size; podIndex++ {
 		podNm := names.GenPodName(vdb, sc, podIndex)
-		pf.Detail[podNm].vnodeName = fmt.Sprintf("v_%s_node%04d", vdb.Spec.DBName, podIndex+1)
+		pf.Detail[podNm].vnodeName = fmt.Sprintf("v_%s_node%04d", strings.ToLower(vdb.Spec.DBName), podIndex+1)
 		pf.Detail[podNm].compat21NodeName = fmt.Sprintf("node%04d", podIndex+1)
 	}
 }


### PR DESCRIPTION
podfacts.go and suite_test.go format incorrect node names when dbName
contains uppercase chars: e.g. "v_MYDB_node1234" instead of the
lowercase'd "v_mydb_node1234". As a result, operator continuously
re-creates database in this scenario because podfacts cannot detect
successful creation due to a malformed filepath.