### PR TITLE
New prometheus metrics for the operator

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -30,20 +30,18 @@ jobs:
         make vdb-gen
         ls -lhrt bin/
 
-    - name: Build RBAC yaml
+    - name: Build Release yaml
       run: |
-        mkdir -p config/samples/rbac
-        make create-default-rbac
-        ls -lhrt config/samples/rbac/
+        make config-transformer
+        ls -lhrt config/release-manifests
 
     - name: Build Bundle
       run: | 
         IMG_REPO=vertica/ make bundle
         ls -lhrt
 
-    - name: Build helm charts
+    - name: Package helm charts
       run: | 
-        make create-helm-charts
         cd helm-charts
         helm package verticadb-operator
         ls -lhrt

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/lithammer/dedent v1.1.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
+	github.com/prometheus/client_golang v1.11.1
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.19.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -50,7 +51,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.11.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/pkg/controllers/vdb/dbremovesubcluster_reconcile.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconcile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	"github.com/vertica/vertica-kubernetes/pkg/metrics"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -86,6 +87,9 @@ func (d *DBRemoveSubclusterReconciler) removeExtraSubclusters(ctx context.Contex
 	}
 
 	for i := range subclusters {
+		// Clear out any metrics for the subcluster we are about to delete
+		metrics.HandleSubclusterDelete(d.Vdb, subclusters[i].Name, d.Log)
+
 		if err := d.removeSubcluster(ctx, subclusters[i].Name); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/controllers/vdb/metrics_reconcile.go
+++ b/pkg/controllers/vdb/metrics_reconcile.go
@@ -1,0 +1,93 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/metrics"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// MetricReconciler will refresh any metrics based on latest podfacts
+type MetricReconciler struct {
+	VRec   *VerticaDBReconciler
+	Vdb    *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	PFacts *PodFacts
+}
+
+// subclusterGaugeDetail will collect information for each gauge.  This is
+// intended to be use per subcluster.
+type subclusterGaugeDetail struct {
+	podCount     float64
+	runningCount float64
+	readyCount   float64
+}
+
+// MakeMetricReconciler will build a MetricReconciler object
+func MakeMetricReconciler(vrec *VerticaDBReconciler, vdb *vapi.VerticaDB, pfacts *PodFacts) controllers.ReconcileActor {
+	return &MetricReconciler{VRec: vrec, Vdb: vdb, PFacts: pfacts}
+}
+
+// Reconcile will update the metrics based on the pod facts
+func (p *MetricReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if err := p.PFacts.Collect(ctx, p.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Initialized any metrics that use the vdb as label.  This sets all of the
+	// metrics for the current vdb to zero.
+	metrics.HandleVDBInit(p.Vdb)
+
+	// Update any gauges that we track for subcluster events
+	rawMetrics := p.captureRawMetrics()
+	metrics.SubclusterCount.With(metrics.MakeVDBLabels(p.Vdb)).Set(float64(len(rawMetrics)))
+	for scName, detail := range rawMetrics {
+		scLabels := metrics.MakeSubclusterLabels(p.Vdb, scName)
+		metrics.SubclusterPodCount.With(scLabels).Set(detail.podCount)
+		metrics.SubclusterReadyPodCount.With(scLabels).Set(detail.readyCount)
+		metrics.SubclusterRunningPodCount.With(scLabels).Set(detail.runningCount)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// captureRawMetrics will summarize the raw metrics for the subcluster gauges
+func (p *MetricReconciler) captureRawMetrics() map[string]*subclusterGaugeDetail {
+	scGaugeSummary := map[string]*subclusterGaugeDetail{}
+	scMap := p.Vdb.GenSubclusterMap()
+	for _, pf := range p.PFacts.Detail {
+		// Only use subclusters from the Vdb.  We omit ones that are scheduled for
+		// deletion because we need to clear metrics for those deleted subclusters
+		// before we actually remove their statefulsets.
+		if _, ok := scMap[pf.subcluster]; !ok {
+			continue
+		}
+		if _, ok := scGaugeSummary[pf.subcluster]; !ok {
+			scGaugeSummary[pf.subcluster] = &subclusterGaugeDetail{}
+		}
+		scGaugeSummary[pf.subcluster].podCount++
+		if pf.isPodRunning {
+			scGaugeSummary[pf.subcluster].runningCount++
+		}
+		if pf.upNode {
+			scGaugeSummary[pf.subcluster].readyCount++
+		}
+	}
+	return scGaugeSummary
+}

--- a/pkg/controllers/vdb/metrics_reconcile_test.go
+++ b/pkg/controllers/vdb/metrics_reconcile_test.go
@@ -1,0 +1,51 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("prometheus_reconcile", func() {
+	ctx := context.Background()
+
+	It("should collect prometheus gauge values based on the pod facts", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters[0].Size = 3
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := MakePodFacts(k8sClient, fpr)
+		actor := MakeMetricReconciler(vdbRec, vdb, &pfacts)
+		r := actor.(*MetricReconciler)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+
+		metrics := r.captureRawMetrics()
+		Expect(metrics[vdb.Spec.Subclusters[0].Name].podCount).Should(Equal(float64(3)))
+		Expect(metrics[vdb.Spec.Subclusters[0].Name].runningCount).Should(Equal(float64(3)))
+		Expect(metrics[vdb.Spec.Subclusters[0].Name].readyCount).Should(Equal(float64(3)))
+	})
+})

--- a/pkg/controllers/vdb/restart_reconcile.go
+++ b/pkg/controllers/vdb/restart_reconcile.go
@@ -330,7 +330,7 @@ func (r *RestartReconciler) execRestartPods(ctx context.Context, downPods []*Pod
 		return stdout, err
 	}
 	r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.NodeRestartSucceeded,
-		"Successfully called 'admintools -t restart_node' and it took %ss", elapsedTimeInSeconds)
+		"Successfully called 'admintools -t restart_node' and it took %ds", int(elapsedTimeInSeconds))
 	return stdout, nil
 }
 
@@ -399,7 +399,7 @@ func (r *RestartReconciler) restartCluster(ctx context.Context, downPods []*PodF
 		return ctrl.Result{}, err
 	}
 	r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.ClusterRestartSucceeded,
-		"Successfully called 'admintools -t start_db' and it took %ss", elapsedTimeInSeconds)
+		"Successfully called 'admintools -t start_db' and it took %ds", int(elapsedTimeInSeconds))
 	return ctrl.Result{}, err
 }
 

--- a/pkg/controllers/vdb/restart_reconcile.go
+++ b/pkg/controllers/vdb/restart_reconcile.go
@@ -330,7 +330,7 @@ func (r *RestartReconciler) execRestartPods(ctx context.Context, downPods []*Pod
 		return stdout, err
 	}
 	r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.NodeRestartSucceeded,
-		"Successfully called 'admintools -t restart_node' and it took %s", time.Since(start))
+		"Successfully called 'admintools -t restart_node' and it took %ss", elapsedTimeInSeconds)
 	return stdout, nil
 }
 
@@ -387,15 +387,15 @@ func (r *RestartReconciler) restartCluster(ctx context.Context, downPods []*PodF
 	r.VRec.EVRec.Event(r.Vdb, corev1.EventTypeNormal, events.ClusterRestartStarted,
 		"Calling 'admintools -t start_db' to restart the cluster")
 	start := time.Now()
-	plabels := metrics.MakeVDBLabels(r.Vdb)
+	labels := metrics.MakeVDBLabels(r.Vdb)
 	_, _, err := r.PRunner.ExecAdmintools(ctx, r.ATPod, names.ServerContainer, cmd...)
 	elapsedTimeInSeconds := time.Since(start).Seconds()
-	metrics.ClusterRestartDuration.With(plabels).Observe(elapsedTimeInSeconds)
-	metrics.ClusterRestartAttempt.With(plabels).Inc()
+	metrics.ClusterRestartDuration.With(labels).Observe(elapsedTimeInSeconds)
+	metrics.ClusterRestartAttempt.With(labels).Inc()
 	if err != nil {
 		r.VRec.EVRec.Event(r.Vdb, corev1.EventTypeWarning, events.ClusterRestartFailed,
 			"Failed while calling 'admintools -t start_db'")
-		metrics.ClusterRestartFailure.With(plabels).Inc()
+		metrics.ClusterRestartFailure.With(labels).Inc()
 		return ctrl.Result{}, err
 	}
 	r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.ClusterRestartSucceeded,

--- a/pkg/controllers/vdb/restart_reconcile.go
+++ b/pkg/controllers/vdb/restart_reconcile.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/metrics"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
@@ -317,10 +318,15 @@ func (r *RestartReconciler) execRestartPods(ctx context.Context, downPods []*Pod
 	r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.NodeRestartStarted,
 		"Calling 'admintools -t restart_node' to restart the following pods: %s", strings.Join(podNames, ", "))
 	start := time.Now()
+	labels := metrics.MakeVDBLabels(r.Vdb)
 	stdout, _, err := r.PRunner.ExecAdmintools(ctx, r.ATPod, names.ServerContainer, cmd...)
+	elapsedTimeInSeconds := time.Since(start).Seconds()
+	metrics.NodesRestartDuration.With(labels).Observe(elapsedTimeInSeconds)
+	metrics.NodesRestartAttempt.With(labels).Inc()
 	if err != nil {
 		r.VRec.EVRec.Event(r.Vdb, corev1.EventTypeWarning, events.NodeRestartFailed,
 			"Failed while calling 'admintools -t restart_node'")
+		metrics.NodesRestartFailed.With(labels).Inc()
 		return stdout, err
 	}
 	r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.NodeRestartSucceeded,
@@ -381,14 +387,19 @@ func (r *RestartReconciler) restartCluster(ctx context.Context, downPods []*PodF
 	r.VRec.EVRec.Event(r.Vdb, corev1.EventTypeNormal, events.ClusterRestartStarted,
 		"Calling 'admintools -t start_db' to restart the cluster")
 	start := time.Now()
+	plabels := metrics.MakeVDBLabels(r.Vdb)
 	_, _, err := r.PRunner.ExecAdmintools(ctx, r.ATPod, names.ServerContainer, cmd...)
+	elapsedTimeInSeconds := time.Since(start).Seconds()
+	metrics.ClusterRestartDuration.With(plabels).Observe(elapsedTimeInSeconds)
+	metrics.ClusterRestartAttempt.With(plabels).Inc()
 	if err != nil {
 		r.VRec.EVRec.Event(r.Vdb, corev1.EventTypeWarning, events.ClusterRestartFailed,
 			"Failed while calling 'admintools -t start_db'")
+		metrics.ClusterRestartFailure.With(plabels).Inc()
 		return ctrl.Result{}, err
 	}
 	r.VRec.EVRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.ClusterRestartSucceeded,
-		"Successfully called 'admintools -t start_db' and it took %s", time.Since(start))
+		"Successfully called 'admintools -t start_db' and it took %ss", elapsedTimeInSeconds)
 	return ctrl.Result{}, err
 }
 

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	"github.com/vertica/vertica-kubernetes/pkg/metrics"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
 	"github.com/vertica/vertica-kubernetes/pkg/version"
@@ -119,10 +120,11 @@ func (i *UpgradeManager) startUpgrade(ctx context.Context) (ctrl.Result, error) 
 		return ctrl.Result{}, err
 	}
 
-	// We only log an event message the first time we begin an upgrade.
+	// We only log an event message and bump a counter the first time we begin an upgrade.
 	if !i.ContinuingUpgrade {
 		i.VRec.EVRec.Eventf(i.Vdb, corev1.EventTypeNormal, events.UpgradeStart,
 			"Vertica server upgrade has started.")
+		metrics.UpgradeCount.With(metrics.MakeVDBLabels(i.Vdb)).Inc()
 	}
 	return ctrl.Result{}, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,242 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	k8sMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	// The namespace for all metrics.  This ends up being a prefix of the name
+	// of each of the metrics.
+	Namespace = "verticadb"
+
+	// The subsystem is the second part of the name.  This comes after the
+	// namespace and before the metric name.
+	UpgradeSubsystem        = "upgrade"
+	ClusterRestartSubsystem = "cluster_restart"
+	NodesRestartSubsystem   = "nodes_restart"
+	SubclusterSubsystem     = "subclusters"
+
+	// Names of the labels that we can apply to metrics.
+	VerticaDBLabel  = "verticadb"
+	SubclusterLabel = "subcluster"
+)
+
+var (
+	AdminToolsBucket = []float64{1, 5, 10, 30, 60, 120, 300, 600}
+
+	UpgradeCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: UpgradeSubsystem,
+			Name:      "total",
+			Help:      "The number of times the operator performed an upgrade caused by an image change",
+		},
+		[]string{VerticaDBLabel},
+	)
+	ClusterRestartAttempt = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: ClusterRestartSubsystem,
+			Name:      "attempted_total",
+			Help:      "The number of times we attempted a full cluster restart",
+		},
+		[]string{VerticaDBLabel},
+	)
+	ClusterRestartFailure = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: ClusterRestartSubsystem,
+			Name:      "failed_total",
+			Help:      "The number of times we failed when attempting a full cluster restart",
+		},
+		[]string{VerticaDBLabel},
+	)
+	ClusterRestartDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: ClusterRestartSubsystem,
+			Name:      "seconds",
+			Help:      "The number of seconds it took to do a full cluster restart",
+			Buckets:   AdminToolsBucket,
+		},
+		[]string{VerticaDBLabel},
+	)
+	NodesRestartAttempt = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: NodesRestartSubsystem,
+			Name:      "attempted_total",
+			Help:      "The number of times we attempted to restart down nodes",
+		},
+		[]string{VerticaDBLabel},
+	)
+	NodesRestartFailed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: NodesRestartSubsystem,
+			Name:      "failed_total",
+			Help:      "The number of times we failed when trying to restart down nodes",
+		},
+		[]string{VerticaDBLabel},
+	)
+	NodesRestartDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: NodesRestartSubsystem,
+			Name:      "seconds",
+			Help:      "The number of seconds it took to restart down nodes",
+			Buckets:   AdminToolsBucket,
+		},
+		[]string{VerticaDBLabel},
+	)
+	SubclusterCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: SubclusterSubsystem,
+			Name:      "count",
+			Help:      "The number of subclusters that exist",
+		},
+		[]string{VerticaDBLabel},
+	)
+	SubclusterPodCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: SubclusterSubsystem,
+			Name:      "pod_count",
+			Help:      "The number of pods that currently exist in a subcluster",
+		},
+		[]string{VerticaDBLabel, SubclusterLabel},
+	)
+	SubclusterRunningPodCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: SubclusterSubsystem,
+			Name:      "running_pod_count",
+			Help:      "The number of running pods in a subcluster",
+		},
+		[]string{VerticaDBLabel, SubclusterLabel},
+	)
+	SubclusterReadyPodCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: SubclusterSubsystem,
+			Name:      "ready_pod_count",
+			Help:      "The number of pods in a subcluster that have vertica running and accepting connections",
+		},
+		[]string{VerticaDBLabel, SubclusterLabel},
+	)
+	// Add new metrics above this comment.
+	//
+	// Once a metric is added a few other things need to be updated:
+	// 1. Register the metric in then init() function
+	// 2. If the metric has subcluster labels, update the function
+	//    HandleSubclusterDelete so that we clean them up when a
+	//    subcluster is removed.
+	// 3. Include the metric in the function HandleVDBDelete.  This is
+	//    called when the VerticaDB is deleted, so will do metric cleanup of any
+	//    metrics tied to the vdb.
+	// 4. Include any metric that only has a verticadb label in HandleVDBInit.
+	//    This will ensure all metrics are initialized with value of zero.
+)
+
+func init() {
+	k8sMetrics.Registry.MustRegister(
+		UpgradeCount,
+		ClusterRestartAttempt,
+		ClusterRestartFailure,
+		ClusterRestartDuration,
+		NodesRestartAttempt,
+		NodesRestartFailed,
+		NodesRestartDuration,
+		SubclusterCount,
+		SubclusterPodCount,
+		SubclusterRunningPodCount,
+		SubclusterReadyPodCount,
+	)
+}
+
+// HandleSubclusterDelete will cleanup metrics upon subcluster
+// deletion.  It will clear out any metrics that are subcluster specific.
+func HandleSubclusterDelete(vdb *vapi.VerticaDB, scName string, log logr.Logger) {
+	log.Info("Removing metrics with subcluster label", "subcluster", scName)
+	labels := prometheus.Labels{VerticaDBLabel: vdb.Name, SubclusterLabel: scName}
+	SubclusterPodCount.Delete(labels)
+	SubclusterRunningPodCount.Delete(labels)
+	SubclusterReadyPodCount.Delete(labels)
+}
+
+// HandleVDBDelete will cleanup metrics when we find out that the
+// VerticaDB no longer exists.  This should include all metrics that include the
+// VerticaDB name in its metrics.
+func HandleVDBDelete(vdbName string, log logr.Logger) {
+	log.Info("Removing metrics with vdb label", "vdb", vdbName)
+	labels := prometheus.Labels{VerticaDBLabel: vdbName}
+	UpgradeCount.Delete(labels)
+	ClusterRestartAttempt.Delete(labels)
+	ClusterRestartFailure.Delete(labels)
+	ClusterRestartDuration.Delete(labels)
+	NodesRestartAttempt.Delete(labels)
+	NodesRestartFailed.Delete(labels)
+	NodesRestartDuration.Delete(labels)
+	SubclusterCount.Delete(labels)
+	// For the subcluster metrics, we don't actually know the subcluster values
+	// we used for the labels.  The current version of the client only allows
+	// deletion if you know all of the labels.  However, a way to delete metrics
+	// based on a partial match was added in
+	// https://github.com/prometheus/client_golang/pull/1013.  Once we have updated
+	// the Go pometheus client to include the above PR, we can use the new
+	// DeletePartialMatch API.
+	// For now, we will orphan the subcluster metrics when a VerticaDB is deleted.
+	// subclusterPodCountMetric.DeletePartialMatch(labels)
+	// subclusterRunningPodCountMetric.DeletePartialMatch(labels)
+	// subclusterReadyPodCountMetric.DeletePartialMatch(labels)
+}
+
+// HandleVDBInit will initialized metrics that use verticadb as a
+// label.  This is necessary to fill in a missing series with a known verticaDB.
+// Otherwise, a metric won't be displayed until we have set some value to it.
+// This may break dashboards that assume the metric exists.
+func HandleVDBInit(vdb *vapi.VerticaDB) {
+	// Intentionally leaving out the subcluster metrics because we don't know
+	// the subcluster names.  Only include metrics that aren't set in the
+	// PrometheusReconciler.
+	UpgradeCount.WithLabelValues(vdb.Name)
+	ClusterRestartAttempt.WithLabelValues(vdb.Name)
+	ClusterRestartFailure.WithLabelValues(vdb.Name)
+	ClusterRestartDuration.WithLabelValues(vdb.Name)
+	NodesRestartAttempt.WithLabelValues(vdb.Name)
+	NodesRestartFailed.WithLabelValues(vdb.Name)
+	NodesRestartDuration.WithLabelValues(vdb.Name)
+}
+
+// MakeVDBLabels return a prometheus.Labels that includes the VerticaDB name
+func MakeVDBLabels(vdb *vapi.VerticaDB) prometheus.Labels {
+	return prometheus.Labels{VerticaDBLabel: vdb.Name}
+}
+
+// MakeSubclusterLabels returns a prometheus.Labels that includes the VerticaDB
+// and subcluster name.
+func MakeSubclusterLabels(vdb *vapi.VerticaDB, scName string) prometheus.Labels {
+	return prometheus.Labels{
+		VerticaDBLabel:  vdb.Name,
+		SubclusterLabel: scName,
+	}
+}

--- a/tests/e2e-extra/operator-metrics/05-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/05-assert.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+spec:
+  containers:
+  - name: manager
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verticadb-operator-webhook-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verticadb-operator-metrics-service

--- a/tests/e2e-extra/operator-metrics/05-deploy-operator.yaml
+++ b/tests/e2e-extra/operator-metrics/05-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && DEPLOY_WITH=helm HELM_OVERRIDES='--set prometheus.expose=EnableWithoutAuth' make deploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/operator-metrics/10-create-communal-creds.yaml
+++ b/tests/e2e-extra/operator-metrics/10-create-communal-creds.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-extra/operator-metrics/20-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/20-assert.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-operator-metrics-pri-sc
+status:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-operator-metrics-sec-sc
+status:
+  replicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-operator-metrics
+status:
+  subclusterCount: 2

--- a/tests/e2e-extra/operator-metrics/20-setup-vdb.yaml
+++ b/tests/e2e-extra/operator-metrics/20-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/operator-metrics/25-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/25-assert.yaml
@@ -1,0 +1,35 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-operator-metrics-pri-sc
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-operator-metrics-sec-sc
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-operator-metrics
+status:
+  upNodeCount: 2

--- a/tests/e2e-extra/operator-metrics/25-wait-for-createdb.yaml
+++ b/tests/e2e-extra/operator-metrics/25-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/operator-metrics/30-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/30-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-metrics
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
+++ b/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
@@ -1,0 +1,64 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies external access through the service to the agent port 5444.  It
+# does this by invoking the REST API and doing basic sanity on what it
+# received.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-metrics
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+    set -o pipefail
+
+    SVC_NAME=verticadb-operator-metrics-service
+    curl http://$SVC_NAME:8443/metrics
+    for metric in verticadb_upgrade verticadb_cluster_restart verticadb_nodes_restart
+    do
+        curl http://$SVC_NAME:8443/metrics | grep $metric
+    done
+    for sc in pri-sc sec-sc
+    do
+        curl http://$SVC_NAME:8443/metrics | grep "verticadb_subclusters_pod_count{subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
+        curl http://$SVC_NAME:8443/metrics | grep "verticadb_subclusters_ready_pod_count{subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
+        curl http://$SVC_NAME:8443/metrics | grep "verticadb_subclusters_running_pod_count{subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
+    done
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-metrics
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-metrics

--- a/tests/e2e-extra/operator-metrics/35-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/35-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-operator-metrics
+status:
+  subclusterCount: 1

--- a/tests/e2e-extra/operator-metrics/35-errors.yaml
+++ b/tests/e2e-extra/operator-metrics/35-errors.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-operator-metrics-sec-sc

--- a/tests/e2e-extra/operator-metrics/35-remove-subcluster.yaml
+++ b/tests/e2e-extra/operator-metrics/35-remove-subcluster.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-operator-metrics
+spec:
+  subclusters:
+    - name: pri-sc
+      size: 1
+      isPrimary: true

--- a/tests/e2e-extra/operator-metrics/40-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/40-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-no-sec-sc-metrics
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e-extra/operator-metrics/40-verify-no-metrics-for-removed-subcluster.yaml
+++ b/tests/e2e-extra/operator-metrics/40-verify-no-metrics-for-removed-subcluster.yaml
@@ -1,0 +1,61 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies external access through the service to the agent port 5444.  It
+# does this by invoking the REST API and doing basic sanity on what it
+# received.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-no-sec-sc-metrics
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    SVC_NAME=verticadb-operator-metrics-service
+    curl --silent http://$SVC_NAME:8443/metrics
+    OLD_METRICS=$(curl --silent http://$SVC_NAME:8443/metrics | grep --count 'sec-sc') || :
+    echo $OLD_METRICS
+    if [ "$OLD_METRICS" -eq "0" ]
+    then
+      exit 0
+    fi
+    echo "*** Unexpected, metrics for removed subcluster still exist"
+    exit 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-no-sec-sc-metrics
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-no-sec-sc-metrics

--- a/tests/e2e-extra/operator-metrics/45-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/45-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-extra/operator-metrics/45-delete-cr.yaml
+++ b/tests/e2e-extra/operator-metrics/45-delete-cr.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/operator-metrics/45-errors.yaml
+++ b/tests/e2e-extra/operator-metrics/45-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-extra/operator-metrics/50-assert.yaml
+++ b/tests/e2e-extra/operator-metrics/50-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-no-vdb-metrics
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e-extra/operator-metrics/50-verify-no-metrics-for-removed-vdb.yaml
+++ b/tests/e2e-extra/operator-metrics/50-verify-no-metrics-for-removed-vdb.yaml
@@ -1,0 +1,66 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies external access through the service to the agent port 5444.  It
+# does this by invoking the REST API and doing basic sanity on what it
+# received.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-no-vdb-metrics
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    SVC_NAME=verticadb-operator-metrics-service
+    curl --silent http://$SVC_NAME:8443/metrics
+    OLD_METRICS=$(curl --silent http://$SVC_NAME:8443/metrics | grep --count 'v-operator-metrics') || :
+    echo $OLD_METRICS
+    # There are 3 subcluster metrics that we don't cleanup yet because we don't
+    # know the subcluster names when we do the cleanup.  There is a PR
+    # (https://github.com/prometheus/client_golang/pull/1013) that will allow
+    # this cleanup.  When we do have that fix, we can check for 0 here.  In the
+    # meantime, we allow 3.
+    if [ "$OLD_METRICS" -eq "3" ]
+    then
+      exit 0
+    fi
+    echo "*** Unexpected, metrics for removed vdb still exist"
+    exit 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-no-vdb-metrics
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-no-vdb-metrics

--- a/tests/e2e-extra/operator-metrics/90-errors.yaml
+++ b/tests/e2e-extra/operator-metrics/90-errors.yaml
@@ -1,0 +1,28 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verticadb-operator-metrics-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: verticadb-operator-webhook-service

--- a/tests/e2e-extra/operator-metrics/90-uninstall-operator.yaml
+++ b/tests/e2e-extra/operator-metrics/90-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/operator-metrics/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-extra/operator-metrics/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-extra/operator-metrics/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/operator-metrics/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-operator-metrics
+spec:
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  dbName: vertdb
+  subclusters:
+    - name: sec-sc
+      size: 1
+      isPrimary: false
+    - name: pri-sc
+      size: 1
+      isPrimary: true
+  kSafety: "0"
+  certSecrets: []


### PR DESCRIPTION
This exports metrics specific to the verticadb operator to the /metrics endpoint.

- number of nodes restarted (Counter)
- number of subclusters (Gauge)
- number of pods (Gauge) using subcluster as label
- number of ready pods (Gauge) using subcluster as label
- number of running pods (Gauge) using subcluster as label
- number of cluster restarts (Counter)
- number of upgrades (Counter)
    
A new reconciler was added to maintain the gauges.  We increment the counters when we do various operations, like cluster restart and upgrade.
