### PR TITLE
Fix pod restart with k-safety 0

### DIFF
--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -727,7 +727,7 @@ func (p *PodFacts) countInstalledAndNotRestartable() int {
 		// sts.  The sts needs to be created or sized first.
 		// We need the pod to have the DC table annotations since the DC
 		// collection is done at start, so these need to set prior to starting.
-		if !v.isPodRunning && v.isInstalled && v.managedByParent && v.hasDCTableAnnotations {
+		if v.isInstalled && v.managedByParent && (!v.isPodRunning || !v.hasDCTableAnnotations) {
 			return 1
 		}
 		return 0


### PR DESCRIPTION
This fixes a regression that was introduced when changing pending pod handling in this release.  When running with k-safety 0, we need to restart all nodes together.  This closes a timing hole where it failed to wait for all of them.  This caused one of the e2e test to fail sporadically.