### PR TITLE
Enforce required fields in VerticaAutoscaler

### DIFF
--- a/api/v1beta1/verticaautoscaler_types.go
+++ b/api/v1beta1/verticaautoscaler_types.go
@@ -27,11 +27,12 @@ import (
 type VerticaAutoscalerSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	// The name of the VerticaDB CR that this autoscaler is defined for.  The
 	// VerticaDB object must exist in the same namespace as this object.
-	VerticaDBName string `json:"verticaDBName,omitempty"`
+	VerticaDBName string `json:"verticaDBName"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +kubebuilder:default:="Subcluster"
@@ -46,6 +47,7 @@ type VerticaAutoscalerSpec struct {
 	//   the last subcluster only.
 	ScalingGranularity ScalingGranularityType `json:"scalingGranularity"`
 
+	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	// This acts as a selector for the subclusters that are being scaled together.
@@ -188,7 +190,7 @@ func MakeVAS() *VerticaAutoscaler {
 		},
 		Spec: VerticaAutoscalerSpec{
 			VerticaDBName:      vdbNm.Name,
-			ScalingGranularity: "Pod",
+			ScalingGranularity: PodScalingGranularity,
 			ServiceName:        "sc1",
 		},
 	}

--- a/tests/e2e/vas-webhook/10-assert.yaml
+++ b/tests/e2e/vas-webhook/10-assert.yaml
@@ -16,6 +16,7 @@ kind: VerticaAutoscaler
 metadata:
   name: vas-webhook
 spec:
+  verticaDBName: vert
   serviceName: sc1
   scalingGranularity: Subcluster
   template:

--- a/tests/e2e/vas-webhook/10-create-vas-with-default-serviceName.yaml
+++ b/tests/e2e/vas-webhook/10-create-vas-with-default-serviceName.yaml
@@ -16,4 +16,8 @@ kind: VerticaAutoscaler
 metadata:
   name: vas-webhook
 spec:
+  verticaDBName: vert
   serviceName: sc1
+  template:
+      serviceName: sc1
+      size: 1


### PR DESCRIPTION
This adds rules to VerticaAutoscaler to make serviceName and
verticaDBName as required.

Also, this relaxes some rules in the webhook wrt serviceName in the
template.  I removed the defaulter that had previously set the service
name in the template to match the one in the spec.  The webhook only
enforces that the service name match between spec and template if the
template is being used.