### PR TITLE
Use en_US.UTF-8 as lang instead of en_US.utf8

### DIFF
--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -92,7 +92,7 @@ COPY --from=builder /home/dbadmin /home/dbadmin
 COPY --from=builder /root/.ssh /root/.ssh
 COPY --from=builder /var/spool/cron/ /var/spool/cron/crontabs
 
-ENV LANG en_US.utf8
+ENV LANG en_US.UTF-8
 ENV TZ UTC
 ENV PATH "$PATH:/opt/vertica/bin:/opt/vertica/sbin"
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Scrutinize collects lang info, and when we used en_US.utf8 it would look
like the language was different across pods.  Using en_US.UTF-8 so that
the lang collected is the same.