### PR TITLE
Use pod limits when running admintools

### DIFF
--- a/changes/unreleased/Changed-20220603-125741.yaml
+++ b/changes/unreleased/Changed-20220603-125741.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Use limits for pod when running admintools
+time: 2022-06-03T12:57:41.161747492Z
+custom:
+  Issue: "218"

--- a/pkg/cmds/exec.go
+++ b/pkg/cmds/exec.go
@@ -128,7 +128,13 @@ func UpdateVsqlCmd(passwd string, cmd ...string) []string {
 
 // UpdateAdmintoolsCmd generates an admintools command appending the options we need
 func UpdateAdmintoolsCmd(passwd string, cmd ...string) []string {
-	prefix := []string{"/opt/vertica/bin/admintools"}
+	// We are running as dbadmin, but we need to do this 'sudo su dbadmin --'
+	// stuff so that we have the proper ulimits set.  When you exec into a pod,
+	// the ulimits you use are for the container runtime.  This can differ from
+	// the actual limits for the pod/container.  So we need this extra bit to
+	// ensure we always run with the pod limits.  This ensures the limits are
+	// the same across all vertica nodes.
+	prefix := []string{"sudo", "su", "dbadmin", "--", "/opt/vertica/bin/admintools"}
 	cmd = append(prefix, cmd...)
 	if passwd == "" {
 		return cmd


### PR DESCRIPTION
When you exec into a pod, the ulimits you use are for the container runtime.  This can differ from the actual limits for the pod/container. This change ensures we use the pod/container limits when running any admintools commands.  This ensures the limits are the same for all pods.