### PR TITLE
Add zlib dev package to vertica-k8s image

### DIFF
--- a/changes/unreleased/Changed-20220603-111623.yaml
+++ b/changes/unreleased/Changed-20220603-111623.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Include zlib dev package in vertica-k8s image
+time: 2022-06-03T11:16:23.572505194-03:00
+custom:
+  Issue: "219"

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x \
   openssh-clients \
   openssl \
   which \
+  zlib-devel \
   && /usr/sbin/groupadd -r verticadba --gid ${DBADMIN_GID} \
   && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba --uid ${DBADMIN_UID} dbadmin \
   && yum localinstall -q -y /tmp/${VERTICA_RPM} \
@@ -117,6 +118,7 @@ RUN set -x \
   dialog \
   iproute2 \
   libkeyutils1\
+  libz-dev \
   procps \
   krb5-user \
   logrotate \


### PR DESCRIPTION
This is a new requirement for the upcoming 12.0 release of the vertica server.