### PR TITLE
Prefix operator image with docker.io

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Build Bundle
       run: | 
-        IMG_REPO=vertica/ DEPLOY_WITH=olm make bundle
+        IMG_REPO=docker.io/vertica/ DEPLOY_WITH=olm make bundle
         ls -lhrt
 
     - name: Package helm charts

--- a/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
+++ b/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
@@ -6,6 +6,7 @@ tests:
     set:
       image:
         name: something:tag
+        repo: null
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].image

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -16,7 +16,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repo: null # null = dockerhub
+  repo: docker.io
   name: vertica/verticadb-operator:1.5.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This corrects a problem when creating the new catalog entry in operatorhub.io.  It uses podman to pull the image to verify.  And podman doesn't assume you are pulling from dockerhub by default.   This change will make the repo explicit.  I had to update the CSV manually for the 1.5.0 release.  This changes the workflow to prefix with docker.io so the manual change isn't needed for the next release.

We only needed to update the bundle generation, but changing the default in the helm chart too to be consistent.