### PR TITLE
Rename Prometheus metrics

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -30,6 +30,7 @@ Prior to developing, the following software needs to be installed manually.  The
 - [krew](https://github.com/kubernetes-sigs/krew/releases/tag/v0.4.1) (version 0.4.1) $HOME/.krew/bin must be in your path
 - [kuttl](https://github.com/kudobuilder/kuttl/) (version 0.9.0)
 - [changie](https://github.com/miniscruff/changie) (version 0.5.0)
+- [jq](https://stedolan.github.io/jq/download/) (version 1.5+)
 
 # Kind
 

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: build
+default: help
 
 ##@ General
 

--- a/changes/unreleased/Changed-20220616-102645.yaml
+++ b/changes/unreleased/Changed-20220616-102645.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Renamed Prometheus metrics exposed through the operator
+time: 2022-06-16T10:26:45.358234028-03:00
+custom:
+  Issue: "223"

--- a/pkg/controllers/vdb/metrics_reconcile.go
+++ b/pkg/controllers/vdb/metrics_reconcile.go
@@ -59,9 +59,9 @@ func (p *MetricReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ct
 	metrics.SubclusterCount.With(metrics.MakeVDBLabels(p.Vdb)).Set(float64(len(rawMetrics)))
 	for scName, detail := range rawMetrics {
 		scLabels := metrics.MakeSubclusterLabels(p.Vdb, scName)
-		metrics.SubclusterPodCount.With(scLabels).Set(detail.podCount)
-		metrics.SubclusterReadyPodCount.With(scLabels).Set(detail.readyCount)
-		metrics.SubclusterRunningPodCount.With(scLabels).Set(detail.runningCount)
+		metrics.TotalNodeCount.With(scLabels).Set(detail.podCount)
+		metrics.UpNodeCount.With(scLabels).Set(detail.readyCount)
+		metrics.RunningNodeCount.With(scLabels).Set(detail.runningCount)
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -86,7 +86,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Remove any metrics for the vdb that we found to be deleted
-			metrics.HandleVDBDelete(req.NamespacedName.Name, log)
+			metrics.HandleVDBDelete(req.NamespacedName.Namespace, req.NamespacedName.Name, log)
 			// Request object not found, cound have been deleted after reconcile request.
 			log.Info("VerticaDB resource not found.  Ignoring since object must be deleted")
 			return ctrl.Result{}, nil

--- a/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
+++ b/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
@@ -29,14 +29,14 @@ data:
 
     SVC_NAME=verticadb-operator-metrics-service
     curl http://$SVC_NAME:8443/metrics
-    for metric in verticadb_upgrade verticadb_cluster_restart verticadb_nodes_restart
+    for metric in vertica_upgrade vertica_cluster_restart vertica_nodes_restart
     do
         curl http://$SVC_NAME:8443/metrics | grep $metric
     done
     for sc in pri-sc sec-sc
     do
-        curl http://$SVC_NAME:8443/metrics | grep "verticadb_subclusters_pod_count{subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
-        curl http://$SVC_NAME:8443/metrics | grep "verticadb_subclusters_running_pod_count{subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
+        curl http://$SVC_NAME:8443/metrics | grep "vertica_total_nodes_count{namespace=".*",subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
+        curl http://$SVC_NAME:8443/metrics | grep "vertica_running_nodes_count{namespace=".*",subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
     done
     # These is timing with the ready pod count.  The pod may be ready but the
     # metrics haven't yet been updated.  We check that a few times before
@@ -47,7 +47,7 @@ data:
       do
         [ $i -gt 1 ] && sleep 10
         curl http://$SVC_NAME:8443/metrics
-        curl http://$SVC_NAME:8443/metrics | grep "verticadb_subclusters_ready_pod_count{subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1" \
+        curl http://$SVC_NAME:8443/metrics | grep "vertica_up_nodes_count{namespace=".*",subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1" \
           && s=0 && break || s=$?
       done
       (exit $s)


### PR DESCRIPTION
This has various changes to the Prometheus metrics to make them more consumable and sync with future metric support in the server
- The prefix for all metrics was renamed from verticadb_* to vertica_*.   Verticadb is a k8s term, and we wanted to generalize it for when we expose the same metrics in non-k8s deployments.
- Rename *verticadb_subcluster_\*_count* gauges.  The subcluster name is a label, so we didn't need to repeat it in the metric name.  When you aggregate this metric to remove the subcluster label to get a cluster-wide view, having subcluster in the metric name didn't make much sense.
- Include namespace label in all of the metrics.  This allows you to distinguish metrics from other instances of the VerticaDB CR if you   have more than one.