### PR TITLE
Allow spread encryption to be set in the VerticaDB CR

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -34,9 +34,6 @@ import (
 
 // Important: Run "make" to regenerate code after modifying this file
 
-// Set constant Upgrade Requeue Time
-const URTime = 30
-
 // VerticaDBSpec defines the desired state of VerticaDB
 type VerticaDBSpec struct {
 	// +kubebuilder:validation:Optional
@@ -294,6 +291,14 @@ type VerticaDBSpec struct {
 	// it has the public keys to be able to ssh to those nodes.  It must have
 	// the following keys present: id_rsa, id_rsa.pub and authorized_keys.
 	SSHSecret string `json:"sshSecret,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	// Controls if the spread communication between pods is encrypted.  Valid
+	// values are 'vertica' or an empty string if not enabled.  This can only be
+	// set during initial creation of the CR.  If set for initPolicy other than
+	// Create, then it has no effect.
+	EncryptSpreadComm string `json:"encryptSpreadComm,omitempty"`
 }
 
 // LocalObjectReference is used instead of corev1.LocalObjectReference and behaves the same.
@@ -346,6 +351,12 @@ const (
 	// automation is disabled when running in this mode.
 	CommunalInitPolicyScheduleOnly = "ScheduleOnly"
 )
+
+// Set constant Upgrade Requeue Time
+const URTime = 30
+
+// Valid values for EncryptSpreadComm
+const EncryptSpreadCommWithVertica = "vertica"
 
 type KSafetyType string
 
@@ -700,6 +711,9 @@ const (
 	ImageChangeInProgress    VerticaDBConditionType = "ImageChangeInProgress"
 	OfflineUpgradeInProgress VerticaDBConditionType = "OfflineUpgradeInProgress"
 	OnlineUpgradeInProgress  VerticaDBConditionType = "OnlineUpgradeInProgress"
+	// VerticaRestartNeeded is a condition that when set to true will force the
+	// operator to stop/start the vertica pods.
+	VerticaRestartNeeded VerticaDBConditionType = "VerticaRestartNeeded"
 )
 
 // Fixed index entries for each condition.
@@ -709,6 +723,7 @@ const (
 	ImageChangeInProgressIndex
 	OfflineUpgradeInProgressIndex
 	OnlineUpgradeInProgressIndex
+	VerticaRestartNeededIndex
 )
 
 // VerticaDBConditionIndexMap is a map of the VerticaDBConditionType to its
@@ -719,6 +734,7 @@ var VerticaDBConditionIndexMap = map[VerticaDBConditionType]int{
 	ImageChangeInProgress:    ImageChangeInProgressIndex,
 	OfflineUpgradeInProgress: OfflineUpgradeInProgressIndex,
 	OnlineUpgradeInProgress:  OnlineUpgradeInProgressIndex,
+	VerticaRestartNeeded:     VerticaRestartNeededIndex,
 }
 
 // VerticaDBConditionNameMap is the reverse of VerticaDBConditionIndexMap.  It
@@ -729,12 +745,13 @@ var VerticaDBConditionNameMap = map[int]VerticaDBConditionType{
 	ImageChangeInProgressIndex:    ImageChangeInProgress,
 	OfflineUpgradeInProgressIndex: OfflineUpgradeInProgress,
 	OnlineUpgradeInProgressIndex:  OnlineUpgradeInProgress,
+	VerticaRestartNeededIndex:     VerticaRestartNeeded,
 }
 
 // VerticaDBCondition defines condition for VerticaDB
 type VerticaDBCondition struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status
-	// Type is the type of the condition
+	// Type is the name of the condition
 	Type VerticaDBConditionType `json:"type"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -295,9 +295,11 @@ type VerticaDBSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	// Controls if the spread communication between pods is encrypted.  Valid
-	// values are 'vertica' or an empty string if not enabled.  This can only be
-	// set during initial creation of the CR.  If set for initPolicy other than
-	// Create, then it has no effect.
+	// values are 'vertica' or an empty string if not enabled.  When set to
+	// 'vertica', Vertica generates the spread encryption key for the cluster
+	// when the database starts up.  This can only be set during initial
+	// creation of the CR.  If set for initPolicy other than Create, then it has
+	// no effect.
 	EncryptSpreadComm string `json:"encryptSpreadComm,omitempty"`
 }
 
@@ -1020,6 +1022,8 @@ func (v *VerticaDB) RequiresTransientSubcluster() bool {
 // IsOnlineUpgradeInProgress returns true if an online upgrade is in progress
 func (v *VerticaDB) IsOnlineUpgradeInProgress() bool {
 	inx := OnlineUpgradeInProgressIndex
+	// SPILLY - could we generalize this.  Maybe make the error case a panic?  It should not be a runtime error
+	// Lets move it to vdb
 	return inx < len(v.Status.Conditions) && v.Status.Conditions[inx].Status == corev1.ConditionTrue
 }
 

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -767,8 +767,7 @@ func (v *VerticaDB) validateEncryptSpreadComm(allErrs field.ErrorList) field.Err
 }
 
 func (v *VerticaDB) isImageChangeInProgress() bool {
-	return len(v.Status.Conditions) > ImageChangeInProgressIndex &&
-		v.Status.Conditions[ImageChangeInProgressIndex].Status == v1.ConditionTrue
+	return v.isConditionIndexSet(ImageChangeInProgressIndex)
 }
 
 // checkImmutableUpgradePolicy will see if it unsafe to change the

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -247,6 +247,7 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 	}
 	allErrs = v.checkImmutableUpgradePolicy(oldObj, allErrs)
 	allErrs = v.checkImmutableTemporarySubclusterRouting(oldObj, allErrs)
+	allErrs = v.checkImmutableEncryptSpreadComm(oldObj, allErrs)
 	return allErrs
 }
 
@@ -271,6 +272,7 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.matchingServiceNamesAreConsistent(allErrs)
 	allErrs = v.transientSubclusterMustMatchTemplate(allErrs)
 	allErrs = v.validateRequeueTimes(allErrs)
+	allErrs = v.validateEncryptSpreadComm(allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -754,6 +756,16 @@ func (v *VerticaDB) validateRequeueTimes(allErrs field.ErrorList) field.ErrorLis
 	return allErrs
 }
 
+func (v *VerticaDB) validateEncryptSpreadComm(allErrs field.ErrorList) field.ErrorList {
+	if v.Spec.EncryptSpreadComm != "" && v.Spec.EncryptSpreadComm != EncryptSpreadCommWithVertica {
+		err := field.Invalid(field.NewPath("spec").Child("encrpytSpreadComm"),
+			v.Spec.EncryptSpreadComm,
+			fmt.Sprintf("encryptSpreadComm can either be an empty string or set to %s", EncryptSpreadCommWithVertica))
+		allErrs = append(allErrs, err)
+	}
+	return allErrs
+}
+
 func (v *VerticaDB) isImageChangeInProgress() bool {
 	return len(v.Status.Conditions) > ImageChangeInProgressIndex &&
 		v.Status.Conditions[ImageChangeInProgressIndex].Status == v1.ConditionTrue
@@ -792,6 +804,16 @@ func (v *VerticaDB) checkImmutableTemporarySubclusterRouting(oldObj *VerticaDB, 
 		err := field.Invalid(field.NewPath("spec").Child("temporarySubclusterRouting").Child("template"),
 			v.Spec.TemporarySubclusterRouting.Template,
 			"template for temporasySubclusterRouting cannot change when an upgrade is in progress")
+		allErrs = append(allErrs, err)
+	}
+	return allErrs
+}
+
+func (v *VerticaDB) checkImmutableEncryptSpreadComm(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
+	if v.Spec.EncryptSpreadComm != oldObj.Spec.EncryptSpreadComm {
+		err := field.Invalid(field.NewPath("spec").Child("encryptSpreadComm"),
+			v.Spec.EncryptSpreadComm,
+			"encryptSpreadComm cannot change after creation")
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -494,6 +494,29 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.UpgradeRequeueTime = 0
 		validateSpecValuesHaveErr(vdb, false)
 	})
+
+	It("should prevent encryptSpreadComm from changing", func() {
+		vdbOrig := MakeVDB()
+		vdbOrig.Spec.EncryptSpreadComm = EncryptSpreadCommWithVertica
+		vdbUpdate := MakeVDB()
+
+		allErrs := vdbOrig.validateImmutableFields(vdbUpdate)
+		Expect(allErrs).ShouldNot(BeNil())
+
+		vdbOrig.Spec.EncryptSpreadComm = ""
+		allErrs = vdbOrig.validateImmutableFields(vdbUpdate)
+		Expect(allErrs).Should(BeNil())
+	})
+
+	It("should validate the value of encryptSpreadComm", func() {
+		vdb := MakeVDB()
+		vdb.Spec.EncryptSpreadComm = "blah"
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.EncryptSpreadComm = ""
+		validateSpecValuesHaveErr(vdb, false)
+		vdb.Spec.EncryptSpreadComm = EncryptSpreadCommWithVertica
+		validateSpecValuesHaveErr(vdb, false)
+	})
 })
 
 func createVDBHelper() *VerticaDB {

--- a/changes/unreleased/Added-20220617-164706.yaml
+++ b/changes/unreleased/Added-20220617-164706.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Allow spread communication encryption to be set in CR
+time: 2022-06-17T16:47:06.488039606-03:00
+custom:
+  Issue: "224"

--- a/changes/unreleased/Added-20220617-164706.yaml
+++ b/changes/unreleased/Added-20220617-164706.yaml
@@ -1,5 +1,5 @@
 kind: Added
-body: Allow spread communication encryption to be set in CR
+body: Allow spread communication encryption to be set in the VerticaDB CR
 time: 2022-06-17T16:47:06.488039606-03:00
 custom:
   Issue: "224"

--- a/pkg/controllers/vdb/createdb_reconcile.go
+++ b/pkg/controllers/vdb/createdb_reconcile.go
@@ -161,7 +161,7 @@ func (c *CreateDBReconciler) preCmdSetup(ctx context.Context, atPod types.Namesp
 	// by DBAddSubclusterReconciler.
 	sc := c.getFirstPrimarySubcluster()
 	sql := fmt.Sprintf(`
-     alter subcluster default_subcluster rename to '%s';
+     alter subcluster default_subcluster rename to \"%s\";
 	`, sc.Name)
 	if c.Vdb.Spec.KSafety == vapi.KSafety0 {
 		sql += "select set_preferred_ksafe(0);\n"

--- a/pkg/controllers/vdb/createdb_reconcile.go
+++ b/pkg/controllers/vdb/createdb_reconcile.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/license"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
+	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -160,15 +161,43 @@ func (c *CreateDBReconciler) preCmdSetup(ctx context.Context, atPod types.Namesp
 	// by DBAddSubclusterReconciler.
 	sc := c.getFirstPrimarySubcluster()
 	sql := fmt.Sprintf(`
-     alter subcluster default_subcluster rename to "%s";
+     alter subcluster default_subcluster rename to '%s';
 	`, sc.Name)
 	if c.Vdb.Spec.KSafety == vapi.KSafety0 {
 		sql += "select set_preferred_ksafe(0);\n"
 	}
+	if c.Vdb.Spec.EncryptSpreadComm != "" {
+		sql += fmt.Sprintf(`alter database default set parameter EncryptSpreadComm = '%s';
+		`, c.Vdb.Spec.EncryptSpreadComm)
+	}
 	_, _, err := c.PRunner.ExecInPod(ctx, atPod, names.ServerContainer,
-		"bash", "-c", "cat > "+PostDBCreateSQLFile+"<<< '"+sql+"'",
+		"bash", "-c", "cat > "+PostDBCreateSQLFile+"<<< \""+sql+"\"",
 	)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// If setting encryptSpreadComm, we need to drive a restart of the vertica
+	// pods immediately after database creation.
+	if c.Vdb.Spec.EncryptSpreadComm != "" {
+		cond := vapi.VerticaDBCondition{Type: vapi.VerticaRestartNeeded, Status: corev1.ConditionTrue}
+		if err := vdbstatus.UpdateCondition(ctx, c.VRec.Client, c.Vdb, cond); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// postCmdCleanup will handle any cleanup action after initializing the database
+func (c *CreateDBReconciler) postCmdCleanup(ctx context.Context) (ctrl.Result, error) {
+	// If encryptSpreadComm was set we need to initiate a restart of the
+	// cluster.  This is done in a separate reconciler.  We will requeue to
+	// drive it.
+	if c.Vdb.Spec.EncryptSpreadComm != "" {
+		c.Log.Info("Requeue reconcile cycle to initiate restart of the server due to encryptSpreadComm setting")
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
 }
 
 // getPodList gets a list of all of the pods we are going to use with create db.

--- a/pkg/controllers/vdb/createdb_reconcile.go
+++ b/pkg/controllers/vdb/createdb_reconcile.go
@@ -178,7 +178,7 @@ func (c *CreateDBReconciler) preCmdSetup(ctx context.Context, atPod types.Namesp
 	}
 
 	// If setting encryptSpreadComm, we need to drive a restart of the vertica
-	// pods immediately after database creation.
+	// pods immediately after database creation for the setting to take effect.
 	if c.Vdb.Spec.EncryptSpreadComm != "" {
 		cond := vapi.VerticaDBCondition{Type: vapi.VerticaRestartNeeded, Status: corev1.ConditionTrue}
 		if err := vdbstatus.UpdateCondition(ctx, c.VRec.Client, c.Vdb, cond); err != nil {

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -47,6 +47,7 @@ type DatabaseInitializer interface {
 	genCmd(ctx context.Context, hostList []string) ([]string, error)
 	execCmd(ctx context.Context, atPod types.NamespacedName, cmd []string) (ctrl.Result, error)
 	preCmdSetup(ctx context.Context, atPod types.NamespacedName) error
+	postCmdCleanup(ctx context.Context) (ctrl.Result, error)
 }
 
 type GenericDatabaseInitializer struct {
@@ -139,7 +140,8 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 	// follow this that will update the Vdb status about the db existence.
 	g.PFacts.Invalidate()
 
-	return ctrl.Result{}, nil
+	// Handle any post initialization actions
+	return g.initializer.postCmdCleanup(ctx)
 }
 
 // getHostList will return a host list from the given pods

--- a/pkg/controllers/vdb/revivedb_reconcile.go
+++ b/pkg/controllers/vdb/revivedb_reconcile.go
@@ -160,6 +160,12 @@ func (r *ReviveDBReconciler) preCmdSetup(ctx context.Context, atPod types.Namesp
 	return nil
 }
 
+// postCmdCleanup is a no-op for revive.  This exists so that we can use the
+// DatabaseInitializer interface.
+func (r *ReviveDBReconciler) postCmdCleanup(ctx context.Context) (ctrl.Result, error) {
+	return ctrl.Result{}, nil
+}
+
 // getPodList gets a list of the pods we are going to use in revive db.
 // If it was not able to generate a list, possibly due to a bad reviveOrder, it
 // return false for the bool return value.

--- a/pkg/controllers/vdb/stopdb_reconcile.go
+++ b/pkg/controllers/vdb/stopdb_reconcile.go
@@ -1,0 +1,126 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+	"time"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// StopDBReconciler will stop the cluster and clear the restart needed status condition
+type StopDBReconciler struct {
+	VRec    *VerticaDBReconciler
+	Vdb     *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	PRunner cmds.PodRunner
+	PFacts  *PodFacts
+}
+
+// MakeStopDBReconciler will build a StopDBReconciler object
+func MakeStopDBReconciler(
+	vdbrecon *VerticaDBReconciler, vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts,
+) controllers.ReconcileActor {
+	return &StopDBReconciler{
+		VRec:    vdbrecon,
+		Vdb:     vdb,
+		PRunner: prunner,
+		PFacts:  pfacts,
+	}
+}
+
+// Reconcile will stop vertica if the status condition indicates a restart is needed
+func (s *StopDBReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if err := s.PFacts.Collect(ctx, s.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// No-op if no database exists
+	if !s.PFacts.doesDBExist() {
+		return ctrl.Result{}, nil
+	}
+
+	// Only proceed if the restart needed status condition is set.
+	isSet, err := vdbstatus.IsConditionSet(s.Vdb, vapi.VerticaRestartNeeded)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if isSet {
+		// Stop vertica if any pods are running
+		if s.PFacts.getUpNodeCount() > 0 {
+			err = s.stopVertica(ctx)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		// Clear the condition now that we stopped the cluster.  We rely on the
+		// restart reconciler that follows this to bring up vertica.
+		err = vdbstatus.UpdateCondition(ctx, s.VRec.Client, s.Vdb,
+			vapi.VerticaDBCondition{Type: vapi.VerticaRestartNeeded, Status: corev1.ConditionFalse},
+		)
+	}
+	return ctrl.Result{}, err
+}
+
+// stopVertica will stop vertica on all of the running pods
+func (s *StopDBReconciler) stopVertica(ctx context.Context) error {
+	pf, ok := s.PFacts.findPodToRunAdmintoolsAny()
+	if !ok {
+		// If no running pod found, then there is nothing to stop and we can just continue one
+		return nil
+	}
+
+	// Run the stop_db command
+	err := s.runATCmd(ctx, pf.name)
+
+	// Invalidate the pod facts now that vertica daemon has been stopped on all of the pods
+	s.PFacts.Invalidate()
+	return err
+}
+
+// runATCmd issues the admintools command to stop the database
+func (s *StopDBReconciler) runATCmd(ctx context.Context, atPod types.NamespacedName) error {
+	cmd := s.genCmd()
+	s.VRec.Event(s.Vdb, corev1.EventTypeNormal, events.StopDBStart,
+		"Calling 'admintools -t stop_db'")
+	start := time.Now()
+	_, _, err := s.PRunner.ExecAdmintools(ctx, atPod, names.ServerContainer, cmd...)
+	if err != nil {
+		s.VRec.Event(s.Vdb, corev1.EventTypeWarning, events.StopDBFailed, "Failed to stop the database")
+		return err
+	}
+	s.VRec.Eventf(s.Vdb, corev1.EventTypeNormal, events.StopDBSucceeded,
+		"Successfully stopped the database.  It took %ds", int(time.Since(start).Seconds()))
+	return nil
+}
+
+// genCmd will return the command to run in the pod to create the database
+func (s *StopDBReconciler) genCmd() []string {
+	// SPILLY - what happens if one of the nodes is down already?
+	return []string{
+		"-t", "stop_db",
+		"--database", s.Vdb.Spec.DBName,
+	}
+}

--- a/pkg/controllers/vdb/stopdb_reconcile.go
+++ b/pkg/controllers/vdb/stopdb_reconcile.go
@@ -88,7 +88,7 @@ func (s *StopDBReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ct
 func (s *StopDBReconciler) stopVertica(ctx context.Context) error {
 	pf, ok := s.PFacts.findPodToRunAdmintoolsAny()
 	if !ok {
-		// If no running pod found, then there is nothing to stop and we can just continue one
+		// If no running pod found, then there is nothing to stop and we can just continue on
 		return nil
 	}
 
@@ -118,7 +118,6 @@ func (s *StopDBReconciler) runATCmd(ctx context.Context, atPod types.NamespacedN
 
 // genCmd will return the command to run in the pod to create the database
 func (s *StopDBReconciler) genCmd() []string {
-	// SPILLY - what happens if one of the nodes is down already?
 	return []string{
 		"-t", "stop_db",
 		"--database", s.Vdb.Spec.DBName,

--- a/pkg/controllers/vdb/stopdb_reconcile.go
+++ b/pkg/controllers/vdb/stopdb_reconcile.go
@@ -62,7 +62,7 @@ func (s *StopDBReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ct
 	}
 
 	// Only proceed if the restart needed status condition is set.
-	isSet, err := vdbstatus.IsConditionSet(s.Vdb, vapi.VerticaRestartNeeded)
+	isSet, err := s.Vdb.IsConditionSet(vapi.VerticaRestartNeeded)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/vdb/stopdb_reconcile_test.go
+++ b/pkg/controllers/vdb/stopdb_reconcile_test.go
@@ -68,7 +68,7 @@ var _ = Describe("stopdb_reconcile", func() {
 		Expect(vdbstatus.UpdateCondition(ctx, k8sClient, vdb,
 			vapi.VerticaDBCondition{Type: vapi.VerticaRestartNeeded, Status: corev1.ConditionTrue},
 		)).Should(Succeed())
-		Expect(vdbstatus.IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeTrue())
+		Expect(vdb.IsConditionSet(vapi.VerticaRestartNeeded)).Should(BeTrue())
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
@@ -78,6 +78,6 @@ var _ = Describe("stopdb_reconcile", func() {
 		Expect(len(hist)).Should(Equal(1))
 
 		// Status condition should be cleared
-		Expect(vdbstatus.IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeFalse())
+		Expect(vdb.IsConditionSet(vapi.VerticaRestartNeeded)).Should(BeFalse())
 	})
 })

--- a/pkg/controllers/vdb/stopdb_reconcile_test.go
+++ b/pkg/controllers/vdb/stopdb_reconcile_test.go
@@ -1,0 +1,83 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("stopdb_reconcile", func() {
+	ctx := context.Background()
+
+	It("should be a no-op if database doesn't exist", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
+		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts)
+		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		Expect(len(fpr.Histories)).Should(Equal(0))
+	})
+
+	It("should be a no-op if status condition isn't set", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := MakePodFacts(vdbRec, fpr)
+		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, &pfacts)
+		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		hist := fpr.FindCommands("stop_db")
+		Expect(len(hist)).Should(Equal(0))
+	})
+
+	It("should attempt a stop_db if status condition is set", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		Expect(vdbstatus.UpdateCondition(ctx, k8sClient, vdb,
+			vapi.VerticaDBCondition{Type: vapi.VerticaRestartNeeded, Status: corev1.ConditionTrue},
+		)).Should(Succeed())
+		Expect(vdbstatus.IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeTrue())
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := MakePodFacts(vdbRec, fpr)
+		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, &pfacts)
+		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		hist := fpr.FindCommands("stop_db")
+		Expect(len(hist)).Should(Equal(1))
+
+		// Status condition should be cleared
+		Expect(vdbstatus.IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeFalse())
+	})
+})

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -83,16 +83,11 @@ func (i *UpgradeManager) IsUpgradeNeeded(ctx context.Context) (bool, error) {
 // is already occurring.
 func (i *UpgradeManager) isUpgradeInProgress() (bool, error) {
 	// We first check if the status condition indicates the upgrade is in progress
-	inx, ok := vapi.VerticaDBConditionIndexMap[i.StatusCondition]
-	if !ok {
-		return false, fmt.Errorf("verticaDB condition '%s' missing from VerticaDBConditionType", i.StatusCondition)
-	}
-	if inx < len(i.Vdb.Status.Conditions) && i.Vdb.Status.Conditions[inx].Status == corev1.ConditionTrue {
-		// Set a flag to indicate that we are continuing an upgrade.  This silences the UpgradeStarted event.
+	isSet, err := vdbstatus.IsConditionSet(i.Vdb, i.StatusCondition)
+	if isSet {
 		i.ContinuingUpgrade = true
-		return true, nil
 	}
-	return false, nil
+	return isSet, err
 }
 
 // isVDBImageDifferent will check if an upgrade is needed based on the

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -83,7 +83,7 @@ func (i *UpgradeManager) IsUpgradeNeeded(ctx context.Context) (bool, error) {
 // is already occurring.
 func (i *UpgradeManager) isUpgradeInProgress() (bool, error) {
 	// We first check if the status condition indicates the upgrade is in progress
-	isSet, err := vdbstatus.IsConditionSet(i.Vdb, i.StatusCondition)
+	isSet, err := i.Vdb.IsConditionSet(i.StatusCondition)
 	if isSet {
 		i.ContinuingUpgrade = true
 	}

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -155,6 +155,8 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeIfNotFound),
 		// Add annotations to each pod about the host running them
 		MakePodAnnotationReconciler(r, vdb, pfacts),
+		// Stop vertica if the status condition indicates
+		MakeStopDBReconciler(r, vdb, prunner, pfacts),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true),
 		MakeMetricReconciler(r, vdb, pfacts),

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -68,6 +68,9 @@ const (
 	DrainNodeRetry                  = "DrainNodeRetry"
 	DrainSubclusterRetry            = "DrainSubclusterRetry"
 	SuboptimalNodeCount             = "SuboptimalNodeCount"
+	StopDBStart                     = "StopDBStart"
+	StopDBSucceeded                 = "StopDBSucceeded"
+	StopDBFailed                    = "StopDBFailed"
 )
 
 // Constants for VerticaAutoscaler reconciler

--- a/pkg/vdbstatus/status.go
+++ b/pkg/vdbstatus/status.go
@@ -99,3 +99,18 @@ func UpdateUpgradeStatus(ctx context.Context, clnt client.Client, vdb *vapi.Vert
 		return nil
 	})
 }
+
+// IsConditionSet will return true if the status condition is set to true.
+// If the condition is not in the array then this implies the condition is
+// false.
+func IsConditionSet(vdb *vapi.VerticaDB, statusCondition vapi.VerticaDBConditionType) (bool, error) {
+	inx, ok := vapi.VerticaDBConditionIndexMap[statusCondition]
+	if !ok {
+		return false, fmt.Errorf("verticaDB condition '%s' missing from VerticaDBConditionType", statusCondition)
+	}
+	if inx < len(vdb.Status.Conditions) {
+		return vdb.Status.Conditions[inx].Status == corev1.ConditionTrue, nil
+	}
+	// A missing condition implies false
+	return false, nil
+}

--- a/pkg/vdbstatus/status.go
+++ b/pkg/vdbstatus/status.go
@@ -99,18 +99,3 @@ func UpdateUpgradeStatus(ctx context.Context, clnt client.Client, vdb *vapi.Vert
 		return nil
 	})
 }
-
-// IsConditionSet will return true if the status condition is set to true.
-// If the condition is not in the array then this implies the condition is
-// false.
-func IsConditionSet(vdb *vapi.VerticaDB, statusCondition vapi.VerticaDBConditionType) (bool, error) {
-	inx, ok := vapi.VerticaDBConditionIndexMap[statusCondition]
-	if !ok {
-		return false, fmt.Errorf("verticaDB condition '%s' missing from VerticaDBConditionType", statusCondition)
-	}
-	if inx < len(vdb.Status.Conditions) {
-		return vdb.Status.Conditions[inx].Status == corev1.ConditionTrue, nil
-	}
-	// A missing condition implies false
-	return false, nil
-}

--- a/pkg/vdbstatus/status_test.go
+++ b/pkg/vdbstatus/status_test.go
@@ -193,4 +193,16 @@ var _ = Describe("status", func() {
 		)).Should(Succeed())
 		Expect(vdb.Status.Conditions[0].LastTransitionTime).ShouldNot(Equal(origTime))
 	})
+
+	It("should return false in IsStatusConditionSet if condition isn't present", func() {
+		vdb := vapi.MakeVDB()
+		Expect(k8sClient.Create(ctx, vdb)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vdb)).Should(Succeed()) }()
+
+		Expect(IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeFalse())
+		Expect(UpdateCondition(ctx, k8sClient, vdb,
+			vapi.VerticaDBCondition{Type: vapi.VerticaRestartNeeded, Status: corev1.ConditionTrue},
+		)).Should(Succeed())
+		Expect(IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeTrue())
+	})
 })

--- a/pkg/vdbstatus/status_test.go
+++ b/pkg/vdbstatus/status_test.go
@@ -199,10 +199,10 @@ var _ = Describe("status", func() {
 		Expect(k8sClient.Create(ctx, vdb)).Should(Succeed())
 		defer func() { Expect(k8sClient.Delete(ctx, vdb)).Should(Succeed()) }()
 
-		Expect(IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeFalse())
+		Expect(vdb.IsConditionSet(vapi.VerticaRestartNeeded)).Should(BeFalse())
 		Expect(UpdateCondition(ctx, k8sClient, vdb,
 			vapi.VerticaDBCondition{Type: vapi.VerticaRestartNeeded, Status: corev1.ConditionTrue},
 		)).Should(Succeed())
-		Expect(IsConditionSet(vdb, vapi.VerticaRestartNeeded)).Should(BeTrue())
+		Expect(vdb.IsConditionSet(vapi.VerticaRestartNeeded)).Should(BeTrue())
 	})
 })

--- a/tests/e2e/client-access/17-assert.yaml
+++ b/tests/e2e/client-access/17-assert.yaml
@@ -28,3 +28,24 @@ status:
     - installCount: 2
       addedToDBCount: 2
       upNodeCount: 2
+---
+# We enable spread encryption so the cluster will restart as part of the create
+apiVersion: v1
+kind: Event
+reason: StopDBSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-client-access
+---
+apiVersion: v1
+kind: Event
+reason: ClusterRestartSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-client-access

--- a/tests/e2e/client-access/17-assert.yaml
+++ b/tests/e2e/client-access/17-assert.yaml
@@ -29,7 +29,7 @@ status:
       addedToDBCount: 2
       upNodeCount: 2
 ---
-# We enable spread encryption so the cluster will restart as part of the create
+# We enable spread encryption, so the cluster will restart as part of the create
 apiVersion: v1
 kind: Event
 reason: StopDBSucceeded

--- a/tests/e2e/client-access/40-assert.yaml
+++ b/tests/e2e/client-access/40-assert.yaml
@@ -11,23 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-client-access
-spec:
-  image: kustomize-vertica-image
-  communal:
-    includeUIDInPath: false
-  local:
-    requestSize: 100Mi
-  dbName: vertdb
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: sc1
-      size: 2
-  kSafety: "0"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: test-verify-spread-encryption
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e/client-access/40-verify-spread-encryption.yaml
+++ b/tests/e2e/client-access/40-verify-spread-encryption.yaml
@@ -1,0 +1,49 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-spread-encryption
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o xtrace
+    set -o errexit
+
+    SEC_CHK=$(kubectl exec svc/v-client-access-sc1 -- vsql -c "SELECT SECURITY_CONFIG_CHECK('NETWORK');")
+    echo $SEC_CHK
+    echo $SEC_CHK | grep -cq 'Spread encryption is enabled'
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-spread-encryption
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: quay.io/helmpack/chart-testing:v3.3.1
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0700
+        name: script-verify-spread-encryption

--- a/tests/e2e/client-access/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/client-access/setup-vdb/base/setup-vdb.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   image: kustomize-vertica-image
   communal:
-    includeUIDInPath: false
+    includeUIDInPath: true
   local:
     requestSize: 100Mi
   dbName: vertdb

--- a/tests/e2e/k-safety-1-scaling/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/k-safety-1-scaling/setup-vdb/base/setup-vdb.yaml
@@ -24,6 +24,7 @@ spec:
     includeUIDInPath: false
   local:
     requestSize: 100Mi
+  encryptSpreadComm: vertica
   subclusters:
     - name: main
       size: 3

--- a/tests/e2e/multi-sc-sanity/19-assert.yaml
+++ b/tests/e2e/multi-sc-sanity/19-assert.yaml
@@ -11,27 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-multi-sc
-spec:
-  image: kustomize-vertica-image
-  superuserPasswordSecret: su-passwd
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  subclusters:
-    - name: sc-2
-      size: 1
-      isPrimary: false
-    - name: sc-1
-      size: 1
-      isPrimary: true
-  kSafety: "0"
-  encryptSpreadComm: vertica
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: test-verify-spread-encryption
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e/multi-sc-sanity/19-verify-spread-encryption.yaml
+++ b/tests/e2e/multi-sc-sanity/19-verify-spread-encryption.yaml
@@ -1,0 +1,49 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-spread-encryption
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o xtrace
+    set -o errexit
+
+    SEC_CHK=$(kubectl exec svc/v-multi-sc-sc-1 -- vsql -w superuser -c "SELECT SECURITY_CONFIG_CHECK('NETWORK');")
+    echo $SEC_CHK
+    echo $SEC_CHK | grep -cq 'Spread encryption is enabled'
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-spread-encryption
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: quay.io/helmpack/chart-testing:v3.3.1
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0700
+        name: script-verify-spread-encryption


### PR DESCRIPTION
The following parm was added to the VerticaDB CR:

```
spec.enableSpreadEncryption
```

When this is set to *vertica*, then the `EncryptSpreadComm` parameter will be set for the database right after it is created.  Setting encryption in spread requires a server restart, which the operator handles automatically.  The default value for this parameter is an empty string, which means no encryption is set.

The events for the VerticaDB will look like the following when enabling spread encryption.  We will show a successful create database, then a complete server restart.

```
Events:
  Type    Reason                   Age   From                Message
  ----    ------                   ----  ----                -------
  Normal  CreateDBStart            78s   verticadb-operator  Calling 'admintools -t create_db'
  Normal  CreateDBSucceeded        48s   verticadb-operator  Successfully created database with subcluster 'my-sc'. It t
ook 30.065841637s
  Normal  StopDBStart              47s   verticadb-operator  Calling 'admintools -t stop_db'
  Normal  StopDBSucceeded          43s   verticadb-operator  Successfully stopped the database.  It took 4s
  Normal  ClusterRestartStarted    42s   verticadb-operator  Calling 'admintools -t start_db' to restart the cluster
  Normal  ClusterRestartSucceeded  33s   verticadb-operator  Successfully called 'admintools -t start_db' and it took 9s
```

This can only be set for new instances of VerticaDB.  It is ignored if the initPolicy is something other than *Create*.  It only accepts an empty string (to clear encryption) or *vertica*.  The webhook enforces these rules.

The restart was generalized with a new condition variable: *VerticaRestartNeeded*.  In the future, if we have other cases where Vertica needs to be restarted we can use this condition variable.

Closes #222
