### PR TITLE
Don't use docker.io repo when deploying through make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 # If this secret does not exist then it is simply ignored.
 deploy-operator: manifests kustomize ## Using helm or olm, deploy the operator in the K8s cluster
 ifeq ($(DEPLOY_WITH), helm)
-	helm install --wait -n $(NAMESPACE) $(HELM_RELEASE_NAME) $(OPERATOR_CHART) --set image.name=${OPERATOR_IMG} --set logging.dev=${DEV_MODE} --set image.pullPolicy=$(HELM_IMAGE_PULL_POLICY) --set imagePullSecrets[0].name=priv-reg-cred $(HELM_OVERRIDES)
+	helm install --wait -n $(NAMESPACE) $(HELM_RELEASE_NAME) $(OPERATOR_CHART) --set image.repo=null --set image.name=${OPERATOR_IMG} --set logging.dev=${DEV_MODE} --set image.pullPolicy=$(HELM_IMAGE_PULL_POLICY) --set imagePullSecrets[0].name=priv-reg-cred $(HELM_OVERRIDES)
 	scripts/wait-for-webhook.sh -n $(NAMESPACE) -t 60
 else ifeq ($(DEPLOY_WITH), olm)
 	scripts/deploy-olm.sh -n $(NAMESPACE) $(OLM_TEST_CATALOG_SOURCE)

--- a/helm-charts/verticadb-operator/README.md
+++ b/helm-charts/verticadb-operator/README.md
@@ -3,7 +3,7 @@ This helm chart will install the operator and an admission controller webhook.  
 | Parameter Name | Description | Default Value |
 |----------------|-------------|---------------|
 | image.name | The name of image that runs the operator. | vertica/verticadb-operator:1.0.0 |
-| image.repo | Repo server hosting image.name | null (DockerHub) |
+| image.repo | Repo server hosting image.name | docker.io |
 | image.pullPolicy | The pull policy for the image that runs the operator  | IfNotPresent |
 | rbac_proxy_image.name | Image name of Kubernetes RBAC proxy. | kubebuilder/kube-rbac-proxy:v0.11.0 |
 | rbac_proxy_image.repo | Repo server hosting rbac_proxy_image.name | gcr.io |


### PR DESCRIPTION
The make target deploy will install using the helm chart.  I am
intentionally clearing the repo to use for the operator image.  That way
the exact image we end up using is the contents of the OPERATOR_IMG
environment variable.  Otherwise, when developing on environments
without kind, we would get pull errors when trying to deploy the
operator.