### PR TITLE
Log warning if v12.0.0 server and cgroups v2

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -53,7 +53,7 @@ type VerticaDBSpec struct {
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="vertica/vertica-k8s:12.0.0-0-minimal"
+	// +kubebuilder:default:="vertica/vertica-k8s:11.1.1-0-minimal"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// The docker image name that contains the Vertica server.  Whenever this
 	// changes, the operator treats this as an upgrade.  The upgrade can be done

--- a/changes/unreleased/Added-20220624-112904.yaml
+++ b/changes/unreleased/Added-20220624-112904.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Warning message if v12.0.0 server and cgroups v2
+time: 2022-06-24T11:29:04.566578794-03:00
+custom:
+  Issue: "227"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -46,6 +46,8 @@ const (
 	ReIPAllowedWithUpNodesVersion = "v11.1.0"
 	// The version that added support a for --host list to start_db command
 	StartDBAcceptsHostListVersion = "v11.0.1"
+	// The version of the server that doesn't support cgroup v2
+	CGroupV2UnsupportedVersion = "v12.0.0"
 )
 
 // UpgradePaths has all of the vertica releases supported by the operator.  For


### PR DESCRIPTION
There is an issue in the v12.0.0 server that prevents it from staring in k8s if running with cgroups v2.  This will log a warning event if we detect this environment.  We will still continue to try and start vertica, just in case we are running with a hotfix that addresses the issue.

I'm changing the default server image to 11.1.1 to make it less likely that we would hit this issue.