### PR TITLE
Add the ability to override names in the helm chart.

### DIFF
--- a/changes/unreleased/Added-20220717-084605.yaml
+++ b/changes/unreleased/Added-20220717-084605.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Ability to override the names of k8s objects in helm chart
+time: 2022-07-17T08:46:05.224081628-03:00
+custom:
+  Issue: "232"

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -119,7 +119,8 @@ func (fc *FlagConfig) setFlagArgs() {
 			"with the path /debug/pprof.  See https://golang.org/pkg/net/http/pprof/ for more info.")
 	flag.StringVar(&fc.ServiceAccountName, "service-account-name", "verticadb-operator-controller-manager",
 		"The name of the serviceAccount to use.")
-	flag.StringVar(&fc.PrefixName, "prefix-name", "", "The common prefix for all objects created during the operator deployment")
+	flag.StringVar(&fc.PrefixName, "prefix-name", "verticadb-operator",
+		"The common prefix for all objects created during the operator deployment")
 	fc.LogArgs = &Logging{}
 	fc.LogArgs.setLoggingFlagArgs()
 }

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -70,6 +70,7 @@ type FlagConfig struct {
 	ProbeAddr            string
 	EnableProfiler       bool
 	ServiceAccountName   string
+	PrefixName           string // Prefix of the name of all objects created when the operator was deployed
 	LogArgs              *Logging
 }
 
@@ -118,6 +119,7 @@ func (fc *FlagConfig) setFlagArgs() {
 			"with the path /debug/pprof.  See https://golang.org/pkg/net/http/pprof/ for more info.")
 	flag.StringVar(&fc.ServiceAccountName, "service-account-name", "verticadb-operator-controller-manager",
 		"The name of the serviceAccount to use.")
+	flag.StringVar(&fc.PrefixName, "prefix-name", "", "The common prefix for all objects created during the operator deployment")
 	fc.LogArgs = &Logging{}
 	fc.LogArgs.setLoggingFlagArgs()
 }
@@ -228,12 +230,15 @@ func getLogger(logArgs Logging) *zap.Logger {
 // handles.  If any failure occurs, if will exit the program.
 func addReconcilersToManager(mgr manager.Manager, restCfg *rest.Config, flagArgs *FlagConfig) {
 	if err := (&vdb.VerticaDBReconciler{
-		Client:             mgr.GetClient(),
-		Log:                ctrl.Log.WithName("controllers").WithName("VerticaDB"),
-		Scheme:             mgr.GetScheme(),
-		Cfg:                restCfg,
-		EVRec:              mgr.GetEventRecorderFor(builder.OperatorName),
-		ServiceAccountName: flagArgs.ServiceAccountName,
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("VerticaDB"),
+		Scheme: mgr.GetScheme(),
+		Cfg:    restCfg,
+		EVRec:  mgr.GetEventRecorderFor(builder.OperatorName),
+		DeploymentNames: builder.DeploymentNames{
+			ServiceAccountName: flagArgs.ServiceAccountName,
+			PrefixName:         flagArgs.PrefixName,
+		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VerticaDB")
 		os.Exit(1)

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -48,3 +48,4 @@ spec:
         - "--maxfilerotation=3"
         - "--level=info"
         - "--dev=false"
+        - "--prefix-name=verticadb-operator"

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
+    vertica.com/svc-type: operator-metrics
   name: metrics-service
   namespace: system
 spec:

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -4,6 +4,9 @@ kind: Service
 metadata:
   name: webhook-service
   namespace: system
+  labels:
+    control-plane: controller-manager
+    vertica.com/svc-type: webhook
 spec:
   ports:
     - port: 443

--- a/helm-charts/verticadb-operator/README.md
+++ b/helm-charts/verticadb-operator/README.md
@@ -5,6 +5,7 @@ This helm chart will install the operator and an admission controller webhook.  
 | image.name | The name of image that runs the operator. | vertica/verticadb-operator:1.6.0 |
 | image.repo | Repo server hosting image.name | docker.io |
 | image.pullPolicy | The pull policy for the image that runs the operator  | IfNotPresent |
+| nameOverride | Setting this allows you to control the prefix of all of the objects created by the helm chart.  If this is left blank, we use the name of the chart as the prefix | |
 | rbac_proxy_image.name | Image name of Kubernetes RBAC proxy. | kubebuilder/kube-rbac-proxy:v0.11.0 |
 | rbac_proxy_image.repo | Repo server hosting rbac_proxy_image.name | gcr.io |
 | imagePullSecrets | List of Secret names containing login credentials for above repos | null (pull images anonymously) |

--- a/helm-charts/verticadb-operator/templates/_helpers.tpl
+++ b/helm-charts/verticadb-operator/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vdb-op.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Choose the serviceAccount name
+*/}}
+{{- define "vdb-op.serviceAccount" -}}
+{{- if .Values.serviceAccountNameOverride }}
+{{ .Values.serviceAccountNameOverride }}
+{{- else }}
+{{- include "vdb-op.name" . }}-controller-manager
+{{- end }}
+{{- end }}

--- a/helm-charts/verticadb-operator/templates/_helpers.tpl
+++ b/helm-charts/verticadb-operator/templates/_helpers.tpl
@@ -10,7 +10,7 @@ Choose the serviceAccount name
 */}}
 {{- define "vdb-op.serviceAccount" -}}
 {{- if .Values.serviceAccountNameOverride }}
-{{ .Values.serviceAccountNameOverride }}
+{{- .Values.serviceAccountNameOverride }}
 {{- else }}
 {{- include "vdb-op.name" . }}-controller-manager
 {{- end }}

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -21,6 +21,9 @@
 # with the default values.
 # -------------------------------------------------------------------------------
 
+# To control the name of all of the objects created in the helm chart.
+# nameOverride: verticadb-operator
+
 image:
   repo: docker.io
   name: vertica/verticadb-operator:1.6.0

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -33,8 +33,7 @@ import (
 )
 
 const (
-	SuperuserPasswordPath     = "superuser-passwd"
-	DefaultServiceAccountName = "verticadb-operator-controller-manager"
+	SuperuserPasswordPath = "superuser-passwd"
 )
 
 // BuildExtSvc creates desired spec for the external service.
@@ -165,9 +164,9 @@ func buildCertSecretVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 }
 
 // buildVolumes builds up a list of volumes to include in the sts
-func buildVolumes(vdb *vapi.VerticaDB) []corev1.Volume {
+func buildVolumes(vdb *vapi.VerticaDB, deployNames *DeploymentNames) []corev1.Volume {
 	vols := []corev1.Volume{}
-	vols = append(vols, buildPodInfoVolume(vdb))
+	vols = append(vols, buildPodInfoVolume(vdb, deployNames))
 	if vdb.Spec.LicenseSecret != "" {
 		vols = append(vols, buildLicenseVolume(vdb))
 	}
@@ -198,10 +197,10 @@ func buildLicenseVolume(vdb *vapi.VerticaDB) corev1.Volume {
 }
 
 // buildPodInfoVolume constructs the volume that has the /etc/podinfo files.
-func buildPodInfoVolume(vdb *vapi.VerticaDB) corev1.Volume {
+func buildPodInfoVolume(vdb *vapi.VerticaDB, deployNames *DeploymentNames) corev1.Volume {
 	projSources := []corev1.VolumeProjection{
 		{DownwardAPI: buildDownwardAPIProjection()},
-		{ConfigMap: buildOperatorConfigMapProjection()},
+		{ConfigMap: buildOperatorConfigMapProjection(deployNames)},
 		// If these is a superuser password, include that in the projection
 		{Secret: buildSuperuserPasswordProjection(vdb)},
 	}
@@ -296,9 +295,9 @@ func buildDownwardAPIProjection() *corev1.DownwardAPIProjection {
 }
 
 // buildOperatorConfigMapProjection creates a projection for inclusion in /etc/podinfo
-func buildOperatorConfigMapProjection() *corev1.ConfigMapProjection {
+func buildOperatorConfigMapProjection(deployNames *DeploymentNames) *corev1.ConfigMapProjection {
 	return &corev1.ConfigMapProjection{
-		LocalObjectReference: corev1.LocalObjectReference{Name: "verticadb-operator-manager-config"},
+		LocalObjectReference: corev1.LocalObjectReference{Name: deployNames.getConfigMapName()},
 		Items: []corev1.KeyToPath{
 			{Key: "DEPLOY_WITH", Path: "operator-deployment-method"},
 			{Key: "VERSION", Path: "operator-version"},
@@ -367,7 +366,7 @@ func buildSSHVolume(vdb *vapi.VerticaDB) corev1.Volume {
 }
 
 // buildPodSpec creates a PodSpec for the statefulset
-func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster, saName string) corev1.PodSpec {
+func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster, deployNames *DeploymentNames) corev1.PodSpec {
 	termGracePeriod := int64(0)
 	return corev1.PodSpec{
 		NodeSelector:                  sc.NodeSelector,
@@ -375,9 +374,9 @@ func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster, saName string) corev
 		Tolerations:                   sc.Tolerations,
 		ImagePullSecrets:              GetK8sLocalObjectReferenceArray(vdb.Spec.ImagePullSecrets),
 		Containers:                    makeContainers(vdb, sc),
-		Volumes:                       buildVolumes(vdb),
+		Volumes:                       buildVolumes(vdb, deployNames),
 		TerminationGracePeriodSeconds: &termGracePeriod,
-		ServiceAccountName:            saName,
+		ServiceAccountName:            deployNames.ServiceAccountName,
 	}
 }
 
@@ -523,7 +522,7 @@ func getStorageClassName(vdb *vapi.VerticaDB) *string {
 }
 
 // BuildStsSpec builds manifest for a subclusters statefulset
-func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster, saName string) *appsv1.StatefulSet {
+func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster, deployNames *DeploymentNames) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
@@ -542,7 +541,7 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 					Labels:      MakeLabelsForObject(vdb, sc),
 					Annotations: MakeAnnotationsForObject(vdb),
 				},
-				Spec: buildPodSpec(vdb, sc, saName),
+				Spec: buildPodSpec(vdb, sc, deployNames),
 			},
 			UpdateStrategy:      makeUpdateStrategy(vdb),
 			PodManagementPolicy: appsv1.ParallelPodManagement,
@@ -578,7 +577,7 @@ func BuildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.
 			Labels:      MakeLabelsForObject(vdb, sc),
 			Annotations: MakeAnnotationsForObject(vdb),
 		},
-		Spec: buildPodSpec(vdb, sc, DefaultServiceAccountName),
+		Spec: buildPodSpec(vdb, sc, DefaultDeploymentNames()),
 	}
 	// Setup default values for the DC table annotations.  These are normally
 	// added by the PodAnnotationReconciler.  However, this function is for test

--- a/pkg/builder/deployment_names.go
+++ b/pkg/builder/deployment_names.go
@@ -17,18 +17,12 @@ package builder
 
 import "fmt"
 
-const (
-	DefaultServiceAccountName = "verticadb-operator-controller-manager"
-	DefaultConfigMapName      = "verticadb-operator-manager-config"
-)
-
 // DeploymentNames gives context about the names used in deploying the operator
 type DeploymentNames struct {
 	ServiceAccountName string // Name of the service account to use for vertica pods
 	PrefixName         string // The common prefix for all objects created when deploying the operator
 }
 
-// SPILLY - separate func for DeploymentNames
 func (d *DeploymentNames) getConfigMapName() string {
 	return fmt.Sprintf("%s-manager-config", d.PrefixName)
 }
@@ -37,7 +31,7 @@ func (d *DeploymentNames) getConfigMapName() string {
 // This is for test purposes.
 func DefaultDeploymentNames() *DeploymentNames {
 	return &DeploymentNames{
-		ServiceAccountName: DefaultServiceAccountName,
+		ServiceAccountName: "verticadb-operator-controller-manager",
 		PrefixName:         "verticadb-operator",
 	}
 }

--- a/pkg/builder/deployment_names.go
+++ b/pkg/builder/deployment_names.go
@@ -1,0 +1,43 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package builder
+
+import "fmt"
+
+const (
+	DefaultServiceAccountName = "verticadb-operator-controller-manager"
+	DefaultConfigMapName      = "verticadb-operator-manager-config"
+)
+
+// DeploymentNames gives context about the names used in deploying the operator
+type DeploymentNames struct {
+	ServiceAccountName string // Name of the service account to use for vertica pods
+	PrefixName         string // The common prefix for all objects created when deploying the operator
+}
+
+// SPILLY - separate func for DeploymentNames
+func (d *DeploymentNames) getConfigMapName() string {
+	return fmt.Sprintf("%s-manager-config", d.PrefixName)
+}
+
+// DefaultDeploymentNames generates a DeploymentNames based on the defaults.
+// This is for test purposes.
+func DefaultDeploymentNames() *DeploymentNames {
+	return &DeploymentNames{
+		ServiceAccountName: DefaultServiceAccountName,
+		PrefixName:         "verticadb-operator",
+	}
+}

--- a/pkg/controllers/vdb/obj_reconcile.go
+++ b/pkg/controllers/vdb/obj_reconcile.go
@@ -335,7 +335,7 @@ func (o *ObjReconciler) createService(ctx context.Context, svc *corev1.Service, 
 func (o *ObjReconciler) reconcileSts(ctx context.Context, sc *vapi.Subcluster) (ctrl.Result, error) {
 	nm := names.GenStsName(o.Vdb, sc)
 	curSts := &appsv1.StatefulSet{}
-	expSts := builder.BuildStsSpec(nm, o.Vdb, sc, o.VRec.ServiceAccountName)
+	expSts := builder.BuildStsSpec(nm, o.Vdb, sc, &o.VRec.DeploymentNames)
 	err := o.VRec.Client.Get(ctx, nm, curSts)
 	if err != nil && errors.IsNotFound(err) {
 		o.Log.Info("Creating statefulset", "Name", nm, "Size", expSts.Spec.Replicas, "Image", expSts.Spec.Template.Spec.Containers[0].Image)

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -75,12 +75,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	vdbRec = &VerticaDBReconciler{
-		Client:             k8sClient,
-		Log:                logger,
-		Scheme:             scheme.Scheme,
-		Cfg:                restCfg,
-		EVRec:              mgr.GetEventRecorderFor(builder.OperatorName),
-		ServiceAccountName: builder.DefaultServiceAccountName,
+		Client:          k8sClient,
+		Log:             logger,
+		Scheme:          scheme.Scheme,
+		Cfg:             restCfg,
+		EVRec:           mgr.GetEventRecorderFor(builder.OperatorName),
+		DeploymentNames: *builder.DefaultDeploymentNames(),
 	}
 }, 60)
 

--- a/pkg/controllers/vdb/upgradeoperator120_reconciler_test.go
+++ b/pkg/controllers/vdb/upgradeoperator120_reconciler_test.go
@@ -36,7 +36,7 @@ var _ = Describe("k8s/upgradeoperator120_reconciler", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
 		nm := names.GenStsName(vdb, sc)
-		sts := builder.BuildStsSpec(nm, vdb, sc, builder.DefaultServiceAccountName)
+		sts := builder.BuildStsSpec(nm, vdb, sc, builder.DefaultDeploymentNames())
 		// Set an old operator version to force the upgrade
 		sts.Labels[builder.OperatorVersionLabel] = builder.OperatorVersion110
 		Expect(k8sClient.Create(ctx, sts)).Should(Succeed())

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -43,11 +43,11 @@ import (
 // VerticaDBReconciler reconciles a VerticaDB object
 type VerticaDBReconciler struct {
 	client.Client
-	Log                logr.Logger
-	Scheme             *runtime.Scheme
-	Cfg                *rest.Config
-	EVRec              record.EventRecorder
-	ServiceAccountName string
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Cfg    *rest.Config
+	EVRec  record.EventRecorder
+	builder.DeploymentNames
 }
 
 //+kubebuilder:rbac:groups=vertica.com,namespace=WATCH_NAMESPACE,resources=verticadbs,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -49,7 +49,7 @@ func CreateSts(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *va
 	scIndex int32, podRunningState PodRunningState) {
 	sts := &appsv1.StatefulSet{}
 	if err := c.Get(ctx, names.GenStsName(vdb, sc), sts); kerrors.IsNotFound(err) {
-		sts = builder.BuildStsSpec(names.GenStsName(vdb, sc), vdb, sc, builder.DefaultServiceAccountName)
+		sts = builder.BuildStsSpec(names.GenStsName(vdb, sc), vdb, sc, builder.DefaultDeploymentNames())
 		ExpectWithOffset(offset, c.Create(ctx, sts)).Should(Succeed())
 	}
 	for j := int32(0); j < sc.Size; j++ {

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -39,7 +39,7 @@ fi
 # Add in the templating
 # 1. Template the namespace
 sed -i 's/verticadb-operator-system/{{ .Release.Namespace }}/g' $TEMPLATE_DIR/*
-sed -i 's/verticadb-operator-.*-webhook-configuration/{{ .Release.Namespace }}-&/' $TEMPLATE_DIR/*
+perl -i -0777 -pe 's/(verticadb-operator)(-.*-webhook-configuration)/$1-{{ .Release.Namespace }}$2/' $TEMPLATE_DIR/*
 # 2. Template image names
 sed -i "s|image: controller|image: '{{ with .Values.image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 sed -i "s|image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0|image: '{{ with .Values.rbac_proxy_image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
@@ -76,8 +76,8 @@ sed -i "s/--level=.*/--level={{ .Values.logging.level }}/" $TEMPLATE_DIR/vertica
 sed -i "s/--dev=.*/--dev={{ .Values.logging.dev }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 
 # 9.  Template the serviceaccount, roles and rolebindings
-sed -i 's/serviceAccountName: verticadb-operator-controller-manager/serviceAccountName: {{ default "verticadb-operator-controller-manager" .Values.serviceAccountNameOverride }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-sed -i 's/--service-account-name=.*/--service-account-name={{ default "verticadb-operator-controller-manager" .Values.serviceAccountNameOverride }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+sed -i 's/serviceAccountName: verticadb-operator-controller-manager/serviceAccountName: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+sed -i 's/--service-account-name=.*/--service-account-name={{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 for f in verticadb-operator-controller-manager-sa.yaml \
     verticadb-operator-manager-role-role.yaml \
     verticadb-operator-manager-rolebinding-rb.yaml \
@@ -126,3 +126,8 @@ perl -i -0777 -pe 's/(.*ports:\n.*containerPort: 9443\n.*webhook-server.*\n.*)/$
 perl -i -0777 -pe 's/(.*- args:.*\n.*secure)/{{- if eq .Values.prometheus.expose "EnableWithAuthProxy" }}\n$1/g' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
 # We need to put the matching end at the end of the container spec.
 perl -i -0777 -pe 's/(memory: 64Mi)/$1\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+
+# 16.  Template places that refer to objects by name.  Do this in all files.
+# In the config/ directory we hardcoded everything to start with
+# verticadb-operator.
+sed -i 's/verticadb-operator/{{ include "vdb-op.name" . }}/g' $TEMPLATE_DIR/*yaml

--- a/scripts/wait-for-verticadb-steady-state.sh
+++ b/scripts/wait-for-verticadb-steady-state.sh
@@ -52,7 +52,7 @@ then
     NS_OPT="-n $NAMESPACE "
 fi
 
-LOG_CMD="kubectl ${NS_OPT}logs -l app.kubernetes.io/name=verticadb-operator -c manager --tail -1"
+LOG_CMD="kubectl ${NS_OPT}logs -l control-plane=controller-manager -c manager --tail -1"
 WEBHOOK_FILTER="--invert-match -e 'controller-runtime.webhook.webhooks' -e 'verticadb-resource'"
 timeout $TIMEOUT bash -c -- "while ! $LOG_CMD | \
     grep $WEBHOOK_FILTER | \

--- a/scripts/wait-for-webhook.sh
+++ b/scripts/wait-for-webhook.sh
@@ -54,7 +54,7 @@ done
 trap "echo 'Failed waiting for webhook service object to exist'" 0 2 3 15
 set -o errexit
 timeout $TIMEOUT bash -c -- "\
-    while ! kubectl get $NAMESPACE_OPT svc --no-headers verticadb-operator-webhook-service 2> /dev/null | grep -cq 'service'; \
+    while ! kubectl get $NAMESPACE_OPT svc --no-headers --selector vertica.com/svc-type=webhook 2> /dev/null | grep -cq 'service'; \
     do \
       sleep 0.1; \
     done"

--- a/tests/e2e-extra/helm-nameoverride/05-create-creds.yaml
+++ b/tests/e2e-extra/helm-nameoverride/05-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-extra/helm-nameoverride/10-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/10-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-extra/helm-nameoverride/10-rbac.yaml
+++ b/tests/e2e-extra/helm-nameoverride/10-rbac.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-extra/helm-nameoverride/15-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/15-assert.yaml
@@ -1,0 +1,40 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matt-webhook-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matt-metrics-service
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matt-controller-manager
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: matt-manager-config

--- a/tests/e2e-extra/helm-nameoverride/15-deploy-operator.yaml
+++ b/tests/e2e-extra/helm-nameoverride/15-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && DEPLOY_WITH=helm HELM_OVERRIDES='--set nameOverride=matt' make deploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/helm-nameoverride/20-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/20-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-helm-nameoverride-pri-sc
+status:
+  replicas: 1

--- a/tests/e2e-extra/helm-nameoverride/20-setup-vdb.yaml
+++ b/tests/e2e-extra/helm-nameoverride/20-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/helm-nameoverride/25-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/25-assert.yaml
@@ -1,0 +1,27 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-helm-nameoverride-pri-sc
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-helm-nameoverride
+status:
+  upNodeCount: 1

--- a/tests/e2e-extra/helm-nameoverride/25-wait-for-createdb.yaml
+++ b/tests/e2e-extra/helm-nameoverride/25-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/helm-nameoverride/30-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/30-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-operator-deployment-method
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e-extra/helm-nameoverride/30-verify-operator-configmap-mount.yaml
+++ b/tests/e2e-extra/helm-nameoverride/30-verify-operator-configmap-mount.yaml
@@ -27,9 +27,7 @@ data:
 
     SVC_NAME=v-helm-nameoverride-pri-sc
     kubectl exec -it svc/$SVC_NAME -- ls /etc/podinfo
-    DEPLOY_METHOD=$(kubectl exec -it svc/$SVC_NAME -- cat /etc/podinfo/operator-deployment-method)
-    echo $DEPLOY_METHOD
-    echo $DEPLOY_METHOD | grep 'helm'
+    kubectl exec -it svc/$SVC_NAME -- test -f /etc/podinfo/operator-deployment-method
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e-extra/helm-nameoverride/30-verify-operator-configmap-mount.yaml
+++ b/tests/e2e-extra/helm-nameoverride/30-verify-operator-configmap-mount.yaml
@@ -1,0 +1,55 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies external access through the service to the agent port 5444.  It
+# does this by invoking the REST API and doing basic sanity on what it
+# received.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-operator-deployment-method
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    SVC_NAME=v-helm-nameoverride-pri-sc
+    kubectl exec -it svc/$SVC_NAME -- ls /etc/podinfo
+    DEPLOY_METHOD=$(kubectl exec -it svc/$SVC_NAME -- cat /etc/podinfo/operator-deployment-method)
+    echo $DEPLOY_METHOD
+    echo $DEPLOY_METHOD | grep 'helm'
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-operator-deployment-method
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-operator-deployment-method

--- a/tests/e2e-extra/helm-nameoverride/35-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/35-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-helm-nameoverride
+spec:
+  initPolicy: Create

--- a/tests/e2e-extra/helm-nameoverride/35-verify-webhook.yaml
+++ b/tests/e2e-extra/helm-nameoverride/35-verify-webhook.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl -n $NAMESPACE get verticadb v-helm-nameoverride -o json | jq '.spec.initPolicy="Revive"' | kubectl -n $NAMESPACE replace -f -
+    ignoreFailure: true
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE"

--- a/tests/e2e-extra/helm-nameoverride/90-errors.yaml
+++ b/tests/e2e-extra/helm-nameoverride/90-errors.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matt-metrics-service
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matt-webhook-service
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matt-controller-manager

--- a/tests/e2e-extra/helm-nameoverride/90-uninstall-operator.yaml
+++ b/tests/e2e-extra/helm-nameoverride/90-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/helm-nameoverride/95-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/95-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-extra/helm-nameoverride/95-delete-cr.yaml
+++ b/tests/e2e-extra/helm-nameoverride/95-delete-cr.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/helm-nameoverride/95-errors.yaml
+++ b/tests/e2e-extra/helm-nameoverride/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-extra/helm-nameoverride/99-delete-ns.yaml
+++ b/tests/e2e-extra/helm-nameoverride/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-extra/helm-nameoverride/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-extra/helm-nameoverride/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-extra/helm-nameoverride/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/helm-nameoverride/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-helm-nameoverride
+spec:
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  dbName: vertdb
+  subclusters:
+    - name: pri-sc
+      size: 1
+      isPrimary: true
+  kSafety: "0"
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e/metrics-disabled/05-assert.yaml
+++ b/tests/e2e/metrics-disabled/05-assert.yaml
@@ -29,6 +29,7 @@ spec:
     - --maxfilerotation=3
     - --level=info
     - --dev=false
+    - --prefix-name=verticadb-operator
 status:
   phase: Running
 ---

--- a/tests/e2e/metrics-no-auth/05-assert.yaml
+++ b/tests/e2e/metrics-no-auth/05-assert.yaml
@@ -30,6 +30,7 @@ spec:
     - --maxfilerotation=3
     - --level=info
     - --dev=true
+    - --prefix-name=verticadb-operator
 status:
   phase: Running
 ---

--- a/tests/e2e/prometheus-service-monitor/10-assert.yaml
+++ b/tests/e2e/prometheus-service-monitor/10-assert.yaml
@@ -30,6 +30,7 @@ spec:
     - --maxfilerotation=3
     - --level=info
     - --dev=false
+    - --prefix-name=verticadb-operator
   - name: kube-rbac-proxy
 status:
   phase: Running

--- a/tests/e2e/prometheus-service-monitor/20-assert.yaml
+++ b/tests/e2e/prometheus-service-monitor/20-assert.yaml
@@ -30,6 +30,7 @@ spec:
     - --maxfilerotation=3
     - --level=info
     - --dev=false
+    - --prefix-name=verticadb-operator
 status:
   phase: Running
 ---


### PR DESCRIPTION
A new helm chart parameter was added that allows you to control the prefix of all of the k8s objects created by the helm chart.  If this is omitted, all of the objects have the name of the chart (verticadb-operator).

For example, to force all objects created by the operator deployment to start with "**special**" you can use the nameOverride parameter.
```
helm install vdb-op vertica-charts/verticadb-operator --set nameOverride=special
```