### PR TITLE
Allow upgrade from 11.x to 12.x

### DIFF
--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -12,6 +12,6 @@ runs:
     - name: Download vertica RPM package
       shell: bash
       env:
-          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-11.1.1-0.x86_64.RHEL6.rpm"
+          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-12.0.0-0.x86_64.RHEL6.rpm"
       run: |
         curl $VERTICA_CE_URL -o docker-vertica/packages/vertica-x86_64.RHEL6.latest.rpm

--- a/.github/workflows/e2e-azb.yml
+++ b/.github/workflows/e2e-azb.yml
@@ -28,7 +28,7 @@ jobs:
         [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
         export KUSTOMIZE_CFG=tests/kustomize-defaults-azb-ci.cfg
         export MINIMAL_VERTICA_IMG=YES
-        scripts/run-k8s-int-tests.sh -e tests/external-images-azb-ci.txt
+        scripts/run-k8s-int-tests.sh -d -e tests/external-images-azb-ci.txt
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-hdfs.yml
+++ b/.github/workflows/e2e-hdfs.yml
@@ -28,7 +28,7 @@ jobs:
         [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
         export KUSTOMIZE_CFG=tests/kustomize-defaults-hdfs-ci.cfg
         export MINIMAL_VERTICA_IMG=YES
-        scripts/run-k8s-int-tests.sh -e tests/external-images-hdfs-ci.txt
+        scripts/run-k8s-int-tests.sh -d -e tests/external-images-hdfs-ci.txt
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-operator-upgrade.yml
+++ b/.github/workflows/e2e-operator-upgrade.yml
@@ -26,7 +26,7 @@ jobs:
         export MINIMAL_VERTICA_IMG=YES
         export E2E_TEST_DIRS=tests/e2e-operator-upgrade-overlays
         scripts/setup-operator-upgrade-testsuite.sh
-        scripts/run-k8s-int-tests.sh
+        scripts/run-k8s-int-tests.sh -d
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-s3.yml
+++ b/.github/workflows/e2e-s3.yml
@@ -27,7 +27,7 @@ jobs:
         E2E_PARALLELISM=${{ github.event.inputs.parallel }}
         [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
         export MINIMAL_VERTICA_IMG=YES
-        scripts/run-k8s-int-tests.sh
+        scripts/run-k8s-int-tests.sh -d
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-server-upgrade.yml
+++ b/.github/workflows/e2e-server-upgrade.yml
@@ -27,9 +27,9 @@ jobs:
         E2E_PARALLELISM=${{ github.event.inputs.parallel }}
         [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
         export MINIMAL_VERTICA_IMG=YES
-        export BASE_VERTICA_IMG=vertica/vertica-k8s:11.1.0-0-minimal
+        export BASE_VERTICA_IMG=vertica/vertica-k8s:11.1.1-0-minimal
         export E2E_TEST_DIRS=tests/e2e-server-upgrade
-        scripts/run-k8s-int-tests.sh
+        scripts/run-k8s-int-tests.sh -d -e tests/external-images-server-upgrade-ci.txt
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/changes/unreleased/Fixed-20220719-083301.yaml
+++ b/changes/unreleased/Fixed-20220719-083301.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Allow Vertica upgrade from 11.x to 12.x.
+time: 2022-07-19T08:33:01.813631821-03:00
+custom:
+  Issue: "233"

--- a/pkg/controllers/vdb/offlineupgrade_reconcile.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconcile.go
@@ -97,6 +97,7 @@ func (o *OfflineUpgradeReconciler) Reconcile(ctx context.Context, req *ctrl.Requ
 		// Start up vertica in each pod.
 		o.postRestartingClusterMsg,
 		o.addPodAnnotations,
+		o.runInstaller,
 		o.restartCluster,
 		// Apply labels so svc objects can route to the new pods that came up
 		o.addClientRoutingLabel,
@@ -255,6 +256,14 @@ func (o *OfflineUpgradeReconciler) postRestartingClusterMsg(ctx context.Context)
 // necessary annotations on the pod prior to restart.
 func (o *OfflineUpgradeReconciler) addPodAnnotations(ctx context.Context) (ctrl.Result, error) {
 	r := MakePodAnnotationReconciler(o.VRec, o.Vdb, o.PFacts)
+	return r.Reconcile(ctx, &ctrl.Request{})
+}
+
+// runInstaller will call the installer reconciler for the purpose of accepting
+// the end user license agreement.  This may have changed when we move to the
+// new vertica version.
+func (o *OfflineUpgradeReconciler) runInstaller(ctx context.Context) (ctrl.Result, error) {
+	r := MakeInstallReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -139,6 +139,7 @@ func (o *OnlineUpgradeReconciler) precomputeStatusMsgs(ctx context.Context) (ctr
 		"Recreating pods for primary subclusters",
 		"Checking if new version is compatible",
 		"Adding annotations to pods",
+		"Running installer",
 		"Waiting for secondary nodes to become read-only",
 		"Restarting vertica in primary subclusters",
 	}
@@ -342,6 +343,7 @@ func (o *OnlineUpgradeReconciler) restartPrimaries(ctx context.Context) (ctrl.Re
 		o.recreateSubclusterWithNewImage,
 		o.checkVersion,
 		o.addPodAnnotations,
+		o.runInstaller,
 		o.waitForReadOnly,
 		o.bringSubclusterOnline,
 	}
@@ -374,6 +376,7 @@ func (o *OnlineUpgradeReconciler) processSecondary(ctx context.Context, sts *app
 		o.recreateSubclusterWithNewImage,
 		o.postNextStatusMsgForSts,
 		o.addPodAnnotations,
+		o.runInstaller,
 		o.bringSubclusterOnline,
 	}
 	for _, fn := range funcs {
@@ -463,6 +466,14 @@ func (o *OnlineUpgradeReconciler) checkVersion(ctx context.Context, sts *appsv1.
 // in-place prior to restart
 func (o *OnlineUpgradeReconciler) addPodAnnotations(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
 	r := MakePodAnnotationReconciler(o.VRec, o.Vdb, o.PFacts)
+	return r.Reconcile(ctx, &ctrl.Request{})
+}
+
+// runInstaller will run the install reconciler.  The main purpose is to accept
+// the end user license agreement (eula).  This may need to be accepted again if
+// the eula changed in this new version of vertica.
+func (o *OnlineUpgradeReconciler) runInstaller(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
+	r := MakeInstallReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 

--- a/tests/e2e-server-upgrade/README.txt
+++ b/tests/e2e-server-upgrade/README.txt
@@ -1,2 +1,0 @@
-Tests that are only compatible when running a server with the Vertica
-11.1 version.

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/00-create-communal-creds.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/00-create-communal-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/05-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/05-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/05-deploy-operator.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/05-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+status:
+  installCount: 3
+  addedToDBCount: 3
+  upNodeCount: 3

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-create-db.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-create-db.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/25-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/25-assert.yaml
@@ -1,0 +1,27 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+status:
+  conditions:
+    - type: AutoRestartVertica
+      status: "True"
+    - type: DBInitialized
+      status: "True"
+    - type: ImageChangeInProgress
+      status: "True"
+    - type: OfflineUpgradeInProgress
+      status: "True"

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/25-initiate-upgrade.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/25-initiate-upgrade.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/30-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/30-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+status:
+  installCount: 3
+  addedToDBCount: 3
+  upNodeCount: 0

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/30-wait-for-shutdown.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/30-wait-for-shutdown.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/35-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/35-assert.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+status:
+  conditions:
+    - type: AutoRestartVertica
+      status: "True"
+    - type: DBInitialized
+      status: "True"
+    - type: ImageChangeInProgress
+      status: "False"
+    - type: OfflineUpgradeInProgress
+      status: "False"
+  subclusterCount: 1
+  installCount: 3
+  upNodeCount: 3

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/35-wait-for-finish.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/35-wait-for-finish.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl wait --for=condition=OfflineUpgradeInProgress=False vdb/v-base-upgrade --timeout=600s
+    namespaced: true

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/95-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/95-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/95-uninstall-operator.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/95-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/97-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/97-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/97-delete-cr.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/97-delete-cr.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/97-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/97-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/99-delete-ns.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/README.txt
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/README.txt
@@ -1,0 +1,3 @@
+This does an offline upgrade from BASE_VERTICA_IMG to VERTICA_IMG.  The other
+offline upgrade tests verify various error cases, so only  change the image to
+a bad invalid image then back to a good image.

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,34 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+spec:
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  kSafety: "1"
+  upgradePolicy: Offline
+  subclusters:
+    - name: pri
+      size: 3
+      isPrimary: true
+  certSecrets: []
+  requeueTime: 4
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/15-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/15-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,4 +25,4 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-start-vertica-upgrade.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-start-vertica-upgrade.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-defsc-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-upgrade-and-scale-up.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-upgrade-and-scale-up.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal
   subclusters:
   - name: defsc
     size: 3

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-upgrade-and-scale-down.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-upgrade-and-scale-down.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal
   subclusters:
   - name: defsc
     size: 1

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/50-upgrade-vertica.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/50-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/55-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/55-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/70-upgrade-vertica.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/70-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/75-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/75-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal
   imagePullPolicy: IfNotPresent
   superuserPasswordSecret: su-passwd
   communal:

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/25-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/25-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-sc1-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-sc1-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-sc1-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-sc1-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.0-0-minimal
+    - image: vertica/vertica-k8s:11.1.1-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-upgrade-vertica.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal
   imagePullPolicy: IfNotPresent
   communal:
     includeUIDInPath: true

--- a/tests/external-images-common-ci.txt
+++ b/tests/external-images-common-ci.txt
@@ -5,7 +5,6 @@
 # nodes.
 #    scripts/push-to-kind.sh -f tests/external-images-common-ci.txt
 #
-vertica/vertica-k8s:11.1.0-0-minimal
 minio/minio:RELEASE.2021-09-03T03-56-13Z
 amazon/aws-cli:2.2.24
 quay.io/helmpack/chart-testing:v3.3.1

--- a/tests/external-images-server-upgrade-ci.txt
+++ b/tests/external-images-server-upgrade-ci.txt
@@ -1,0 +1,3 @@
+# List of images that we pull during the e2e tests for server-upgrade.
+#
+vertica/vertica-k8s:11.1.1-0-minimal

--- a/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
+++ b/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
@@ -16,4 +16,4 @@ kind: ConfigMap
 metadata:
   name: upgrade-vertica-1
 data:
-  image: vertica/vertica-k8s:11.1.0-0-minimal
+  image: vertica/vertica-k8s:11.1.1-0-minimal


### PR DESCRIPTION
Upgrades to 12.x were broken because we had to accept updated terms to the EULA.  This adds a path to the offline and online upgrade that will run the installer to re-accept the EULA if it changed.

We were hitting disk full errors in the GitHub CI, so this also does various things to save space in the CI:
- delete the RPM once the vertica image has been built
- use 11.1.1 as the base image for upgrades.  We used to use 11.1.0 but that image is quite a bit bigger because its CentOS base.
- don't pre-pull the vertica-k8s:11.1.0-0-minimal image for all e2e runs.  This is only needed for the server upgrade tests.