### PR TITLE
Better support for upgrade of the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.0
+VERSION ?= 1.7.0
 export VERSION
 
 # VLOGGER_VERSION defines the version to use for the Vertica logger image

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -795,6 +795,7 @@ type SubclusterStatus struct {
 	UpNodeCount int32 `json:"upNodeCount"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +kubebuilder:validation:Optional
 	// A count of the number of pods that are in read-only state in this subcluster.
 	ReadOnlyCount int32 `json:"readOnlyCount"`
 
@@ -818,6 +819,7 @@ type VerticaDBPodStatus struct {
 	// connections on port 5433.
 	UpNode bool `json:"upNode"`
 	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +kubebuilder:validation:Optional
 	// True means the vertica process on this pod is in read-only state
 	ReadOnly bool `json:"readOnly"`
 }

--- a/changes/unreleased/Fixed-20220719-145459.yaml
+++ b/changes/unreleased/Fixed-20220719-145459.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Update app.kubernetes.io/version in all objects when upgrading the operator
+time: 2022-07-19T14:54:59.206392217-03:00
+custom:
+  Issue: "234"

--- a/changes/unreleased/Fixed-20220719-145535.yaml
+++ b/changes/unreleased/Fixed-20220719-145535.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Prevent the need to restart the pods when the operator is upgraded
+time: 2022-07-19T14:55:35.768110388-03:00
+custom:
+  Issue: "234"

--- a/changes/unreleased/Fixed-20220719-160434.yaml
+++ b/changes/unreleased/Fixed-20220719-160434.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Allow operator upgrade from <= 1.1.0
+time: 2022-07-19T16:04:34.132425051-03:00
+custom:
+  Issue: "234"

--- a/helm-charts/verticadb-operator/Chart.yaml
+++ b/helm-charts/verticadb-operator/Chart.yaml
@@ -15,4 +15,4 @@ name: verticadb-operator
 description: An operator that can deploy and manage Vertica clusters
 type: application
 # Versions follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -23,7 +23,7 @@
 
 image:
   repo: docker.io
-  name: vertica/verticadb-operator:1.6.0
+  name: vertica/verticadb-operator:1.7.0
   pullPolicy: IfNotPresent
 
 rbac_proxy_image:

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -581,7 +581,7 @@ func BuildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.
 		Spec: buildPodSpec(vdb, sc, DefaultServiceAccountName),
 	}
 	// Setup default values for the DC table annotations.  These are normally
-	// added by the PodAnnotationReconciler.  However, this function is for test
+	// added by the AnnotationAndLabelPodReconciler.  However, this function is for test
 	// purposes, and we have a few dependencies on these annotations.  Rather
 	// than having many tests run the reconciler, we will add in sample values.
 	pod.Annotations[KubernetesBuildDateAnnotation] = "2022-03-16T15:58:47Z"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -528,7 +528,7 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      MakeLabelsForObject(vdb, sc),
+			Labels:      makeLabelsForObject(vdb, sc, false),
 			Annotations: MakeAnnotationsForObject(vdb),
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -539,7 +539,7 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 			Replicas:    &sc.Size,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      MakeLabelsForObject(vdb, sc),
+					Labels:      MakeLabelsForPodObject(vdb, sc),
 					Annotations: MakeAnnotationsForObject(vdb),
 				},
 				Spec: buildPodSpec(vdb, sc, saName),
@@ -575,7 +575,7 @@ func BuildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      MakeLabelsForObject(vdb, sc),
+			Labels:      MakeLabelsForPodObject(vdb, sc),
 			Annotations: MakeAnnotationsForObject(vdb),
 		},
 		Spec: buildPodSpec(vdb, sc, DefaultServiceAccountName),

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -58,7 +58,7 @@ const (
 	OperatorVersion170 = CurOperatorVersion
 
 	// Annotations that we set in each of the pod.  These are set by the
-	// PodAnnotationReconciler.  They are available in the pod with the
+	// AnnotateAndLabelPodReconciler.  They are available in the pod with the
 	// downwardAPI so they can be picked up by the Vertica data collector (DC).
 	KubernetesVersionAnnotation   = "kubernetes.io/version"   // Version of the k8s server
 	KubernetesGitCommitAnnotation = "kubernetes.io/gitcommit" // Git commit of the k8s server

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -46,7 +46,7 @@ const (
 	ManagedByLabel       = "app.kubernetes.io/managed-by"
 	OperatorName         = "verticadb-operator" // The name of the operator
 
-	CurOperatorVersion = "1.6.0" // The version number of the operator
+	CurOperatorVersion = "1.7.0" // The version number of the operator
 	OperatorVersion100 = "1.0.0"
 	OperatorVersion110 = "1.1.0"
 	OperatorVersion120 = "1.2.0"
@@ -54,7 +54,8 @@ const (
 	OperatorVersion131 = "1.3.1"
 	OperatorVersion140 = "1.4.0"
 	OperatorVersion150 = "1.5.0"
-	OperatorVersion160 = CurOperatorVersion
+	OperatorVersion160 = "1.6.0"
+	OperatorVersion170 = CurOperatorVersion
 
 	// Annotations that we set in each of the pod.  These are set by the
 	// PodAnnotationReconciler.  They are available in the pod with the
@@ -91,12 +92,16 @@ func MakeOperatorLabels(vdb *vapi.VerticaDB) map[string]string {
 }
 
 // MakeCommonLabels returns the labels that are common to all objects.
-func MakeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
+func MakeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map[string]string {
 	labels := MakeOperatorLabels(vdb)
-	// Apply a label to indicate a version of the operator that created the
-	// object.  This is separate from makeOperatorLabels as we don't want to
-	// include that in any sort of label selector.
-	labels[OperatorVersionLabel] = CurOperatorVersion
+	if !forPod {
+		// Apply a label to indicate a version of the operator that created the
+		// object.  This is separate from MakeOperatorLabels as we don't want to
+		// set this for pods in the template.  We set the operator version in
+		// the pods as part of a reconciler so that we don't have to reschedule
+		// the pods.
+		labels[OperatorVersionLabel] = CurOperatorVersion
+	}
 
 	// Remaining labels are for objects that are subcluster specific
 	if sc == nil {
@@ -111,8 +116,8 @@ func MakeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]strin
 }
 
 // MakeLabelsForObjects constructs the labels for a new k8s object
-func MakeLabelsForObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
-	labels := MakeCommonLabels(vdb, sc)
+func makeLabelsForObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map[string]string {
+	labels := MakeCommonLabels(vdb, sc, forPod)
 
 	// Add any custom labels that were in the spec.
 	for k, v := range vdb.Spec.Labels {
@@ -122,9 +127,19 @@ func MakeLabelsForObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]st
 	return labels
 }
 
+// MakeLabelsForPodObject constructs the labels that are common for all pods
+func MakeLabelsForPodObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
+	return makeLabelsForObject(vdb, sc, true)
+}
+
+// MakeLabelsForStsObject constructs the labels that are common for all statefulsets.
+func MakeLabelsForStsObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
+	return makeLabelsForObject(vdb, sc, false)
+}
+
 // MakeLabelsForSvcObject will create the set of labels for use with service objects
 func MakeLabelsForSvcObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, svcType string) map[string]string {
-	labels := MakeLabelsForObject(vdb, sc)
+	labels := makeLabelsForObject(vdb, sc, false)
 	labels[SvcTypeLabel] = svcType
 	return labels
 }

--- a/pkg/controllers/vdb/annotateandlabelpod_reconcile.go
+++ b/pkg/controllers/vdb/annotateandlabelpod_reconcile.go
@@ -29,23 +29,23 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// PodAnnotateLabelReconciler will maintain annotations and labels in pods about the running system
-type PodAnnotateLabelReconciler struct {
+// AnnotateAndLabelPodReconciler will maintain annotations and labels in pods about the running system
+type AnnotateAndLabelPodReconciler struct {
 	VRec   *VerticaDBReconciler
 	Vdb    *vapi.VerticaDB
 	PFacts *PodFacts
 }
 
-// MakePodAnnotateLabelReconciler will build a PodAnnotateLabelReconciler object
-func MakePodAnnotateLabelReconciler(vdbrecon *VerticaDBReconciler,
+// MakeAnnotateAndLabelPodReconciler will build a AnnotateAndLabelPodReconciler object
+func MakeAnnotateAndLabelPodReconciler(vdbrecon *VerticaDBReconciler,
 	vdb *vapi.VerticaDB, pfacts *PodFacts) controllers.ReconcileActor {
-	return &PodAnnotateLabelReconciler{VRec: vdbrecon, Vdb: vdb, PFacts: pfacts}
+	return &AnnotateAndLabelPodReconciler{VRec: vdbrecon, Vdb: vdb, PFacts: pfacts}
 }
 
 // Reconcile will add annotations to each of the pods so that we flow down
 // system information with the downwardAPI.  The intent of this additional data
 // is for inclusion in Vertica data collector (DC) tables.
-func (s *PodAnnotateLabelReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+func (s *AnnotateAndLabelPodReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
 	if err := s.PFacts.Collect(ctx, s.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -69,7 +69,7 @@ func (s *PodAnnotateLabelReconciler) Reconcile(ctx context.Context, req *ctrl.Re
 }
 
 // generateAnnotations will generate static annotations that will be applied to each running pod
-func (s *PodAnnotateLabelReconciler) generateAnnotations() (map[string]string, error) {
+func (s *AnnotateAndLabelPodReconciler) generateAnnotations() (map[string]string, error) {
 	// We get the k8s server information from the client.  It would be better to
 	// get the node the pod was assigned and fetch the system info from the
 	// node.  This will give us more details information like what container
@@ -98,14 +98,14 @@ func (s *PodAnnotateLabelReconciler) generateAnnotations() (map[string]string, e
 }
 
 // generateLabels will generate static labels that will be applied to each running pod
-func (s *PodAnnotateLabelReconciler) generateLabels() map[string]string {
+func (s *AnnotateAndLabelPodReconciler) generateLabels() map[string]string {
 	return map[string]string{
 		builder.OperatorVersionLabel: builder.CurOperatorVersion,
 	}
 }
 
 // applyAnnotationsAndLabels will ensure the annotations and labels passed in are set for the given pod
-func (s *PodAnnotateLabelReconciler) applyAnnotationsAndLabels(ctx context.Context,
+func (s *AnnotateAndLabelPodReconciler) applyAnnotationsAndLabels(ctx context.Context,
 	podName types.NamespacedName,
 	anns, labels map[string]string) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {

--- a/pkg/controllers/vdb/offlineupgrade_reconcile.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconcile.go
@@ -255,7 +255,7 @@ func (o *OfflineUpgradeReconciler) postRestartingClusterMsg(ctx context.Context)
 // addPodAnnotations will call the PodAnnotationReconciler so that we have the
 // necessary annotations on the pod prior to restart.
 func (o *OfflineUpgradeReconciler) addPodAnnotations(ctx context.Context) (ctrl.Result, error) {
-	r := MakePodAnnotationReconciler(o.VRec, o.Vdb, o.PFacts)
+	r := MakePodAnnotateLabelReconciler(o.VRec, o.Vdb, o.PFacts)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 

--- a/pkg/controllers/vdb/offlineupgrade_reconcile.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconcile.go
@@ -255,7 +255,7 @@ func (o *OfflineUpgradeReconciler) postRestartingClusterMsg(ctx context.Context)
 // addPodAnnotations will call the PodAnnotationReconciler so that we have the
 // necessary annotations on the pod prior to restart.
 func (o *OfflineUpgradeReconciler) addPodAnnotations(ctx context.Context) (ctrl.Result, error) {
-	r := MakePodAnnotateLabelReconciler(o.VRec, o.Vdb, o.PFacts)
+	r := MakeAnnotateAndLabelPodReconciler(o.VRec, o.Vdb, o.PFacts)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -465,7 +465,7 @@ func (o *OnlineUpgradeReconciler) checkVersion(ctx context.Context, sts *appsv1.
 // addPodAnnotations will add the necessary pod annotations that need to be
 // in-place prior to restart
 func (o *OnlineUpgradeReconciler) addPodAnnotations(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
-	r := MakePodAnnotationReconciler(o.VRec, o.Vdb, o.PFacts)
+	r := MakePodAnnotateLabelReconciler(o.VRec, o.Vdb, o.PFacts)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -465,7 +465,7 @@ func (o *OnlineUpgradeReconciler) checkVersion(ctx context.Context, sts *appsv1.
 // addPodAnnotations will add the necessary pod annotations that need to be
 // in-place prior to restart
 func (o *OnlineUpgradeReconciler) addPodAnnotations(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
-	r := MakePodAnnotateLabelReconciler(o.VRec, o.Vdb, o.PFacts)
+	r := MakeAnnotateAndLabelPodReconciler(o.VRec, o.Vdb, o.PFacts)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 

--- a/pkg/controllers/vdb/podannotatelabel_reconcile.go
+++ b/pkg/controllers/vdb/podannotatelabel_reconcile.go
@@ -29,23 +29,23 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// PodAnnotationReconciler will maintain annotations in the pod about the running system
-type PodAnnotationReconciler struct {
+// PodAnnotateLabelReconciler will maintain annotations and labels in pods about the running system
+type PodAnnotateLabelReconciler struct {
 	VRec   *VerticaDBReconciler
 	Vdb    *vapi.VerticaDB
 	PFacts *PodFacts
 }
 
-// MakePodAnnotationReconciler will build a PodAnnotationReconciler object
-func MakePodAnnotationReconciler(vdbrecon *VerticaDBReconciler,
+// MakePodAnnotateLabelReconciler will build a PodAnnotateLabelReconciler object
+func MakePodAnnotateLabelReconciler(vdbrecon *VerticaDBReconciler,
 	vdb *vapi.VerticaDB, pfacts *PodFacts) controllers.ReconcileActor {
-	return &PodAnnotationReconciler{VRec: vdbrecon, Vdb: vdb, PFacts: pfacts}
+	return &PodAnnotateLabelReconciler{VRec: vdbrecon, Vdb: vdb, PFacts: pfacts}
 }
 
 // Reconcile will add annotations to each of the pods so that we flow down
 // system information with the downwardAPI.  The intent of this additional data
 // is for inclusion in Vertica data collector (DC) tables.
-func (s *PodAnnotationReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+func (s *PodAnnotateLabelReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
 	if err := s.PFacts.Collect(ctx, s.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -55,11 +55,12 @@ func (s *PodAnnotationReconciler) Reconcile(ctx context.Context, req *ctrl.Reque
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	labels := s.generateLabels()
 
 	// Iterate over pod that exists.
 	for pn, pf := range s.PFacts.Detail {
 		if pf.exists {
-			if err := s.applyAnnotations(ctx, pn, annotations); err != nil {
+			if err := s.applyAnnotationsAndLabels(ctx, pn, annotations, labels); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -68,7 +69,7 @@ func (s *PodAnnotationReconciler) Reconcile(ctx context.Context, req *ctrl.Reque
 }
 
 // generateAnnotations will generate static annotations that will be applied to each running pod
-func (s *PodAnnotationReconciler) generateAnnotations() (map[string]string, error) {
+func (s *PodAnnotateLabelReconciler) generateAnnotations() (map[string]string, error) {
 	// We get the k8s server information from the client.  It would be better to
 	// get the node the pod was assigned and fetch the system info from the
 	// node.  This will give us more details information like what container
@@ -96,8 +97,17 @@ func (s *PodAnnotationReconciler) generateAnnotations() (map[string]string, erro
 	}, nil
 }
 
-// applyAnnotations will ensure the annotations passed in are set for the given pod
-func (s *PodAnnotationReconciler) applyAnnotations(ctx context.Context, podName types.NamespacedName, anns map[string]string) error {
+// generateLabels will generate static labels that will be applied to each running pod
+func (s *PodAnnotateLabelReconciler) generateLabels() map[string]string {
+	return map[string]string{
+		builder.OperatorVersionLabel: builder.CurOperatorVersion,
+	}
+}
+
+// applyAnnotationsAndLabels will ensure the annotations and labels passed in are set for the given pod
+func (s *PodAnnotateLabelReconciler) applyAnnotationsAndLabels(ctx context.Context,
+	podName types.NamespacedName,
+	anns, labels map[string]string) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		pod := &corev1.Pod{}
 		if err := s.VRec.Client.Get(ctx, podName, pod); err != nil {
@@ -107,17 +117,24 @@ func (s *PodAnnotationReconciler) applyAnnotations(ctx context.Context, podName 
 			return err
 		}
 
-		annotationsChanged := false
+		annotationsOrLabelsChanged := false
 		for k, v := range anns {
 			if pod.Annotations[k] != v {
 				if pod.Annotations == nil {
 					pod.Annotations = map[string]string{}
 				}
 				pod.Annotations[k] = v
-				annotationsChanged = true
+				annotationsOrLabelsChanged = true
 			}
 		}
-		if annotationsChanged {
+		for k, v := range labels {
+			if pod.Labels == nil {
+				pod.Labels = map[string]string{}
+			}
+			pod.Labels[k] = v
+			annotationsOrLabelsChanged = true
+		}
+		if annotationsOrLabelsChanged {
 			err := s.VRec.Client.Update(ctx, pod)
 			if err == nil {
 				// We have added/updated the annotations.  Refresh the podfacts.

--- a/pkg/controllers/vdb/podannotatelabel_reconcile_test.go
+++ b/pkg/controllers/vdb/podannotatelabel_reconcile_test.go
@@ -39,7 +39,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		act := MakePodAnnotateLabelReconciler(vdbRec, vdb, &pfacts)
+		act := MakeAnnotateAndLabelPodReconciler(vdbRec, vdb, &pfacts)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		pod := &corev1.Pod{}
@@ -67,7 +67,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		act := MakePodAnnotateLabelReconciler(vdbRec, vdb, &pfacts)
+		act := MakeAnnotateAndLabelPodReconciler(vdbRec, vdb, &pfacts)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())

--- a/pkg/controllers/vdb/podannotatelabel_reconcile_test.go
+++ b/pkg/controllers/vdb/podannotatelabel_reconcile_test.go
@@ -29,7 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var _ = Describe("podannotation_reconcile", func() {
+var _ = Describe("podannotatelabel_reconcile", func() {
 	ctx := context.Background()
 
 	It("should fetch node information and include it in the pod as annotations", func() {
@@ -37,21 +37,40 @@ var _ = Describe("podannotation_reconcile", func() {
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
-		// The pod we created will already have the annotatons we want to add.
-		// We remove them to test having the reconciler add them.
-		pod := &corev1.Pod{}
-		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
-		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		pod.SetAnnotations(map[string]string{})
-
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		act := MakePodAnnotationReconciler(vdbRec, vdb, &pfacts)
+		act := MakePodAnnotateLabelReconciler(vdbRec, vdb, &pfacts)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
+		pod := &corev1.Pod{}
+		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
 		Expect(pod.Annotations[builder.KubernetesBuildDateAnnotation]).ShouldNot(Equal(""))
 		Expect(pod.Annotations[builder.KubernetesGitCommitAnnotation]).ShouldNot(Equal(""))
 		Expect(pod.Annotations[builder.KubernetesVersionAnnotation]).ShouldNot(Equal(""))
+	})
+
+	It("should include operator version in the pod", func() {
+		vdb := vapi.MakeVDB()
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		// The pod we created will already have the labels we want to add.
+		// We change them to test having the reconciler update them.
+		pod := &corev1.Pod{}
+		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
+		pod.SetAnnotations(map[string]string{
+			builder.OperatorVersionLabel: "1.0.0",
+		})
+		Expect(k8sClient.Update(ctx, pod)).Should(Succeed())
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := MakePodFacts(vdbRec, fpr)
+		act := MakePodAnnotateLabelReconciler(vdbRec, vdb, &pfacts)
+		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+
+		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
+		Expect(pod.Labels[builder.OperatorVersionLabel]).Should(Equal(builder.CurOperatorVersion))
 	})
 })

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -154,7 +154,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// to go through necessary admintools commands to handle a scale down.
 		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeIfNotFound),
 		// Add annotations to each pod about the host running them
-		MakePodAnnotationReconciler(r, vdb, pfacts),
+		MakePodAnnotateLabelReconciler(r, vdb, pfacts),
 		// Stop vertica if the status condition indicates
 		MakeStopDBReconciler(r, vdb, prunner, pfacts),
 		// Handles restart + re_ip of vertica

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -153,8 +153,8 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// pods are missing.  We don't want to apply all updates as we may need
 		// to go through necessary admintools commands to handle a scale down.
 		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeIfNotFound),
-		// Add annotations to each pod about the host running them
-		MakePodAnnotateLabelReconciler(r, vdb, pfacts),
+		// Add annotations/labels to each pod about the host running them
+		MakeAnnotateAndLabelPodReconciler(r, vdb, pfacts),
 		// Stop vertica if the status condition indicates
 		MakeStopDBReconciler(r, vdb, prunner, pfacts),
 		// Handles restart + re_ip of vertica

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/15-assert.yaml
@@ -11,8 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: kubectl apply -f ../../../helm-charts/verticadb-operator/crds/*yaml
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+spec:
+  containers:
+  - name: manager
+    image: docker.io/vertica/verticadb-operator:1.6.0
+  - name: kube-rbac-proxy
+status:
+  phase: Running

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/15-install-chart.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/15-install-chart.yaml
@@ -14,5 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl apply -f ../../../helm-charts/verticadb-operator/crds/*yaml
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"
+  - command: helm install --wait -n $NAMESPACE vdb-op vertica-charts/verticadb-operator --version 1.6.0

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/31-add-autoscaler.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/31-add-autoscaler.yaml
@@ -11,8 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: kubectl apply -f ../../../helm-charts/verticadb-operator/crds/*yaml
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-from-x
+spec:
+  verticaDBName: v-from-x
+  serviceName: sec1
+  scalingGranularity: Subcluster
+  template:
+    name: as
+    size: 1
+    serviceName: sec1
+    isPrimary: false

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/31-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/31-assert.yaml
@@ -11,8 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: kubectl apply -f ../../../helm-charts/verticadb-operator/crds/*yaml
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-from-x
+status:
+  scalingCount: 0
+  currentSize: 1

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/41-errors.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/41-errors.yaml
@@ -1,0 +1,48 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We are done with this step when the statefulset has updated its operator
+# version so it no longer is the old one.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-from-x-pri1
+  labels:
+    app.kubernetes.io/version: 1.6.0
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/version: 1.6.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-from-x-pri1-0
+  labels:
+    app.kubernetes.io/version: 1.6.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: v-from-x-pri1
+  labels:
+    app.kubernetes.io/version: 1.6.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: v-from-x
+  labels:
+    app.kubernetes.io/version: 1.6.0

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/41-wait-for-label-update.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/41-wait-for-label-update.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/46-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/46-assert.yaml
@@ -11,8 +11,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: kubectl apply -f ../../../helm-charts/verticadb-operator/crds/*yaml
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-from-x
+spec:
+  verticaDBName: v-from-x
+  serviceName: sec1
+  scalingGranularity: Subcluster
+  template:
+    name: as
+    size: 2
+    serviceName: sec1
+    isPrimary: false
+status:
+  scalingCount: 0
+  currentSize: 1

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/46-change-autoscaler.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/46-change-autoscaler.yaml
@@ -11,8 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: kubectl apply -f ../../../helm-charts/verticadb-operator/crds/*yaml
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-from-x
+spec:
+  template:
+    size: 2

--- a/tests/e2e-operator-upgrade-template/template/99-delete-ns.yaml
+++ b/tests/e2e-operator-upgrade-template/template/99-delete-ns.yaml
@@ -14,5 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl apply -f ../../../helm-charts/verticadb-operator/crds/*yaml
-  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"
+  - command: kubectl delete ns $NAMESPACE


### PR DESCRIPTION
A bunch of changes and fixes related to upgrade of the operator:
- This increases the operator to 1.7.0.
- Added a new testcase to verify the upgrading of the operator from 1.6.0.
- Fixed an issue where the operator wouldn't update the operator version in k8s objects (app.kubernetes.io/version).  It stays on the version that originally created it. 
- Fixes an issue that every time we updated the operator version, it would force all of the pods to be rescheduled.  This happened because we changed a label for the pod in the sts template portion.  I now add a label for the version through a reconciler rather than through the statefulset template.  Unfortunately, we can't do anything for the next release (1.7.0) -- since we have to update the sts template to remove the label.  But the next operator version after 1.7.0 should not require a pod restart.
- readOnly status fields were made optional.  These fields were added in 1.2.0 of the operator as required field.  This prevented upgrade of the operator from versons <= 1.1.0 to the current version.  So, this change unblocks that.