### PR TITLE
Missing manifest with 'prometheus.createProxyRBAC'

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -97,6 +97,13 @@ jobs:
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-reader-cr.yaml
 
 
+    - name: Upload ClusterRoleBinding to bind non-resource access of the /metrics endpoint
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-artifacts
+        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-reader-crb.yaml
+
+
     - name: Upload ServiceMonitor object for integration with Prometheus operator
       uses: actions/upload-artifact@v2
       with:

--- a/changes/unreleased/Fixed-20220719-165250.yaml
+++ b/changes/unreleased/Fixed-20220719-165250.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Helm chart parm 'prometheus.createProxyRBAC' missed a required manifest
+time: 2022-07-19T16:52:50.228247737-03:00
+custom:
+  Issue: "235"

--- a/config/rbac/auth_proxy_client_clusterrolebinding.yaml
+++ b/config/rbac/auth_proxy_client_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- auth_proxy_client_clusterrolebinding.yaml

--- a/scripts/gen-release-artifacts.sh
+++ b/scripts/gen-release-artifacts.sh
@@ -42,7 +42,8 @@ mkdir -p $RELEASE_ARTIFACT_TARGET_DIR
 for f in verticadb-operator-metrics-monitor-servicemonitor.yaml \
     verticadb-operator-proxy-rolebinding-crb.yaml \
     verticadb-operator-proxy-role-cr.yaml \
-    verticadb-operator-metrics-reader-cr.yaml
+    verticadb-operator-metrics-reader-cr.yaml \
+    verticadb-operator-metrics-reader-crb.yaml
 do
   cp $MANIFEST_DIR/$f $RELEASE_ARTIFACT_TARGET_DIR
   # Modify the artifact we are copying over by removing any namespace field.

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -105,7 +105,8 @@ echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-metrics-service-svc.yaml
 # 12.  Template the roles/rolebindings for access to the rbac proxy
 for f in verticadb-operator-proxy-rolebinding-crb.yaml \
     verticadb-operator-proxy-role-cr.yaml \
-    verticadb-operator-metrics-reader-cr.yaml
+    verticadb-operator-metrics-reader-cr.yaml \
+    verticadb-operator-metrics-reader-crb.yaml
 do
     sed -i '1s/^/{{- if .Values.prometheus.createProxyRBAC -}}\n/' $TEMPLATE_DIR/$f
     echo "{{- end }}" >> $TEMPLATE_DIR/$f


### PR DESCRIPTION
When the helm chart parm 'prometheus.createProxyRBAC=true' is suppose to install all of the manifests necessary to allow access to the metrics through the rbac proxy sidecar.  However, it was missing a manifest -- a ClusterRoleBinding to allow us to use the ClusterRole through a non-resource object.