### PR TITLE
Revamp CI

### DIFF
--- a/.github/actions/download-rpm/action.yaml
+++ b/.github/actions/download-rpm/action.yaml
@@ -1,0 +1,11 @@
+name: 'Download the Vertica RPM'
+description: 'Will download the RPM as prep for container building'
+runs:
+  using: "composite"
+  steps:
+    - name: Download vertica RPM package
+      shell: bash
+      env:
+          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-12.0.0-0.x86_64.RHEL6.rpm"
+      run: |
+        curl $VERTICA_CE_URL -o docker-vertica/packages/vertica-x86_64.RHEL6.latest.rpm

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -8,10 +8,3 @@ runs:
 
     - name: Install kubectl and related tools
       uses: ./.github/actions/setup-kubectl
-    
-    - name: Download vertica RPM package
-      shell: bash
-      env:
-          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-12.0.0-0.x86_64.RHEL6.rpm"
-      run: |
-        curl $VERTICA_CE_URL -o docker-vertica/packages/vertica-x86_64.RHEL6.latest.rpm

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -17,9 +17,10 @@ runs:
       if: ${{ github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        docker load --input full-vertica-image.tar
-        docker load --input minimal-vertica-image.tar
-        docker load --input operator-image.tar
-        docker load --input vlogger-image.tar
+        find .
+        docker load --input full-vertica-image/full-vertica-image.tar
+        docker load --input minimal-vertica-image/minimal-vertica-image.tar
+        docker load --input operator-image/operator-image.tar
+        docker load --input vlogger-image/vlogger-image.tar
         docker image ls -a
 

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -17,7 +17,7 @@ runs:
       if: ${{ github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        find .
+        find . -name \*.tar
         docker load --input full-vertica-image/full-vertica-image.tar
         docker load --input minimal-vertica-image/minimal-vertica-image.tar
         docker load --input operator-image/operator-image.tar

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -15,6 +15,7 @@ runs:
 
     - name: Load the docker images for PRs
       if: ${{ github.event_name == 'pull_request' }}
+      shell: bash
       run: |
         docker load --input full-vertica-image.tar
         docker load --input minimal-vertica-image.tar

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -8,3 +8,17 @@ runs:
 
     - name: Install kubectl and related tools
       uses: ./.github/actions/setup-kubectl
+
+    - name: Download all the docker image for PRs
+      uses: actions/download-artifact@v2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    - name: Load the docker images for PRs
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        docker load --input full-vertica-image.tar
+        docker load --input minimal-vertica-image.tar
+        docker load --input operator-image.tar
+        docker load --input vlogger-image.tar
+        docker image ls -a
+

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -36,12 +36,6 @@ on:
       DOCKERHUB_TOKEN:
         description: 'When working with images from docker.io, this is the password for login purposes'
         required: true
-      PR_GITHUB_USERNAME:
-        description: 'For pull requests, this is the GitHub username that accompanies the personal access token'
-        required: true
-      PR_GITHUB_PAT:
-        description: 'For pull requests, this is the personal access token that goes along with PR_GITHUB_USERNAME. This PAT is used to write to the container registry.'
-        required: true
     outputs:
       operator-image:
         description: "The image name of the VerticaDB operator"
@@ -56,7 +50,10 @@ on:
         description: "The image name of the vertica logger sidecar"
         value: ${{ jobs.build-vlogger.outputs.image }}
 
-
+# These permissions only apply when not running a PR.  GitHub actions makes PRs
+# from forked repositories with extremely limited permissions that cannot be
+# overwritten:
+# https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
 permissions:
   packages: write
   security-events: write
@@ -75,7 +72,7 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
-          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/vertica-k8s:pr-${{ github.sha }}
+          ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
@@ -84,17 +81,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    # We need a separate login for PRs because the GITHUB_TOKEN only allows
-    # read access to the container registry for PRs:
-    # https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
-    - name: Login to GitHub Container registry for PRs
-      uses: docker/login-action@v2
-      if: ${{ inputs.full_vertica_image == '' && github.event_name == 'pull_request' }}
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.PR_GITHUB_USERNAME }}
-        password: ${{ secrets.PR_GITHUB_PAT }}
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
@@ -110,11 +96,25 @@ jobs:
       uses: ./.github/actions/download-rpm
       if: ${{ inputs.full_vertica_image == '' }}
       
-    - name: Build and push full server image
+    - name: Build and optionally push full server image
       if: ${{ inputs.full_vertica_image == '' }}
       run: |
         export VERTICA_IMG=${{ steps.full_vertica_image.outputs.value }}
-        make docker-build-vertica docker-push-vertica
+        make docker-build-vertica
+        if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+          make docker-push-vertica
+        fi
+
+    - name: Save the image for consumption by dependent jobs (PRs only)
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        docker save ${{ steps.full_vertica_image.outputs.value }} > full_vertica_image.tar
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        name: full_vertica_image
+        path: full_vertica_image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.full_vertica_image != '' }}
@@ -178,7 +178,7 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}-minimal
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
-          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/vertica-k8s:pr-${{ github.sha }}-minimal
+          ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind-minimal
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
@@ -187,14 +187,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Login to GitHub Container registry for PRs
-      uses: docker/login-action@v2
-      if: ${{ inputs.minimal_vertica_image == '' && github.event_name == 'pull_request' }}
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.PR_GITHUB_USERNAME }}
-        password: ${{ secrets.PR_GITHUB_PAT }}
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
@@ -210,12 +202,26 @@ jobs:
       uses: ./.github/actions/download-rpm
       if: ${{ inputs.minimal_vertica_image == '' }}
       
-    - name: Build and push minimal server image
+    - name: Build and optionally push minimal server image
       if: ${{ inputs.minimal_vertica_image == '' }}
       run: |
         export VERTICA_IMG=${{ steps.minimal_vertica_image.outputs.value }}
         export MINIMAL_VERTICA_IMG=yes
-        make docker-build-vertica docker-push-vertica
+        make docker-build-vertica
+        if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+          make docker-push-vertica
+        fi
+
+    - name: Save the image for consumption by dependent jobs (PRs only)
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        docker save ${{ steps.minimal_vertica_image.outputs.value }} > minimal_vertica_image.tar
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        name: minimal_vertica_image
+        path: minimal_vertica_image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.minimal_vertica_image != '' }}
@@ -241,7 +247,7 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/verticadb-operator:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.operator_image != '' }} => ${{ inputs.operator_image }}
-          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/verticadb-operator:pr-${{ github.sha }}
+          ${{ github.event_name == 'pull_request' }} => verticadb-operator:kind
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
@@ -251,22 +257,28 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Login to GitHub Container registry for PRs
-      uses: docker/login-action@v2
-      if: ${{ inputs.operator_image == '' && github.event_name == 'pull_request' }}
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.PR_GITHUB_USERNAME }}
-        password: ${{ secrets.PR_GITHUB_PAT }}
-
     - uses: actions/checkout@v2
       if: ${{ inputs.operator_image == '' }}
 
-    - name: Build and push operator image
+    - name: Build and optionally push operator image
       if: ${{ inputs.operator_image == '' }}
       run: |
         export OPERATOR_IMG=${{ steps.operator_image.outputs.value }}
-        make docker-build-operator docker-push-operator
+        make docker-build-operator
+        if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+          make docker-push-operator
+        fi
+
+    - name: Save the image for consumption by dependent jobs (PRs only)
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        docker save ${{ steps.operator_image.outputs.value }} > operator_image.tar
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        name: operator_image
+        path: operator_image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.operator_image != '' }}
@@ -324,7 +336,7 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/vertica-logger:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.vlogger_image != '' }} => ${{ inputs.vlogger_image }}
-          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/vertica-logger:pr-${{ github.sha }}
+          ${{ github.event_name == 'pull_request' }} => vertica-logger:kind
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
@@ -334,24 +346,28 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Login to GitHub Container registry for PRs
-      uses: docker/login-action@v2
-      if: ${{ inputs.vlogger_image == '' && github.event_name == 'pull_request' }}
-      with:
-        registry: ghcr.io
-        #username: ${{ secrets.PR_GITHUB_USERNAME }}
-        #password: ${{ secrets.PR_GITHUB_PAT }}
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
     - uses: actions/checkout@v2
       if: ${{ inputs.vlogger_image == '' }}
 
-    - name: Build and push vlogger image
+    - name: Build and optionally push vlogger image
       if: ${{ inputs.vlogger_image == '' }}
       run: |
         export VLOGGER_IMG=${{ steps.vlogger_image.outputs.value }}
-        make docker-build-vlogger docker-push-vlogger
+        make docker-build-vlogger
+        if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+          make docker-push-vlogger
+        fi
+
+    - name: Save the image for consumption by dependent jobs (PRs only)
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        docker save ${{ steps.vlogger_image.outputs.value }} > vlogger_image.tar
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ github.event_name == 'pull_request' }}
+      with:
+        name: vlogger_image
+        path: vlogger_image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.vlogger_image != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -102,6 +102,7 @@ jobs:
         export VERTICA_IMG=${{ steps.full_vertica_image.outputs.value }}
         make docker-build-vertica
         if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+        then
           make docker-push-vertica
         fi
 
@@ -209,6 +210,7 @@ jobs:
         export MINIMAL_VERTICA_IMG=yes
         make docker-build-vertica
         if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+        then
           make docker-push-vertica
         fi
 
@@ -266,6 +268,7 @@ jobs:
         export OPERATOR_IMG=${{ steps.operator_image.outputs.value }}
         make docker-build-operator
         if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+        then
           make docker-push-operator
         fi
 
@@ -355,6 +358,7 @@ jobs:
         export VLOGGER_IMG=${{ steps.vlogger_image.outputs.value }}
         make docker-build-vlogger
         if [ $GITHUB_EVENT_NAME != 'pull_request' ]
+        then
           make docker-push-vlogger
         fi
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -165,6 +165,8 @@ jobs:
         echo "Image Name: **${{ steps.full_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.full_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
 
   build-server-minimal:
     runs-on: ubuntu-latest
@@ -235,6 +237,8 @@ jobs:
         echo "Image Name: **${{ steps.minimal_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.minimal_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
+        echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
 
   build-operator:
     runs-on: ubuntu-latest
@@ -325,6 +329,8 @@ jobs:
         echo "Image Name: **${{ steps.operator_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.operator_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.operator_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
 
   build-vlogger:
     runs-on: ubuntu-latest
@@ -415,4 +421,6 @@ jobs:
         echo "Image Name: **${{ steps.vlogger_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.vlogger_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.vlogger_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -168,6 +168,7 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
         echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.full_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
@@ -244,6 +245,7 @@ jobs:
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
         echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.minimal_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
@@ -340,6 +342,7 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 
   build-vlogger:
     runs-on: ubuntu-latest
@@ -433,4 +436,5 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -164,6 +164,7 @@ jobs:
       run: |
         echo "Image Name: **${{ steps.full_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.full_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Pushed: ${{ inputs.full_vertica_image == '' && github.event_name != 'pull_request' && '**Yes**' || '**No**' }}"
         echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
@@ -236,6 +237,7 @@ jobs:
       run: |
         echo "Image Name: **${{ steps.minimal_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.minimal_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Pushed: ${{ inputs.minimal_vertica_image == '' && github.event_name != 'pull_request' && '**Yes**' || '**No**' }}"
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
@@ -328,6 +330,7 @@ jobs:
       run: |
         echo "Image Name: **${{ steps.operator_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.operator_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Pushed: ${{ inputs.operator_image == '' && github.event_name != 'pull_request' && '**Yes**' || '**No**' }}"
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
@@ -420,6 +423,7 @@ jobs:
       run: |
         echo "Image Name: **${{ steps.vlogger_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
         echo "Was Built: ${{ inputs.vlogger_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Pushed: ${{ inputs.vlogger_image == '' && github.event_name != 'pull_request' && '**Yes**' || '**No**' }}"
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -66,7 +66,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: full_vertica_image
       with:
-        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}
+        default: ghcr.io/${{ github.repository }}/vertica-k8s:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
 
@@ -155,7 +155,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: minimal_vertica_image
       with:
-        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}-minimal
+        default: ghcr.io/${{ github.repository }}/vertica-k8s:${{ github.sha }}-minimal
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 
@@ -209,7 +209,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: operator_image
       with:
-        default: ghcr.io/${{ github.actor }}/verticadb-operator:${{ github.sha }}
+        default: ghcr.io/${{ github.repository }}/verticadb-operator:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.operator_image != '' }} => ${{ inputs.operator_image }}
 
@@ -283,7 +283,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: vlogger_image
       with:
-        default: ghcr.io/${{ github.actor }}/vertica-logger:${{ github.sha }}
+        default: ghcr.io/${{ github.repository }}/vertica-logger:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.vlogger_image != '' }} => ${{ inputs.vlogger_image }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Save the image for consumption by dependent jobs (PRs only)
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        docker save ${{ steps.full_vertica_image.outputs.value }} > full_vertica_image.tar
+        docker save ${{ steps.full_vertica_image.outputs.value }} > full-vertica-image.tar
 
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}
@@ -217,7 +217,7 @@ jobs:
     - name: Save the image for consumption by dependent jobs (PRs only)
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        docker save ${{ steps.minimal_vertica_image.outputs.value }} > minimal_vertica_image.tar
+        docker save ${{ steps.minimal_vertica_image.outputs.value }} > minimal-vertica-image.tar
 
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}
@@ -275,7 +275,7 @@ jobs:
     - name: Save the image for consumption by dependent jobs (PRs only)
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        docker save ${{ steps.operator_image.outputs.value }} > operator_image.tar
+        docker save ${{ steps.operator_image.outputs.value }} > operator-image.tar
 
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}
@@ -365,7 +365,7 @@ jobs:
     - name: Save the image for consumption by dependent jobs (PRs only)
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        docker save ${{ steps.vlogger_image.outputs.value }} > vlogger_image.tar
+        docker save ${{ steps.vlogger_image.outputs.value }} > vlogger-image.tar
 
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -166,7 +166,7 @@ jobs:
         echo "Was Built: ${{ inputs.full_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 
   build-server-minimal:
     runs-on: ubuntu-latest
@@ -238,7 +238,7 @@ jobs:
         echo "Was Built: ${{ inputs.minimal_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 
   build-operator:
     runs-on: ubuntu-latest
@@ -330,7 +330,7 @@ jobs:
         echo "Was Built: ${{ inputs.operator_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.operator_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 
   build-vlogger:
     runs-on: ubuntu-latest
@@ -422,5 +422,5 @@ jobs:
         echo "Was Built: ${{ inputs.vlogger_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.vlogger_image.outputs.valul }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,349 @@
+name: Build images
+
+on:
+  workflow_call:
+    inputs:
+      operator_image:
+        description: 'Name of an existing Vertica operator image. If blank we will build one using the default name'
+        type: string
+        required: true
+      full_vertica_image:
+        description: 'Name of an existing full Vertica server image. If blank we will build one using the default name'
+        type: string
+        required: true
+      minimal_vertica_image:
+        description: 'Name of an existing minimal Vertica server image. If blank we will build one using the default name'
+        type: string
+        required: true
+      vlogger_image:
+        description: 'Name of an existing vlogger image. If blank we will build one using the default name'
+        type: string
+        required: true
+      security_scan_exit_code:
+        description: 'The exit code to use for any security vulnerabilities found. Set this to 1 to fail the build if a vulnerability is found'
+        type: string
+        required: false
+        default: '0'
+      run_security_scan:
+        description: 'What images to scan?'
+        type: string
+        required: false
+        default: 'all, except vertica server'
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'When working with images from docker.io, this is the username for login purposes'
+        required: true
+      DOCKERHUB_TOKEN:
+        description: 'When working with images from docker.io, this is the password for login purposes'
+        required: true
+    outputs:
+      operator-image:
+        description: "The image name of the VerticaDB operator"
+        value: ${{ jobs.build-operator.outputs.image }}
+      full-vertica-image:
+        description: "The image name of the full vertica server image"
+        value: ${{ jobs.build-server-full.outputs.image }}
+      minimal-vertica-image:
+        description: "The image name of the vertica server, but with optional software removed"
+        value: ${{ jobs.build-server-minimal.outputs.image }}
+      vlogger-image:
+        description: "The image name of the vertica logger sidecar"
+        value: ${{ jobs.build-vlogger.outputs.image }}
+
+
+permissions:
+  packages: write
+  security-events: write
+
+jobs:
+  build-server-full:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.full_vertica_image.outputs.value }}
+    steps:
+
+    - name: Pick the name of the image
+      uses: dkershner6/switch-case-action@v1
+      id: full_vertica_image
+      with:
+        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}
+        conditionals-with-values: |
+          ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
+
+    - name: Login to GitHub Container registry
+      uses: docker/login-action@v2
+      if: ${{ inputs.full_vertica_image == '' }}
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: ${{ inputs.full_vertica_image != '' && startsWith(inputs.full_vertica_image, 'docker.io') }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - uses: actions/checkout@v2
+      if: ${{ inputs.full_vertica_image == '' }}
+
+    - name: Download the RPM
+      uses: ./.github/actions/download-rpm
+      if: ${{ inputs.full_vertica_image == '' }}
+      
+    - name: Build and push full server image
+      if: ${{ inputs.full_vertica_image == '' }}
+      run: |
+        export VERTICA_IMG=${{ steps.full_vertica_image.outputs.value }}
+        make docker-build-vertica docker-push-vertica
+
+    - name: Do a local pull of the image if we didn't create it
+      if: ${{ inputs.full_vertica_image != '' }}
+      run: |
+        docker pull ${{ inputs.full_vertica_image }}
+
+    - name: Run the Trivy vulnerability scanner (sarif)
+      uses: aquasecurity/trivy-action@0.6.2
+      if: ${{ inputs.run_security_scan == 'all' }}
+      with:
+        image-ref: ${{ steps.full_vertica_image.outputs.value }}
+        exit-code: ${{ inputs.security_scan_exit_code }}
+        ignore-unfixed: true
+        security-checks: vuln
+        timeout: '10m0s'
+        format: 'sarif'
+        output: 'trivy-results-vertica-image.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      if: ${{ always() && inputs.run_security_scan == 'all' }}
+      with:
+        sarif_file: 'trivy-results-vertica-image.sarif'
+
+    - name: Run the Trivy vulnerability scanner (pretty print)
+      uses: aquasecurity/trivy-action@0.6.2
+      if: ${{ inputs.run_security_scan == 'all' }}
+      with:
+        image-ref: ${{ steps.full_vertica_image.outputs.value }}
+        exit-code: ${{ inputs.security_scan_exit_code }}
+        ignore-unfixed: true
+        security-checks: vuln
+        timeout: '10m0s'
+        format: 'table'
+        output: 'trivy-results-vertica-image.out'
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() && inputs.run_security_scan == 'all' }}
+      with:
+        name: security-scan
+        path: 'trivy-results-vertica-image.out'
+
+    - name: Print a summary of the job
+      run: |
+        echo "Image Name: **${{ steps.full_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
+        echo "Was Built: ${{ inputs.full_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+
+  build-server-minimal:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.minimal_vertica_image.outputs.value }}
+    steps:
+
+    - name: Pick the name of the image
+      uses: dkershner6/switch-case-action@v1
+      id: minimal_vertica_image
+      with:
+        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}-minimal
+        conditionals-with-values: |
+          ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
+
+    - name: Login to GitHub Container registry
+      uses: docker/login-action@v2
+      if: ${{ inputs.minimal_vertica_image == '' }}
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: ${{ inputs.full_vertica_image != '' && startsWith(inputs.full_vertica_image, 'docker.io') }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - uses: actions/checkout@v2
+      if: ${{ inputs.minimal_vertica_image == '' }}
+
+    - name: Download the RPM
+      uses: ./.github/actions/download-rpm
+      if: ${{ inputs.minimal_vertica_image == '' }}
+      
+    - name: Build and push minimal server image
+      if: ${{ inputs.minimal_vertica_image == '' }}
+      run: |
+        export VERTICA_IMG=${{ steps.minimal_vertica_image.outputs.value }}
+        export MINIMAL_VERTICA_IMG=yes
+        make docker-build-vertica docker-push-vertica
+
+    - name: Do a local pull of the image if we didn't create it
+      if: ${{ inputs.minimal_vertica_image != '' }}
+      run: |
+        docker pull ${{ inputs.minimal_vertica_image }}
+
+    - name: Print a summary of the job
+      run: |
+        echo "Image Name: **${{ steps.minimal_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
+        echo "Was Built: ${{ inputs.minimal_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
+
+  build-operator:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.operator_image.outputs.value }}
+    steps:
+
+    - name: Pick the name of the image
+      uses: dkershner6/switch-case-action@v1
+      id: operator_image
+      with:
+        default: ghcr.io/${{ github.actor }}/verticadb-operator:${{ github.sha }}
+        conditionals-with-values: |
+          ${{ inputs.operator_image != '' }} => ${{ inputs.operator_image }}
+
+    - name: Login to GitHub Container registry
+      uses: docker/login-action@v2
+      if: ${{ inputs.operator_image == '' }}
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: actions/checkout@v2
+      if: ${{ inputs.operator_image == '' }}
+
+    - name: Build and push operator image
+      if: ${{ inputs.operator_image == '' }}
+      run: |
+        export OPERATOR_IMG=${{ steps.operator_image.outputs.value }}
+        make docker-build-operator docker-push-operator
+
+    - name: Do a local pull of the image if we didn't create it
+      if: ${{ inputs.operator_image != '' }}
+      run: |
+        docker pull ${{ inputs.operator_image }}
+
+    - name: Run the Trivy vulnerability scanner (sarif)
+      uses: aquasecurity/trivy-action@0.6.2
+      if: ${{ inputs.run_security_scan != 'none' }}
+      with:
+        image-ref: ${{ steps.operator_image.outputs.value }}
+        exit-code: ${{ inputs.security_scan_exit_code }}
+        ignore-unfixed: true
+        format: 'sarif'
+        output: 'trivy-results-verticadb-operator-image.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      if: ${{ always() && inputs.run_security_scan != 'none' }}
+      with:
+        sarif_file: 'trivy-results-verticadb-operator-image.sarif'
+
+    - name: Run the Trivy vulnerability scanner (pretty print)
+      uses: aquasecurity/trivy-action@0.6.2
+      if: ${{ inputs.run_security_scan != 'none' }}
+      with:
+        image-ref: ${{ steps.operator_image.outputs.value }}
+        exit-code: ${{ inputs.security_scan_exit_code }}
+        ignore-unfixed: true
+        format: 'table'
+        output: 'trivy-results-verticadb-operator-image.out'
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() && inputs.run_security_scan != 'none' }}
+      with:
+        name: security-scan
+        path: 'trivy-results-verticadb-operator-image.out'
+
+    - name: Print a summary of the job
+      run: |
+        echo "Image Name: **${{ steps.operator_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
+        echo "Was Built: ${{ inputs.operator_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+
+  build-vlogger:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.vlogger_image.outputs.value }}
+    steps:
+
+    - name: Pick the name of the image
+      uses: dkershner6/switch-case-action@v1
+      id: vlogger_image
+      with:
+        default: ghcr.io/${{ github.actor }}/vertica-logger:${{ github.sha }}
+        conditionals-with-values: |
+          ${{ inputs.vlogger_image != '' }} => ${{ inputs.vlogger_image }}
+
+    - name: Login to GitHub Container registry
+      uses: docker/login-action@v2
+      if: ${{ inputs.vlogger_image == '' }}
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: actions/checkout@v2
+      if: ${{ inputs.vlogger_image == '' }}
+
+    - name: Build and push vlogger image
+      if: ${{ inputs.vlogger_image == '' }}
+      run: |
+        export VLOGGER_IMG=${{ steps.vlogger_image.outputs.value }}
+        make docker-build-vlogger docker-push-vlogger
+
+    - name: Do a local pull of the image if we didn't create it
+      if: ${{ inputs.vlogger_image != '' }}
+      run: |
+        docker pull ${{ inputs.vlogger_image }}
+
+    - name: Run the Trivy vulnerability scanner (sarif)
+      uses: aquasecurity/trivy-action@0.6.2
+      if: ${{ inputs.run_security_scan != 'none' }}
+      with:
+        image-ref: ${{ steps.vlogger_image.outputs.value }}
+        exit-code: ${{ inputs.security_scan_exit_code }}
+        ignore-unfixed: true
+        format: 'sarif'
+        output: 'trivy-results-vertica-logger-image.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      if: ${{ always() && inputs.run_security_scan != 'none' }}
+      with:
+        sarif_file: 'trivy-results-vertica-logger-image.sarif'
+
+    - name: Run the Trivy vulnerability scanner (pretty print)
+      uses: aquasecurity/trivy-action@0.6.2
+      if: ${{ inputs.run_security_scan != 'none' }}
+      with:
+        image-ref: ${{ steps.vlogger_image.outputs.value }}
+        exit-code: ${{ inputs.security_scan_exit_code }}
+        ignore-unfixed: true
+        format: 'table'
+        output: 'trivy-results-vertica-logger-image.out'
+
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() && inputs.run_security_scan != 'none' }}
+      with:
+        name: security-scan
+        path: 'trivy-results-vertica-logger-image.out'
+
+    - name: Print a summary of the job
+      run: |
+        echo "Image Name: **${{ steps.vlogger_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
+        echo "Was Built: ${{ inputs.vlogger_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -114,8 +114,8 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: full_vertica_image
-        path: full_vertica_image.tar
+        name: full-vertica-image
+        path: full-vertica-image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.full_vertica_image != '' }}
@@ -222,8 +222,8 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: minimal_vertica_image
-        path: minimal_vertica_image.tar
+        name: minimal-vertica-image
+        path: minimal-vertica-image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.minimal_vertica_image != '' }}
@@ -280,8 +280,8 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: operator_image
-        path: operator_image.tar
+        name: operator-image
+        path: operator-image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.operator_image != '' }}
@@ -370,8 +370,8 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: vlogger_image
-        path: vlogger_image.tar
+        name: vlogger-image
+        path: vlogger-image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.vlogger_image != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -66,7 +66,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: full_vertica_image
       with:
-        default: ghcr.io/${{ github.repository }}/vertica-k8s:${{ github.sha }}
+        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
 
@@ -75,7 +75,7 @@ jobs:
       if: ${{ inputs.full_vertica_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hub
@@ -155,7 +155,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: minimal_vertica_image
       with:
-        default: ghcr.io/${{ github.repository }}/vertica-k8s:${{ github.sha }}-minimal
+        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}-minimal
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 
@@ -164,7 +164,7 @@ jobs:
       if: ${{ inputs.minimal_vertica_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hub
@@ -209,7 +209,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: operator_image
       with:
-        default: ghcr.io/${{ github.repository }}/verticadb-operator:${{ github.sha }}
+        default: ghcr.io/${{ github.actor }}/verticadb-operator:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.operator_image != '' }} => ${{ inputs.operator_image }}
 
@@ -218,7 +218,7 @@ jobs:
       if: ${{ inputs.operator_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v2
@@ -283,7 +283,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: vlogger_image
       with:
-        default: ghcr.io/${{ github.repository }}/vertica-logger:${{ github.sha }}
+        default: ghcr.io/${{ github.actor }}/vertica-logger:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.vlogger_image != '' }} => ${{ inputs.vlogger_image }}
 
@@ -292,7 +292,7 @@ jobs:
       if: ${{ inputs.vlogger_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v2

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -168,6 +168,9 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
+        echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.full_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
+        echo "**" >> $GITHUB_STEP_SUMMARY
 
   build-server-minimal:
     runs-on: ubuntu-latest
@@ -241,6 +244,9 @@ jobs:
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
+        echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.minimal_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
+        echo "**" >> $GITHUB_STEP_SUMMARY
 
   build-operator:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -69,14 +69,26 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
+          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/vertica-k8s:pr-${{ github.sha }}
 
-    - name: Login to GitHub Container registry
+    - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
-      if: ${{ inputs.full_vertica_image == '' }}
+      if: ${{ inputs.full_vertica_image == '' && github.event_name != 'pull_request' }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    # We need a separate login for PRs because the GITHUB_TOKEN only allows
+    # read access to the container registry for PRs:
+    # https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
+    - name: Login to GitHub Container registry for PRs
+      uses: docker/login-action@v2
+      if: ${{ inputs.full_vertica_image == '' && github.event_name == 'pull_request' }}
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.PR_GITHUB_USERNAME }}
+        password: ${{ secrets.PR_GITHUB_PAT }}
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
@@ -103,9 +115,11 @@ jobs:
       run: |
         docker pull ${{ inputs.full_vertica_image }}
 
+    # We never run the sarif scanner in PRs because PRs don't have permission
+    # to upload the results to github.
     - name: Run the Trivy vulnerability scanner (sarif)
       uses: aquasecurity/trivy-action@0.6.2
-      if: ${{ inputs.run_security_scan == 'all' }}
+      if: ${{ inputs.run_security_scan == 'all' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.full_vertica_image.outputs.value }}
         exit-code: ${{ inputs.security_scan_exit_code }}
@@ -117,7 +131,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v2
-      if: ${{ always() && inputs.run_security_scan == 'all' }}
+      if: ${{ always() && inputs.run_security_scan == 'all' && github.event_name != 'pull_request' }}
       with:
         sarif_file: 'trivy-results-vertica-image.sarif'
 
@@ -158,14 +172,23 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}-minimal
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
+          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/vertica-k8s:pr-${{ github.sha }}-minimal
 
-    - name: Login to GitHub Container registry
+    - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
-      if: ${{ inputs.minimal_vertica_image == '' }}
+      if: ${{ inputs.minimal_vertica_image == '' && github.event_name != 'pull_request' }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to GitHub Container registry for PRs
+      uses: docker/login-action@v2
+      if: ${{ inputs.minimal_vertica_image == '' && github.event_name == 'pull_request' }}
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.PR_GITHUB_USERNAME }}
+        password: ${{ secrets.PR_GITHUB_PAT }}
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
@@ -212,14 +235,23 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/verticadb-operator:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.operator_image != '' }} => ${{ inputs.operator_image }}
+          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/verticadb-operator:pr-${{ github.sha }}
 
-    - name: Login to GitHub Container registry
+    - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
-      if: ${{ inputs.operator_image == '' }}
+      if: ${{ inputs.operator_image == '' && github.event_name != 'pull_request' }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to GitHub Container registry for PRs
+      uses: docker/login-action@v2
+      if: ${{ inputs.operator_image == '' && github.event_name == 'pull_request' }}
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.PR_GITHUB_USERNAME }}
+        password: ${{ secrets.PR_GITHUB_PAT }}
 
     - uses: actions/checkout@v2
       if: ${{ inputs.operator_image == '' }}
@@ -237,7 +269,7 @@ jobs:
 
     - name: Run the Trivy vulnerability scanner (sarif)
       uses: aquasecurity/trivy-action@0.6.2
-      if: ${{ inputs.run_security_scan != 'none' }}
+      if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.operator_image.outputs.value }}
         exit-code: ${{ inputs.security_scan_exit_code }}
@@ -247,7 +279,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v2
-      if: ${{ always() && inputs.run_security_scan != 'none' }}
+      if: ${{ always() && inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
 
@@ -286,14 +318,23 @@ jobs:
         default: ghcr.io/${{ github.repository_owner }}/vertica-logger:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.vlogger_image != '' }} => ${{ inputs.vlogger_image }}
+          ${{ github.event_name == 'pull_request' }} => ghcr.io/${{ github.repository_owner }}/vertica-logger:pr-${{ github.sha }}
 
-    - name: Login to GitHub Container registry
+    - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
-      if: ${{ inputs.vlogger_image == '' }}
+      if: ${{ inputs.vlogger_image == '' && github.event_name != 'pull_request' }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to GitHub Container registry for PRs
+      uses: docker/login-action@v2
+      if: ${{ inputs.vlogger_image == '' && github.event_name == 'pull_request' }}
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.PR_GITHUB_USERNAME }}
+        password: ${{ secrets.PR_GITHUB_PAT }}
 
     - uses: actions/checkout@v2
       if: ${{ inputs.vlogger_image == '' }}
@@ -311,7 +352,7 @@ jobs:
 
     - name: Run the Trivy vulnerability scanner (sarif)
       uses: aquasecurity/trivy-action@0.6.2
-      if: ${{ inputs.run_security_scan != 'none' }}
+      if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.vlogger_image.outputs.value }}
         exit-code: ${{ inputs.security_scan_exit_code }}
@@ -321,7 +362,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v2
-      if: ${{ always() && inputs.run_security_scan != 'none' }}
+      if: ${{ always() && inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         sarif_file: 'trivy-results-vertica-logger-image.sarif'
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -168,7 +168,6 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
         echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.full_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
@@ -245,7 +244,6 @@ jobs:
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
         echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.minimal_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
@@ -342,7 +340,6 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 
   build-vlogger:
     runs-on: ubuntu-latest
@@ -436,5 +433,4 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker images --format '{{.Size}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker images --format '{{.ID}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Image Digest: **$(docker images --format '{{.Digest}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -36,6 +36,12 @@ on:
       DOCKERHUB_TOKEN:
         description: 'When working with images from docker.io, this is the password for login purposes'
         required: true
+      PR_GITHUB_USERNAME:
+        description: 'For pull requests, this is the GitHub username that accompanies the personal access token'
+        required: true
+      PR_GITHUB_PAT:
+        description: 'For pull requests, this is the personal access token that goes along with PR_GITHUB_USERNAME. This PAT is used to write to the container registry.'
+        required: true
     outputs:
       operator-image:
         description: "The image name of the VerticaDB operator"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -66,7 +66,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: full_vertica_image
       with:
-        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}
+        default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
 
@@ -155,7 +155,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: minimal_vertica_image
       with:
-        default: ghcr.io/${{ github.actor }}/vertica-k8s:${{ github.sha }}-minimal
+        default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}-minimal
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 
@@ -209,7 +209,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: operator_image
       with:
-        default: ghcr.io/${{ github.actor }}/verticadb-operator:${{ github.sha }}
+        default: ghcr.io/${{ github.repository_owner }}/verticadb-operator:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.operator_image != '' }} => ${{ inputs.operator_image }}
 
@@ -283,7 +283,7 @@ jobs:
       uses: dkershner6/switch-case-action@v1
       id: vlogger_image
       with:
-        default: ghcr.io/${{ github.actor }}/vertica-logger:${{ github.sha }}
+        default: ghcr.io/${{ github.repository_owner }}/vertica-logger:${{ github.sha }}
         conditionals-with-values: |
           ${{ inputs.vlogger_image != '' }} => ${{ inputs.vlogger_image }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -75,7 +75,7 @@ jobs:
       if: ${{ inputs.full_vertica_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hub
@@ -164,7 +164,7 @@ jobs:
       if: ${{ inputs.minimal_vertica_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hub
@@ -218,7 +218,7 @@ jobs:
       if: ${{ inputs.operator_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v2
@@ -292,7 +292,7 @@ jobs:
       if: ${{ inputs.vlogger_image == '' }}
       with:
         registry: ghcr.io
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/checkout@v2

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -339,8 +339,10 @@ jobs:
       if: ${{ inputs.vlogger_image == '' && github.event_name == 'pull_request' }}
       with:
         registry: ghcr.io
-        username: ${{ secrets.PR_GITHUB_USERNAME }}
-        password: ${{ secrets.PR_GITHUB_PAT }}
+        #username: ${{ secrets.PR_GITHUB_USERNAME }}
+        #password: ${{ secrets.PR_GITHUB_PAT }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - uses: actions/checkout@v2
       if: ${{ inputs.vlogger_image == '' }}

--- a/.github/workflows/e2e-azb.yml
+++ b/.github/workflows/e2e-azb.yml
@@ -1,18 +1,42 @@
 name: e2e (azb) tests
 
 on: 
-  push:
-     branches: [main, vnext]
-  pull_request:
+  workflow_call:
+    inputs:
+      vlogger-image:
+        type: string
+        required: false
+      operator-image:
+        type: string
+        required: false
+      vertica-image:
+        type: string
+        required: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'When working with images from docker.io, this is the username for login purposes'
+        required: true
+      DOCKERHUB_TOKEN:
+        description: 'When working with images from docker.io, this is the password for login purposes'
+        required: true
   workflow_dispatch:
     inputs:
-      parallel:
-        description: 'Maximum number of tests to run at once'
+      vlogger-image:
+        description: 'Name of the vertica logger image'
+        type: string
+        required: false
+      operator-image:
+        description: 'Name of the operator image'
+        type: string
+        required: false
+      vertica-image:
+        description: 'Name of the vertica server image'
+        type: string
         required: false
 
 jobs:
 
-  e2e-azb:
+  test:
 
     runs-on: ubuntu-latest
     steps:
@@ -22,13 +46,20 @@ jobs:
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Run e2e tests
       run: |
-        E2E_PARALLELISM=${{ github.event.inputs.parallel }}
-        [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
         export KUSTOMIZE_CFG=tests/kustomize-defaults-azb-ci.cfg
-        export MINIMAL_VERTICA_IMG=YES
-        scripts/run-k8s-int-tests.sh -d -e tests/external-images-azb-ci.txt
+        export VERTICA_IMG=${{ inputs.vertica-image }}
+        export OPERATOR_IMG=${{ inputs.operator-image }}
+        export VLOGGER_IMG=${{ inputs.vlogger-image }}
+        scripts/run-k8s-int-tests.sh -s -e tests/external-images-azb-ci.txt
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-hdfs.yml
+++ b/.github/workflows/e2e-hdfs.yml
@@ -1,18 +1,42 @@
 name: e2e (hdfs) tests
 
 on: 
-  push:
-     branches: [main, vnext]
-  pull_request:
+  workflow_call:
+    inputs:
+      vlogger-image:
+        type: string
+        required: false
+      operator-image:
+        type: string
+        required: false
+      vertica-image:
+        type: string
+        required: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'When working with images from docker.io, this is the username for login purposes'
+        required: true
+      DOCKERHUB_TOKEN:
+        description: 'When working with images from docker.io, this is the password for login purposes'
+        required: true
   workflow_dispatch:
     inputs:
-      parallel:
-        description: 'Maximum number of tests to run at once'
+      vlogger-image:
+        description: 'Name of the vertica logger image'
+        type: string
+        required: false
+      operator-image:
+        description: 'Name of the operator image'
+        type: string
+        required: false
+      vertica-image:
+        description: 'Name of the vertica server image'
+        type: string
         required: false
 
 jobs:
 
-  e2e-hdfs:
+  test:
 
     runs-on: ubuntu-latest
     steps:
@@ -22,13 +46,20 @@ jobs:
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Run e2e tests
       run: |
-        E2E_PARALLELISM=${{ github.event.inputs.parallel }}
-        [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
         export KUSTOMIZE_CFG=tests/kustomize-defaults-hdfs-ci.cfg
-        export MINIMAL_VERTICA_IMG=YES
-        scripts/run-k8s-int-tests.sh -d -e tests/external-images-hdfs-ci.txt
+        export VERTICA_IMG=${{ inputs.vertica-image }}
+        export OPERATOR_IMG=${{ inputs.operator-image }}
+        export VLOGGER_IMG=${{ inputs.vlogger-image }}
+        scripts/run-k8s-int-tests.sh -s -e tests/external-images-hdfs-ci.txt
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-operator-upgrade.yml
+++ b/.github/workflows/e2e-operator-upgrade.yml
@@ -1,14 +1,42 @@
 name: e2e (operator-upgrade) tests
 
 on: 
-  push:
-     branches: [main, vnext]
-  pull_request:
+  workflow_call:
+    inputs:
+      vlogger-image:
+        type: string
+        required: false
+      operator-image:
+        type: string
+        required: false
+      vertica-image:
+        type: string
+        required: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'When working with images from docker.io, this is the username for login purposes'
+        required: true
+      DOCKERHUB_TOKEN:
+        description: 'When working with images from docker.io, this is the password for login purposes'
+        required: true
   workflow_dispatch:
+    inputs:
+      vlogger-image:
+        description: 'Name of the vertica logger image'
+        type: string
+        required: false
+      operator-image:
+        description: 'Name of the operator image'
+        type: string
+        required: false
+      vertica-image:
+        description: 'Name of the vertica server image'
+        type: string
+        required: false
 
 jobs:
 
-  e2e-operator-upgrade:
+  test:
 
     runs-on: ubuntu-latest
     steps:
@@ -18,15 +46,24 @@ jobs:
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Run e2e tests
       run: |
         # Parallelism must be 1.  The testcases will uninstall and install CRDs,
         # which are cluster scoped items.
         export E2E_PARALLELISM=1
-        export MINIMAL_VERTICA_IMG=YES
         export E2E_TEST_DIRS=tests/e2e-operator-upgrade-overlays
+        export VERTICA_IMG=${{ inputs.vertica-image }}
+        export OPERATOR_IMG=${{ inputs.operator-image }}
+        export VLOGGER_IMG=${{ inputs.vlogger-image }}
         scripts/setup-operator-upgrade-testsuite.sh
-        scripts/run-k8s-int-tests.sh -d
+        scripts/run-k8s-int-tests.sh -s
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-s3.yml
+++ b/.github/workflows/e2e-s3.yml
@@ -1,18 +1,42 @@
 name: e2e (s3) tests
 
 on: 
-  push:
-     branches: [main, vnext]
-  pull_request:
+  workflow_call:
+    inputs:
+      vlogger-image:
+        type: string
+        required: false
+      operator-image:
+        type: string
+        required: false
+      vertica-image:
+        type: string
+        required: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'When working with images from docker.io, this is the username for login purposes'
+        required: true
+      DOCKERHUB_TOKEN:
+        description: 'When working with images from docker.io, this is the password for login purposes'
+        required: true
   workflow_dispatch:
     inputs:
-      parallel:
-        description: 'Maximum number of tests to run at once'
+      vlogger-image:
+        description: 'Name of the vertica logger image'
+        type: string
+        required: false
+      operator-image:
+        description: 'Name of the operator image'
+        type: string
+        required: false
+      vertica-image:
+        description: 'Name of the vertica server image'
+        type: string
         required: false
 
 jobs:
 
-  e2e-s3:
+  test:
 
     runs-on: ubuntu-latest
     steps:
@@ -22,12 +46,19 @@ jobs:
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Run e2e tests
       run: |
-        E2E_PARALLELISM=${{ github.event.inputs.parallel }}
-        [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
-        export MINIMAL_VERTICA_IMG=YES
-        scripts/run-k8s-int-tests.sh -d
+        export VERTICA_IMG=${{ inputs.vertica-image }}
+        export OPERATOR_IMG=${{ inputs.operator-image }}
+        export VLOGGER_IMG=${{ inputs.vlogger-image }}
+        scripts/run-k8s-int-tests.sh -s
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e-server-upgrade.yml
+++ b/.github/workflows/e2e-server-upgrade.yml
@@ -1,18 +1,42 @@
 name: e2e (server upgrade) tests
 
 on: 
-  push:
-     branches: [main, vnext]
-  pull_request:
+  workflow_call:
+    inputs:
+      vlogger-image:
+        type: string
+        required: false
+      operator-image:
+        type: string
+        required: false
+      vertica-image:
+        type: string
+        required: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'When working with images from docker.io, this is the username for login purposes'
+        required: true
+      DOCKERHUB_TOKEN:
+        description: 'When working with images from docker.io, this is the password for login purposes'
+        required: true
   workflow_dispatch:
     inputs:
-      parallel:
-        description: 'Maximum number of tests to run at once'
+      vlogger-image:
+        description: 'Name of the vertica logger image'
+        type: string
+        required: false
+      operator-image:
+        description: 'Name of the operator image'
+        type: string
+        required: false
+      vertica-image:
+        description: 'Name of the vertica server image'
+        type: string
         required: false
 
 jobs:
 
-  e2e-server-upgrade:
+  test:
 
     runs-on: ubuntu-latest
     steps:
@@ -22,14 +46,21 @@ jobs:
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
     - name: Run e2e tests
       run: |
-        E2E_PARALLELISM=${{ github.event.inputs.parallel }}
-        [ ! -z "$E2E_PARALLELISM" ] && export E2E_PARALLELISM
-        export MINIMAL_VERTICA_IMG=YES
         export BASE_VERTICA_IMG=vertica/vertica-k8s:11.1.1-0-minimal
         export E2E_TEST_DIRS=tests/e2e-server-upgrade
-        scripts/run-k8s-int-tests.sh -d -e tests/external-images-server-upgrade-ci.txt
+        export VERTICA_IMG=${{ inputs.vertica-image }}
+        export OPERATOR_IMG=${{ inputs.operator-image }}
+        export VLOGGER_IMG=${{ inputs.vlogger-image }}
+        scripts/run-k8s-int-tests.sh -s -e tests/external-images-server-upgrade-ci.txt
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,8 +62,6 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      PR_GITHUB_USERNAME: ${{ secrets.PR_GITHUB_USERNAME }}
-      PR_GITHUB_PAT: ${{ secrets.PR_GITHUB_PAT }}
 
   unittests:
     uses: ./.github/workflows/unittests.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,6 +62,8 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      PR_GITHUB_USERNAME: ${{ secrets.PR_GITHUB_USERNAME }}
+      PR_GITHUB_PAT: ${{ secrets.PR_GITHUB_PAT }}
 
   unittests:
     uses: ./.github/workflows/unittests.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,130 @@
 name: e2e tests
 
 on: 
+  push:
+    branches: [main, vnext]
+  pull_request:
   workflow_dispatch:
+    inputs:
+      operator_image:
+        description: 'Name of an existing operator image. Leave blank to build one with the default name'
+        type: string
+        required: false
+      full_vertica_image:
+        description: 'Name of an existing full vertica image. Leave blank to build one with the default name'
+        type: string
+        required: false
+      minimal_vertica_image:
+        description: 'Name of an existing minimal vertica image. Leave blank to build one with the default name'
+        type: string
+        required: false
+      vlogger_image:
+        description: 'Name of an existing vlogger image. Leave blank to build oe with the default name'
+        type: string
+        required: false
+      e2e_test_suites:
+        description: 'E2E test suites to run'
+        required: false
+        type: choice
+        default: all
+        options:
+        - all
+        - none
+        - s3
+        - azb
+        - hdfs
+        - server upgrade
+        - operator upgrade
+      security_scan_exit_code:
+        description: 'Set to 1 to fail the build for security vulnerabilities. Otherwise set to 0'
+        required: false
+        type: string
+        default: '0'
+      run_security_scan:
+        description: 'What images to scan?'
+        type: choice
+        default: 'all, except vertica server'
+        options:
+        - all
+        - none
+        - all, except vertica server
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run
-        run: echo Hello, World!
+  build:
+    uses: ./.github/workflows/build-images.yml
+    with:
+      vlogger_image: ${{ inputs.vlogger_image }}
+      operator_image: ${{ inputs.operator_image }}
+      minimal_vertica_image: ${{ inputs.minimal_vertica_image }}
+      full_vertica_image: ${{ inputs.full_vertica_image }}
+      security_scan_exit_code: ${{ inputs.security_scan_exit_code }}
+      run_security_scan: ${{ inputs.run_security_scan }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  unittests:
+    uses: ./.github/workflows/unittests.yml
+
+  scorecardtests:
+    uses: ./.github/workflows/scorecardtests.yml
+
+  e2e-s3:
+    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 's3' || inputs.e2e_test_suites == '' }}
+    needs: [build] 
+    uses: ./.github/workflows/e2e-s3.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  e2e-hdfs:
+    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'hdfs' || inputs.e2e_test_suites == '' }}
+    needs: [build] 
+    uses: ./.github/workflows/e2e-hdfs.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  e2e-azb:
+    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'azb' || inputs.e2e_test_suites == '' }}
+    needs: [build] 
+    uses: ./.github/workflows/e2e-azb.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  e2e-server-upgrade:
+    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'server upgrade' || inputs.e2e_test_suites == '' }}
+    needs: [build] 
+    uses: ./.github/workflows/e2e-server-upgrade.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  e2e-operator-upgrade:
+    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'operator upgrade' || inputs.e2e_test_suites == '' }}
+    needs: [build] 
+    uses: ./.github/workflows/e2e-operator-upgrade.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/scorecardtests.yml
+++ b/.github/workflows/scorecardtests.yml
@@ -1,6 +1,6 @@
 name: Scorecard tests
 
-on: [push, workflow_call]
+on: [workflow_call]
 
 jobs:
 

--- a/.github/workflows/scorecardtests.yml
+++ b/.github/workflows/scorecardtests.yml
@@ -1,6 +1,6 @@
 name: Scorecard tests
 
-on: [push, pull_request]
+on: [push, workflow_call]
 
 jobs:
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,6 @@
 name: Unit tests
 
-on: [push, pull_request]
+on: [push, workflow_call]
 
 jobs:
 
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.3
+        go-version: 1.18.5
 
     - name: Run unit tests
       run: make test

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,6 @@
 name: Unit tests
 
-on: [push, workflow_call]
+on: [workflow_call]
 
 jobs:
 

--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ OLM_TEST_CATALOG_SOURCE=e2e-test-catalog
 GOPATH?=${HOME}/go
 TMPDIR?=$(PWD)
 HELM_UNITTEST_PLUGIN_INSTALLED:=$(shell helm plugin list | grep -c '^unittest')
-KUTTL_PLUGIN_INSTALLED:=$(shell kubectl krew list | grep -c '^kuttl')
-STERN_PLUGIN_INSTALLED:=$(shell kubectl krew list | grep -c '^stern')
+KUTTL_PLUGIN_INSTALLED:=$(shell kubectl krew list 2>/dev/null | grep -c '^kuttl')
+STERN_PLUGIN_INSTALLED:=$(shell kubectl krew list 2>/dev/null | grep -c '^stern')
 INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
 OPERATOR_CHART = $(shell pwd)/helm-charts/verticadb-operator
 
@@ -363,9 +363,9 @@ docker-build-olm-catalog: opm ## Build an OLM catalog that includes our bundle (
 docker-push-olm-catalog:
 	docker push $(OLM_CATALOG_IMG)
 
-docker-build: docker-build-vertica docker-build-operator docker-build-vlogger docker-build-bundle ## Build all docker images except OLM catalog
+docker-build: docker-build-vertica docker-build-operator docker-build-vlogger ## Build all docker images except OLM catalog
 
-docker-push: docker-push-vertica docker-push-operator docker-push-vlogger docker-push-bundle ## Push all docker images except OLM catalog
+docker-push: docker-push-vertica docker-push-operator docker-push-vlogger ## Push all docker images except OLM catalog
 
 echo-images:  ## Print the names of all of the images used
 	@echo "OPERATOR_IMG=$(OPERATOR_IMG)"

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run cmd/operator/main.go -enable-profiler
 
-docker-build-operator: test ## Build operator docker image with the manager.
+docker-build-operator: ## Build operator docker image with the manager.
 	docker build -t ${OPERATOR_IMG} -f docker-operator/Dockerfile .
 
 docker-build-vlogger:  ## Build vertica logger docker image

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run cmd/operator/main.go -enable-profiler
 
-docker-build-operator: ## Build operator docker image with the manager.
+docker-build-operator: manifests generate fmt vet ## Build operator docker image with the manager.
 	docker build -t ${OPERATOR_IMG} -f docker-operator/Dockerfile .
 
 docker-build-vlogger:  ## Build vertica logger docker image

--- a/changes/unreleased/Changed-20220805-091928.yaml
+++ b/changes/unreleased/Changed-20220805-091928.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: GitHub CI overhaul
+time: 2022-08-05T09:19:28.746834248-03:00
+custom:
+  Issue: "239"

--- a/docker-operator/Dockerfile
+++ b/docker-operator/Dockerfile
@@ -25,3 +25,9 @@ COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]
+
+LABEL org.opencontainers.image.source=https://github.com/vertica/vertica-kubernetes/tree/main/docker-operator \
+      org.opencontainers.image.title='VerticaDB Operator' \
+      org.opencontainers.image.description='Deploys the VerticaDB operator.  The operator manages a Vertica Eon Mode database in Kubernetes, and automates administative tasks.' \
+      org.opencontainers.image.url=https://github.com/vertica/vertica-kubernetes/ \
+      org.opencontainers.image.documentation=https://www.vertica.com/docs/latest/HTML/Content/Authoring/Containers/ContainerizedVertica.htm

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -149,3 +149,8 @@ USER dbadmin
 LABEL os-family="ubuntu"
 LABEL image-name="vertica_k8s"
 LABEL maintainer="K8s Team"
+LABEL org.opencontainers.image.source=https://github.com/vertica/vertica-kubernetes/tree/main/docker-vertica \
+      org.opencontainers.image.title='Vertica Server' \
+      org.opencontainers.image.description='Runs the Vertica server that is optimized for use with the VerticaDB operator' \
+      org.opencontainers.image.url=https://github.com/vertica/vertica-kubernetes/ \
+      org.opencontainers.image.documentation=https://www.vertica.com/docs/latest/HTML/Content/Authoring/Containers/ContainerizedVertica.htm

--- a/docker-vlogger/Dockerfile
+++ b/docker-vlogger/Dockerfile
@@ -25,3 +25,10 @@ ENTRYPOINT ["/sbin/tini", "--"]
 # the cluster. 
 # Note: we use the '-F' option with tail so that it survives log rotations.
 CMD ["sh", "-c", "FN=$DBPATH/v_*_catalog/vertica.log; until [ -f $FN ]; do sleep 5; done; tail -n 1 -F $FN"]
+
+LABEL org.opencontainers.image.source=https://github.com/vertica/vertica-kubernetes/tree/main/docker-vlogger \
+      org.opencontainers.image.title='Vertica Logger' \
+      org.opencontainers.image.description='A sidecar utility container that assists with logging of the Vertica server image' \
+      org.opencontainers.image.url=https://github.com/vertica/vertica-kubernetes/ \
+      org.opencontainers.image.documentation=https://www.vertica.com/docs/latest/HTML/Content/Authoring/Containers/ContainerizedVertica.htm
+

--- a/scripts/run-k8s-int-tests.sh
+++ b/scripts/run-k8s-int-tests.sh
@@ -18,38 +18,31 @@ set -o pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 REPO_DIR=$(dirname $SCRIPT_DIR)
-TAG=kind
 BUILD_IMAGES=1
 INT_TEST_OUTPUT_DIR=${REPO_DIR}/int-tests-output
 CLUSTER_NAME=vertica
 EXTRA_EXTERNAL_IMAGE_FILE=
-DELETE_RPM=
 
 # The make targets and  the invoked shell scripts are directly run from the root directory.
 function usage {
-    echo "$0 -l <log_dir>  -n <cluster_name> -t <tag_name> -e <ext-image-file> [-hsd]"
+    echo "$0 -l <log_dir>  -n <cluster_name> -e <ext-image-file> [-hs]"
     echo
     echo "Options:"
     echo "  -l <log_dir>        Log directory.   default: $INT_TEST_OUTPUT_DIR"
     echo "  -n <cluster_name>   Name of the kind cluster. default: $CLUSTER_NAME"
-    echo "  -t <tag_name>       Tag. default: $TAG"
     echo "  -e <ext-image-file> File with list of additional images to pull prior to running e2e tests"
-    echo "  -s                  Skip the building of the container images"
-    echo "  -d                  Delete the RPM after the vertica image is built"
+    echo "  -s                  Skip the building of the container images we publish externally"
     exit
 }
 
 OPTIND=1
-while getopts l:n:t:hse:d opt; do
+while getopts l:n:hse: opt; do
     case ${opt} in
         l)
             INT_TEST_OUTPUT_DIR=${OPTARG}
             ;;
         n)
             CLUSTER_NAME=${OPTARG}
-            ;;
-        t)
-            TAG=${OPTARG}
             ;;
         s)
             BUILD_IMAGES=
@@ -61,9 +54,6 @@ while getopts l:n:t:hse:d opt; do
                 echo "*** File '$EXTRA_EXTERNAL_IMAGE_FILE' does not exist"
                 exit 1
             fi
-            ;;
-        d)
-            DELETE_RPM=1
             ;;
         h)
             usage
@@ -81,10 +71,8 @@ shift "$((OPTIND-1))"
 PACKAGES_DIR=docker-vertica/packages #RPM file should be in this directory to create docker image.
 RPM_FILE=vertica-x86_64.RHEL6.latest.rpm
 RPM_PATH="${PACKAGES_DIR}/${RPM_FILE}"
+# It is expected that the caller has set the appropriate *_IMG environment variables
 export INT_TEST_OUTPUT_DIR
-export VERTICA_IMG=vertica-k8s:$TAG
-export OPERATOR_IMG=verticadb-operator:$TAG
-export VLOGGER_IMG=vertica-logger:$TAG
 export PATH=$PATH:$HOME/.krew/bin
 export DEPLOY_WITH=random  # Randomly pick between helm and OLM
 
@@ -116,14 +104,16 @@ function build {
     fi
 
     echo "Building all of the container images"
-    make  docker-build vdb-gen
+    make docker-build
 
-    # To save space in CI, delete the RPM since we have create the image out of it
-    if [ -n "$DELETE_RPM" ]
-    then
-        rm -v $RPM_PATH
-    fi
     df -h
+}
+
+function build_push_olm_bundle {
+    # This one is handle separately because its not a container that we publish
+    # externally.  So it needs to be build each time we run the e2e tests.
+    echo "Building and pushing the OLM bundle"
+    make docker-build-bundle docker-push-bundle
 }
 
 # Build vertica images and push them to the kind environment
@@ -152,5 +142,6 @@ then
     build
 fi
 push
+build_push_olm_bundle
 run_integration_tests
 cleanup


### PR DESCRIPTION
This is a major overhaul of the CI:
- We now build all of the images first and store them in the GitHub container registry.  The e2e tests in turn use the container registry, previously they each would create the containers themselves.  The main benefit is that we preserve the containers that we tested with so that we can release the actual containers that were used in our CI.
- Add security vulnerability scanning of the images.  Scanning doesn't fail the built.  But findings from the scans are now an artifact provided by the build and and can be found in the Security tab of the repo.
- Allow the CI to be run with pre-built containers that are stored in a private repostiory in dockerhub.  This will allow us to run the CI against unreleased versions of the Vertica server.
- Add some standard labels to the containers