### PR TITLE
install_vertica fix when running on VM in AWS

### DIFF
--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -44,6 +44,7 @@ RUN set -x \
   --license CE \
   --hosts 127.0.0.1 \
   --no-system-configuration \
+  --ignore-install-config \
   -U \
   --data-dir /home/dbadmin \
   && mkdir -p /home/dbadmin/licensing/ce \


### PR DESCRIPTION
This is a small fix to allow the vertica-k8s container to be built on a machine running in the AWS environment.  We run the install to setup the directory structure for the container.  It is detecting we are running in AWS so is checking other things and failing.  The `--ignore-install-config` option should bypass the AWS check entirely.