### PR TITLE
Fix timing in update-strategy e2e test

### DIFF
--- a/tests/e2e/update-strategy/50-assert.yaml
+++ b/tests/e2e/update-strategy/50-assert.yaml
@@ -1,0 +1,28 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-ks-0-update-strategy
+status:
+  subclusters:
+    - upNodeCount: 0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-ks-0-update-strategy-sc1-0
+status:
+  containerStatuses:
+    - ready: false


### PR DESCRIPTION
This fixes a small timing window in update-strategy where it was possible to advance too fast past a test step.  We delete a pod in one step (50), then suppose to wait for it to come back up in the next step (55).  But we didn't properly wait for the pod to be deleted in step 50.  So, it was possibly to quickly advance through step 55 before the pod really came back.