### PR TITLE
Automatic resize of the PV

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,7 @@ on:
         options:
         - all
         - none
-        default: none
+        default: all
         required: false
 
 jobs:

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -505,7 +505,9 @@ type LocalStorage struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:="500Gi"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// The minimum size of the local data volume when picking a PV.
+	// The minimum size of the local data volume when picking a PV.  If changing
+	// this after the PV have been created, it will cause a resize of the PV to
+	// the new size.  When changing the value, it can only increase.
 	RequestSize resource.Quantity `json:"requestSize,omitempty"`
 
 	// +kubebuilder:validation:Optional
@@ -917,8 +919,9 @@ func MakeVDB() *VerticaDB {
 				CredentialSecret: "s3-auth",
 			},
 			Local: LocalStorage{
-				DataPath:  "/data",
-				DepotPath: "/depot",
+				DataPath:    "/data",
+				DepotPath:   "/depot",
+				RequestSize: resource.MustParse("10Gi"),
 			},
 			KSafety:    KSafety1,
 			DBName:     "db",

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -507,7 +507,7 @@ type LocalStorage struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// The minimum size of the local data volume when picking a PV.  If changing
 	// this after the PV have been created, it will cause a resize of the PV to
-	// the new size.  When changing the value, it can only increase.
+	// the new size.
 	RequestSize resource.Quantity `json:"requestSize,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -216,13 +216,6 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 			"communal.endpoint cannot change after creation")
 		allErrs = append(allErrs, err)
 	}
-	// local.requestSize cannot change after creation
-	if v.Spec.Local.RequestSize.Cmp(oldObj.Spec.Local.RequestSize) != 0 {
-		err := field.Invalid(field.NewPath("spec").Child("local").Child("requestSize"),
-			v.Spec.Local.RequestSize,
-			"local.requestSize cannot change after creation")
-		allErrs = append(allErrs, err)
-	}
 	// local.storageClass cannot change after creation
 	if v.Spec.Local.StorageClass != oldObj.Spec.Local.StorageClass {
 		err := field.Invalid(field.NewPath("spec").Child("local").Child("storageClass"),

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -243,11 +243,6 @@ var _ = Describe("verticadb_webhook", func() {
 		vdbUpdate.Spec.Communal.Endpoint = "https://minio"
 		validateImmutableFields(vdbUpdate)
 	})
-	It("should not change local.requestSize after creation", func() {
-		vdbUpdate := createVDBHelper()
-		vdbUpdate.Spec.Local.RequestSize = resource.MustParse("600Gi")
-		validateImmutableFields(vdbUpdate)
-	})
 	It("should not change local.storageClass after creation", func() {
 		vdbUpdate := createVDBHelper()
 		vdbUpdate.Spec.Local.StorageClass = "MyStorageClass"

--- a/changes/unreleased/Added-20220811-085256.yaml
+++ b/changes/unreleased/Added-20220811-085256.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Automated resize of the PV
+time: 2022-08-11T08:52:56.355845029-03:00
+custom:
+  Issue: "244"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -28,12 +28,14 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	SuperuserPasswordPath = "superuser-passwd"
+	TestStorageClassName  = "test-storage-class"
 )
 
 // BuildExtSvc creates desired spec for the external service.
@@ -555,7 +557,7 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 						StorageClassName: getStorageClassName(vdb),
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								"storage": vdb.Spec.Local.RequestSize,
+								corev1.ResourceStorage: vdb.Spec.Local.RequestSize,
 							},
 						},
 					},
@@ -593,13 +595,69 @@ func BuildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.
 		Name: vapi.LocalDataPVC,
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: vapi.LocalDataPVC + "-" + vdb.ObjectMeta.Name + "-" + sc.Name + fmt.Sprintf("%d", podIndex),
+				ClaimName: names.GenPVCName(vdb, sc, podIndex).Name,
 			},
 		},
 	})
 	pod.Spec.Hostname = nm.Name
 	pod.Spec.Subdomain = names.GenHlSvcName(vdb).Name
 	return pod
+}
+
+// BuildPVC will build a PVC for test purposes
+func BuildPVC(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.PersistentVolumeClaim {
+	scn := TestStorageClassName
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.GenPVCName(vdb, sc, podIndex).Name,
+			Namespace: vdb.Namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				"ReadWriteOnce",
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: vdb.Spec.Local.RequestSize,
+				},
+			},
+			StorageClassName: &scn,
+		},
+	}
+}
+
+func BuildPV(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.PersistentVolume {
+	hostPathType := corev1.HostPathDirectoryOrCreate
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: names.GenPVName(vdb, sc, podIndex).Name,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				"ReadWriteOnce",
+			},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: vdb.Spec.Local.RequestSize,
+			},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/host",
+					Type: &hostPathType,
+				},
+			},
+		},
+	}
+}
+
+// BuildStorageClass will construct a storageClass for test purposes
+func BuildStorageClass(allowVolumeExpansion bool) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestStorageClassName,
+		},
+		Provisioner:          "vertica.com/dummy-provisioner",
+		AllowVolumeExpansion: &allowVolumeExpansion,
+	}
 }
 
 // BuildS3CommunalCredSecret is a test helper to build up the Secret spec to store communal credentials

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -626,6 +626,7 @@ func BuildPVC(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.
 	}
 }
 
+// BuildPV will build a PV for test purposes
 func BuildPV(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.PersistentVolume {
 	hostPathType := corev1.HostPathDirectoryOrCreate
 	return &corev1.PersistentVolume{

--- a/pkg/controllers/vdb/obj_reconcile.go
+++ b/pkg/controllers/vdb/obj_reconcile.go
@@ -385,6 +385,12 @@ func (o *ObjReconciler) reconcileSts(ctx context.Context, sc *vapi.Subcluster) (
 		expSts.Spec.Template.Spec.Containers[i].Image = curSts.Spec.Template.Spec.Containers[i].Image
 	}
 
+	// We allow the requestSize to change in the VerticaDB.  But we cannot
+	// propagate that in the sts spec.  We handle that by modifying the PVC in a
+	// separate reconciler.  Reset the volume claim spec so that we don't try to
+	// change it here.
+	expSts.Spec.VolumeClaimTemplates = curSts.Spec.VolumeClaimTemplates
+
 	// Update the sts by patching in fields that changed according to expSts.
 	// Due to the omission of default fields in expSts, curSts != expSts.  We
 	// always send a patch request, then compare what came back against origSts

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -325,4 +325,16 @@ var _ = Describe("podfacts", func() {
 		Expect(setShardSubscription("3\n", pf)).Should(Succeed())
 		Expect(pf.shardSubscriptions).Should(Equal(3))
 	})
+
+	It("should parse depot details output", func() {
+		pf := &PodFact{}
+		Expect(pf.setDepotDetails("1248116736|60%\n")).Should(Succeed())
+		Expect(pf.maxDepotSize).Should(Equal(1248116736))
+		Expect(pf.depotDiskPercentSize).Should(Equal("60%"))
+		Expect(pf.setDepotDetails("3248116736|\n")).Should(Succeed())
+		Expect(pf.maxDepotSize).Should(Equal(3248116736))
+		Expect(pf.depotDiskPercentSize).Should(Equal(""))
+		Expect(pf.setDepotDetails("a|b|c")).ShouldNot(Succeed())
+		Expect(pf.setDepotDetails("not-a-number|blah")).ShouldNot(Succeed())
+	})
 })

--- a/pkg/controllers/vdb/resizepv_reconcile.go
+++ b/pkg/controllers/vdb/resizepv_reconcile.go
@@ -109,7 +109,6 @@ func (r *ResizePVReconcile) reconcilePvc(ctx context.Context, pf *PodFact, pvc *
 
 	// Requeue to wait for the PVC to be expanded.
 	r.VRec.Log.Info("Wait for PVC to be expanded", "pvc", pvc.Name, "capacity", pvc.Status.Capacity.Storage())
-
 	return ctrl.Result{Requeue: true}, nil
 }
 
@@ -207,7 +206,6 @@ func (r *ResizePVReconcile) getLocalDataSize(ctx context.Context, pvc *corev1.Pe
 	// for test purposes.  The PVC capacity was close to 100mb larger than then
 	// disk size that Vertica calculates, which is why it isn't the default.
 	if op == "" {
-		// If we can't represent the capacity as an int, we will unconditionally update the location size
 		curCapacity, ok := pvc.Status.Capacity.Storage().AsInt64()
 		if !ok {
 			return 0, fmt.Errorf("cannot get capacity as int64: %s", pvc.Status.Capacity.Storage().String())

--- a/pkg/controllers/vdb/resizepv_reconcile.go
+++ b/pkg/controllers/vdb/resizepv_reconcile.go
@@ -1,0 +1,230 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ResizePVReconcile will handle resizing of the PV when the local data size changes
+type ResizePVReconcile struct {
+	VRec    *VerticaDBReconciler
+	Vdb     *vapi.VerticaDB
+	PRunner cmds.PodRunner
+	PFacts  *PodFacts
+}
+
+// MakeResizePVReconciler will build and return the ResizePVReconcile object.
+func MakeResizePVReconciler(vdbrecon *VerticaDBReconciler,
+	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) controllers.ReconcileActor {
+	return &ResizePVReconcile{
+		VRec:    vdbrecon,
+		Vdb:     vdb,
+		PRunner: prunner,
+		PFacts:  pfacts,
+	}
+}
+
+// Reconcile will ensure Vertica is installed and running in the pods.
+func (r *ResizePVReconcile) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if err := r.PFacts.Collect(ctx, r.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	returnRes := ctrl.Result{}
+	for _, pf := range r.PFacts.Detail {
+		if res, err := r.reconcilePod(ctx, pf); verrors.IsReconcileAborted(res, err) {
+			// Errors always abort right away.  But if we get a requeue, we
+			// will remember this and go onto the next pod
+			if err != nil {
+				return res, err
+			}
+			returnRes = res
+		}
+	}
+
+	return returnRes, nil
+}
+
+// reconcilePod will handle a single pod to see if its PV needs to be resized
+func (r *ResizePVReconcile) reconcilePod(ctx context.Context, pf *PodFact) (ctrl.Result, error) {
+	pvcName := types.NamespacedName{
+		Namespace: pf.name.Namespace,
+		Name:      fmt.Sprintf("%s-%s", vapi.LocalDataPVC, pf.name.Name),
+	}
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.VRec.Client.Get(ctx, pvcName, pvc); err != nil {
+		if errors.IsNotFound(err) {
+			r.VRec.Log.Info("PVC was not found. Requeuing.", "pvc", pvcName)
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	return r.reconcilePvc(ctx, pf, pvc)
+}
+
+// reconcilePvc will handle a single PVC and see if it needs to be resized
+func (r *ResizePVReconcile) reconcilePvc(ctx context.Context, pf *PodFact, pvc *corev1.PersistentVolumeClaim) (ctrl.Result, error) {
+	// Resize is necessary if the PVC storage is smaller than the size in the vdb
+	if pvc.Spec.Resources.Requests.Storage().Cmp(r.Vdb.Spec.Local.RequestSize) < 0 {
+		return r.updatePVC(ctx, pvc)
+	}
+
+	// We are done with the PVC if the spec <= capacity size in the PVC.  It
+	// isn't a strict equality check because the actual size of the PVC may be
+	// larger than what was requested.  GCP rounds up to the nearest GB for
+	// instance.
+	if pvc.Spec.Resources.Requests.Storage().Cmp(*pvc.Status.Capacity.Storage()) <= 0 {
+		return r.updateDepotSize(ctx, pvc, pf)
+	}
+
+	// Requeue to wait for the PVC to be expanded.
+	r.VRec.Log.Info("Wait for PVC to be expanded", "pvc", pvc.Name, "capacity", pvc.Status.Capacity.Storage())
+
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// updatePVC will update the PVCs size with the size in the vdb.
+func (r *ResizePVReconcile) updatePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (ctrl.Result, error) {
+	nm := types.NamespacedName{
+		Name:      pvc.Name,
+		Namespace: pvc.Namespace,
+	}
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fetchedPVC := &corev1.PersistentVolumeClaim{}
+		if err := r.VRec.Client.Get(ctx, nm, fetchedPVC); err != nil {
+			return err
+		}
+
+		fetchedPVC.Spec.Resources.Requests[corev1.ResourceStorage] = r.Vdb.Spec.Local.RequestSize
+		return r.VRec.Client.Update(ctx, fetchedPVC)
+	})
+
+	// Some storage classes forbid volume expansion.  We will ignore those
+	// errors so that we can finish up the reconciler.
+	if err != nil {
+		k8sError, ok := err.(errors.APIStatus)
+		if ok && k8sError.Status().Reason == metav1.StatusReasonForbidden {
+			r.VRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.SkipPVCExpansion,
+				"Skipping expansion of PVC '%s' because volume expansion is forbidden",
+				pvc.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	r.VRec.Log.Info("PVC resized, so requeue iteration to wait for PV to get resized.", "pvc", pvc.Name)
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// updateDepotSize will call alter_location_size in vertica if necessary
+func (r *ResizePVReconcile) updateDepotSize(ctx context.Context, pvc *corev1.PersistentVolumeClaim,
+	pf *PodFact) (ctrl.Result, error) {
+	if !pf.upNode {
+		r.VRec.Log.Info("Depot size needs to be updated in vertica. Requeue to wait for vertica to come up")
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if pf.depotDiskPercentSize == "" {
+		r.VRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.SkipDepotResize,
+			"Skipping depot resize for pod '%s' because its size is fixed and not a percentage of the disk space.",
+			pf.name.Name)
+		return ctrl.Result{}, nil
+	}
+	if !strings.HasSuffix(pf.depotDiskPercentSize, "%") {
+		return ctrl.Result{}, fmt.Errorf("depot disk percent must end with %%: %s", pf.depotDiskPercentSize)
+	}
+	dpAsInt, err := strconv.Atoi(pf.depotDiskPercentSize[:len(pf.depotDiskPercentSize)-1])
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot convert depot disk percent (%s) to an int: %w", pf.depotDiskPercentSize, err)
+	}
+	curLocalDataSize, err := r.getLocalDataSize(ctx, pvc, pf)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// Calculate a lowerbound of the expected depot size.  We calculate it with
+	// the capacity of the local disk then reduce it by a constant amount.  This
+	// fudge is here in case Vertica and our operator calculate the expected
+	// depot size differently (i.e. rounding, etc.)
+	depotSizeLB := (curLocalDataSize * int64(dpAsInt) / 100) - (5 * 1024 * 1024)
+	if int64(pf.maxDepotSize) >= depotSizeLB {
+		return ctrl.Result{}, nil
+	}
+	r.VRec.Log.Info("alter_location_size needed", "curLocalDataSize", curLocalDataSize,
+		"maxDepotSize", pf.maxDepotSize, "depotSizeLB", depotSizeLB)
+	sql := []string{
+		"-tAc",
+		fmt.Sprintf("select alter_location_size('depot', '%s', '%s')",
+			pf.vnodeName, pf.depotDiskPercentSize),
+	}
+	_, _, err = r.PRunner.ExecVSQL(ctx, pf.name, ServerContainer, sql...)
+	if err == nil {
+		r.VRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.DepotResized,
+			"Depot was resized in pod '%s' to be %s of expanded PVC", pf.name.Name, pf.depotDiskPercentSize)
+	}
+	return ctrl.Result{}, err
+}
+
+// getLocalDataSize returns the size of the mount that contains the depot
+func (r *ResizePVReconcile) getLocalDataSize(ctx context.Context, pvc *corev1.PersistentVolumeClaim, pf *PodFact) (int64, error) {
+	c := []string{
+		"bash",
+		"-c",
+		fmt.Sprintf("df --block-size=1 --output=size %s", r.Vdb.Spec.Local.DataPath),
+	}
+	op, _, err := r.PRunner.ExecInPod(ctx, pf.name, ServerContainer, c...)
+	if err != nil {
+		return 0, err
+	}
+	// If the output is empty, we will use the size from the PVC.  These is here
+	// for test purposes.  The PVC capacity was close to 100mb larger than then
+	// disk size that Vertica calculates, which is why it isn't the default.
+	if op == "" {
+		// If we can't represent the capacity as an int, we will unconditionally update the location size
+		curCapacity, ok := pvc.Status.Capacity.Storage().AsInt64()
+		if !ok {
+			return 0, fmt.Errorf("cannot get capacity as int64: %s", pvc.Status.Capacity.Storage().String())
+		}
+		return curCapacity, nil
+	}
+	return parseDFOutput(op)
+}
+
+// parseDFOutput will parse the output of the df to return the size of the depot drive
+func parseDFOutput(op string) (int64, error) {
+	lines := strings.Split(op, "\n")
+	const ExpectedLines = 2
+	if len(lines) < ExpectedLines {
+		return 0, fmt.Errorf("not enough lines in output: %s", op)
+	}
+	const Base10 = 10
+	const BitSize = 64
+	return strconv.ParseInt(strings.TrimSpace(lines[1]), Base10, BitSize)
+}

--- a/pkg/controllers/vdb/resizepv_reconcile_test.go
+++ b/pkg/controllers/vdb/resizepv_reconcile_test.go
@@ -1,0 +1,141 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("resizepv_reconcile", func() {
+	ctx := context.Background()
+	const NewPVSize = "55Gi"
+
+	It("should resize PVC when requestSize changes", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateStorageClass(ctx, k8sClient, true)
+		defer test.DeleteStorageClass(ctx, k8sClient)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		resizeLocalStorage(ctx, vdb, NewPVSize)
+		runResizePVReconciler(ctx, vdb, true, false)
+		checkPVCSize(ctx, vdb, true)
+		runResizePVReconciler(ctx, vdb, true, false)
+		mockResizeStatusUpdate(ctx, vdb, NewPVSize)
+		runResizePVReconciler(ctx, vdb, false, true)
+	})
+
+	It("should skip resize if provisioner doesn't allow volume expansion", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateStorageClass(ctx, k8sClient, false)
+		defer test.DeleteStorageClass(ctx, k8sClient)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		checkPVCSize(ctx, vdb, true)
+		resizeLocalStorage(ctx, vdb, NewPVSize)
+		runResizePVReconciler(ctx, vdb, false, false)
+		// Verify that we didn't update the PVC because the storage class
+		// doesn't allow volume expansion
+		checkPVCSize(ctx, vdb, false)
+	})
+
+	It("should requeue if database isn't up", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateStorageClass(ctx, k8sClient, true)
+		defer test.DeleteStorageClass(ctx, k8sClient)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		resizeLocalStorage(ctx, vdb, NewPVSize)
+		// Run reconciler to update the PVC
+		runResizePVReconciler(ctx, vdb, true, false)
+		checkPVCSize(ctx, vdb, true)
+		mockResizeStatusUpdate(ctx, vdb, NewPVSize)
+		// Run reconciler to update vertica.  This will requeue because database isn't up
+		runResizePVReconciler(ctx, vdb, true, false)
+	})
+
+	It("should parse df output", func() {
+		Expect(parseDFOutput(`   1B-blocks
+        490577010688
+		`)).Should(Equal(int64(490577010688)))
+		// Bad input -- not enough lines
+		_, err := parseDFOutput(`   1B-blocks`)
+		Expect(err).ShouldNot(Succeed())
+	})
+})
+
+func resizeLocalStorage(ctx context.Context, vdb *vapi.VerticaDB, newSize string) {
+	ExpectWithOffset(1, k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+	vdb.Spec.Local.RequestSize = resource.MustParse(newSize)
+	ExpectWithOffset(1, k8sClient.Update(ctx, vdb)).Should(Succeed())
+}
+
+func runResizePVReconciler(ctx context.Context, vdb *vapi.VerticaDB, expectedRequeue, expectedDepotAlter bool) {
+	fpr := &cmds.FakePodRunner{}
+	pfacts := MakePodFacts(vdbRec, fpr)
+	ExpectWithOffset(1, pfacts.Collect(ctx, vdb)).Should(Succeed())
+	// Mock that depot size for each pod is 60%
+	for i := range pfacts.Detail {
+		pfacts.Detail[i].depotDiskPercentSize = "60%"
+	}
+	r := MakeResizePVReconciler(vdbRec, vdb, fpr, &pfacts)
+	res, err := r.Reconcile(ctx, &ctrl.Request{})
+	ExpectWithOffset(1, err).Should(Succeed())
+	ExpectWithOffset(1, res).Should(Equal(ctrl.Result{Requeue: expectedRequeue}))
+	alterCommands := fpr.FindCommands("select alter_location_size")
+	ExpectWithOffset(1, len(alterCommands) > 0).Should(Equal(expectedDepotAlter))
+}
+
+func checkPVCSize(ctx context.Context, vdb *vapi.VerticaDB, expectedMatch bool) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	for s := range vdb.Spec.Subclusters {
+		for i := int32(0); i < vdb.Spec.Subclusters[s].Size; i++ {
+			ExpectWithOffset(1, k8sClient.Get(ctx, names.GenPVCName(vdb, &vdb.Spec.Subclusters[s], i), pvc)).Should(Succeed())
+			ExpectWithOffset(1, pvc.Spec.Resources.Requests.Storage().Equal(vdb.Spec.Local.RequestSize)).Should(Equal(expectedMatch))
+		}
+	}
+}
+
+func mockResizeStatusUpdate(ctx context.Context, vdb *vapi.VerticaDB, newSize string) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	for s := range vdb.Spec.Subclusters {
+		for i := int32(0); i < vdb.Spec.Subclusters[s].Size; i++ {
+			ExpectWithOffset(1, k8sClient.Get(ctx, names.GenPVCName(vdb, &vdb.Spec.Subclusters[s], i), pvc)).Should(Succeed())
+			pvc.Status.Capacity = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse(newSize),
+			}
+			ExpectWithOffset(1, k8sClient.Status().Update(ctx, pvc)).Should(Succeed())
+		}
+	}
+}

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -58,6 +58,7 @@ type VerticaDBReconciler struct {
 // +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=pods,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=core,namespace=WATCH_NAMESPACE,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=persistentvolumeclaims,verbs=get;list;watch;update
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VerticaDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -208,6 +209,8 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Update the label in pods so that Service routing uses them if they
 		// have finished being rebalanced.
 		MakeClientRoutingLabelReconciler(r, vdb, pfacts, AddNodeApplyMethod, ""),
+		// Resize any PVs if the local data size changed in the vdb
+		MakeResizePVReconciler(r, vdb, prunner, pfacts),
 	}
 }
 

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -71,6 +71,9 @@ const (
 	StopDBStart                     = "StopDBStart"
 	StopDBSucceeded                 = "StopDBSucceeded"
 	StopDBFailed                    = "StopDBFailed"
+	SkipPVCExpansion                = "SkipPVCExpansion"
+	SkipDepotResize                 = "SkipDepotResize"
+	DepotResized                    = "DepotResized"
 )
 
 // Constants for VerticaAutoscaler reconciler

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -81,3 +81,15 @@ func GenPodNameFromSts(vdb *vapi.VerticaDB, sts *appsv1.StatefulSet, podIndex in
 		Namespace: vdb.Namespace,
 	}
 }
+
+// GenPVCName returns the name of a specific pod's PVC.  This is for test purposes only.
+func GenPVCName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.Name, podIndex))
+}
+
+// GenPVName returns the name of a dummy PV for test purposes
+func GenPVName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
+	return types.NamespacedName{
+		Name: fmt.Sprintf("pv-%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.Name, podIndex),
+	}
+}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +46,11 @@ func CreatePods(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, podRu
 	}
 }
 
+func CreateStorageClass(ctx context.Context, c client.Client, allowVolumeExpansion bool) {
+	stoclass := builder.BuildStorageClass(allowVolumeExpansion)
+	Expect(c.Create(ctx, stoclass)).Should(Succeed())
+}
+
 func CreateSts(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *vapi.Subcluster, offset int,
 	scIndex int32, podRunningState PodRunningState) {
 	sts := &appsv1.StatefulSet{}
@@ -58,6 +64,18 @@ func CreateSts(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *va
 			pod = builder.BuildPod(vdb, sc, j)
 			ExpectWithOffset(offset, c.Create(ctx, pod)).Should(Succeed())
 			setPodStatusHelper(ctx, c, offset+1, names.GenPodName(vdb, sc, j), scIndex, j, podRunningState, false)
+		}
+		pv := &corev1.PersistentVolume{}
+		if err := c.Get(ctx, names.GenPVName(vdb, sc, j), pv); kerrors.IsNotFound(err) {
+			pv := builder.BuildPV(vdb, sc, j)
+			ExpectWithOffset(offset, c.Create(ctx, pv)).Should(Succeed())
+		}
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(ctx, names.GenPVCName(vdb, sc, j), pvc); kerrors.IsNotFound(err) {
+			pvc := builder.BuildPVC(vdb, sc, j)
+			ExpectWithOffset(offset, c.Create(ctx, pvc)).Should(Succeed())
+			pvc.Status.Phase = corev1.ClaimBound
+			ExpectWithOffset(offset, c.Status().Update(ctx, pvc)).Should(Succeed())
 		}
 	}
 	// Update the status in the sts to reflect the number of pods we created
@@ -144,12 +162,35 @@ func DeletePods(ctx context.Context, c client.Client, vdb *vapi.VerticaDB) {
 	}
 }
 
+func DeleteStorageClass(ctx context.Context, c client.Client) {
+	stoclass := &storagev1.StorageClass{}
+	err := c.Get(ctx, types.NamespacedName{Name: builder.TestStorageClassName}, stoclass)
+	if !kerrors.IsNotFound(err) {
+		Expect(c.Delete(ctx, stoclass)).Should(Succeed())
+	}
+}
+
 func DeleteSts(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *vapi.Subcluster, offset int) {
 	for j := int32(0); j < sc.Size; j++ {
 		pod := &corev1.Pod{}
 		err := c.Get(ctx, names.GenPodName(vdb, sc, j), pod)
 		if !kerrors.IsNotFound(err) {
 			ExpectWithOffset(offset, c.Delete(ctx, pod)).Should(Succeed())
+		}
+		pvc := &corev1.PersistentVolumeClaim{}
+		err = c.Get(ctx, names.GenPVCName(vdb, sc, j), pvc)
+		if !kerrors.IsNotFound(err) {
+			// Clear the finalizer to allow us to delete the PVC
+			pvc.Finalizers = nil
+			ExpectWithOffset(1, c.Update(ctx, pvc)).Should(Succeed())
+			ExpectWithOffset(offset, c.Delete(ctx, pvc)).Should(Succeed())
+			err = c.Get(ctx, names.GenPVCName(vdb, sc, j), pvc)
+			ExpectWithOffset(1, err).ShouldNot(Succeed())
+		}
+		pv := &corev1.PersistentVolume{}
+		err = c.Get(ctx, names.GenPVName(vdb, sc, j), pv)
+		if !kerrors.IsNotFound(err) {
+			ExpectWithOffset(offset, c.Delete(ctx, pv)).Should(Succeed())
 		}
 	}
 	sts := &appsv1.StatefulSet{}

--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -704,6 +704,23 @@ EOF
     popd > /dev/null
 }
 
+function create_volume_expansion_overlay {
+    # Some tests have different outcomes depending on whether volume expansion
+    # is allowed with the PVC.
+    TDIR=$1
+    VOL_EXPANSION_ENABLED_SUBDIR=$2
+    VOL_EXPANSION_DISABLED_SUBDIR=$3
+
+    OVERLAY_DIR=${TDIR}/overlay
+    rm -rf $OVERLAY_DIR
+    if [ -n "$ALLOW_VOLUME_EXPANSION" ]
+    then
+        cp -r ${TDIR}/$VOL_EXPANSION_ENABLED_SUBDIR $OVERLAY_DIR
+    else
+        cp -r ${TDIR}/$VOL_EXPANSION_DISABLED_SUBDIR $OVERLAY_DIR
+    fi
+}
+
 cd $REPO_DIR/tests
 
 # Create the configMap that is used to control the communal endpoint and creds.
@@ -728,4 +745,8 @@ done
 for tdir in e2e/* e2e-extra/* e2e-disabled/* e2e-server-upgrade/* e2e-operator-upgrade-overlays/*
 do
     clean_communal_kustomization $tdir
+done
+for tdir in e2e-extra/pvc-expansion/verify-pvc-change
+do
+    create_volume_expansion_overlay $tdir volume-expansion-enabled volume-expansion-disabled
 done

--- a/scripts/wait-for-cert-manager-ready.sh
+++ b/scripts/wait-for-cert-manager-ready.sh
@@ -58,5 +58,8 @@ while [[ $ERR_MSG != '' ]]; do
         exit 1
     fi
     sleep 1
-    ERR_MSG=$(kubectl apply -f config/samples/test-cert-manager.yaml 2>&1 1>/dev/null)
+    if kubectl apply -f config/samples/test-cert-manager.yaml 2>&1 1>/dev/null
+    then
+        break
+    fi
 done

--- a/tests/e2e-extra/pvc-expansion/05-create-communal-creds.yaml
+++ b/tests/e2e-extra/pvc-expansion/05-create-communal-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-extra/pvc-expansion/10-assert.yaml
+++ b/tests/e2e-extra/pvc-expansion/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-extra/pvc-expansion/10-deploy-operator.yaml
+++ b/tests/e2e-extra/pvc-expansion/10-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/pvc-expansion/15-assert.yaml
+++ b/tests/e2e-extra/pvc-expansion/15-assert.yaml
@@ -11,9 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: kubectl -n $NAMESPACE get verticadb v-webhook -o json | jq '.spec.local.requestSize="600Gi"' | kubectl -n $NAMESPACE replace -f -
-    ignoreFailure: true
-  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE"
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-pvc-expansion-main
+status:
+  currentReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-pvc-expansion
+status:
+  subclusters:
+    - installCount: 1

--- a/tests/e2e-extra/pvc-expansion/15-setup-vdb.yaml
+++ b/tests/e2e-extra/pvc-expansion/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/pvc-expansion/20-assert.yaml
+++ b/tests/e2e-extra/pvc-expansion/20-assert.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-pvc-expansion-main
+status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-pvc-expansion
+status:
+  subclusters:
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-extra/pvc-expansion/20-wait-for-createdb.yaml
+++ b/tests/e2e-extra/pvc-expansion/20-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/pvc-expansion/25-resize-local-data.yaml
+++ b/tests/e2e-extra/pvc-expansion/25-resize-local-data.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-pvc-expansion
+spec:
+  local:
+    requestSize: 2Gi

--- a/tests/e2e-extra/pvc-expansion/30-verify-pvc-change.yaml
+++ b/tests/e2e-extra/pvc-expansion/30-verify-pvc-change.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "kubectl kuttl assert -n $NAMESPACE verify-pvc-change/overlay/assert.yaml --timeout 600"
+

--- a/tests/e2e-extra/pvc-expansion/35-assert.yaml
+++ b/tests/e2e-extra/pvc-expansion/35-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-pvc-expansion
+status:
+  subclusters:
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-extra/pvc-expansion/35-verify-db-is-up.yaml
+++ b/tests/e2e-extra/pvc-expansion/35-verify-db-is-up.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/pvc-expansion/40-wait-for-steady-state.yaml
+++ b/tests/e2e-extra/pvc-expansion/40-wait-for-steady-state.yaml
@@ -11,33 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-mc-restart
-spec:
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  dbName: vertdb
-  shardCount: 16
-  subclusters:
-    - name: sc1
-      size: 1
-      isPrimary: true
-    - name: sc2
-      size: 1
-      isPrimary: true
-    - name: sc3
-      size: 2
-      isPrimary: false
-  requeueTime: 10
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -t 360"

--- a/tests/e2e-extra/pvc-expansion/90-errors.yaml
+++ b/tests/e2e-extra/pvc-expansion/90-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-extra/pvc-expansion/90-uninstall-operator.yaml
+++ b/tests/e2e-extra/pvc-expansion/90-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-extra/pvc-expansion/95-assert.yaml
+++ b/tests/e2e-extra/pvc-expansion/95-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-extra/pvc-expansion/95-delete-crd.yaml
+++ b/tests/e2e-extra/pvc-expansion/95-delete-crd.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-extra/pvc-expansion/95-errors.yaml
+++ b/tests/e2e-extra/pvc-expansion/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-extra/pvc-expansion/99-delete-ns.yaml
+++ b/tests/e2e-extra/pvc-expansion/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-extra/pvc-expansion/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-extra/pvc-expansion/setup-vdb/base/kustomization.yaml
@@ -11,11 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-webhook
-spec:
-  local:
-    requestSize: 100Mi
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-extra/pvc-expansion/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/pvc-expansion/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,36 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-pvc-expansion
+spec:
+  image: kustomize-vertica-image
+  sidecars:
+    - name: vlogger
+      image: kustomize-vlogger-image
+  dbName: data_base
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 1Gi
+  subclusters:
+    - name: main
+      size: 1
+  kSafety: "0"
+  certSecrets: []
+  requeueTime: 5
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-extra/pvc-expansion/verify-pvc-change/volume-expansion-disabled/assert.yaml
+++ b/tests/e2e-extra/pvc-expansion/verify-pvc-change/volume-expansion-disabled/assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: SkipPVCExpansion
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-pvc-expansion

--- a/tests/e2e-extra/pvc-expansion/verify-pvc-change/volume-expansion-enabled/assert.yaml
+++ b/tests/e2e-extra/pvc-expansion/verify-pvc-change/volume-expansion-enabled/assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: DepotResized
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-pvc-expansion

--- a/tests/kustomize-defaults.cfg
+++ b/tests/kustomize-defaults.cfg
@@ -100,3 +100,10 @@ PRIVATE_REG_PASSWORD=
 #
 # Set some value in this variable to use the server mount patch.
 USE_SERVER_MOUNT_PATCH=
+
+# When using kind, the default provisioner doesn't allow volume expansion.
+# Some tests rely on this, so this knob changes those tests so that it knows
+# thate volume expansion isn't allowed.  If you are running in a cloud vendor
+# such as AWS or GCP, then the default storage class does allow volume
+# expansion.  Set this value to 1 for those environments.
+ALLOW_VOLUME_EXPANSION=


### PR DESCRIPTION
This adds automatic resize of the PV.  Whenever the `spec.local.requestSize` increases in the VerticaDB, this will trigger increasing the size of each pod's PV and a resize of the depot inside Vertica.  An event will be written for the VerticaDB when the resize is done.

A few caveats with this:
- The depot must be sized to a percentage of the disk space for it to be updated.  If it is sized to be a fixed size, the PVC will change but the depot won't.
- The storage provisioner must allow volume expansion.  Most of the ones used by cloud vendors support this.  If you are using one such as rancher.io/local-path, the default when running k8s with kind, then the PV will not increase in size.

Webhook rules were removed to allow the `spec.local.requestSize` to change.  In theory, only increases to the requestSize should be allowed.  But an edge case exists when changing the size for a storage provisioner that doesn't allow volume expansion.  In such a case, we would want to be able to decrease the requestSize back to its original value.

A new e2e test was added for this.  When run in our CI, which uses rancher.io/local-path as the default, the test expects the PV not to expand.  When run in an environment that allows volume expansion, then the test uses a different expected result.

Closes #231