### PR TITLE
Update vertica server image to ubuntu focal-20220801

### DIFF
--- a/changes/unreleased/Changed-20220812-082810.yaml
+++ b/changes/unreleased/Changed-20220812-082810.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Update server container base image to Ubuntu focal-20220801
+time: 2022-08-12T08:28:10.182187973-03:00
+custom:
+  Issue: "245"

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Vertica
 #
 
-ARG BASE_OS_VERSION="focal-20220316"
+ARG BASE_OS_VERSION="focal-20220801"
 ARG BUILDER_OS_VERSION="7.9.2009"
 FROM centos:centos${BUILDER_OS_VERSION} as builder
 


### PR DESCRIPTION
Increase the Vertica server base image to the latest Ubuntu (focal-20220801) to resolve some security vulnerabilities.