### PR TITLE
Add webhook rule to prevent restricted paths

### DIFF
--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -273,6 +273,7 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.transientSubclusterMustMatchTemplate(allErrs)
 	allErrs = v.validateRequeueTimes(allErrs)
 	allErrs = v.validateEncryptSpreadComm(allErrs)
+	allErrs = v.validateLocalPaths(allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -761,6 +762,46 @@ func (v *VerticaDB) validateEncryptSpreadComm(allErrs field.ErrorList) field.Err
 		err := field.Invalid(field.NewPath("spec").Child("encrpytSpreadComm"),
 			v.Spec.EncryptSpreadComm,
 			fmt.Sprintf("encryptSpreadComm can either be an empty string or set to %s", EncryptSpreadCommWithVertica))
+		allErrs = append(allErrs, err)
+	}
+	return allErrs
+}
+
+func (v *VerticaDB) validateLocalPaths(allErrs field.ErrorList) field.ErrorList {
+	// We cannot let any of the local paths be the same as important paths in
+	// the image.  Otherwise, we risk losing the contents of those directory in
+	// the container, which can mess up the deployment.
+	invalidPaths := []string{
+		"/home",
+		"/home/dbadmin",
+		"/opt",
+		"/opt/vertica",
+		"/opt/vertica/bin",
+		"/opt/vertica/sbin",
+		"/opt/vertica/include",
+		"/opt/vertica/java",
+		"/opt/vertica/lib",
+		"/opt/vertica/oss",
+		"/opt/vertica/packages",
+		"/opt/vertica/share",
+		"/opt/vertica/scripts",
+		"/opt/vertica/spread",
+	}
+	for _, invalidPath := range invalidPaths {
+		if v.Spec.Local.DataPath != invalidPath && v.Spec.Local.DepotPath != invalidPath {
+			continue
+		}
+		var fieldRef interface{}
+		var fieldPathName string
+		if v.Spec.Local.DataPath == invalidPath {
+			fieldPathName = "dataPath"
+			fieldRef = v.Spec.Local.DataPath
+		} else {
+			fieldPathName = "depotPath"
+			fieldRef = v.Spec.Local.DepotPath
+		}
+		err := field.Invalid(field.NewPath("spec").Child("local").Child(fieldPathName),
+			fieldRef, fmt.Sprintf("%s cannot be set to %s. This is a restricted path.", fieldPathName, invalidPath))
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -517,6 +517,17 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.EncryptSpreadComm = EncryptSpreadCommWithVertica
 		validateSpecValuesHaveErr(vdb, false)
 	})
+
+	It("should validate we cannot have invalid paths for depot and data", func() {
+		vdb := MakeVDB()
+		vdb.Spec.Local.DataPath = "/home/dbadmin"
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.Local.DataPath = "/data"
+		vdb.Spec.Local.DepotPath = "/opt/vertica/bin"
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.Local.DepotPath = "/depot"
+		validateSpecValuesHaveErr(vdb, false)
+	})
 })
 
 func createVDBHelper() *VerticaDB {

--- a/changes/unreleased/Fixed-20220812-164753.yaml
+++ b/changes/unreleased/Fixed-20220812-164753.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Add webhook rule to prevent use of restricted paths for local paths (data or
+  depot)
+time: 2022-08-12T16:47:53.497874076-03:00
+custom:
+  Issue: "247"


### PR DESCRIPTION
There are certain paths that if chosen for data or depot will mess up the deployment.  These are paths that exist in the image and cannot be chosen as a PV mount point.  Adding a webhook rule to prevent their use.