### PR TITLE
Introduce readOnlyRootFilesystem in manager

### DIFF
--- a/changes/unreleased/Added-20220928-165145.yaml
+++ b/changes/unreleased/Added-20220928-165145.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Run the operator with readOnlyRootFilesystem set to true
+time: 2022-09-28T16:51:45.243295919-03:00
+custom:
+  Issue: "257"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,12 +30,16 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
+        volumeMounts:
+        - name: tmp
+          mountPath: "/tmp"
         readinessProbe:
           httpGet:
             path: /readyz
@@ -50,3 +54,8 @@ spec:
                 fieldPath: metadata.namespace
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: tmp
+        emptyDir:
+          sizeLimit: "10Mi"
+          medium: "Memory"


### PR DESCRIPTION
Closes #253

An immutable root filesystem prevents applications from writing to their local disk. This is desirable in the event of an intrusion as the attacker will not be able to tamper with the filesystem or write foreign executables to disk.