### PR TITLE
Don't interrupt a slow Vertica startup

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -168,7 +168,7 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan == 'all' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.full_vertica_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.full_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Digest: **$(IFS=":" read image tag <<< ${{ steps.full_vertica_image.outputs.value }}; docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2)**" >> $GITHUB_STEP_SUMMARY
+        echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.full_vertica_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
         echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
         echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.full_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
@@ -245,7 +245,7 @@ jobs:
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.minimal_vertica_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.minimal_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Digest: **$(IFS=":" read image tag <<< ${{ steps.minimal_vertica_image.outputs.value }}; docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2)**" >> $GITHUB_STEP_SUMMARY
+        echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.minimal_vertica_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
         echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
         echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.minimal_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
@@ -342,7 +342,7 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.operator_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.operator_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Digest: **$(IFS=":" read image tag <<< ${{ steps.operator_image.outputs.value }}; docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2)**" >> $GITHUB_STEP_SUMMARY
+        echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.operator_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
 
   build-vlogger:
     runs-on: ubuntu-latest
@@ -436,5 +436,5 @@ jobs:
         echo "Was Scanned: ${{ inputs.run_security_scan != 'none' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
         echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.vlogger_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Digest: **$(IFS=":" read image tag <<< ${{ steps.vlogger_image.outputs.value }}; docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2)**" >> $GITHUB_STEP_SUMMARY
+        echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.vlogger_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
 

--- a/Makefile
+++ b/Makefile
@@ -379,6 +379,7 @@ vdb-gen: generate manifests ## Builds the vdb-gen tool
 	go build -o bin/$@ ./cmd/$@
 
 ##@ Deployment
+# When changing this version be sure to update tests/external-images-common-ci.txt
 CERT_MANAGER_VER=1.5.3
 install-cert-manager: ## Install the cert-manager
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v$(CERT_MANAGER_VER)/cert-manager.yaml

--- a/changes/unreleased/Fixed-20220929-144054.yaml
+++ b/changes/unreleased/Fixed-20220929-144054.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Don't interrupt a slow Vertica startup
+time: 2022-09-29T14:40:54.794595732-03:00
+custom:
+  Issue: "258"

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -47,6 +47,7 @@ const (
 	ClusterRestartStarted           = "ClusterRestartStarted"
 	ClusterRestartFailed            = "ClusterRestartFailed"
 	ClusterRestartSucceeded         = "ClusterRestartSucceeded"
+	SlowRestartDetected             = "SlowRestartDetected"
 	SubclusterAdded                 = "SubclusterAdded"
 	SubclusterRemoved               = "SubclusterRemoved"
 	SuperuserPasswordSecretNotFound = "SuperuserPasswordSecretNotFound"

--- a/tests/external-images-common-ci.txt
+++ b/tests/external-images-common-ci.txt
@@ -13,3 +13,6 @@ minio/operator:v4.2.7
 minio/console:v0.9.8
 rancher/local-path-provisioner:v0.0.19
 gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+quay.io/jetstack/cert-manager-controller:v1.5.3
+quay.io/jetstack/cert-manager-cainjector:v1.5.3
+quay.io/jetstack/cert-manager-webhook:v1.5.3


### PR DESCRIPTION
When the operator needs to restart a node, it would kill any running Vertica process before it attemps to restart.  This was done initially in case a vertica process that was up, stops resonding.  However, this behaviour has been problematic if the Vertica startup is just too slow.

This commit will change the behaviour so that it won't uncondionally kill the Vertica process.  If the startup.log shows that Vertica is in the process of starting up, then the process is left as is and we requeue the iteration.