### PR TITLE
Hide communal credentials from the operator log

### DIFF
--- a/changes/unreleased/Fixed-20220929-165740.yaml
+++ b/changes/unreleased/Fixed-20220929-165740.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Hide communal credentials from the operator log
+time: 2022-09-29T16:57:40.08595858-03:00
+custom:
+  Issue: "259"

--- a/pkg/cmds/exec_test.go
+++ b/pkg/cmds/exec_test.go
@@ -1,0 +1,35 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cmds
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("exec", func() {
+	It("should obfuscate password", func() {
+		s := generateLogOutput("vsql", "--password", "silly", "-c", "select 1")
+		Expect(s).Should(Equal("vsql --password ******* -c select 1 "))
+	})
+
+	It("should obfuscate credentials", func() {
+		s := generateLogOutput(`cat > auth_parms.conf<<< '
+awsauth = user:pass
+awsendpoint = minio`)
+		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\nawsauth = ****\nawsendpoint = minio "))
+	})
+})


### PR DESCRIPTION
This obfuscates the communal credentials when logging commands that the operator runs.