### PR TITLE
Hide more communal secrets from operator log

### DIFF
--- a/pkg/cmds/exec.go
+++ b/pkg/cmds/exec.go
@@ -79,8 +79,15 @@ func generateLogOutput(cmd ...string) string {
 // obfuscateForLog is a helper function to obfuscate any sensitive info in a
 // command. It returns the obfuscated string.
 func obfuscateForLog(s string) string {
-	r := regexp.MustCompile("awsauth = .*")
-	s = r.ReplaceAllString(s, "awsauth = ****")
+	pats := map[string]string{
+		"awsauth = .*":                 "awsauth = ****",
+		"GCSAuth = .*":                 "GCSAuth = ****",
+		"AzureStorageCredentials = .*": "AzureStorageCredentials = ****",
+	}
+	for expr, replacement := range pats {
+		r := regexp.MustCompile(expr)
+		s = r.ReplaceAllString(s, replacement)
+	}
 	return s
 }
 

--- a/pkg/cmds/exec_test.go
+++ b/pkg/cmds/exec_test.go
@@ -26,10 +26,23 @@ var _ = Describe("exec", func() {
 		Expect(s).Should(Equal("vsql --password ******* -c select 1 "))
 	})
 
-	It("should obfuscate credentials", func() {
+	It("should obfuscate aws credentials", func() {
 		s := generateLogOutput(`cat > auth_parms.conf<<< '
 awsauth = user:pass
 awsendpoint = minio`)
 		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\nawsauth = ****\nawsendpoint = minio "))
+	})
+
+	It("should obfuscate gcs credentials", func() {
+		s := generateLogOutput(`cat > auth_parms.conf<<< '
+GCSAuth = user:pass
+GCSEndpoint = google`)
+		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\nGCSAuth = ****\nGCSEndpoint = google "))
+	})
+
+	It("should obfuscate azure credentials", func() {
+		s := generateLogOutput(`cat > auth_parms.conf<<< '
+AzureStorageCredentials = {"elem1": "a", "elem2": "b"}`)
+		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\nAzureStorageCredentials = **** "))
 	})
 })


### PR DESCRIPTION
This adds a few more secrets that we should not include as plain-text in the operator log.

This is a follow-up from a few things that were missed in #259.