### PR TITLE
Fix vdbgen

### DIFF
--- a/changes/unreleased/Fixed-20221011-234913.yaml
+++ b/changes/unreleased/Fixed-20221011-234913.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'The vdbgen tool should be able to set ksafety, image and requestSize, when
+  needed, to appropriate values taken from the database'
+time: 2022-10-11T23:49:13.5872721+02:00
+custom:
+  Issue: "262"

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -224,7 +224,7 @@ func (d *DBGenerator) setKSafety(ctx context.Context) error {
 	return nil
 }
 
-// countNodes counts the number of nodes in the cluster.
+// countNodes fetch the number of nodes in the cluster.
 func (d *DBGenerator) countNodes(ctx context.Context) (int, error) {
 	q := Queries[NodeCountQueryKey]
 	rows, err := d.Conn.QueryContext(ctx, q)

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -210,6 +210,7 @@ func (d *DBGenerator) setKSafety(ctx context.Context) error {
 	}
 	if designKSafe == "0" {
 		if nodeCount, err := d.countNodes(ctx); err == nil {
+			// vdbgen will fail if kasety is 0 and there are more than 3 nodes
 			if nodeCount > MaxNodeCountForKSafety0 {
 				return fmt.Errorf("ksafety 0 is not recommended for a %d nodes cluster", nodeCount)
 			}
@@ -223,6 +224,7 @@ func (d *DBGenerator) setKSafety(ctx context.Context) error {
 	return nil
 }
 
+// countNodes counts the number of nodes in the cluster.
 func (d *DBGenerator) countNodes(ctx context.Context) (int, error) {
 	q := Queries[NodeCountQueryKey]
 	rows, err := d.Conn.QueryContext(ctx, q)

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -224,7 +224,7 @@ func (d *DBGenerator) setKSafety(ctx context.Context) error {
 	return nil
 }
 
-// countNodes fetch the number of nodes in the cluster.
+// countNodes will fetch the number of nodes from the database.
 func (d *DBGenerator) countNodes(ctx context.Context) (int, error) {
 	q := Queries[NodeCountQueryKey]
 	rows, err := d.Conn.QueryContext(ctx, q)

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -241,7 +241,7 @@ var _ = Describe("vdb", func() {
 		mock.ExpectQuery(Queries[KSafetyQueryKey]).
 			WillReturnRows(sqlmock.NewRows([]string{"get_design_ksafe"}).
 				AddRow("0"))
-		mock.ExpectQuery("SELECT COUNT.* FROM SUBCLUSTERS").
+		mock.ExpectQuery("SELECT COUNT.* FROM NODES").
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).
 				AddRow("2"))
 
@@ -258,7 +258,7 @@ var _ = Describe("vdb", func() {
 		mock.ExpectQuery(Queries[KSafetyQueryKey]).
 			WillReturnRows(sqlmock.NewRows([]string{"get_design_ksafe"}).
 				AddRow("2"))
-		mock.ExpectQuery("SELECT COUNT.* FROM SUBCLUSTERS").
+		mock.ExpectQuery("SELECT COUNT.* FROM NODES").
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).
 				AddRow("4"))
 
@@ -275,7 +275,7 @@ var _ = Describe("vdb", func() {
 		mock.ExpectQuery(Queries[KSafetyQueryKey]).
 			WillReturnRows(sqlmock.NewRows([]string{"get_design_ksafe"}).
 				AddRow("0"))
-		mock.ExpectQuery("SELECT COUNT.* FROM SUBCLUSTERS").
+		mock.ExpectQuery("SELECT COUNT.* FROM NODES").
 			WillReturnRows(sqlmock.NewRows([]string{"count"}).
 				AddRow("4"))
 

--- a/tests/e2e-extra/vdb-gen/65-assert.yaml
+++ b/tests/e2e-extra/vdb-gen/65-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-vdb-gen
+status:
+  subclusterCount: 2
+  upNodeCount: 2
+  addedToDBCount: 2
+  installCount: 2

--- a/tests/e2e-extra/vdb-gen/65-scale-sc1.yaml
+++ b/tests/e2e-extra/vdb-gen/65-scale-sc1.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+   name: v-vdb-gen
+spec:
+   subclusters:
+      - name: sc1
+        size: 1
+      - name: sc2
+        size: 1

--- a/tests/e2e-extra/vdb-gen/66-wait-for-steady-state.yaml
+++ b/tests/e2e-extra/vdb-gen/66-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -t 360"

--- a/tests/e2e-extra/vdb-gen/70-assert.yaml
+++ b/tests/e2e-extra/vdb-gen/70-assert.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-vdb-gen-revive2-sc1
+status:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-vdb-gen-revive2-sc2
+status:
+  replicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-vdb-gen-revive2
+status:
+  installCount: 2

--- a/tests/e2e-extra/vdb-gen/70-run-vdbgen.yaml
+++ b/tests/e2e-extra/vdb-gen/70-run-vdbgen.yaml
@@ -14,13 +14,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  # Copy vdb-gen into the container.  We run it in the container so that it has
-  # access to k8s network.  Running it outside k8s, it would only have access to
-  # what is exposed.
-  - command: kubectl -n $NAMESPACE cp ../../../bin/vdb-gen v-vdb-gen-sc1-0:/tmp/vdb-gen
-  - command: kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- chmod +x /tmp/vdb-gen
-  - command: kubectl -n $NAMESPACE cp run-vdb-gen.sh v-vdb-gen-sc1-0:/tmp/run-vdb-gen.sh
-  - command: kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- chmod +x /tmp/run-vdb-gen.sh
+  # We have already copied vdb-gen at step 45. Now we run it again, in the container.
   - script: sh -c "kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- sh -c \"/tmp/run-vdb-gen.sh $NAMESPACE $(cd ../../.. && make echo-images | grep ^VERTICA_IMG= | cut -d'=' -f2) v-vdb-gen-revive2 $(kubectl get cm e2e -n $NAMESPACE -o jsonpath='{.data.caFileSecretName}')\" > /tmp/$NAMESPACE-vdb-gen.yaml"
   - command: cat /tmp/$NAMESPACE-vdb-gen.yaml
   # Apply the generated CR

--- a/tests/e2e-extra/vdb-gen/70-run-vdbgen.yaml
+++ b/tests/e2e-extra/vdb-gen/70-run-vdbgen.yaml
@@ -21,7 +21,7 @@ commands:
   - command: kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- chmod +x /tmp/vdb-gen
   - command: kubectl -n $NAMESPACE cp run-vdb-gen.sh v-vdb-gen-sc1-0:/tmp/run-vdb-gen.sh
   - command: kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- chmod +x /tmp/run-vdb-gen.sh
-  - script: sh -c "kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- sh -c \"/tmp/run-vdb-gen.sh $NAMESPACE $(cd ../../.. && make echo-images | grep ^VERTICA_IMG= | cut -d'=' -f2) v-vdb-gen-revive $(kubectl get cm e2e -n $NAMESPACE -o jsonpath='{.data.caFileSecretName}')\" > /tmp/$NAMESPACE-vdb-gen.yaml"
+  - script: sh -c "kubectl -n $NAMESPACE exec v-vdb-gen-sc1-0 -- sh -c \"/tmp/run-vdb-gen.sh $NAMESPACE $(cd ../../.. && make echo-images | grep ^VERTICA_IMG= | cut -d'=' -f2) v-vdb-gen-revive2 $(kubectl get cm e2e -n $NAMESPACE -o jsonpath='{.data.caFileSecretName}')\" > /tmp/$NAMESPACE-vdb-gen.yaml"
   - command: cat /tmp/$NAMESPACE-vdb-gen.yaml
   # Apply the generated CR
   - command: kubectl -n $NAMESPACE apply -f /tmp/$NAMESPACE-vdb-gen.yaml

--- a/tests/e2e-extra/vdb-gen/75-assert.yaml
+++ b/tests/e2e-extra/vdb-gen/75-assert.yaml
@@ -23,6 +23,7 @@ spec:
   local:
     dataPath: /data
     depotPath: /depot
+  kSafety: "0"
   subclusters:
     - name: sc1
       isPrimary: true

--- a/tests/e2e-extra/vdb-gen/75-assert.yaml
+++ b/tests/e2e-extra/vdb-gen/75-assert.yaml
@@ -1,0 +1,37 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-vdb-gen-revive2
+spec:
+  initPolicy: Revive
+  dbName: vertdb
+  shardCount: 6
+  superuserPasswordSecret: v-vdb-gen-revive2-su-passwd
+  local:
+    dataPath: /data
+    depotPath: /depot
+  subclusters:
+    - name: sc1
+      isPrimary: true
+      size: 1
+    - name: sc2
+      isPrimary: true
+      size: 1
+status:
+  installCount: 2
+  subclusterCount: 2
+  upNodeCount: 2
+  addedToDBCount: 2

--- a/tests/e2e-extra/vdb-gen/75-wait-for-revive.yaml
+++ b/tests/e2e-extra/vdb-gen/75-wait-for-revive.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-extra/vdb-gen/run-vdb-gen.sh
+++ b/tests/e2e-extra/vdb-gen/run-vdb-gen.sh
@@ -21,7 +21,8 @@ set -o pipefail
 
 NAMESPACE=$1
 VERTICA_IMG=$2
-COMMUNAL_EP_CERT_SECRET=$3
+VDB_NAME=$3
+COMMUNAL_EP_CERT_SECRET=$4
 
 # The ca.cert is optional.
 if [ -f "/certs/$COMMUNAL_EP_CERT_SECRET/ca.crt" ]
@@ -42,7 +43,7 @@ fi
 /tmp/vdb-gen \
     -license /home/dbadmin/licensing/ce/vertica_community_edition.license.key \
     -image $VERTICA_IMG \
-    -name v-vdb-gen-revive \
+    -name $VDB_NAME \
     -password superuser \
     -ignore-cluster-lease \
     $CA_CERT_OPT \


### PR DESCRIPTION
This fixes some vdbgen issues by:
- fetching the ksafety from the server
- fetching the depot and data sizes from the server, and using them to calculate the local requestSize.
- fetching the server version and using it to build the image name.

