### PR TITLE
Upgrade github actions that used node 12

### DIFF
--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -10,7 +10,7 @@ runs:
       uses: ./.github/actions/setup-kubectl
 
     - name: Download all the docker image for PRs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
 
     - name: Load the docker images for PRs

--- a/.github/actions/setup-go-kctx/action.yaml
+++ b/.github/actions/setup-go-kctx/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18.5
     

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
 
     - name: Pick the name of the image
-      uses: dkershner6/switch-case-action@v1
+      uses: spilchen/switch-case-action@v1
       id: full_vertica_image
       with:
         default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}
@@ -89,7 +89,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: ${{ inputs.full_vertica_image == '' }}
 
     - name: Download the RPM
@@ -111,7 +111,7 @@ jobs:
       run: |
         docker save ${{ steps.full_vertica_image.outputs.value }} > full-vertica-image.tar
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: full-vertica-image
@@ -154,7 +154,7 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-image.out'
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ always() && inputs.run_security_scan == 'all' }}
       with:
         name: security-scan
@@ -180,7 +180,7 @@ jobs:
     steps:
 
     - name: Pick the name of the image
-      uses: dkershner6/switch-case-action@v1
+      uses: spilchen/switch-case-action@v1
       id: minimal_vertica_image
       with:
         default: ghcr.io/${{ github.repository_owner }}/vertica-k8s:${{ github.sha }}-minimal
@@ -203,7 +203,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: ${{ inputs.minimal_vertica_image == '' }}
 
     - name: Download the RPM
@@ -226,7 +226,7 @@ jobs:
       run: |
         docker save ${{ steps.minimal_vertica_image.outputs.value }} > minimal-vertica-image.tar
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: minimal-vertica-image
@@ -257,7 +257,7 @@ jobs:
     steps:
 
     - name: Pick the name of the image
-      uses: dkershner6/switch-case-action@v1
+      uses: spilchen/switch-case-action@v1
       id: operator_image
       with:
         default: ghcr.io/${{ github.repository_owner }}/verticadb-operator:${{ github.sha }}
@@ -273,7 +273,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: ${{ inputs.operator_image == '' }}
 
     - name: Build and optionally push operator image
@@ -291,7 +291,7 @@ jobs:
       run: |
         docker save ${{ steps.operator_image.outputs.value }} > operator-image.tar
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: operator-image
@@ -328,7 +328,7 @@ jobs:
         format: 'table'
         output: 'trivy-results-verticadb-operator-image.out'
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ always() && inputs.run_security_scan != 'none' }}
       with:
         name: security-scan
@@ -351,7 +351,7 @@ jobs:
     steps:
 
     - name: Pick the name of the image
-      uses: dkershner6/switch-case-action@v1
+      uses: spilchen/switch-case-action@v1
       id: vlogger_image
       with:
         default: ghcr.io/${{ github.repository_owner }}/vertica-logger:${{ github.sha }}
@@ -367,7 +367,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: ${{ inputs.vlogger_image == '' }}
 
     - name: Build and optionally push vlogger image
@@ -385,7 +385,7 @@ jobs:
       run: |
         docker save ${{ steps.vlogger_image.outputs.value }} > vlogger-image.tar
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: vlogger-image
@@ -422,7 +422,7 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-logger-image.out'
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ always() && inputs.run_security_scan != 'none' }}
       with:
         name: security-scan

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
       
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up environment
       uses: ./.github/actions/setup-go-kctx
@@ -48,72 +48,72 @@ jobs:
         ls -lhrt
     
     - name: Upload CRDs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/verticadb-operator/crds/*-crd.yaml 
 
     - name: Upload Custom SCC
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/samples/custom-scc.yaml
     
     - name: Upload RBAC to run Operator
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/operator-rbac.yaml
 
     - name: Upload Helm Charts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/*.tgz
 
     - name: Upload vdb-gen
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/bin/vdb-gen
 
     - name: Upload ClusterRole to allow auth proxy to lookup access privileges
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-proxy-role-cr.yaml
 
 
     - name: Upload ClusterRoleBinding to bind a ServiceAccount to the role allowing access privilege lookups
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-proxy-rolebinding-crb.yaml
 
 
     - name: Upload ClusterRole for non-resource access of the /metrics endpoint
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-reader-cr.yaml
 
 
     - name: Upload ClusterRoleBinding to bind non-resource access of the /metrics endpoint
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-reader-crb.yaml
 
 
     - name: Upload ServiceMonitor object for integration with Prometheus operator
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-monitor-servicemonitor.yaml
 
 
     - name: Upload Bundle
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: olm-bundle
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/bundle

--- a/.github/workflows/e2e-azb.yml
+++ b/.github/workflows/e2e-azb.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
@@ -61,7 +61,7 @@ jobs:
         export VLOGGER_IMG=${{ inputs.vlogger-image }}
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-azb-ci.txt
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: logs-e2e-azb

--- a/.github/workflows/e2e-hdfs.yml
+++ b/.github/workflows/e2e-hdfs.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
@@ -61,7 +61,7 @@ jobs:
         export VLOGGER_IMG=${{ inputs.vlogger-image }}
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-hdfs-ci.txt
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: logs-e2e-hdfs

--- a/.github/workflows/e2e-operator-upgrade.yml
+++ b/.github/workflows/e2e-operator-upgrade.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
@@ -65,7 +65,7 @@ jobs:
         scripts/setup-operator-upgrade-testsuite.sh
         scripts/run-k8s-int-tests.sh -s
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: logs-e2e-operator-upgrade

--- a/.github/workflows/e2e-s3.yml
+++ b/.github/workflows/e2e-s3.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
@@ -60,7 +60,7 @@ jobs:
         export VLOGGER_IMG=${{ inputs.vlogger-image }}
         scripts/run-k8s-int-tests.sh -s
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: logs-e2e-s3

--- a/.github/workflows/e2e-server-upgrade.yml
+++ b/.github/workflows/e2e-server-upgrade.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
@@ -62,7 +62,7 @@ jobs:
         export VLOGGER_IMG=${{ inputs.vlogger-image }}
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-server-upgrade-ci.txt
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: logs-e2e-server-upgrade

--- a/.github/workflows/e2e-udx.yml
+++ b/.github/workflows/e2e-udx.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
@@ -67,7 +67,7 @@ jobs:
         scripts/setup-e2e-udx.sh -v
         scripts/run-k8s-int-tests.sh -s
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: logs-e2e-udx

--- a/.github/workflows/scorecardtests.yml
+++ b/.github/workflows/scorecardtests.yml
@@ -7,7 +7,7 @@ jobs:
   sct:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
         
     - name: Set up Go and kubectx
       uses: ./.github/actions/setup-go-kctx

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -7,10 +7,10 @@ jobs:
   ut:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18.5
 

--- a/.github/workflows/verify-public-artifacts.yml
+++ b/.github/workflows/verify-public-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go and kubectx
       uses: ./.github/actions/setup-go-kctx


### PR DESCRIPTION
Node.js 12 actions are deprecated in GitHub actions. If you use an action with this version, you get a warning. This upgrades any action that was rely on node 12 to one that supports node 16.