### PR TITLE
Allow IAM authentication to communal storage

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -470,7 +470,7 @@ type CommunalStorage struct {
 	// communal endpoint (only applies to s3://, gs:// or azb://). Certain keys
 	// need to be set, depending on the endpoint type:
 	// - s3:// or gs:// - If storing credentials in a secret, the secret must
-	//     have the following keys set: accessey and secretkey.  When using
+	//     have the following keys set: accesskey and secretkey.  When using
 	//     Google Cloud Storage, the IDs set in the secret are taken
 	//     from the hash-based message authentication code (HMAC) keys.
 	// - azb:// - It must have the following keys set:

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -469,8 +469,9 @@ type CommunalStorage struct {
 	// The name of a secret that contains the credentials to connect to the
 	// communal endpoint (only applies to s3://, gs:// or azb://). Certain keys
 	// need to be set, depending on the endpoint type:
-	// - s3:// or gs:// - It must have the following keys set: accessey and secretkey.
-	//     When using Google Cloud Storage, the IDs set in the secret are taken
+	// - s3:// or gs:// - If storing credentials in a secret, the secret must
+	//     have the following keys set: accessey and secretkey.  When using
+	//     Google Cloud Storage, the IDs set in the secret are taken
 	//     from the hash-based message authentication code (HMAC) keys.
 	// - azb:// - It must have the following keys set:
 	//     accountName - Name of the Azure account
@@ -481,8 +482,11 @@ type CommunalStorage struct {
 	//     sharedAccessSignature - If accessing with a shared access signature,
 	//     	  set it here
 	//
-	// When initPolicy is Create or Revive, and not using HDFS this field is
-	// required.
+	// This field is optional. For AWS, authentication to communal storage can
+	// be provided through an attached IAM profile: attached to the EC2 instance
+	// or to a ServiceAccount with IRSA (see
+	// https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+	// IRSA requires a Vertica server running at least with version >= 12.0.3.
 	CredentialSecret string `json:"credentialSecret"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -254,7 +254,6 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.validateCommunalPath(allErrs)
 	allErrs = v.validateEndpoint(allErrs)
 	allErrs = v.hasValidDomainName(allErrs)
-	allErrs = v.credentialSecretExists(allErrs)
 	allErrs = v.hasValidNodePort(allErrs)
 	allErrs = v.isNodePortProperlySpecified(allErrs)
 	allErrs = v.isServiceTypeValid(allErrs)
@@ -331,24 +330,6 @@ func (v *VerticaDB) validateEndpoint(allErrs field.ErrorList) field.ErrorList {
 		err := field.Invalid(field.NewPath("spec").Child("communal").Child("endpoint"),
 			v.Spec.Communal.Endpoint,
 			"communal.endpoint must be prefaced with http:// or https:// to know what protocol to connect with")
-		allErrs = append(allErrs, err)
-	}
-	return allErrs
-}
-
-func (v *VerticaDB) credentialSecretExists(allErrs field.ErrorList) field.ErrorList {
-	if v.Spec.InitPolicy == CommunalInitPolicyScheduleOnly {
-		return allErrs
-	}
-	// Credential secrets are not needed if communal path is HDFS
-	if v.IsHDFS() {
-		return allErrs
-	}
-	// communal.credentialSecret must exist
-	if v.Spec.Communal.CredentialSecret == "" {
-		err := field.Invalid(field.NewPath("spec").Child("communal").Child("credentialSecret"),
-			v.Spec.Communal.CredentialSecret,
-			"communal.credentialSecret must exist")
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -94,10 +94,10 @@ var _ = Describe("verticadb_webhook", func() {
 		sc.Name = "default_subcluster"
 		validateSpecValuesHaveErr(vdb, true)
 	})
-	It("should not have empty credentialsecret", func() {
+	It("should be allowed to have empty credentialsecret", func() {
 		vdb := createVDBHelper()
 		vdb.Spec.Communal.CredentialSecret = ""
-		validateSpecValuesHaveErr(vdb, true)
+		validateSpecValuesHaveErr(vdb, false)
 	})
 	It("should not have nodePort smaller than 30000", func() {
 		vdb := createVDBHelper()

--- a/changes/unreleased/Added-20221013-111702.yaml
+++ b/changes/unreleased/Added-20221013-111702.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Allow IAM authentication to communal storage
+time: 2022-10-13T11:17:02.4083894-03:00
+custom:
+  Issue: "265"


### PR DESCRIPTION
This relaxes things in the operator so that the communal credential secret isn't required. Prior to this, the credential secret was required if connecting to a s3://, azb://, or gs:// endpoint.

This will allow us to authenticate with IAM when connecting on AWS. AWS provides two methods of authenticating with IAM:
- EC2 IAM authentication: an IAM role is attached to the EC2 instance. All pods running on the EC2 instance will be able to use the attached roles.
- IAM roles for service accounts (#200): this is for more fine-grained access control. You can use this to attach IAM roles to a ServiceAccount. All pods running with the ServiceAccount will be able to use the roles. This feature requires a Vertica service of at least 12.0.3 (not yet available at the time of this PR). You will need to specify an existing ServiceAccount in the helm chart when deploying the operator. More details will be included in the official Vertica documentation once a server with support is GA'd.