### PR TITLE
Some pods may fail to run for a server upgrade change

### DIFF
--- a/changes/unreleased/Fixed-20221020-093854.yaml
+++ b/changes/unreleased/Fixed-20221020-093854.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: "Some pods may fail to run for a server upgrade change"
+time: 2022-10-20T09:38:54.287714342-03:00
+custom:
+  Issue: "271"

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/05-create-communal-creds.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/05-create-communal-creds.yaml
@@ -11,22 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/10-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/10-assert.yaml
@@ -11,22 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-base-upgrade
+  labels:
+    control-plane: controller-manager
 status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  phase: Running

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/10-deploy-operator.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/10-deploy-operator.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/15-create-cm.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/15-create-cm.yaml
@@ -11,22 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  name: vdb-state-orig-name
+data:
+  LOCATION: Charlottetown

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/20-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/20-assert.yaml
@@ -11,22 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-s0
+status:
+  replicas: 1
+---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  subclusters:
+    - installCount: 1

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/20-setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/20-setup-vdb.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/25-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/25-assert.yaml
@@ -21,12 +21,3 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/25-wait-for-createdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/25-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/30-verify-cm-mount.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/30-verify-cm-mount.yaml
@@ -11,22 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+# Start another upgrade but with a bogus image that doesn't exist.  The purpose
+# of this is abort an upgrade that is improgress and get it back to a good
+# state.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl -n $NAMESPACE exec -it v-base-upgrade-s0-0 -- cat /configmap/LOCATION
+  - command: kubectl -n $NAMESPACE exec -it v-base-upgrade-s0-0 -- grep -q Charlottetown /configmap/LOCATION

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/35-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/35-assert.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  name: vdb-state-new-name

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/35-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/35-errors.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  name: vdb-state-orig-name

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/35-rename-cm.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/35-rename-cm.yaml
@@ -11,22 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  name: vdb-state-new-name
+data:
+  LOCATION: Charlottetown
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: ConfigMap
+    name: vdb-state-orig-name

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/40-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/40-assert.yaml
@@ -22,11 +22,6 @@ status:
     - type: DBInitialized
       status: "True"
     - type: ImageChangeInProgress
-      status: "False"
+      status: "True"
     - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+      status: "True"

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/40-initiate-upgrade-and-mount-change.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/40-initiate-upgrade-and-mount-change.yaml
@@ -11,22 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade
+  - command: kubectl patch -n $NAMESPACE vdb v-base-upgrade --type=json --patch-file cm-patch.json

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/45-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/45-assert.yaml
@@ -16,17 +16,6 @@ kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  installCount: 1
+  addedToDBCount: 1
+  upNodeCount: 0

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/45-wait-for-shutdown.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/45-wait-for-shutdown.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/50-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/50-assert.yaml
@@ -25,8 +25,6 @@ status:
       status: "False"
     - type: OfflineUpgradeInProgress
       status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
+  subclusterCount: 1
+  installCount: 1
   upNodeCount: 1

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/50-wait-for-finish.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/50-wait-for-finish.yaml
@@ -11,22 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl wait --for=condition=OfflineUpgradeInProgress=False vdb/v-base-upgrade --timeout=600s
+    namespaced: true

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/55-verify-cm-mount.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/55-verify-cm-mount.yaml
@@ -11,22 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+# Start another upgrade but with a bogus image that doesn't exist.  The purpose
+# of this is abort an upgrade that is improgress and get it back to a good
+# state.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl -n $NAMESPACE exec -it v-base-upgrade-s0-0 -- cat /configmap/LOCATION
+  - command: kubectl -n $NAMESPACE exec -it v-base-upgrade-s0-0 -- grep -q Charlottetown /configmap/LOCATION

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/95-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/95-errors.yaml
@@ -11,22 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/95-uninstall-operator.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/95-uninstall-operator.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/97-delete-crd.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/97-delete-crd.yaml
@@ -11,22 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/97-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/97-errors.yaml
@@ -11,22 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/99-delete-ns.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/99-delete-ns.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/cm-patch.json
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/cm-patch.json
@@ -1,0 +1,1 @@
+[{"op": "replace", "path": "/spec/volumes/0/configMap/name", "value": "vdb-state-new-name"}]

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/setup-vdb/base/kustomization.yaml
@@ -11,22 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/setup-vdb/base/setup-vdb.yaml
@@ -15,18 +15,29 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-base-upgrade
-status:
-  conditions:
-    - type: AutoRestartVertica
-      status: "True"
-    - type: DBInitialized
-      status: "True"
-    - type: ImageChangeInProgress
-      status: "False"
-    - type: OfflineUpgradeInProgress
-      status: "False"
-    - type: OnlineUpgradeInProgress
-      status: "False"
-  subclusterCount: 2
-  installCount: 2
-  upNodeCount: 1
+spec:
+  image: kustomize-vertica-image
+  imagePullPolicy: IfNotPresent
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  dbName: vertica
+  upgradePolicy: Offline
+  shardCount: 12
+  kSafety: "0"
+  subclusters:
+    - name: s0
+      size: 1
+  # Set requeueTime to prevent the exponential backoff kicking in, which can
+  # cause the test to timeout.
+  requeueTime: 5
+  certSecrets: []
+  imagePullSecrets: []
+  volumes:
+    - name: cm
+      configMap:
+        name: vdb-state-orig-name
+  volumeMounts:
+    - name: cm
+      mountPath: /configmap


### PR DESCRIPTION
This fixes a problem where a server upgrade, accompanied with other CR changes, may prevent pods from starting. If the image change in the CR along with some other change that requires a change in the pod spec then the operator was failing to get the pods running. The change in the pod spec had to be something that was required for it to run. The example that we hit with the bug is if one of the mounted volume names change. Such a change requires the pod spec to be updated to point to the new.

To solve this, we run the ObjReconciler, which is responsible for sts/pod spec updates, ahead of the upgrade reconcilers.

A new e2e test was added that was able to mimic the error.