### PR TITLE
Allow local paths to share the same mount point

### DIFF
--- a/changes/unreleased/Fixed-20221024-202149.yaml
+++ b/changes/unreleased/Fixed-20221024-202149.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Allow local paths to share the same mount point
+time: 2022-10-24T20:21:49.321480449-03:00
+custom:
+  Issue: "275"

--- a/pkg/controllers/vdb/paths.go
+++ b/pkg/controllers/vdb/paths.go
@@ -71,6 +71,10 @@ func debugDumpAdmintoolsConfForPods(ctx context.Context, prunner cmds.PodRunner,
 // the ownership of the config, log and data directory.  This function exists to
 // handle the depot directory.
 func changeDepotPermissions(ctx context.Context, vdb *vapi.VerticaDB, prunner cmds.PodRunner, podList []*PodFact) error {
+	// Early out if depotPath is shared with one of the data or catalog paths.
+	if vdb.Spec.Local.DepotPath == vdb.Spec.Local.DataPath || vdb.Spec.Local.DepotPath == vdb.Spec.Local.CatalogPath {
+		return nil
+	}
 	cmd := []string{
 		"sudo", "chown", "dbadmin:verticadba", "-R", fmt.Sprintf("%s/%s", paths.LocalDataPath, vdb.GetPVSubPath("depot")),
 	}

--- a/tests/e2e-extra/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-extra/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
@@ -22,7 +22,7 @@ spec:
   initPolicy: Create
   local:
     dataPath: /my-data
-    depotPath: /home/dbadmin/depot
+    depotPath: /my-data
     requestSize: 100Mi
   dbName: vertdb
   requeueTime: 5

--- a/tests/e2e-extra/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-extra/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
@@ -23,7 +23,7 @@ spec:
   initPolicy: Revive
   local:
     dataPath: /my-data
-    depotPath: /home/dbadmin/depot
+    depotPath: /my-data
     requestSize: 100Mi
   dbName: vertdb
   requeueTime: 5


### PR DESCRIPTION
This is a bug fix for when the local paths (data, depot, catalog) all share the same mount location. Previous to this change, the pods in a statefulset will fail to start if the paths are all the same. It fails to start because they all shared the same mount. This fixes it by adding a mount only if the local paths differ.