### PR TITLE
Add pod security policy to helm charts

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 - ../prometheus
+- ../psp
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/psp/custom_psp.yaml
+++ b/config/psp/custom_psp.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: custom-psp
+spec:
+  privileged: false
+  hostNetwork: false
+  allowPrivilegeEscalation: true
+  hostPID: false
+  hostIPC: false
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+  allowedCapabilities:
+  - 'SYS_CHROOT'
+  - 'AUDIT_WRITE'
+  - 'SYS_PTRACE'
+  requiredDropCapabilities:
+  - 'SYS_ADMIN'

--- a/config/psp/custom_psp_rb.yaml
+++ b/config/psp/custom_psp_rb.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: custom-psp-rb
+  namespace: system
+roleRef:
+  kind: Role
+  name: custom-psp-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize all authenticated users in a namespace:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated

--- a/config/psp/custom_psp_role.yaml
+++ b/config/psp/custom_psp_role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: custom-psp-role
+  namespace: system
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - custom-psp
+  verbs:
+  - use

--- a/config/psp/kustomization.yaml
+++ b/config/psp/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- custom_psp.yaml
+- custom_psp_role.yaml
+- custom_psp_rb.yaml

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -154,3 +154,9 @@ prometheus:
   # Note: setting this to true for multiple operator installs on the same
   # system will fail due to the cluster scoped nature of the rbac rules.
   createProxyRBAC: false
+
+psp:
+  # Set this to true if pod security policies (psp) are enabled on your cluster.
+  # The helm install will create a custom psp and rbac rules for later validating 
+  # pods that will be deployed in the same namespace as the operator.
+  enable: false

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -165,3 +165,12 @@ perl -i -0777 -pe 's/(memory: 64Mi)/$1\n{{- end }}/g' $TEMPLATE_DIR/verticadb-op
 # In the config/ directory we hardcoded everything to start with
 # verticadb-operator.
 sed -i 's/verticadb-operator/{{ include "vdb-op.name" . }}/g' $TEMPLATE_DIR/*yaml
+
+# 17.   Template pod security policy manifests.
+sed -i 's/{{ include "vdb-op.name" . }}-//g' $TEMPLATE_DIR/verticadb-operator-custom-psp-podsecuritypolicy.yaml
+sed -i '1s/^/{{- if .Values.psp.enable -}}\n/' $TEMPLATE_DIR/verticadb-operator-custom-psp-podsecuritypolicy.yaml
+echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-custom-psp-podsecuritypolicy.yaml
+sed -i '1s/^/{{- if .Values.psp.enable -}}\n/' $TEMPLATE_DIR/verticadb-operator-custom-psp-role-role.yaml
+echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-custom-psp-role-role.yaml
+sed -i '1s/^/{{- if .Values.psp.enable -}}\n/' $TEMPLATE_DIR/verticadb-operator-custom-psp-rb-rb.yaml
+echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-custom-psp-rb-rb.yaml


### PR DESCRIPTION
On  a cluster with Pod Security Policies (PSP) enabled, vertica pods need to be validated by at least 1 psp.
This PR adds to the helm charts:
- psp that has the minimum features to validate our pods without giving them more permissions than they need.
- a role and rolebinding to allow pods in the same namespace as the operator to get validated.

As psp is a cluster scoped resource, it is disabled by default.
As the operator is namespace scoped I prefered role/rolebinding to clusterrole/clusterrolebinding. So there will be a psp object and a pair of role/rolebinding for each helm instance of the operator. 