### PR TITLE
Add option to skip package install during create DB

### DIFF
--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -6,6 +6,13 @@ runs:
     - name: Set up Go and kubectx
       uses: ./.github/actions/setup-go-kctx
 
+    - name: Free up space on the hosted runner by removing unnecessary software
+      shell: bash
+      run: |
+        sudo rm -rf /usr/local/lib/android/sdk
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/swift
+
     - name: Install kubectl and related tools
       uses: ./.github/actions/setup-kubectl
 

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -382,6 +382,10 @@ const (
 	// you want to provision new nodes to run inside Kubernetes.  Most of the
 	// automation is disabled when running in this mode.
 	CommunalInitPolicyScheduleOnly = "ScheduleOnly"
+	// Like CommunalInitPolicyCreate, except it will skip the install of the
+	// packages. This will speed up the time it takes to create the db. This is
+	// only supported in Vertica release 12.0.1 or higher.
+	CommunalInitPolicyCreateSkipPackageInstall = "CreateSkipPackageInstall"
 )
 
 // Set constant Upgrade Requeue Time

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -294,12 +294,15 @@ func (v *VerticaDB) hasAtLeastOneSC(allErrs field.ErrorList) field.ErrorList {
 func (v *VerticaDB) hasValidInitPolicy(allErrs field.ErrorList) field.ErrorList {
 	switch v.Spec.InitPolicy {
 	case CommunalInitPolicyCreate:
+	case CommunalInitPolicyCreateSkipPackageInstall:
 	case CommunalInitPolicyRevive:
 	case CommunalInitPolicyScheduleOnly:
 	default:
 		err := field.Invalid(field.NewPath("spec").Child("initPolicy"),
 			v.Spec.InitPolicy,
-			"initPolicy should either be Create, Revive or ScheduleOnly.")
+			fmt.Sprintf("initPolicy should either be %s, %s, %s or %s",
+				CommunalInitPolicyCreate, CommunalInitPolicyCreateSkipPackageInstall,
+				CommunalInitPolicyRevive, CommunalInitPolicyScheduleOnly))
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/changes/unreleased/Added-20221104-162409.yaml
+++ b/changes/unreleased/Added-20221104-162409.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Ability to skip package install during create db
+time: 2022-11-04T16:24:09.179367795-03:00
+custom:
+  Issue: "282"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -50,6 +50,9 @@ const (
 	CGroupV2UnsupportedVersion = "v12.0.0"
 	// The minimum version that can start Vertica's http server
 	HTTPServerMinVersion = "v12.0.1"
+	// The minimum version that we can use the option with create DB to skip the
+	// package install.
+	CreateDBSkipPackageInstallVersion = "v12.0.1"
 )
 
 // UpgradePaths has all of the vertica releases supported by the operator.  For

--- a/tests/e2e-extra/createdb-failures/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/createdb-failures/setup-vdb/base/setup-vdb.yaml
@@ -27,6 +27,7 @@ spec:
     - name: sc
       size: 1
   kSafety: "0"
+  initPolicy: CreateSkipPackageInstall
   # Set requeueTime since we are intentionally failing.  This prevents the
   # exponential backoff kicking in, which can cause the test to timeout.
   requeueTime: 4

--- a/tests/e2e-extra/disable-webhook/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/disable-webhook/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-disable-webhook
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e-extra/helm-nameoverride/35-assert.yaml
+++ b/tests/e2e-extra/helm-nameoverride/35-assert.yaml
@@ -17,4 +17,4 @@ kind: VerticaDB
 metadata:
   name: v-helm-nameoverride
 spec:
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall

--- a/tests/e2e-extra/helm-nameoverride/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/helm-nameoverride/setup-vdb/base/setup-vdb.yaml
@@ -22,6 +22,7 @@ spec:
   local:
     requestSize: 100Mi
   dbName: vertdb
+  initPolicy: CreateSkipPackageInstall
   subclusters:
     - name: pri-sc
       size: 1

--- a/tests/e2e-extra/operator-metrics/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/operator-metrics/setup-vdb/base/setup-vdb.yaml
@@ -22,6 +22,7 @@ spec:
   local:
     requestSize: 100Mi
   dbName: vertdb
+  initPolicy: CreateSkipPackageInstall
   subclusters:
     - name: sec-sc
       size: 1

--- a/tests/e2e-extra/pending-pod/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/pending-pod/setup-vdb/base/setup-vdb.yaml
@@ -21,6 +21,7 @@ spec:
     - name: vlogger
       image: kustomize-vlogger-image
   dbName: Db
+  initPolicy: CreateSkipPackageInstall
   communal:
     includeUIDInPath: true
   local:

--- a/tests/e2e-extra/pvc-expansion/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/pvc-expansion/setup-vdb/base/setup-vdb.yaml
@@ -21,6 +21,7 @@ spec:
     - name: vlogger
       image: kustomize-vlogger-image
   dbName: data_base
+  initPolicy: CreateSkipPackageInstall
   communal:
     includeUIDInPath: true
   local:

--- a/tests/e2e-extra/restart-kill-sts/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/restart-kill-sts/setup-vdb/base/setup-vdb.yaml
@@ -22,6 +22,7 @@ spec:
   local:
     requestSize: 100Mi
   dbName: vertica1
+  initPolicy: CreateSkipPackageInstall
   requeueTime: 5
   subclusters:
     - name: pri1

--- a/tests/e2e-extra/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-extra/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
@@ -22,7 +22,7 @@ spec:
     includeUIDInPath: false
   local:
     requestSize: 100Mi
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall
   dbName: vertdb
   subclusters:
     - name: sc1

--- a/tests/e2e-extra/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-extra/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
@@ -19,7 +19,7 @@ spec:
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall
   local:
     dataPath: /my-data
     depotPath: /my-data

--- a/tests/e2e-extra/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-extra/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
@@ -22,7 +22,7 @@ spec:
       image: kustomize-vlogger-image
   communal:
     includeUIDInPath: false
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall
   local:
     dataPath: /data
     depotPath: /depot

--- a/tests/e2e-extra/vdb-gen/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-extra/vdb-gen/setup-vdb/base/setup-vdb.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
+  initPolicy: CreateSkipPackageInstall
   communal:
     includeUIDInPath: false
   local:

--- a/tests/e2e-udx/udx-cpp/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-udx/udx-cpp/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-udx-cpp
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e-udx/udx-java/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-udx/udx-java/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-udx-java
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e-udx/udx-python/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-udx/udx-python/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-udx-python
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/auto-restart-vertica/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/auto-restart-vertica/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-auto-restart-vertica
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   sidecars:
     - name: vlogger

--- a/tests/e2e/autoscale-by-pod/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/autoscale-by-pod/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-autoscale-by-pod
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/autoscale-by-subcluster/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/autoscale-by-subcluster/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-autoscale-by-subcluster
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/client-access/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/client-access/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-client-access
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/crash-before-createdb/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/crash-before-createdb/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-crash-before-createdb
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: verticadb-sample
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/custom-cert-webhook-cabundle-as-parm/20-assert.yaml
+++ b/tests/e2e/custom-cert-webhook-cabundle-as-parm/20-assert.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-custom-cert-webhook-cabundle-as-parm
 spec:
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall

--- a/tests/e2e/custom-cert-webhook-cabundle-as-parm/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/custom-cert-webhook-cabundle-as-parm/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-custom-cert-webhook-cabundle-as-parm
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/custom-cert-webhook-cabundle-in-secret/25-assert.yaml
+++ b/tests/e2e/custom-cert-webhook-cabundle-in-secret/25-assert.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-custom-cert-webhook-cabundle-in-secret
 spec:
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall

--- a/tests/e2e/custom-cert-webhook-cabundle-in-secret/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/custom-cert-webhook-cabundle-in-secret/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-custom-cert-webhook-cabundle-in-secret
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/custom-operator-log-path/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/custom-operator-log-path/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-custom-operator-log-path
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/k-safety-0-scaling/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/k-safety-0-scaling/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-k-safety-0-scaling
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   sidecars:
     - name: vlogger

--- a/tests/e2e/k-safety-1-scaling/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/k-safety-1-scaling/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-scale-up-and-down
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   sidecars:
     - name: vlogger

--- a/tests/e2e/kill-controller/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/kill-controller/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-kill-controller
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/kill-during-add-node/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/kill-during-add-node/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-kill
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   sidecars:
     - name: vlogger

--- a/tests/e2e/labels-annotations/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/labels-annotations/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: vdb-label-ant
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/mount-certs/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/mount-certs/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-mount-certs
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/multi-sc-sanity/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/multi-sc-sanity/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-multi-sc
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
   communal:

--- a/tests/e2e/restart-node-multi-sc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/restart-node-multi-sc/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-mc-restart
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   sidecars:
     - name: vlogger

--- a/tests/e2e/restart-sanity/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/restart-sanity/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-restart
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd
   communal:

--- a/tests/e2e/revivedb-failures/vdb-create-db/base/setup-vdb.yaml
+++ b/tests/e2e/revivedb-failures/vdb-create-db/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-revive-failures
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/scale-down-drain/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/scale-down-drain/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-scale-down-drain
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/schedule-only/setup-managed-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/schedule-only/setup-managed-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-managed
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   sidecars:
     - name: vlogger

--- a/tests/e2e/shared-svc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/shared-svc/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-shared-svc
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true

--- a/tests/e2e/use-preexisting-sa-incl-rbac/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/use-preexisting-sa-incl-rbac/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-use-preexisting-sa-incl-rbac
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/use-preexisting-sa-skip-rbac/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/use-preexisting-sa-skip-rbac/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-use-preexisting-sa-skip-rbac
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: false

--- a/tests/e2e/webhook/20-assert.yaml
+++ b/tests/e2e/webhook/20-assert.yaml
@@ -17,4 +17,4 @@ kind: VerticaDB
 metadata:
   name: v-webhook
 spec:
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall

--- a/tests/e2e/webhook/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e/webhook/setup-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-webhook
 spec:
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   sidecars:
     - name: vlogger


### PR DESCRIPTION
This adds a new `initPolicy` called `CreateSkipPackageInstall`. This option will allow us to create a DB and skip the package installation (availableonly when running with Vertica server 12.0.1+). Packages can still be installed after the fact using `admintools -t install_package`. This is mainly added for testing as we can spin up a new Vertica cluster faster.

Sample CR to use the new policy:
```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: v
spec:
  communal:
    ...
  initPolicy: CreateSkipPackageInstall
  subclusters:
    - name: sc
```