### PR TITLE
Improve the stability of the operator in big clusters

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -177,7 +177,7 @@ This method runs the operator synchronously in your shell. It is the fastest way
 Enter the following command:
 
 ```shell
-make install run ENABLE_WEBHOOKS=false
+make install run
 ```
 
 Press **Ctrl+C** to stop the operator.
@@ -186,7 +186,7 @@ Press **Ctrl+C** to stop the operator.
 
 This disables the webhook from running too, as running the webhook requires TLS certs to be available.
 
-This will monitor VerticaDB CR's across all namespaces.  So, make sure that when you run in this mode that you don't have any old VerticaDB's lying around.
+This will monitor VerticaDB CR's in the current namespace only. You need to update your kubectl config and change the namespace if you want to monitor a different one.
 
 ### Option 2: Kubernetes Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,9 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/operator/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run cmd/operator/main.go -enable-profiler
+	mkdir -p int-tests-output
+	sed 's/\(WEBHOOK_CERT_SOURCE\).*/\1: internal/;s/\(name:\) .*/\1 verticadb-operator-manager-config/;s/namespace: .*//' helm-charts/verticadb-operator/templates/verticadb-operator-manager-config-cm.yaml | kubectl apply -f -
+	ENABLE_WEBHOOKS=false go run cmd/operator/main.go -enable-profiler -service-account-name=default | tee int-tests-output/verticadb-operator.log
 
 docker-build-operator: manifests generate fmt vet ## Build operator docker image with the manager.
 	docker build -t ${OPERATOR_IMG} -f docker-operator/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -305,9 +305,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/operator/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	mkdir -p int-tests-output
-	sed 's/\(WEBHOOK_CERT_SOURCE\).*/\1: internal/;s/\(name:\) .*/\1 verticadb-operator-manager-config/;s/namespace: .*//' helm-charts/verticadb-operator/templates/verticadb-operator-manager-config-cm.yaml | kubectl apply -f -
-	ENABLE_WEBHOOKS=false go run cmd/operator/main.go -enable-profiler -service-account-name=default | tee int-tests-output/verticadb-operator.log
+	scripts/run-operator.sh
 
 docker-build-operator: manifests generate fmt vet ## Build operator docker image with the manager.
 	docker build -t ${OPERATOR_IMG} -f docker-operator/Dockerfile .

--- a/changes/unreleased/Fixed-20221107-103657.yaml
+++ b/changes/unreleased/Fixed-20221107-103657.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Improve the stability of the operator in big clusters
+time: 2022-11-07T10:36:57.957077201-04:00
+custom:
+  Issue: "283"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	sigs.k8s.io/controller-runtime v0.12.2
-	yunion.io/x/pkg v0.0.0-20210218105412-13a69f60034c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -987,5 +987,3 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZa
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-yunion.io/x/pkg v0.0.0-20210218105412-13a69f60034c h1:J/joqbA1N2mAlOl0Uqd4LpAq3+DK5aoFMdz+p9Ld7pQ=
-yunion.io/x/pkg v0.0.0-20210218105412-13a69f60034c/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=

--- a/pkg/cmds/fake.go
+++ b/pkg/cmds/fake.go
@@ -89,9 +89,13 @@ func (f *FakePodRunner) ExecVSQL(ctx context.Context, podName types.NamespacedNa
 
 // CopyToPod will mimic a real copy file into a pod
 func (f *FakePodRunner) CopyToPod(ctx context.Context, podName types.NamespacedName,
-	contName string, sourceFile string, destFile string) (stdout, stderr string, err error) {
+	contName string, sourceFile string, destFile string, executeCmd ...string) (stdout, stderr string, err error) {
 	command := []string{"sh", "-c", fmt.Sprintf("cat > %s", destFile)}
-	return f.ExecInPod(ctx, podName, contName, command...)
+	sout, serr, err := f.ExecInPod(ctx, podName, contName, command...)
+	if executeCmd == nil {
+		return sout, serr, err
+	}
+	return f.ExecInPod(ctx, podName, contName, executeCmd...)
 }
 
 // FindCommands will search through the command history for any command that

--- a/pkg/controllers/vdb/createdb_reconcile.go
+++ b/pkg/controllers/vdb/createdb_reconcile.go
@@ -237,6 +237,16 @@ func (c *CreateDBReconciler) getPodList() ([]*PodFact, bool) {
 	return podList, true
 }
 
+// findPodToRunInit will return a PodFact of the pod that should run the init
+// command from
+func (c *CreateDBReconciler) findPodToRunInit() (*PodFact, bool) {
+	// Always return the first pod of the first primary subcluster. We do this
+	// so that we can consistently pick the same pod if we have redo the create.
+	sc := c.getFirstPrimarySubcluster()
+	pf, ok := c.PFacts.Detail[names.GenPodName(c.Vdb, sc, 0)]
+	return pf, ok
+}
+
 // getFirstPrimarySubcluster returns the first primary subcluster defined in the vdb
 func (c *CreateDBReconciler) getFirstPrimarySubcluster() *vapi.Subcluster {
 	for i := range c.Vdb.Spec.Subclusters {

--- a/pkg/controllers/vdb/createdb_reconcile_test.go
+++ b/pkg/controllers/vdb/createdb_reconcile_test.go
@@ -42,8 +42,8 @@ var _ = Describe("createdb_reconciler", func() {
 		defer deleteCommunalCredSecret(ctx, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.Histories[len(fpr.Histories)-1]
 		Expect(lastCall.Command).ShouldNot(ContainElements("/opt/vertica/bin/admintools", "create_db"))

--- a/pkg/controllers/vdb/createdb_reconcile_test.go
+++ b/pkg/controllers/vdb/createdb_reconcile_test.go
@@ -177,6 +177,29 @@ var _ = Describe("createdb_reconciler", func() {
 		Expect(res).Should(Equal(ctrl.Result{}))
 	})
 
+	It("should always run AT commands from the first pod of the first primary subcluster", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "sec", IsPrimary: false, Size: 1},
+			{Name: "pri", IsPrimary: true, Size: 2},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		createS3CredSecret(ctx, vdb)
+		defer deleteCommunalCredSecret(ctx, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size+vdb.Spec.Subclusters[1].Size))
+		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		Expect(len(fpr.Histories)).Should(BeNumerically(">", 0))
+		hist := fpr.FindCommands("-t create_db")
+		Expect(len(hist)).Should(Equal(1))
+		Expect(hist[0].Pod.Name).Should(Equal(names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0).Name))
+	})
+
 	It("should use option with create_db if skipping install", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.InitPolicy = vapi.CommunalInitPolicyCreateSkipPackageInstall

--- a/pkg/controllers/vdb/dbaddnode_reconcile.go
+++ b/pkg/controllers/vdb/dbaddnode_reconcile.go
@@ -101,15 +101,11 @@ func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, pods []*PodFact) (
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	if err := changeDepotPermissions(ctx, d.Vdb, d.PRunner, pods); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	for _, pod := range pods {
 		// admintools will not cleanup the local directories after a failed attempt
 		// to add node. So we ensure those directories are clear at each pod before
 		// proceeding.
-		if err := cleanupLocalFiles(ctx, d.Vdb, d.PRunner, pod.name); err != nil {
+		if err := prepLocalData(ctx, d.Vdb, d.PRunner, pod.name); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/controllers/vdb/dbaddnode_reconcile.go
+++ b/pkg/controllers/vdb/dbaddnode_reconcile.go
@@ -110,7 +110,9 @@ func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, pods []*PodFact) (
 		}
 	}
 
-	debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
+	if d.VRec.OpCfg.DevMode {
+		debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
+	}
 
 	if stdout, err := d.runAddNodeForPod(ctx, pods, atPod); err != nil {
 		// If we reached the node limit according to the license, end this
@@ -123,7 +125,9 @@ func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, pods []*PodFact) (
 		return ctrl.Result{}, err
 	}
 
-	debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
+	if d.VRec.OpCfg.DevMode {
+		debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
+	}
 
 	// Invalidate the cached pod facts now that some pods have a DB now.
 	d.PFacts.Invalidate()

--- a/pkg/controllers/vdb/dbaddnode_reconcile_test.go
+++ b/pkg/controllers/vdb/dbaddnode_reconcile_test.go
@@ -38,8 +38,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.Histories[len(fpr.Histories)-1]
 		Expect(lastCall.Command).ShouldNot(ContainElements("/opt/vertica/bin/admintools", "db_add_node"))
@@ -81,7 +81,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		// Make a specific pod as not having a db.
 		podWithNoDB := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 1)
@@ -99,7 +99,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 					"already contains 3 node(s), Sqlstate: V2001",
 			},
 		}
-		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
 		Expect(len(lastCall)).Should(Equal(1))
@@ -126,8 +126,8 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
 		Expect(len(atCmd)).Should(Equal(0))
@@ -142,14 +142,14 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		// Make a specific pod as not having a db and not running
 		podWithNoDB := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 1)
 		pfacts.Detail[podWithNoDB].dbExists = false
 		pfacts.Detail[podWithNoDB].upNode = false
 		pfacts.Detail[podWithNoDB].isPodRunning = false
-		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
 		Expect(len(lastCall)).Should(Equal(0))

--- a/pkg/controllers/vdb/dbaddsubcluster_reconcile_test.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconcile_test.go
@@ -66,7 +66,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		const PodIndex = 0
 		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], PodIndex)
@@ -76,7 +76,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 				{Stdout: " sc1\n"},
 			},
 		}
-		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// Last command should be AT -t db_add_subcluster
 		atCmdHistory := fpr.Histories[len(fpr.Histories)-1]

--- a/pkg/controllers/vdb/dbremovenode_reconcile_test.go
+++ b/pkg/controllers/vdb/dbremovenode_reconcile_test.go
@@ -51,8 +51,8 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		uninstallPod := builder.BuildPod(vdb, sc, 1)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		actor := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		actor := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		recon := actor.(*DBRemoveNodeReconciler)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		fpr.Histories = make([]cmds.CmdHistory, 0) // reset the calls so the first one is admintools
@@ -77,8 +77,8 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		uninstallPods := []types.NamespacedName{names.GenPodName(vdb, sc, 1), names.GenPodName(vdb, sc, 2)}
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
 		Expect(res.Requeue).Should(BeFalse())

--- a/pkg/controllers/vdb/dbremovesubcluster_reconcile_test.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconcile_test.go
@@ -61,8 +61,8 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 		}
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, lookupVdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, lookupVdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// One command should be AT -t db_remove_subcluster and one should be
 		// changing the default subcluster

--- a/pkg/controllers/vdb/drainnode_reconcile_test.go
+++ b/pkg/controllers/vdb/drainnode_reconcile_test.go
@@ -42,8 +42,8 @@ var _ = Describe("drainnode_reconcile", func() {
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeDrainNodeReconciler(vdbRec, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeDrainNodeReconciler(vdbRec, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		cmds := fpr.FindCommands("select count(*) from session")
 		Expect(len(cmds)).Should(Equal(1))
@@ -79,14 +79,14 @@ var _ = Describe("drainnode_reconcile", func() {
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		penDelPodName := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 1)
 		fpr.Results[penDelPodName] = []cmds.CmdResult{
 			{Stdout: "10\n"},
 		}
 
-		r := MakeDrainNodeReconciler(vdbRec, vdb, fpr, &pfacts)
+		r := MakeDrainNodeReconciler(vdbRec, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		cmds := fpr.FindCommands("select count(*) from session")
 		Expect(len(cmds)).Should(Equal(1))

--- a/pkg/controllers/vdb/eula.go
+++ b/pkg/controllers/vdb/eula.go
@@ -29,7 +29,7 @@ import (
 // acceptEulaIfMissing will accept the end user license agreement if any pods have not yet signed it
 func acceptEulaIfMissing(ctx context.Context, pFacts *PodFacts, pRunner cmds.PodRunner) error {
 	for _, p := range pFacts.Detail {
-		if !p.eulaAccepted.IsFalse() || !p.isPodRunning {
+		if p.eulaAccepted || !p.isPodRunning {
 			continue
 		}
 		if err := acceptEulaInPod(ctx, p, pRunner); err != nil {

--- a/pkg/controllers/vdb/eula.go
+++ b/pkg/controllers/vdb/eula.go
@@ -61,14 +61,8 @@ func acceptEulaInPod(ctx context.Context, pf *PodFact, pRunner cmds.PodRunner) e
 	}
 	tmp.Close()
 
-	_, _, err = pRunner.CopyToPod(ctx, pf.name, names.ServerContainer, tmp.Name(), paths.EulaAcceptanceScript)
-	if err != nil {
-		return err
-	}
-
-	_, _, err = pRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "/opt/vertica/oss/python3/bin/python3", paths.EulaAcceptanceScript)
-	if err != nil {
-		return err
-	}
-	return nil
+	// Copy and execute the script
+	_, _, err = pRunner.CopyToPod(ctx, pf.name, names.ServerContainer, tmp.Name(), paths.EulaAcceptanceScript,
+		"/opt/vertica/oss/python3/bin/python3", paths.EulaAcceptanceScript)
+	return err
 }

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -105,11 +105,7 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 	}
 
 	// Cleanup for any prior failed attempt.
-	if err := g.cleanupLocalFilesInPods(ctx, podList); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if err := changeDepotPermissions(ctx, g.Vdb, g.PRunner, podList); err != nil {
+	if err := g.prepLocalDataInPods(ctx, podList); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -166,13 +162,14 @@ func (g *GenericDatabaseInitializer) checkPodList(podList []*PodFact) bool {
 	return true
 }
 
-// cleanupLocalFilesInPods will go through each pod and ensure their local files are gone.
-// This step is necessary because a failed create_db can leave old state around.
-func (g *GenericDatabaseInitializer) cleanupLocalFilesInPods(ctx context.Context, podList []*PodFact) error {
+// prepLocalDataInPods will go through each pod and ensure their local files are
+// prepared correctly.  This step is necessary because a failed create_db can
+// leave old state around.
+func (g *GenericDatabaseInitializer) prepLocalDataInPods(ctx context.Context, podList []*PodFact) error {
 	for _, pod := range podList {
 		// Cleanup any local paths. This step is needed if an earlier create_db
 		// fails -- admintools does not clean everything up.
-		if err := cleanupLocalFiles(ctx, g.Vdb, g.PRunner, pod.name); err != nil {
+		if err := prepLocalData(ctx, g.Vdb, g.PRunner, pod.name); err != nil {
 			return err
 		}
 	}

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -109,7 +109,9 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{}, err
 	}
 
-	debugDumpAdmintoolsConf(ctx, g.PRunner, atPod)
+	if g.VRec.OpCfg.DevMode {
+		debugDumpAdmintoolsConf(ctx, g.PRunner, atPod)
+	}
 
 	cmd, err := g.initializer.genCmd(ctx, getHostList(podList))
 	if err != nil {
@@ -119,7 +121,9 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 		return res, err
 	}
 
-	debugDumpAdmintoolsConf(ctx, g.PRunner, atPod)
+	if g.VRec.OpCfg.DevMode {
+		debugDumpAdmintoolsConf(ctx, g.PRunner, atPod)
+	}
 
 	cond := vapi.VerticaDBCondition{Type: vapi.DBInitialized, Status: corev1.ConditionTrue}
 	if err := vdbstatus.UpdateCondition(ctx, g.VRec.Client, g.Vdb, cond); err != nil {

--- a/pkg/controllers/vdb/install_reconcile.go
+++ b/pkg/controllers/vdb/install_reconcile.go
@@ -135,12 +135,16 @@ func (d *InstallReconciler) addHostsToATConf(ctx context.Context) error {
 	}
 	defer os.Remove(atConfTempFile)
 
-	debugDumpAdmintoolsConfForPods(ctx, d.PRunner, installedPods)
+	if d.VRec.OpCfg.DevMode {
+		debugDumpAdmintoolsConfForPods(ctx, d.PRunner, installedPods)
+	}
 	if err := distributeAdmintoolsConf(ctx, d.Vdb, d.VRec, d.PFacts, d.PRunner, atConfTempFile); err != nil {
 		return err
 	}
 	installedPods = append(installedPods, pods...)
-	debugDumpAdmintoolsConfForPods(ctx, d.PRunner, installedPods)
+	if d.VRec.OpCfg.DevMode {
+		debugDumpAdmintoolsConfForPods(ctx, d.PRunner, installedPods)
+	}
 
 	// Invalidate the pod facts cache since its out of date due to the install
 	d.PFacts.Invalidate()

--- a/pkg/controllers/vdb/install_reconcile.go
+++ b/pkg/controllers/vdb/install_reconcile.go
@@ -18,8 +18,9 @@ package vdb
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
-	"regexp"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -90,7 +91,7 @@ func (d *InstallReconciler) analyzeFacts(ctx context.Context) (ctrl.Result, erro
 
 	fns := []func(context.Context) error{
 		d.acceptEulaIfMissing,
-		d.checkConfigDir,
+		d.createConfigDirsIfNecessary,
 		// This has to be after accepting the EULA.  re_ip will not succeed if
 		// the EULA is not accepted and a re_ip can happen before coming to this
 		// reconcile function.  So if the pod is rescheduled after adding
@@ -158,31 +159,35 @@ func (d *InstallReconciler) acceptEulaIfMissing(ctx context.Context) error {
 	return acceptEulaIfMissing(ctx, d.PFacts, d.PRunner)
 }
 
-// checkConfigDir will check that certain directories in /opt/vertica/config
+// createConfigDirsIfNecessary will check that certain directories in /opt/vertica/config
 // exists and are writable by dbadmin
-func (d *InstallReconciler) checkConfigDir(ctx context.Context) error {
+func (d *InstallReconciler) createConfigDirsIfNecessary(ctx context.Context) error {
 	for _, p := range d.PFacts.Detail {
 		if !p.isPodRunning {
 			continue
 		}
-		if p.configLogrotateExists && !p.configLogrotateWritable {
-			// We enforce this in the docker entrypoint of the container too.  But
-			// we have this here for backwards compatibility for the 11.0 image.
-			// The 10.1.1 image doesn't even have logrotate, which is why we
-			// first check if the directory exists.
-			_, _, err := d.PRunner.ExecInPod(ctx, p.name, names.ServerContainer,
-				"sudo", "chown", "-R", "dbadmin:verticadba", paths.ConfigLogrotatePath)
-			if err != nil {
-				return err
-			}
+		tmp, err := ioutil.TempFile("", "create-config-dirs.sh.")
+		if err != nil {
+			return err
 		}
+		defer tmp.Close()
+		defer os.Remove(tmp.Name())
 
-		if !p.configShareExists {
-			_, _, err := d.PRunner.ExecInPod(ctx, p.name, names.ServerContainer,
-				"mkdir", paths.ConfigSharePath)
-			if err != nil {
-				return err
-			}
+		script := d.genCreateConfigDirsScript(p)
+		if script == "" {
+			continue
+		}
+		_, err = tmp.WriteString(script)
+		if err != nil {
+			return err
+		}
+		tmp.Close()
+
+		// Copy the script into the pod and execute it
+		_, _, err = d.PRunner.CopyToPod(ctx, p.name, names.ServerContainer, tmp.Name(), paths.CreateConfigDirsScript,
+			"bash", paths.CreateConfigDirsScript)
+		if err != nil {
+			return errors.Wrap(err, "failed to copy and execute the config dirs script")
 		}
 	}
 	return nil
@@ -192,14 +197,7 @@ func (d *InstallReconciler) checkConfigDir(ctx context.Context) error {
 // communicate with the Vertica's http server.
 func (d *InstallReconciler) generateHTTPCerts(ctx context.Context) error {
 	// Early out if the http service isn't enabled
-	if !d.Vdb.IsHTTPServerEnabled() {
-		return nil
-	}
-	vinf, ok := version.MakeInfoFromVdb(d.Vdb)
-	if !ok || vinf.IsOlder(version.HTTPServerMinVersion) {
-		d.VRec.Eventf(d.Vdb, corev1.EventTypeWarning, events.HTTPServerNotSetup,
-			"Skipping http server cert setup because the Vertica version doesn't have "+
-				"support for it. A Vertica version of '%s' or newer is needed", version.HTTPServerMinVersion)
+	if !d.doHTTPInstall(true) {
 		return nil
 	}
 	for _, p := range d.PFacts.Detail {
@@ -207,9 +205,6 @@ func (d *InstallReconciler) generateHTTPCerts(ctx context.Context) error {
 			continue
 		}
 		if !p.httpTLSConfExists {
-			if _, _, err := d.PRunner.ExecInPod(ctx, p.name, names.ServerContainer, "mkdir", "-p", paths.HTTPTLSConfDir); err != nil {
-				return err
-			}
 			frwt := httpconf.FileWriter{}
 			secretName := names.GenNamespacedName(d.Vdb, d.Vdb.Spec.HTTPServerSecret)
 			fname, err := frwt.GenConf(ctx, d.VRec.Client, secretName)
@@ -271,17 +266,13 @@ func (d *InstallReconciler) getInstallTargets(ctx context.Context) ([]*PodFact, 
 // createInstallIndicators will create the install indicator file for all pods passed in
 func (d *InstallReconciler) createInstallIndicators(ctx context.Context, pods []*PodFact) error {
 	for _, v := range pods {
-		compat21Node, err := d.fetchCompat21NodeNum(ctx, v)
-		if err != nil {
-			return fmt.Errorf("failed to extract compat21 node name: %w", err)
-		}
 		// Create the install indicator file. This is used to know that this
 		// instance of the vdb has setup the config for this pod. The
 		// /opt/vertica/config is backed by a PV, so it is possible that we
 		// see state in there for a prior instance of the vdb. We use the
 		// UID of the vdb to know the current instance.
 		d.Log.Info("create installer indicator file", "Pod", v.name)
-		cmd := d.genCmdCreateInstallIndicator(compat21Node)
+		cmd := d.genCmdCreateInstallIndicator(v)
 		if stdout, _, err := d.PRunner.ExecInPod(ctx, v.name, names.ServerContainer, cmd...); err != nil {
 			return fmt.Errorf("failed to create installer indicator with command '%s', output was '%s': %w", cmd, stdout, err)
 		}
@@ -289,29 +280,15 @@ func (d *InstallReconciler) createInstallIndicators(ctx context.Context, pods []
 	return nil
 }
 
-// fetchCompat21NodeNum will figure out the compat21 node name that was assigned to the given pod
-func (d *InstallReconciler) fetchCompat21NodeNum(ctx context.Context, pf *PodFact) (string, error) {
-	cmd := []string{
-		"bash", "-c", fmt.Sprintf("grep -E '^node[0-9]{4} = %s,' %s", pf.podIP, paths.AdminToolsConf),
-	}
-	var stdout string
-	var err error
-	if stdout, _, err = d.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, cmd...); err != nil {
-		return "", fmt.Errorf("failed to find compat21 node for IP '%s', output was '%s': %w", pf.podIP, stdout, err)
-	}
-	re := regexp.MustCompile(`^(node\d{4}) = .*`)
-	match := re.FindAllStringSubmatch(stdout, 1)
-	if len(match) > 0 && len(match[0]) > 0 {
-		return match[0][1], nil
-	}
-	return "", fmt.Errorf("could not find compat21 node in output")
-}
-
 // genCmdCreateInstallIndicator generates the command to create the install indicator file
-func (d *InstallReconciler) genCmdCreateInstallIndicator(compat21Node string) []string {
+func (d *InstallReconciler) genCmdCreateInstallIndicator(pf *PodFact) []string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("grep -E '^node[0-9]{4} = %s,' %s", pf.podIP, paths.AdminToolsConf))
+	sb.WriteString(" | head -1 | cut -d' ' -f1 | tee ")
 	// The install indicator file has the UID of the vdb. This allows us to know
 	// that we are working with a different life in the vdb is ever recreated.
-	return []string{"bash", "-c", fmt.Sprintf("echo %s > %s", compat21Node, d.Vdb.GenInstallerIndicatorFileName())}
+	sb.WriteString(d.Vdb.GenInstallerIndicatorFileName())
+	return []string{"bash", "-c", sb.String()}
 }
 
 // genCmdRemoveOldConfig generates the command to remove the old admintools.conf file
@@ -321,4 +298,54 @@ func (d *InstallReconciler) genCmdRemoveOldConfig() []string {
 		paths.AdminToolsConf,
 		fmt.Sprintf("%s.uid.%s", paths.AdminToolsConf, string(d.Vdb.UID)),
 	}
+}
+
+// doHTTPInstall will return true if the installer should setup for the http server
+func (d *InstallReconciler) doHTTPInstall(logEvent bool) bool {
+	// Early out if the http service isn't enabled
+	if !d.Vdb.IsHTTPServerEnabled() {
+		return false
+	}
+	vinf, ok := version.MakeInfoFromVdb(d.Vdb)
+	if !ok || vinf.IsOlder(version.HTTPServerMinVersion) {
+		if logEvent {
+			d.VRec.Eventf(d.Vdb, corev1.EventTypeWarning, events.HTTPServerNotSetup,
+				"Skipping http server cert setup because the Vertica version doesn't have "+
+					"support for it. A Vertica version of '%s' or newer is needed", version.HTTPServerMinVersion)
+		}
+		return false
+	}
+	return true
+}
+
+// genCreateConfigDirsScript will create a script to be run in a pod to create
+// the necessary dirs for install. This will return an empty string if nothing
+// needs to happen.
+func (d *InstallReconciler) genCreateConfigDirsScript(p *PodFact) string {
+	var sb strings.Builder
+	sb.WriteString("set -o errexit\n")
+	numCmds := 0
+	if p.configLogrotateExists && !p.configLogrotateWritable {
+		// We enforce this in the docker entrypoint of the container too.  But
+		// we have this here for backwards compatibility for the 11.0 image.
+		// The 10.1.1 image doesn't even have logrotate, which is why we
+		// first check if the directory exists.
+		sb.WriteString(fmt.Sprintf("sudo chown -R dbadmin:verticadba %s\n", paths.ConfigLogrotatePath))
+		numCmds++
+	}
+
+	if !p.configShareExists {
+		sb.WriteString(fmt.Sprintf("mkdir %s\n", paths.ConfigSharePath))
+		numCmds++
+	}
+
+	if !d.doHTTPInstall(false) && !p.httpTLSConfExists {
+		sb.WriteString(fmt.Sprintf("mkdir -p %s\n", paths.HTTPTLSConfDir))
+		numCmds++
+	}
+
+	if numCmds == 0 {
+		return ""
+	}
+	return sb.String()
 }

--- a/pkg/controllers/vdb/install_reconcile_test.go
+++ b/pkg/controllers/vdb/install_reconcile_test.go
@@ -75,7 +75,6 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		fpr.Results = cmds.CmdResults{
 			names.GenPodName(vdb, sc, 1): []cmds.CmdResult{
 				{}, // remove old config
-				{}, // Debug info for admintools.conf after admintools.conf update
 				{}, // Copy admintools.conf to the pod
 				{Stdout: "node0003 = 192.168.0.1,/d,/d\n"}}, // Get of compat21 node name
 		}
@@ -112,12 +111,10 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		fpr.Results = cmds.CmdResults{
 			names.GenPodName(vdb, sc, 1): []cmds.CmdResult{
 				{}, // Remove old admintools.conf
-				{}, // Debug info for admintools.conf after updating admintools.conf
 				{}, // Copy admintools.conf to the pod
 				{Stdout: "node0003 = 192.168.0.1,/d,/d\n"}}, // Get of compat21 node name
 			names.GenPodName(vdb, sc, 2): []cmds.CmdResult{
 				{}, // Remove old admintools.conf
-				{}, // Debug info for admintools.conf after updating admintools.conf
 				{}, // Copy admintools.conf to the pod
 				{Stdout: "node0003 = 192.168.0.2,/d,/d\n"}}, // Get of compat21 node name
 		}

--- a/pkg/controllers/vdb/install_reconcile_test.go
+++ b/pkg/controllers/vdb/install_reconcile_test.go
@@ -65,15 +65,6 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		pfact.Detail[names.GenPodName(vdb, sc, 1)].isInstalled = false
 		pfact.Detail[names.GenPodName(vdb, sc, 2)].dbExists = false
 		pfact.Detail[names.GenPodName(vdb, sc, 2)].isInstalled = false
-		// Reset the pod runner output to dump the compat21 node number
-		fpr.Results = cmds.CmdResults{
-			names.GenPodName(vdb, sc, 1): []cmds.CmdResult{
-				{}, // Copy admintools.conf to the pod
-				{Stdout: "node0003 = 192.168.0.1,/d,/d\n"}}, // Get of compat21 node name
-			names.GenPodName(vdb, sc, 2): []cmds.CmdResult{
-				{}, // Copy admintools.conf to the pod
-				{Stdout: "node0003 = 192.168.0.2,/d,/d\n"}}, // Get of compat21 node name
-		}
 		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, pfact)
 		drecon := actor.(*InstallReconciler)
 		drecon.ATWriter = &atconf.FakeWriter{}
@@ -81,7 +72,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		cmdHist := fpr.FindCommands(fmt.Sprintf("cat > %s", paths.AdminToolsConf))
 		Expect(len(cmdHist)).Should(Equal(3))
 		// We should see two instances of creating the install indicator -- one at each host that we install at
-		cmdHist = fpr.FindCommands(drecon.genCmdCreateInstallIndicator("node0003")...)
+		cmdHist = fpr.FindCommands(vdb.GenInstallerIndicatorFileName())
 		Expect(len(cmdHist)).Should(Equal(2))
 	})
 

--- a/pkg/controllers/vdb/metrics_reconcile_test.go
+++ b/pkg/controllers/vdb/metrics_reconcile_test.go
@@ -37,9 +37,8 @@ var _ = Describe("prometheus_reconcile", func() {
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
-		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		actor := MakeMetricReconciler(vdbRec, vdb, &pfacts)
+		pfacts := createPodFactsDefault(&cmds.FakePodRunner{})
+		actor := MakeMetricReconciler(vdbRec, vdb, pfacts)
 		r := actor.(*MetricReconciler)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 

--- a/pkg/controllers/vdb/offlineupgrade_reconcile_test.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconcile_test.go
@@ -164,7 +164,7 @@ func updateVdbToCauseUpgrade(ctx context.Context, vdb *vapi.VerticaDB, newImage 
 // createOfflineUpgradeReconciler is a helper to run the OfflineUpgradeReconciler.
 func createOfflineUpgradeReconciler(vdb *vapi.VerticaDB) (*OfflineUpgradeReconciler, *cmds.FakePodRunner, *PodFacts) {
 	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
-	pfacts := MakePodFacts(vdbRec, fpr)
-	actor := MakeOfflineUpgradeReconciler(vdbRec, logger, vdb, fpr, &pfacts)
-	return actor.(*OfflineUpgradeReconciler), fpr, &pfacts
+	pfacts := createPodFactsDefault(fpr)
+	actor := MakeOfflineUpgradeReconciler(vdbRec, logger, vdb, fpr, pfacts)
+	return actor.(*OfflineUpgradeReconciler), fpr, pfacts
 }

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -368,7 +368,7 @@ func (p *PodFacts) genGatherScript(vdb *vapi.VerticaDB) string {
 		echo -n 'compat21NodeName: '
 		test -f %s && echo -n '"' && echo -n $(cat %s) && echo '"' || echo '""'
 		echo -n 'vnodeName: '
-		cd %s/v_%s_node????_data 2> /dev/null && basename $(pwd) | cut -d'_' -f1-3 || echo ""
+		cd %s/v_%s_node????_data 2> /dev/null && basename $(pwd) | rev | cut -c6- | rev || echo ""
 		echo -n 'verticaPIDRunning: '
 		[[ $(pgrep ^vertica) ]] && echo true || echo false
 		echo -n 'startupComplete: '

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -328,13 +328,12 @@ func (p *PodFacts) runGather(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFa
 	}
 	tmp.Close()
 
-	_, _, err = p.PRunner.CopyToPod(ctx, pf.name, names.ServerContainer, tmp.Name(), paths.PodFactGatherScript)
-	if err != nil {
-		return errors.Wrap(err, "failed to copy the gather script")
-	}
+	// Copy the script into the pod and execute it
 	var out string
-	if out, _, err = p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "bash", paths.PodFactGatherScript); err != nil {
-		return errors.Wrap(err, "failed calling gather script")
+	out, _, err = p.PRunner.CopyToPod(ctx, pf.name, names.ServerContainer, tmp.Name(), paths.PodFactGatherScript,
+		"bash", paths.PodFactGatherScript)
+	if err != nil {
+		return errors.Wrap(err, "failed to copy and execute the gather script")
 	}
 	err = yaml.Unmarshal([]byte(out), gs)
 	if err != nil {

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -18,11 +18,16 @@ package vdb
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/ghodss/yaml"
+	"github.com/lithammer/dedent"
+	"github.com/pkg/errors"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
@@ -32,9 +37,8 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"yunion.io/x/pkg/tristate"
 )
 
 // PodFact keeps track of facts for a specific pod
@@ -109,7 +113,7 @@ type PodFact struct {
 	compat21NodeName string
 
 	// True if the end user license agreement has been accepted
-	eulaAccepted tristate.TriState
+	eulaAccepted bool
 
 	// True if /opt/vertica/config/logrotate exists
 	configLogrotateExists bool
@@ -145,21 +149,35 @@ type PodFact struct {
 
 type PodFactDetail map[types.NamespacedName]*PodFact
 
+// CheckerFunc is the function signature for individual functions that help
+// populate a PodFact.
+type CheckerFunc func(context.Context, *vapi.VerticaDB, *PodFact, *GatherState) error
+
 // A collection of facts for many pods.
 type PodFacts struct {
 	VRec           *VerticaDBReconciler
 	PRunner        cmds.PodRunner
 	Detail         PodFactDetail
 	NeedCollection bool
+	OverrideFunc   CheckerFunc // Set this if you want to be able to control the PodFact
 }
 
-type CheckType string
-
-const (
-	CheckDirExists  CheckType = "-d"
-	CheckFileExists CheckType = "-f"
-	CheckWritable   CheckType = "-w"
-)
+// GatherState is the data exchanged with the gather pod facts script. We
+// parse the data from the script in YAML into this struct.
+type GatherState struct {
+	InstallIndicatorExists  bool   `json:"installIndicatorExists"`
+	AdmintoolsConfExists    bool   `json:"admintoolsConfExists"`
+	EulaAccepted            bool   `json:"eulaAccepted"`
+	ConfigLogrotateExists   bool   `json:"configLogrotateExists"`
+	ConfigLogrotateWritable bool   `json:"configLogrotateWritable"`
+	ConfigShareExists       bool   `json:"configShareExists"`
+	HTTPTLSConfExists       bool   `json:"httpTLSConfExists"`
+	DBExists                bool   `json:"dbExists"`
+	VerticaPIDRunning       bool   `json:"verticaPIDRunning"`
+	StartupComplete         bool   `json:"startupComplete"`
+	Compat21NodeName        string `json:"compat21NodeName"`
+	VNodeName               string `json:"vnodeName"`
+}
 
 // MakePodFacts will create a PodFacts object and return it
 func MakePodFacts(vrec *VerticaDBReconciler, prunner cmds.PodRunner) PodFacts {
@@ -206,7 +224,7 @@ func (p *PodFacts) collectSubcluster(ctx context.Context, vdb *vapi.VerticaDB, s
 	maxStsSize := sc.Size
 	// Attempt to fetch the sts.  We continue even for 'not found' errors
 	// because we want to populate the missing pods into the pod facts.
-	if err := p.VRec.Client.Get(ctx, names.GenStsName(vdb, sc), sts); err != nil && !errors.IsNotFound(err) {
+	if err := p.VRec.Client.Get(ctx, names.GenStsName(vdb, sc), sts); err != nil && !k8sErrors.IsNotFound(err) {
 		return fmt.Errorf("could not fetch statefulset for pod fact collection %s %w", sc.Name, err)
 	} else if sts.Spec.Replicas != nil && *sts.Spec.Replicas > maxStsSize {
 		maxStsSize = *sts.Spec.Replicas
@@ -236,7 +254,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 	}
 
 	pod := &corev1.Pod{}
-	if err := p.VRec.Client.Get(ctx, pf.name, pod); err != nil && !errors.IsNotFound(err) {
+	if err := p.VRec.Client.Get(ctx, pf.name, pod); err != nil && !k8sErrors.IsNotFound(err) {
 		return err
 	} else if err == nil {
 		// Treat not found errors as if the pod is not running.  We continue
@@ -256,22 +274,26 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		pf.hasDCTableAnnotations = p.checkDCTableAnnotations(pod)
 	}
 
-	fns := []func(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error{
+	fns := []CheckerFunc{
+		p.runGather,
 		p.checkIsInstalled,
 		p.checkIsDBCreated,
 		p.checkIfNodeIsUpAndReadOnly,
 		p.checkIfNodeIsDoingStartup,
-		p.checkEulaAcceptance,
-		p.checkLogrotateExists,
-		p.checkIsLogrotateWritable,
-		p.checkThatConfigShareExists,
-		p.checkThatHTTPTLSConfExists,
+		p.checkForSimpleGatherStateMapping,
 		p.checkShardSubscriptions,
 		p.queryDepotDetails,
+		// Override function must be last one as we can use it to override any
+		// of the facts set earlier.
+		p.OverrideFunc,
 	}
 
+	var gatherState GatherState
 	for _, fn := range fns {
-		if err := fn(ctx, vdb, &pf); err != nil {
+		if fn == nil {
+			continue
+		}
+		if err := fn(ctx, vdb, &pf, &gatherState); err != nil {
 			return err
 		}
 	}
@@ -280,8 +302,92 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 	return nil
 }
 
+// runGather will generate a script to get multiple state information
+// from the pod. This is done this way to cut down on the number exec calls we
+// do into the pod. Exec can be quite expensive in terms of memory consumption
+// and will slow down the pod fact collection considerably.
+func (p *PodFacts) runGather(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
+	// Early out if the pod isn't running
+	if !pf.isPodRunning {
+		return nil
+	}
+	tmp, err := ioutil.TempFile("", "gather_pod.sh.")
+	if err != nil {
+		return err
+	}
+	defer tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	_, err = tmp.WriteString(p.genGatherScript(vdb))
+	if err != nil {
+		return err
+	}
+	tmp.Close()
+
+	_, _, err = p.PRunner.CopyToPod(ctx, pf.name, names.ServerContainer, tmp.Name(), paths.PodFactGatherScript)
+	if err != nil {
+		return errors.Wrap(err, "failed to copy the gather script")
+	}
+	var out string
+	if out, _, err = p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "bash", paths.PodFactGatherScript); err != nil {
+		return errors.Wrap(err, "failed calling gather script")
+	}
+	err = yaml.Unmarshal([]byte(out), gs)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal YAML data")
+	}
+	return nil
+}
+
+// genGatherScript will generate the script that gathers multiple pieces of state in the pod
+func (p *PodFacts) genGatherScript(vdb *vapi.VerticaDB) string {
+	// The output of the script is yaml. We use a yaml package to unmarshal the
+	// output directly into a GatherState struct. And changes to this script
+	// must have a corresponding change in GatherState.
+	return dedent.Dedent(fmt.Sprintf(`
+		set -o errexit
+		echo -n 'installIndicatorExists: '
+		test -f %s && echo true || echo false
+		echo -n 'admintoolsConfExists: '
+		test -f %s && echo true || echo false
+		echo -n 'eulaAccepted: '
+		test -f %s && echo true || echo false
+		echo -n 'configLogrotateExists: '
+		test -d %s && echo true || echo false
+		echo -n 'configLogrotateWritable: '
+		test -w %s && echo true || echo false
+		echo -n 'configShareExists: '
+		test -d %s && echo true || echo false
+		echo -n 'httpTLSConfExists: '
+		test -f %s/%s && echo true || echo false
+		echo -n 'dataPathExists: '
+		test -d %s/v_%s_node????_data && echo true || echo false
+		echo -n 'compat21NodeName: '
+		test -f %s && echo -n '"' && echo -n $(cat %s) && echo '"' || echo '""'
+		echo -n 'vnodeName: '
+		cd %s/v_%s_node????_data 2> /dev/null && basename $(pwd) | cut -d'_' -f1-3 || echo ""
+		echo -n 'verticaPIDRunning: '
+		[[ $(pgrep ^vertica) ]] && echo true || echo false
+		echo -n 'startupComplete: '
+		grep --quiet -e 'Startup Complete' -e 'Database Halted' %s && echo true || echo false
+ 	`,
+		vdb.GenInstallerIndicatorFileName(),
+		paths.AdminToolsConf,
+		paths.EulaAcceptanceFile,
+		paths.ConfigLogrotatePath,
+		paths.ConfigLogrotatePath,
+		paths.ConfigSharePath,
+		paths.HTTPTLSConfDir, paths.HTTPTLSConfFile,
+		vdb.GetDBDataPath(), strings.ToLower(vdb.Spec.DBName),
+		vdb.GenInstallerIndicatorFileName(),
+		vdb.GenInstallerIndicatorFileName(),
+		vdb.GetDBDataPath(), strings.ToLower(vdb.Spec.DBName),
+		fmt.Sprintf("%s/%s/*_catalog/startup.log", vdb.Spec.Local.GetCatalogPath(), vdb.Spec.DBName),
+	))
+}
+
 // checkIsInstalled will check a single pod to see if the installation has happened.
-func (p *PodFacts) checkIsInstalled(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
+func (p *PodFacts) checkIsInstalled(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	pf.isInstalled = false
 
 	scs, ok := vdb.FindSubclusterStatus(pf.subcluster)
@@ -303,9 +409,7 @@ func (p *PodFacts) checkIsInstalled(ctx context.Context, vdb *vapi.VerticaDB, pf
 	// of admintools.conf.
 	if vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly {
 		if !pf.isInstalled {
-			if _, _, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "test", "-f", paths.AdminToolsConf); err == nil {
-				pf.isInstalled = true
-			}
+			pf.isInstalled = gs.AdmintoolsConfExists
 		}
 
 		// We can't reliably set compat21NodeName because the operator didn't
@@ -315,80 +419,34 @@ func (p *PodFacts) checkIsInstalled(ctx context.Context, vdb *vapi.VerticaDB, pf
 		return nil
 	}
 
-	fn := vdb.GenInstallerIndicatorFileName()
-	if stdout, stderr, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "cat", fn); err != nil {
-		if !strings.Contains(stderr, "cat: "+fn+": No such file or directory") {
-			return err
-		}
-		pf.isInstalled = false
-
-		// Check if there is a stale admintools.conf
-		cmd := []string{"ls", paths.AdminToolsConf}
-		if _, stderr, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, cmd...); err != nil {
-			if !strings.Contains(stderr, "No such file or directory") {
-				return err
-			}
-			pf.hasStaleAdmintoolsConf = false
-		} else {
-			pf.hasStaleAdmintoolsConf = true
-		}
+	pf.isInstalled = gs.InstallIndicatorExists
+	if !pf.isInstalled {
+		// If an admintools.conf exists without the install indicator, this
+		// indicates the admintools.conf and should be tossed.
+		pf.hasStaleAdmintoolsConf = gs.AdmintoolsConfExists
 	} else {
-		pf.isInstalled = true
-		pf.compat21NodeName = strings.TrimSuffix(stdout, "\n")
+		pf.compat21NodeName = gs.Compat21NodeName
 	}
 	return nil
 }
 
-// checkEulaAcceptance will check if the end user license agreement has been accepted
-func (p *PodFacts) checkEulaAcceptance(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
-	if pf.isPodRunning {
-		if _, stderr, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "cat", paths.EulaAcceptanceFile); err != nil {
-			if !strings.Contains(stderr, fmt.Sprintf("cat: %s: No such file or directory", paths.EulaAcceptanceFile)) {
-				return err
-			}
-			pf.eulaAccepted = tristate.False
-		} else {
-			pf.eulaAccepted = tristate.True
-		}
+// checkForSimpleGatherStateMapping will do any simple conversion of the gather state to pod facts.
+func (p *PodFacts) checkForSimpleGatherStateMapping(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
+	// Gather state is only valid if the pod was running
+	if !pf.isPodRunning {
+		return nil
 	}
-	return nil
-}
-
-// checkLogrotateExists will verify that that /opt/vertica/config/logrotate exists
-func (p *PodFacts) checkLogrotateExists(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
-	return p.checkDir(ctx, pf, CheckDirExists, paths.ConfigLogrotatePath, func() { pf.configLogrotateExists = true })
-}
-
-// checkIsLogrotateWritable will verify that dbadmin has write access to /opt/vertica/config/logrotate
-func (p *PodFacts) checkIsLogrotateWritable(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
-	return p.checkDir(ctx, pf, CheckWritable, paths.ConfigLogrotatePath, func() { pf.configLogrotateWritable = true })
-}
-
-// checkThatConfigShareExists will verify that /opt/vertica/config/share exists
-func (p *PodFacts) checkThatConfigShareExists(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
-	return p.checkDir(ctx, pf, CheckDirExists, paths.ConfigSharePath, func() { pf.configShareExists = true })
-}
-
-// checkThatHTTPTLSConfExists will verify that http service config file exists
-func (p *PodFacts) checkThatHTTPTLSConfExists(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
-	return p.checkDir(ctx, pf, CheckFileExists, fmt.Sprintf("%s/%s", paths.HTTPTLSConfDir, paths.HTTPTLSConfFile),
-		func() { pf.httpTLSConfExists = true })
-}
-
-// checkDir is a general function that will check if a directory (exists,
-// writable, etc.) and callback to a function when it passes the check.
-func (p *PodFacts) checkDir(ctx context.Context, pf *PodFact, check CheckType, dir string, onSuccessCallback func()) error {
-	if pf.isPodRunning {
-		if _, _, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, "test", string(check), dir); err == nil {
-			onSuccessCallback()
-		}
-	}
+	pf.eulaAccepted = gs.EulaAccepted
+	pf.configLogrotateExists = gs.ConfigLogrotateExists
+	pf.configLogrotateWritable = gs.ConfigLogrotateWritable
+	pf.configShareExists = gs.ConfigShareExists
+	pf.httpTLSConfExists = gs.HTTPTLSConfExists
 	return nil
 }
 
 // checkShardSubscriptions will count the number of shards that are subscribed
 // to the current node
-func (p *PodFacts) checkShardSubscriptions(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
+func (p *PodFacts) checkShardSubscriptions(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	// This check depends on the vnode, which is only present if the pod is
 	// running and the database exists at the node.
 	if !pf.isPodRunning || !pf.dbExists {
@@ -408,7 +466,7 @@ func (p *PodFacts) checkShardSubscriptions(ctx context.Context, vdb *vapi.Vertic
 }
 
 // queryDepotDetails will query the database to get info about the depot for the node
-func (p *PodFacts) queryDepotDetails(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
+func (p *PodFacts) queryDepotDetails(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	// This check depends on the database being up
 	if !pf.isPodRunning || !pf.upNode {
 		return nil
@@ -457,7 +515,7 @@ func (p *PodFacts) checkDCTableAnnotations(pod *corev1.Pod) bool {
 
 // checkIsDBCreated will check for evidence of a database at the local node.
 // If a db is found, we will set the vertica node name.
-func (p *PodFacts) checkIsDBCreated(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
+func (p *PodFacts) checkIsDBCreated(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	pf.dbExists = false
 
 	scs, ok := vdb.FindSubclusterStatus(pf.subcluster)
@@ -475,28 +533,14 @@ func (p *PodFacts) checkIsDBCreated(ctx context.Context, vdb *vapi.VerticaDB, pf
 	if !pf.isPodRunning {
 		return nil
 	}
-
-	cmd := []string{
-		"bash",
-		"-c",
-		fmt.Sprintf("ls -d %s/v_%s_node????_data", vdb.GetDBDataPath(), strings.ToLower(vdb.Spec.DBName)),
-	}
-	if stdout, stderr, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, cmd...); err != nil {
-		if !strings.Contains(stderr, "No such file or directory") {
-			return err
-		}
-		pf.dbExists = false
-	} else {
-		pf.dbExists = true
-		pf.vnodeName = parseVerticaNodeName(stdout)
-	}
-
+	pf.dbExists = gs.DBExists
+	pf.vnodeName = gs.VNodeName
 	return nil
 }
 
 // checkIfNodeIsUpAndReadOnly will determine whether Vertica process is running
 // in the pod and whether it is in read-only mode.
-func (p *PodFacts) checkIfNodeIsUpAndReadOnly(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
+func (p *PodFacts) checkIfNodeIsUpAndReadOnly(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	if !pf.dbExists || !pf.isPodRunning {
 		pf.upNode = false
 		pf.readOnly = false
@@ -515,47 +559,13 @@ func (p *PodFacts) checkIfNodeIsUpAndReadOnly(ctx context.Context, vdb *vapi.Ver
 
 // checkIfNodeIsDoingStartup will determine if the pod has vertica process
 // running but not yet ready for connections.
-func (p *PodFacts) checkIfNodeIsDoingStartup(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact) error {
+func (p *PodFacts) checkIfNodeIsDoingStartup(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	pf.startupInProgress = false
-	if !pf.dbExists || !pf.isPodRunning || pf.upNode {
+	if !pf.dbExists || !pf.isPodRunning || pf.upNode || !gs.VerticaPIDRunning {
 		return nil
 	}
-
-	// vertica must be running
-	cmd := []string{
-		"bash",
-		"-c",
-		"pgrep ^vertica",
-	}
-	_, _, err := p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, cmd...)
-	// We intentionally don't return an error back. Any error assumes vertica isn't running.
-	if err != nil {
-		return nil
-	}
-
-	// Next, check the startup log.  We can't have a 'Startup Complete' message
-	// or 'Database Halted' command.  If the command fails at all, then we
-	// assume startup is in progress.
-	startupLog := pf.getStartupLogPath(vdb)
-	cmd = []string{
-		"bash",
-		"-c",
-		fmt.Sprintf(
-			"grep 'stage' %s && grep --quiet -e 'Startup Complete' -e 'Database Halted' %s",
-			startupLog, startupLog),
-	}
-	_, _, err = p.PRunner.ExecInPod(ctx, pf.name, names.ServerContainer, cmd...)
-	pf.startupInProgress = (err != nil)
-	return nil // Intentionally eating the err as that just means the grep of startup.log failed to find pattern
-}
-
-// getStartupLogPath returns the path to the startup.log
-func (p *PodFact) getStartupLogPath(vdb *vapi.VerticaDB) string {
-	return fmt.Sprintf("%s/%s/%s_catalog/startup.log",
-		vdb.Spec.Local.GetCatalogPath(),
-		vdb.Spec.DBName,
-		p.vnodeName,
-	)
+	pf.startupInProgress = !gs.StartupComplete
+	return nil
 }
 
 // checkIfNodeIsUp will check if the Vertica is up and running in this process.

--- a/pkg/controllers/vdb/resizepv_reconcile_test.go
+++ b/pkg/controllers/vdb/resizepv_reconcile_test.go
@@ -103,13 +103,13 @@ func resizeLocalStorage(ctx context.Context, vdb *vapi.VerticaDB, newSize string
 
 func runResizePVReconciler(ctx context.Context, vdb *vapi.VerticaDB, expectedRequeue, expectedDepotAlter bool) {
 	fpr := &cmds.FakePodRunner{}
-	pfacts := MakePodFacts(vdbRec, fpr)
+	pfacts := createPodFactsDefault(fpr)
 	ExpectWithOffset(1, pfacts.Collect(ctx, vdb)).Should(Succeed())
 	// Mock that depot size for each pod is 60%
 	for i := range pfacts.Detail {
 		pfacts.Detail[i].depotDiskPercentSize = "60%"
 	}
-	r := MakeResizePVReconciler(vdbRec, vdb, fpr, &pfacts)
+	r := MakeResizePVReconciler(vdbRec, vdb, fpr, pfacts)
 	res, err := r.Reconcile(ctx, &ctrl.Request{})
 	ExpectWithOffset(1, err).Should(Succeed())
 	ExpectWithOffset(1, res).Should(Equal(ctrl.Result{Requeue: expectedRequeue}))

--- a/pkg/controllers/vdb/resizepv_reconcile_test.go
+++ b/pkg/controllers/vdb/resizepv_reconcile_test.go
@@ -84,15 +84,6 @@ var _ = Describe("resizepv_reconcile", func() {
 		// Run reconciler to update vertica.  This will requeue because database isn't up
 		runResizePVReconciler(ctx, vdb, true, false)
 	})
-
-	It("should parse df output", func() {
-		Expect(parseDFOutput(`   1B-blocks
-        490577010688
-		`)).Should(Equal(int64(490577010688)))
-		// Bad input -- not enough lines
-		_, err := parseDFOutput(`   1B-blocks`)
-		Expect(err).ShouldNot(Succeed())
-	})
 })
 
 func resizeLocalStorage(ctx context.Context, vdb *vapi.VerticaDB, newSize string) {

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -372,7 +372,7 @@ var _ = Describe("restart_reconciler", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		for podIndex := int32(0); podIndex < vdb.Spec.Subclusters[0].Size; podIndex++ {
 			downPodNm := names.GenPodName(vdb, sc, podIndex)
@@ -382,7 +382,7 @@ var _ = Describe("restart_reconciler", func() {
 			pfacts.Detail[downPodNm].isInstalled = true
 		}
 
-		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, &pfacts, RestartProcessReadOnly)
+		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		listCmd := fpr.FindCommands("start_db")
 		Expect(len(listCmd)).Should(Equal(1))
@@ -615,7 +615,7 @@ var _ = Describe("restart_reconciler", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		for podIndex := int32(0); podIndex < vdb.Spec.Subclusters[0].Size; podIndex++ {
 			downPodNm := names.GenPodName(vdb, sc, podIndex)
@@ -626,7 +626,7 @@ var _ = Describe("restart_reconciler", func() {
 			pfacts.Detail[downPodNm].isPodRunning = podIndex != 0
 		}
 
-		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, &pfacts, RestartProcessReadOnly)
+		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		listCmd := fpr.FindCommands("start_db")
 		Expect(len(listCmd)).Should(Equal(0))
@@ -648,7 +648,7 @@ var _ = Describe("restart_reconciler", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		for podIndex := int32(0); podIndex < vdb.Spec.Subclusters[0].Size; podIndex++ {
 			downPodNm := names.GenPodName(vdb, sc, podIndex)
@@ -658,7 +658,7 @@ var _ = Describe("restart_reconciler", func() {
 			pfacts.Detail[downPodNm].startupInProgress = true
 		}
 
-		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, &pfacts, RestartSkipReadOnly)
+		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartSkipReadOnly)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		killCmd := fpr.FindCommands("kill")
 		Expect(len(killCmd)).Should(Equal(0))

--- a/pkg/controllers/vdb/revivedb_reconcile.go
+++ b/pkg/controllers/vdb/revivedb_reconcile.go
@@ -234,6 +234,12 @@ func (r *ReviveDBReconciler) getPodList() ([]*PodFact, bool) {
 	return podList, true
 }
 
+// findPodToRunInit will return a PodFact of the pod that should run the init
+// command from
+func (r *ReviveDBReconciler) findPodToRunInit() (*PodFact, bool) {
+	return r.PFacts.findPodToRunAdmintoolsOffline()
+}
+
 // genCmd will return the command to run in the pod to create the database
 func (r *ReviveDBReconciler) genCmd(ctx context.Context, hostList []string) ([]string, error) {
 	cmd := []string{

--- a/pkg/controllers/vdb/revivedb_reconcile_test.go
+++ b/pkg/controllers/vdb/revivedb_reconcile_test.go
@@ -54,8 +54,8 @@ var _ = Describe("revivedb_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		reviveCalls := fpr.FindCommands("/opt/vertica/bin/admintools", "revive_db")
 		Expect(len(reviveCalls)).Should(Equal(0))

--- a/pkg/controllers/vdb/status_reconcile_test.go
+++ b/pkg/controllers/vdb/status_reconcile_test.go
@@ -39,9 +39,8 @@ var _ = Describe("status_reconcile", func() {
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
-		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, &pfacts)
+		pfacts := createPodFactsDefault(&cmds.FakePodRunner{})
+		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -81,8 +80,8 @@ var _ = Describe("status_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -109,8 +108,8 @@ var _ = Describe("status_reconcile", func() {
 		test.SetPodStatus(ctx, k8sClient, 1 /* funcOffset */, names.GenPodName(vdb, &sc, PodIndex), ScIndex, PodIndex, test.AllPodsRunning)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -135,8 +134,8 @@ var _ = Describe("status_reconcile", func() {
 		Expect(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}

--- a/pkg/controllers/vdb/stopdb_reconcile_test.go
+++ b/pkg/controllers/vdb/stopdb_reconcile_test.go
@@ -71,8 +71,8 @@ var _ = Describe("stopdb_reconcile", func() {
 		Expect(vdb.IsConditionSet(vapi.VerticaRestartNeeded)).Should(BeTrue())
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		hist := fpr.FindCommands("stop_db")
 		Expect(len(hist)).Should(Equal(1))

--- a/pkg/controllers/vdb/uninstall_reconcile_test.go
+++ b/pkg/controllers/vdb/uninstall_reconcile_test.go
@@ -50,9 +50,9 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		updatePodFactsForUninstall(ctx, &pfacts, vdb, sc, 1, 1)
-		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		pfacts := createPodFactsDefault(fpr)
+		updatePodFactsForUninstall(ctx, pfacts, vdb, sc, 1, 1)
+		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		recon := actor.(*UninstallReconciler)
 		recon.ATWriter = &atconf.FakeWriter{}
 		_, err := recon.uninstallPodsInSubcluster(ctx, sc, 1, 1)
@@ -93,10 +93,10 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		sc.Size = 1 // mimic a pending db_remove_node
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		updatePodFactsForUninstall(ctx, &pfacts, vdb, sc, 1, 2)
+		pfacts := createPodFactsDefault(fpr)
+		updatePodFactsForUninstall(ctx, pfacts, vdb, sc, 1, 2)
 
-		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		r := actor.(*UninstallReconciler)
 		r.ATWriter = &atconf.FakeWriter{}
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
@@ -116,12 +116,12 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		sc.Size = 1 // mimic a pending db_remove_node
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := createPodFactsDefault(fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pn := names.GenPodName(vdb, sc, 1)
 		Expect(pfacts.Detail[pn].dbExists).Should(BeTrue())
 
-		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		actor := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		r := actor.(*UninstallReconciler)
 		r.ATWriter = &atconf.FakeWriter{}
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -48,7 +48,7 @@ type VerticaDBReconciler struct {
 	Scheme *runtime.Scheme
 	Cfg    *rest.Config
 	EVRec  record.EventRecorder
-	OpCfg  opcfg.OperatorConfig // When enabled, it includes extra debug logging
+	OpCfg  opcfg.OperatorConfig
 	builder.DeploymentNames
 }
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/metrics"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/opcfg"
 )
 
 // VerticaDBReconciler reconciles a VerticaDB object
@@ -47,6 +48,7 @@ type VerticaDBReconciler struct {
 	Scheme *runtime.Scheme
 	Cfg    *rest.Config
 	EVRec  record.EventRecorder
+	OpCfg  opcfg.OperatorConfig // When enabled, it includes extra debug logging
 	builder.DeploymentNames
 }
 

--- a/pkg/opcfg/config.go
+++ b/pkg/opcfg/config.go
@@ -1,0 +1,165 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package opcfg
+
+import (
+	"flag"
+	"log"
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+)
+
+const (
+	DefaultZapcoreLevel    = zapcore.InfoLevel
+	First                  = 100
+	ThereAfter             = 100
+	DefaultMaxFileSize     = 500
+	DefaultMaxFileAge      = 7
+	DefaultMaxFileRotation = 3
+	DefaultLevel           = "info"
+	DefaultDevMode         = true
+)
+
+type OperatorConfig struct {
+	MetricsAddr          string
+	EnableLeaderElection bool
+	ProbeAddr            string
+	EnableProfiler       bool
+	ServiceAccountName   string
+	PrefixName           string // Prefix of the name of all objects created when the operator was deployed
+	WebhookCertSecret    string // when this is empty we will generate the webhook cert
+	DevMode              bool
+	Logging
+}
+
+type Logging struct {
+	FilePath        string
+	Level           string
+	MaxFileSize     int
+	MaxFileAge      int
+	MaxFileRotation int
+}
+
+// SetFlagArgs define flags with specified names and default values
+func (o *OperatorConfig) SetFlagArgs() {
+	flag.StringVar(&o.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&o.EnableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&o.EnableProfiler, "enable-profiler", false,
+		"Enables runtime profiling collection.  The profiling data can be inspected by connecting to port 6060 "+
+			"with the path /debug/pprof.  See https://golang.org/pkg/net/http/pprof/ for more info.")
+	flag.StringVar(&o.ServiceAccountName, "service-account-name", "verticadb-operator-controller-manager",
+		"The name of the serviceAccount to use.")
+	flag.StringVar(&o.PrefixName, "prefix-name", "verticadb-operator",
+		"The common prefix for all objects created during the operator deployment")
+	flag.StringVar(&o.WebhookCertSecret, "webhook-cert-secret", "",
+		"Specifies the secret that contains the webhook cert. If this option is omitted, "+
+			"then the operator will generate the certificate.")
+	flag.BoolVar(&o.DevMode, "dev", DefaultDevMode,
+		"Enables development mode if true and production mode otherwise.")
+	flag.StringVar(&o.FilePath, "filepath", "",
+		"The path to the log file. If omitted, all logging will be written to stdout.")
+	flag.IntVar(&o.MaxFileSize, "maxfilesize", DefaultMaxFileSize,
+		"The maximum size in megabytes of the log file "+
+			"before it gets rotated.")
+	flag.IntVar(&o.MaxFileAge, "maxfileage", DefaultMaxFileAge,
+		"The maximum number of days to retain old log files based on the timestamp encoded in the file.")
+	flag.IntVar(&o.MaxFileRotation, "maxfilerotation", DefaultMaxFileRotation,
+		"The maximum number of files that are kept in rotation before the old ones are removed.")
+	flag.StringVar(&o.Level, "level", DefaultLevel,
+		"The minimum logging level.  Valid values are: debug, info, warn, and error.")
+}
+
+// SPILLY - make these functions of OperatorConfig
+
+// getEncoderConfig returns a concrete encoders configuration
+func getEncoderConfig(devMode bool) zapcore.EncoderConfig {
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	if !devMode {
+		encoderConfig = zap.NewProductionEncoderConfig()
+		encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+		encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	}
+	return encoderConfig
+}
+
+// getLogger is a wrapper that calls other functions
+// to build a logger.
+func (o *OperatorConfig) GetLogger() *zap.Logger {
+	encoderConfig := getEncoderConfig(o.DevMode)
+	writes := []zapcore.WriteSyncer{}
+	opts := []zap.Option{}
+	lvl := zap.NewAtomicLevelAt(getZapcoreLevel(o.Logging.Level))
+	if o.FilePath != "" {
+		w := getLogWriter(o)
+		writes = append(writes, w)
+	}
+	if o.FilePath == "" || o.DevMode {
+		writes = append(writes, zapcore.AddSync(os.Stdout))
+	}
+	core := zapcore.NewCore(
+		zapcore.NewConsoleEncoder(encoderConfig),
+		zapcore.NewMultiWriteSyncer(writes...),
+		lvl,
+	)
+	opts = append(opts, getStackTrace(o.DevMode))
+	if !o.DevMode {
+		// This enables sampling only in prod
+		core = zapcore.NewSamplerWithOptions(core, time.Second, First, ThereAfter)
+	}
+	return zap.New(core, opts...)
+}
+
+// getLogWriter returns an io.writer (setting up rolling files) converted
+// into a zapcore.WriteSyncer
+func getLogWriter(oc *OperatorConfig) zapcore.WriteSyncer {
+	lumberJackLogger := &lumberjack.Logger{
+		Filename:   oc.FilePath,
+		MaxSize:    oc.MaxFileSize, // megabytes
+		MaxBackups: oc.MaxFileRotation,
+		MaxAge:     oc.MaxFileAge, // days
+	}
+	return zapcore.AddSync(lumberJackLogger)
+}
+
+// getZapcoreLevel takes the level as string and returns the corresponding
+// zapcore.Level. If the string level is invalid, it returns the default
+// level
+func getZapcoreLevel(lvl string) zapcore.Level {
+	var level = new(zapcore.Level)
+	err := level.UnmarshalText([]byte(lvl))
+	if err != nil {
+		log.Printf("unrecognized level, %s level will be used instead", DefaultLevel)
+		return DefaultZapcoreLevel
+	}
+	return *level
+}
+
+// getStackTrace returns an option that configures
+// the logger to record a stack strace.
+func getStackTrace(devMode bool) zap.Option {
+	lvl := zapcore.ErrorLevel
+	if devMode {
+		lvl = zapcore.WarnLevel
+	}
+	return zap.AddStacktrace(zapcore.LevelEnabler(lvl))
+}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -35,6 +35,7 @@ const (
 	AuthParmsFile          = "/home/dbadmin/auth_parms.conf"
 	PrepScript             = "/home/dbadmin/db_prep.sh"
 	PodFactGatherScript    = "/home/dbadmin/pod-fact-gather.sh"
+	CreateConfigDirsScript = "/home/dbadmin/create-config-dirs.sh"
 	EulaAcceptanceFile     = "/opt/vertica/config/d5415f948449e9d4c421b568f2411140.dat"
 	EulaAcceptanceScript   = "/opt/vertica/config/accept_eula.py"
 	CertsRoot              = "/certs"

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -33,6 +33,7 @@ const (
 	PodInfoPath            = "/etc/podinfo"
 	AdminToolsConf         = "/opt/vertica/config/admintools.conf"
 	AuthParmsFile          = "/home/dbadmin/auth_parms.conf"
+	PrepScript             = "/home/dbadmin/db_prep.sh"
 	EulaAcceptanceFile     = "/opt/vertica/config/d5415f948449e9d4c421b568f2411140.dat"
 	EulaAcceptanceScript   = "/opt/vertica/config/accept_eula.py"
 	CertsRoot              = "/certs"

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -34,6 +34,7 @@ const (
 	AdminToolsConf         = "/opt/vertica/config/admintools.conf"
 	AuthParmsFile          = "/home/dbadmin/auth_parms.conf"
 	PrepScript             = "/home/dbadmin/db_prep.sh"
+	PodFactGatherScript    = "/home/dbadmin/pod-fact-gather.sh"
 	EulaAcceptanceFile     = "/opt/vertica/config/d5415f948449e9d4c421b568f2411140.dat"
 	EulaAcceptanceScript   = "/opt/vertica/config/accept_eula.py"
 	CertsRoot              = "/certs"

--- a/scripts/run-operator.sh
+++ b/scripts/run-operator.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_DIR=$(dirname $SCRIPT_DIR)
+INT_TEST_OUTPUT_DIR=${REPO_DIR}/int-tests-output
+NS=$(kubectl config view --minify --output 'jsonpath={..namespace}' 2> /dev/null)
+CYAN='\033[0;36m'
+RED='\033[1;31m'
+NC='\033[0m'  # No color
+
+set -o errexit
+set -o pipefail
+
+# This is a script that will run the operator from your local environment. It
+# won't run it in a k8s pod. This has the advantage of starting quicker, since
+# we can use the Go cache to speed up the build times. The downside is that the
+# webhook has to be disabled. There is no way for k8s to send webhook requests
+# to your local environment.
+
+function usage {
+    echo "$0 [-l <log_dir>] [-v]"
+    echo
+    echo "Options:"
+    echo "  -l <log_dir>        Log directory.   default: $INT_TEST_OUTPUT_DIR"
+    echo "  -v                  Verbose output"
+    exit 1
+}
+
+OPTIND=1
+while getopts l:hv opt; do
+    case ${opt} in
+        l)
+            INT_TEST_OUTPUT_DIR=${OPTARG}
+            ;;
+        h)
+            usage
+            ;;
+        v)
+            set -o xtrace
+            ;;
+        \?)
+            echo "ERROR: unrecognized option: -$opt"
+            usage
+            ;;
+    esac
+done
+
+function logGeneric {
+    printf $1
+    shift
+    printf $(date "+%D")
+    printf " "
+    printf $(date "+%T")
+    printf " [$1]  "
+    shift
+    for i in $*; do
+        printf "$i "
+    done
+    printf "$NC\n"
+
+}
+
+function logInfo {
+    logGeneric ${CYAN} "ℹ" $@
+}
+
+function logError {
+    logGeneric ${RED} "!" $@
+}
+
+cd $REPO_DIR
+
+mkdir -p $INT_TEST_OUTPUT_DIR
+OP="${INT_TEST_OUTPUT_DIR}/local-verticadb-operator.log"
+
+if helm list -o json | jq --exit-status '.[] | select(.chart|test("^verticadb-operator")) | .name'
+then
+    logError "verticadb-operator helm chart already installed in namespace"
+    exit 1
+fi
+
+logInfo "Creating operator ConfigMap"
+TMPFILE=$(mktemp /tmp/configmap.yaml.XXXXXX)
+
+# The operator depends on the existence of a ConfigMap. We create it here.
+sed 's/\(WEBHOOK_CERT_SOURCE\).*/\1: internal/;s/\(name:\) .*/\1 verticadb-operator-manager-config/;s/namespace: .*//' helm-charts/verticadb-operator/templates/verticadb-operator-manager-config-cm.yaml > $TMPFILE
+kubectl apply -f $TMPFILE
+
+trap \
+    "if [ -f $TMPFILE ]; then logInfo 'Deleting operator ConfigMap'; kubectl delete -f $TMPFILE; rm $TMPFILE; fi; trap - SIGTERM && kill -- -$$ 2> /dev/null" \
+    SIGINT SIGTERM ERR EXIT
+
+# We cannot have webhooks enabled when running in this mode. With the operator
+# running locally, there is no way for k8s to callout to us.
+logInfo "Starting operator. Hit CTRL-C to quit."
+logInfo "Watching namespace: $NS"
+logInfo "Output send to: $OP"
+WATCH_NAMESPACE=$NS ENABLE_WEBHOOKS=false go run cmd/operator/main.go -enable-profiler -service-account-name=default 2>&1 1> $OP &
+OP_PID=$!
+wait $OP_PID


### PR DESCRIPTION
This change improves the stability of the operator for big clusters. When used to create big clusters (> 40 nodes), the number of things it had to do per pod starts adding up. Calls to 'kubectl exec' to get various state (cmds package) can take a while. There is also a lot of memory pressure when 'kubectl exec' is called frequently -- we send the command to the REST endpoint that uses gzip to compress/uncompress the input/output. The compression library, which we don't have any control over, uses a lot of memory. Go is a garbage collection language, so the memory is eventually freed, but the GC can take some time to kick in. 

The approach taken in this change is to batch as many 'kubectl exec' commands as we can. This change impacts the podfacts collector, installer reconciler and create db reconciler. The end result is that there is less memory pressure and it is quicker for a reconcile iteration to get through its various state checks.

Refactor of the main.go module. Most of the command line argument handling was moved to a separate package called opcfg. This was changed because I wanted to flow down the command line arguments into the controllers so that we can log things only when in dev mode. So, we need to put the arguments in an exported struct from a new package that the controllers would have access to.

Included in this is a change to make it easier to run the operator locally. A new script was added that handles proper setup and teardown.