### PR TITLE
Use Vertica 12.0.1 for e2e tests

### DIFF
--- a/.github/actions/download-rpm/action.yaml
+++ b/.github/actions/download-rpm/action.yaml
@@ -6,6 +6,6 @@ runs:
     - name: Download vertica RPM package
       shell: bash
       env:
-          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-12.0.0-0.x86_64.RHEL6.rpm"
+          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-12.0.1-0.x86_64.RHEL6.rpm"
       run: |
         curl $VERTICA_CE_URL -o docker-vertica/packages/vertica-x86_64.RHEL6.latest.rpm


### PR DESCRIPTION
Uses the newer RPM. This has the added benefit that the e2e tests will run faster because it can take advantage of skipping package install during create_db.