### PR TITLE
Skip some checks if vertica pid not running

### DIFF
--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -456,7 +456,7 @@ func (p *PodFacts) checkForSimpleGatherStateMapping(ctx context.Context, vdb *va
 func (p *PodFacts) checkShardSubscriptions(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	// This check depends on the vnode, which is only present if the pod is
 	// running and the database exists at the node.
-	if !pf.isPodRunning || !pf.dbExists {
+	if !pf.isPodRunning || !pf.dbExists || !gs.VerticaPIDRunning {
 		return nil
 	}
 	cmd := []string{
@@ -475,7 +475,7 @@ func (p *PodFacts) checkShardSubscriptions(ctx context.Context, vdb *vapi.Vertic
 // queryDepotDetails will query the database to get info about the depot for the node
 func (p *PodFacts) queryDepotDetails(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	// This check depends on the database being up
-	if !pf.isPodRunning || !pf.upNode {
+	if !pf.isPodRunning || !pf.upNode || !gs.VerticaPIDRunning {
 		return nil
 	}
 	cmd := []string{
@@ -548,7 +548,7 @@ func (p *PodFacts) checkIsDBCreated(ctx context.Context, vdb *vapi.VerticaDB, pf
 // checkIfNodeIsUpAndReadOnly will determine whether Vertica process is running
 // in the pod and whether it is in read-only mode.
 func (p *PodFacts) checkIfNodeIsUpAndReadOnly(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
-	if !pf.dbExists || !pf.isPodRunning {
+	if !pf.dbExists || !pf.isPodRunning || !gs.VerticaPIDRunning {
 		pf.upNode = false
 		pf.readOnly = false
 		return nil

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -205,7 +205,7 @@ var _ = Describe("podfacts", func() {
 		}
 		pfs := MakePodFacts(vdbRec, fpr)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs := &GatherState{}
+		gs := &GatherState{VerticaPIDRunning: true}
 		Expect(pfs.checkIfNodeIsUpAndReadOnly(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pf.upNode).Should(BeTrue())
 	})
@@ -223,7 +223,7 @@ var _ = Describe("podfacts", func() {
 		}
 		pfs := MakePodFacts(vdbRec, fpr)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs := &GatherState{}
+		gs := &GatherState{VerticaPIDRunning: true}
 		Expect(pfs.checkIfNodeIsUpAndReadOnly(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pf.upNode).Should(BeTrue())
 		Expect(pf.readOnly).Should(BeTrue())


### PR DESCRIPTION
Some follow-up from the podfacts change. I noticed that we do some checks in podfacts that rely on the database up that can be skipped if the vertica pid isn't running. This will save a few 'kubectl exec' calls during a reconcile iteration when vertica isn't running.