### PR TITLE
Installer to create http conf dir if enabled

### DIFF
--- a/pkg/controllers/vdb/install_reconcile.go
+++ b/pkg/controllers/vdb/install_reconcile.go
@@ -316,7 +316,7 @@ func (d *InstallReconciler) genCreateConfigDirsScript(p *PodFact) string {
 		numCmds++
 	}
 
-	if !d.doHTTPInstall(false) && !p.httpTLSConfExists {
+	if d.doHTTPInstall(false) && !p.httpTLSConfExists {
 		sb.WriteString(fmt.Sprintf("mkdir -p %s\n", paths.HTTPTLSConfDir))
 		numCmds++
 	}

--- a/pkg/controllers/vdb/install_reconcile_test.go
+++ b/pkg/controllers/vdb/install_reconcile_test.go
@@ -182,12 +182,18 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		pfact := createPodFactsWithInstallNeeded(ctx, vdb, fpr)
 		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, pfact)
 		drecon := actor.(*InstallReconciler)
+		for _, val := range pfact.Detail {
+			Expect(drecon.genCreateConfigDirsScript(val)).ShouldNot(ContainSubstring(paths.HTTPTLSConfDir))
+		}
 		err := drecon.generateHTTPCerts(ctx)
 		Expect(err).Should(Succeed())
 		cmds := fpr.FindCommands(paths.HTTPTLSConfFile)
 		Expect(len(cmds)).Should(Equal(0))
 
 		vdb.Annotations[vapi.VersionAnnotation] = version.HTTPServerMinVersion
+		for _, val := range pfact.Detail {
+			Expect(drecon.genCreateConfigDirsScript(val)).Should(ContainSubstring(paths.HTTPTLSConfDir))
+		}
 		err = drecon.generateHTTPCerts(ctx)
 		Expect(err).Should(Succeed())
 		cmds = fpr.FindCommands(paths.HTTPTLSConfFile)


### PR DESCRIPTION
This fixes a bug that was introduced earlier in this release (#283) when we did the podfacts refactor. We were failing to create the http conf dir in the installer reconciler if the http server is enabled. The plan is enable the http e2e tests, which would have caught this, when we use the 12.0.2 server release in the CI.