### PR TITLE
vdb-gen to handle db that have no communal auth

### DIFF
--- a/changes/unreleased/Fixed-20221124-103144.yaml
+++ b/changes/unreleased/Fixed-20221124-103144.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: vdb-gen to handle db's that don't have authentication parms for communal storage
+time: 2022-11-24T10:31:44.437130694-04:00
+custom:
+  Issue: "291"

--- a/pkg/vdbgen/generator.go
+++ b/pkg/vdbgen/generator.go
@@ -55,19 +55,32 @@ func Generate(wr io.Writer, cr VDBCreator) error {
 
 // writeManifest will print out the objects in pretty-print yaml output
 func writeManifest(wr io.Writer, objs *KObjs) (err error) {
-	y, err := yaml.Marshal(objs.CredSecret)
+	y, err := yaml.Marshal(objs.Vdb)
 	if err != nil {
 		return err
 	}
 	fmt.Fprint(wr, string(y))
+
+	printManifestWithSeparator := func(y []byte) {
+		fmt.Fprint(wr, "---\n")
+		fmt.Fprint(wr, string(y))
+	}
+
+	// Skip if secret data is empty
+	if len(objs.CredSecret.Data) != 0 {
+		y, err = yaml.Marshal(objs.CredSecret)
+		if err != nil {
+			return err
+		}
+		printManifestWithSeparator(y)
+	}
 
 	if objs.HasPassword {
 		y, err = yaml.Marshal(objs.SuperuserPasswordSecret)
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(wr, "---\n")
-		fmt.Fprint(wr, string(y))
+		printManifestWithSeparator(y)
 	}
 
 	if objs.HasLicense {
@@ -75,8 +88,7 @@ func writeManifest(wr io.Writer, objs *KObjs) (err error) {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(wr, "---\n")
-		fmt.Fprint(wr, string(y))
+		printManifestWithSeparator(y)
 	}
 
 	if objs.HasCAFile {
@@ -84,8 +96,7 @@ func writeManifest(wr io.Writer, objs *KObjs) (err error) {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(wr, "---\n")
-		fmt.Fprint(wr, string(y))
+		printManifestWithSeparator(y)
 	}
 
 	if objs.HasHadoopConfig {
@@ -93,8 +104,7 @@ func writeManifest(wr io.Writer, objs *KObjs) (err error) {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(wr, "---\n")
-		fmt.Fprint(wr, string(y))
+		printManifestWithSeparator(y)
 	}
 
 	if objs.HasKerberosSecret {
@@ -102,15 +112,7 @@ func writeManifest(wr io.Writer, objs *KObjs) (err error) {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(wr, "---\n")
-		fmt.Fprint(wr, string(y))
+		printManifestWithSeparator(y)
 	}
-
-	y, err = yaml.Marshal(objs.Vdb)
-	if err != nil {
-		return err
-	}
-	fmt.Fprint(wr, "---\n")
-	fmt.Fprint(wr, string(y))
 	return nil
 }

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -159,7 +159,11 @@ func (d *DBGenerator) setParmsFromOptions() {
 	if d.Opts.Image != "" {
 		d.Objs.Vdb.Spec.Image = d.Opts.Image
 	}
+}
 
+// setupCredSecret will link a credential secret into the VerticaDB. Use this if
+// you know you will populate the credential secret with data.
+func (d *DBGenerator) setupCredSecret() {
 	d.Objs.CredSecret.TypeMeta.APIVersion = SecretAPIVersion
 	d.Objs.CredSecret.TypeMeta.Kind = SecretKindName
 	d.Objs.CredSecret.ObjectMeta.Name = fmt.Sprintf("%s-credentials", d.Opts.VdbName)
@@ -334,6 +338,7 @@ func (d *DBGenerator) setCommunalEndpointAzure(ctx context.Context) error {
 		}
 	}
 
+	d.setupCredSecret()
 	d.Objs.CredSecret.Data = map[string][]byte{}
 	if cred.AccountKey != "" {
 		d.Objs.CredSecret.Data[cloud.AzureAccountKey] = []byte(cred.AccountKey)
@@ -381,6 +386,7 @@ func (d *DBGenerator) setCommunalEndpointGeneric(httpsKey, endpointKey, authKey,
 		authRE := regexp.MustCompile(`:`)
 		const NumAuthComponents = 2
 		auth := authRE.Split(value, NumAuthComponents)
+		d.setupCredSecret()
 		d.Objs.CredSecret.Data = map[string][]byte{
 			cloud.CommunalAccessKeyName: []byte(auth[0]),
 			cloud.CommunalSecretKeyName: []byte(auth[1]),

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -120,6 +120,28 @@ var _ = Describe("vdb", func() {
 		Expect(mock.ExpectationsWereMet()).Should(Succeed())
 	})
 
+	It("should handle case where auth isn't present for s3 communal db", func() {
+		createMock()
+		defer deleteMock()
+
+		dbGen := DBGenerator{Conn: db}
+		dbGen.Objs.Vdb.Spec.Communal.Path = "s3://my-bucket-ut"
+
+		mock.ExpectQuery(Queries[DBCfgKey]).
+			WillReturnRows(sqlmock.NewRows([]string{"key", "value"}).
+				AddRow("AWSEndpoint", "s3.amazonaws.com").
+				AddRow("AWSEnableHttps", "1"))
+		Expect(dbGen.fetchDatabaseConfig(ctx)).Should(Succeed())
+		Expect(dbGen.setCommunalEndpointAWS(ctx)).Should(Succeed())
+		Expect(dbGen.Objs.Vdb.Spec.Communal.Endpoint).Should(Equal("https://s3.amazonaws.com"))
+		_, ok := dbGen.Objs.CredSecret.Data[cloud.CommunalAccessKeyName]
+		Expect(ok).Should(BeFalse())
+		_, ok = dbGen.Objs.CredSecret.Data[cloud.CommunalSecretKeyName]
+		Expect(ok).Should(BeFalse())
+
+		Expect(mock.ExpectationsWereMet()).Should(Succeed())
+	})
+
 	It("should get communal endpoint for GCS from show database", func() {
 		createMock()
 		defer deleteMock()

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -92,7 +92,7 @@ var _ = Describe("vdb", func() {
 		createMock()
 		defer deleteMock()
 
-		dbGen := DBGenerator{Conn: db}
+		dbGen := DBGenerator{Conn: db, Opts: &Options{}}
 		dbGen.Objs.Vdb.Spec.Communal.Path = "s3://"
 
 		mock.ExpectQuery(Queries[DBCfgKey]).
@@ -146,7 +146,7 @@ var _ = Describe("vdb", func() {
 		createMock()
 		defer deleteMock()
 
-		dbGen := DBGenerator{Conn: db}
+		dbGen := DBGenerator{Conn: db, Opts: &Options{}}
 		dbGen.Objs.Vdb.Spec.Communal.Path = "gs://"
 
 		mock.ExpectQuery(Queries[DBCfgKey]).


### PR DESCRIPTION
There are a couple of cases where a Vertica database can be created without storing authentication parms for communal:
- using HDFS as the communal store
- using AWS S3, but using IAM profiles for authentication

vdb-gen wasn't handling this case well. For AWS S3, it was expecting to see the authentication parms. It failed when it couldn't find it. And it handles the HDFS case, but still prints out an empty credential secret when it dumps the manifests.

This fixes both scenarios in vdb-gen.