### PR TITLE
Extend admintools timeout for a slow revive

### DIFF
--- a/changes/unreleased/Fixed-20221124-142513.yaml
+++ b/changes/unreleased/Fixed-20221124-142513.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Extend the internal timeout for admintools to allow a slow revive to succeed
+time: 2022-11-24T14:25:13.134678971-04:00
+custom:
+  Issue: "292"

--- a/pkg/atconf/file_writer.go
+++ b/pkg/atconf/file_writer.go
@@ -327,6 +327,7 @@ func (f *FileWriter) writeDefaultAdmintoolsConf(file *os.File) error {
 		sync_catalog_retries = 2000
 		client_connect_timeout_sec = 5.0
 		admintools_config_version = 110
+		thread_timeout = 1200
 
 		[Cluster]
 


### PR DESCRIPTION
There is an internal 5-minute timeout while bootstrapping the database during revive. If this timeout is exceeded the revive will fail. I'm extending this time to 20-minutes to allow slow revives to succeed.