### PR TITLE
Include metrics label to uniquely identify the database

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -926,6 +926,8 @@ const (
 	VersionAnnotation   = "vertica.com/version"
 	BuildDateAnnotation = "vertica.com/buildDate"
 	BuildRefAnnotation  = "vertica.com/buildRef"
+	// Annotation for the database's revive_instance_id
+	ReviveInstanceIDAnnotation = "vertica.com/revive-instance-id"
 
 	DefaultS3Region       = "us-east-1"
 	DefaultGCloudRegion   = "US-EAST1"
@@ -1017,6 +1019,31 @@ func IsValidSubclusterName(scName string) bool {
 func (v *VerticaDB) GetVerticaVersion() (string, bool) {
 	ver, ok := v.ObjectMeta.Annotations[VersionAnnotation]
 	return ver, ok
+}
+
+// HasReviveInstanceIDAnnotation is true when an annotation exists for the db's
+// revive_instance_id.
+func (v *VerticaDB) HasReviveInstanceIDAnnotation() bool {
+	_, ok := v.ObjectMeta.Annotations[ReviveInstanceIDAnnotation]
+	return ok
+}
+
+// MergeAnnotations will merge new annotations with vdb.  It will return true if
+// any annotation changed.  Caller is responsible for updating the Vdb in the
+// API server.
+func (v *VerticaDB) MergeAnnotations(newAnnotations map[string]string) bool {
+	changedAnnotations := false
+	for k, newValue := range newAnnotations {
+		oldValue, ok := v.ObjectMeta.Annotations[k]
+		if !ok || oldValue != newValue {
+			if v.ObjectMeta.Annotations == nil {
+				v.ObjectMeta.Annotations = map[string]string{}
+			}
+			v.ObjectMeta.Annotations[k] = newValue
+			changedAnnotations = true
+		}
+	}
+	return changedAnnotations
 }
 
 // GenInstallerIndicatorFileName returns the name of the installer indicator file.

--- a/changes/unreleased/Added-20221208-151541.yaml
+++ b/changes/unreleased/Added-20221208-151541.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Include a label for the database name in the operator's Prometheus metrics
+time: 2022-12-08T15:15:41.574904895-04:00
+custom:
+  Issue: "300"

--- a/changes/unreleased/Added-20221208-151541.yaml
+++ b/changes/unreleased/Added-20221208-151541.yaml
@@ -1,5 +1,5 @@
 kind: Added
-body: Include a label for the database name in the operator's Prometheus metrics
+body: Include a label in the operator's Prometheus metrics to identify the database uniquely
 time: 2022-12-08T15:15:41.574904895-04:00
 custom:
   Issue: "300"

--- a/pkg/controllers/vdb/metrics_reconcile_test.go
+++ b/pkg/controllers/vdb/metrics_reconcile_test.go
@@ -37,8 +37,9 @@ var _ = Describe("prometheus_reconcile", func() {
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
-		pfacts := createPodFactsDefault(&cmds.FakePodRunner{})
-		actor := MakeMetricReconciler(vdbRec, vdb, pfacts)
+		prunner := &cmds.FakePodRunner{}
+		pfacts := createPodFactsDefault(prunner)
+		actor := MakeMetricReconciler(vdbRec, vdb, prunner, pfacts)
 		r := actor.(*MetricReconciler)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 

--- a/pkg/controllers/vdb/version_reconciler.go
+++ b/pkg/controllers/vdb/version_reconciler.go
@@ -150,7 +150,7 @@ func (v *VersionReconciler) updateVDBVersion(ctx context.Context, newVersion str
 		if err != nil {
 			return err
 		}
-		if version.MergeAnnotations(v.Vdb, versionAnnotations) {
+		if v.Vdb.MergeAnnotations(versionAnnotations) {
 			err = v.VRec.Client.Update(ctx, v.Vdb)
 			if err != nil {
 				return err

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -146,7 +146,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 	return []controllers.ReconcileActor{
 		// Always start with a status reconcile in case the prior reconcile failed.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
-		MakeMetricReconciler(r, vdb, pfacts),
+		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		// Handle upgrade actions for any k8s objects created in prior versions
 		// of the operator.
 		MakeUpgradeOperator120Reconciler(r, log, vdb),
@@ -170,7 +170,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeStopDBReconciler(r, vdb, prunner, pfacts),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true),
-		MakeMetricReconciler(r, vdb, pfacts),
+		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Ensure we add labels to any pod rescheduled so that Service objects route traffic to it.
 		MakeClientRoutingLabelReconciler(r, vdb, pfacts, PodRescheduleApplyMethod, ""),
@@ -184,7 +184,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handles calls to admintools -t db_remove_node
 		MakeDBRemoveNodeReconciler(r, log, vdb, prunner, pfacts),
-		MakeMetricReconciler(r, vdb, pfacts),
+		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to remove hosts from admintools.conf
 		MakeUninstallReconciler(r, log, vdb, prunner, pfacts),
@@ -201,7 +201,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeCreateDBReconciler(r, log, vdb, prunner, pfacts),
 		// Handle calls to admintools -t revive_db
 		MakeReviveDBReconciler(r, log, vdb, prunner, pfacts),
-		MakeMetricReconciler(r, vdb, pfacts),
+		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		// Create and revive are mutually exclusive exclusive, so this handles
 		// status updates after both of them.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
@@ -209,7 +209,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeClientRoutingLabelReconciler(r, vdb, pfacts, AddNodeApplyMethod, ""),
 		// Handle calls to admintools -t db_add_subcluster
 		MakeDBAddSubclusterReconciler(r, log, vdb, prunner, pfacts),
-		MakeMetricReconciler(r, vdb, pfacts),
+		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to admintools -t db_add_node
 		MakeDBAddNodeReconciler(r, log, vdb, prunner, pfacts),

--- a/pkg/version/metadata.go
+++ b/pkg/version/metadata.go
@@ -21,24 +21,6 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 )
 
-// MergeAnnotations will merge new annotations with vdb.  It will return true if
-// any annotation changed.  Caller is responsible for updating the Vdb in the
-// API server.
-func MergeAnnotations(vdb *vapi.VerticaDB, newAnnotations map[string]string) bool {
-	changedAnnotations := false
-	for k, newValue := range newAnnotations {
-		oldValue, ok := vdb.ObjectMeta.Annotations[k]
-		if !ok || oldValue != newValue {
-			if vdb.ObjectMeta.Annotations == nil {
-				vdb.ObjectMeta.Annotations = map[string]string{}
-			}
-			vdb.ObjectMeta.Annotations[k] = newValue
-			changedAnnotations = true
-		}
-	}
-	return changedAnnotations
-}
-
 // ParseVersionOutput will parse the raw output from the --version call and
 // build an annotation map.
 //

--- a/pkg/version/metadata_test.go
+++ b/pkg/version/metadata_test.go
@@ -44,7 +44,7 @@ vertica(v11.0.0-20210601) built by @re-docker2 from master@da8f0e93f1ee720d8e4f8
 		op := `Vertica Analytic Database v11.0.0
 vertica(v11.0.0) built by @re-docker2 from master@abcd on 'Tue Jun 10' $BuildId$
 `
-		chg := MergeAnnotations(vdb, ParseVersionOutput(op))
+		chg := vdb.MergeAnnotations(ParseVersionOutput(op))
 		Expect(chg).Should(BeFalse())
 	})
 
@@ -59,13 +59,13 @@ vertica(v11.0.0) built by @re-docker2 from master@abcd on 'Tue Jun 10' $BuildId$
 		op := `Vertica Analytic Database v11.0.0-1
 vertica(v11.0.0-1) built by @re-docker2 from master@abcd on 'Tue Jun 10' $BuildId$
 `
-		chg := MergeAnnotations(vdb, ParseVersionOutput(op))
+		chg := vdb.MergeAnnotations(ParseVersionOutput(op))
 		Expect(chg).Should(BeTrue())
 
 		vdb.ObjectMeta.Annotations = map[string]string{
 			vapi.BuildDateAnnotation: "Tue Jun 10",
 		}
-		chg = MergeAnnotations(vdb, ParseVersionOutput(op))
+		chg = vdb.MergeAnnotations(ParseVersionOutput(op))
 		Expect(chg).Should(BeTrue())
 	})
 

--- a/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
+++ b/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
@@ -35,8 +35,9 @@ data:
     done
     for sc in pri-sc sec-sc
     do
-        curl http://$SVC_NAME:8443/metrics | grep "vertica_total_nodes_count{namespace=".*",subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
-        curl http://$SVC_NAME:8443/metrics | grep "vertica_running_nodes_count{namespace=".*",subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1"
+        curl http://$SVC_NAME:8443/metrics | grep "vertica_total_nodes_count{.*subcluster=\"$sc\".*} 1"
+        curl http://$SVC_NAME:8443/metrics | grep "vertica_running_nodes_count{.*verticadb=\"v-operator-metrics\".*} 1"
+        curl http://$SVC_NAME:8443/metrics | grep "vertica_cluster_restart_failed_total{.*db_name=\"vertdb\".*}"
     done
     # These is timing with the ready pod count.  The pod may be ready but the
     # metrics haven't yet been updated.  We check that a few times before
@@ -47,7 +48,7 @@ data:
       do
         [ $i -gt 1 ] && sleep 10
         curl http://$SVC_NAME:8443/metrics
-        curl http://$SVC_NAME:8443/metrics | grep "vertica_up_nodes_count{namespace=".*",subcluster=\"$sc\",verticadb=\"v-operator-metrics\"} 1" \
+        curl http://$SVC_NAME:8443/metrics | grep "vertica_up_nodes_count{.*subcluster=\"$sc\".*} 1" \
           && s=0 && break || s=$?
       done
       (exit $s)

--- a/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
+++ b/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
@@ -37,7 +37,7 @@ data:
     do
         curl http://$SVC_NAME:8443/metrics | grep "vertica_total_nodes_count{.*subcluster=\"$sc\".*} 1"
         curl http://$SVC_NAME:8443/metrics | grep "vertica_running_nodes_count{.*verticadb=\"v-operator-metrics\".*} 1"
-        curl http://$SVC_NAME:8443/metrics | grep "vertica_cluster_restart_failed_total{.*db_name=\"vertdb\".*}"
+        curl http://$SVC_NAME:8443/metrics | grep -e 'vertica_cluster_restart_failed_total{.*revive_instance_id="\([0-9a-f]\)*".*}'
     done
     # These is timing with the ready pod count.  The pod may be ready but the
     # metrics haven't yet been updated.  We check that a few times before


### PR DESCRIPTION
Adding a new label to all of the Prometheus metrics that the operator collects. We include the revive instance ID. Here is a sample metric:
```
vertica_up_nodes_count{namespace="vertica",revive_instance_id="566b8f9590b771272b918c86a17a7b",subcluster="defaultsubcluster",verticadb="vert"} 3
```

The label `revive_instance_id` will allow us to match labels generated at the server. This will help allow us to pull metrics into the same dashboard for operator and server.