### PR TITLE
Don't start metric endpoint if metrics are disabled

### DIFF
--- a/changes/unreleased/Fixed-20221209-092713.yaml
+++ b/changes/unreleased/Fixed-20221209-092713.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Don't start the metric endpoint if metrics are disabled
+time: 2022-12-09T09:27:13.333127284-04:00
+custom:
+  Issue: "301"

--- a/pkg/opcfg/config.go
+++ b/pkg/opcfg/config.go
@@ -59,7 +59,8 @@ type Logging struct {
 
 // SetFlagArgs define flags with specified names and default values
 func (o *OperatorConfig) SetFlagArgs() {
-	flag.StringVar(&o.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&o.MetricsAddr, "metrics-bind-address", "0",
+		"The address the metric endpoint binds to. Setting this to 0 will disable metric serving.")
 	flag.StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&o.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+


### PR DESCRIPTION
When the metrics are disabled (through helm chart parmeter `prometheus.expose=Disable`), we weren't closing off the metrics endpoint. It was still being started on port :8080. There is an option to the operator called `--metrics-bind-address`. We were omitting this when metrics were disabled, but we ended up picking the default for this option and starting the metrics serving anyway. This fixes it by changing the default value for that parameter to "0", which prevents the metrics server from starting.