### PR TITLE
Include subcluster_oid in metrics

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -848,6 +848,10 @@ type SubclusterStatus struct {
 	Name string `json:"name"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// Object ID of the subcluster.
+	Oid string `json:"oid"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
 	// A count of the number of pods that have been installed into the subcluster.
 	InstallCount int32 `json:"installCount"`
 

--- a/changes/unreleased/Changed-20221213-150739.yaml
+++ b/changes/unreleased/Changed-20221213-150739.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Prometheus metrics for subcluster to include label for subcluster oid rather than subcluster name
+time: 2022-12-13T15:07:39.456726189-04:00
+custom:
+  Issue: "304"

--- a/pkg/controllers/vdb/clientroutinglabel_reconcile.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconcile.go
@@ -71,7 +71,7 @@ func (c *ClientRoutingLabelReconciler) Reconcile(ctx context.Context, req *ctrl.
 
 	var savedRes ctrl.Result
 	for pn, pf := range c.PFacts.Detail {
-		if c.ScName != "" && pf.subcluster != c.ScName {
+		if c.ScName != "" && pf.subclusterName != c.ScName {
 			continue
 		}
 		if res, err := c.reconcilePod(ctx, pn, c.PFacts.Detail[pn]); verrors.IsReconcileAborted(res, err) {

--- a/pkg/controllers/vdb/dbaddnode_reconcile.go
+++ b/pkg/controllers/vdb/dbaddnode_reconcile.go
@@ -176,7 +176,7 @@ func (d *DBAddNodeReconciler) genAddNodeCommand(pods []*PodFact) []string {
 		"-t", "db_add_node",
 		"--hosts", strings.Join(hostNames, ","),
 		"--database", d.Vdb.Spec.DBName,
-		"--subcluster", pods[0].subcluster,
+		"--subcluster", pods[0].subclusterName,
 		"--noprompt",
 	}
 }

--- a/pkg/controllers/vdb/metrics_reconcile_test.go
+++ b/pkg/controllers/vdb/metrics_reconcile_test.go
@@ -44,8 +44,10 @@ var _ = Describe("prometheus_reconcile", func() {
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		metrics := r.captureRawMetrics()
-		Expect(metrics[vdb.Spec.Subclusters[0].Name].podCount).Should(Equal(float64(3)))
-		Expect(metrics[vdb.Spec.Subclusters[0].Name].runningCount).Should(Equal(float64(3)))
-		Expect(metrics[vdb.Spec.Subclusters[0].Name].readyCount).Should(Equal(float64(3)))
+		for oid := range metrics {
+			Expect(metrics[oid].podCount).Should(Equal(float64(3)))
+			Expect(metrics[oid].runningCount).Should(Equal(float64(3)))
+			Expect(metrics[oid].readyCount).Should(Equal(float64(3)))
+		}
 	})
 })

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -453,7 +453,7 @@ func (o *OnlineUpgradeReconciler) checkVersion(ctx context.Context, sts *appsv1.
 	scName := sts.Labels[builder.SubclusterNameLabel]
 	vr.FindPodFunc = func() (*PodFact, bool) {
 		for _, v := range o.PFacts.Detail {
-			if v.isPodRunning && v.subcluster == scName {
+			if v.isPodRunning && v.subclusterName == scName {
 				return v, true
 			}
 		}

--- a/pkg/controllers/vdb/rebalanceshards_reconcile.go
+++ b/pkg/controllers/vdb/rebalanceshards_reconcile.go
@@ -86,11 +86,11 @@ func (s *RebalanceShardsReconciler) findShardsToRebalance() []string {
 	scToRebalance := []string{}
 
 	for _, pf := range s.PFacts.Detail {
-		if (s.ScName == "" || s.ScName == pf.subcluster) && pf.isPodRunning && pf.upNode && pf.shardSubscriptions == 0 {
-			_, ok := scRebalanceMap[pf.subcluster]
+		if (s.ScName == "" || s.ScName == pf.subclusterName) && pf.isPodRunning && pf.upNode && pf.shardSubscriptions == 0 {
+			_, ok := scRebalanceMap[pf.subclusterName]
 			if !ok {
-				scToRebalance = append(scToRebalance, pf.subcluster)
-				scRebalanceMap[pf.subcluster] = true
+				scToRebalance = append(scToRebalance, pf.subclusterName)
+				scRebalanceMap[pf.subclusterName] = true
 			}
 		}
 	}

--- a/pkg/controllers/vdb/revivedb_reconcile_test.go
+++ b/pkg/controllers/vdb/revivedb_reconcile_test.go
@@ -174,7 +174,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		expectedSubclusterOrder := []string{"s2", "s1", "s1", "s0", "s0", "s1", "s2", "s2", "s0"}
 		Expect(len(pods)).Should(Equal(len(expectedSubclusterOrder)))
 		for i, expectedSC := range expectedSubclusterOrder {
-			Expect(pods[i].subcluster).Should(Equal(expectedSC), "Subcluster index %d", i)
+			Expect(pods[i].subclusterName).Should(Equal(expectedSC), "Subcluster index %d", i)
 		}
 	})
 
@@ -202,7 +202,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		expectedSubclusterOrder := []string{"s2", "s2", "s2", "s1", "s1", "s1", "s0", "s0", "s0"}
 		Expect(len(pods)).Should(Equal(len(expectedSubclusterOrder)))
 		for i, expectedSC := range expectedSubclusterOrder {
-			Expect(pods[i].subcluster).Should(Equal(expectedSC), "Subcluster index %d", i)
+			Expect(pods[i].subclusterName).Should(Equal(expectedSC), "Subcluster index %d", i)
 		}
 	})
 

--- a/pkg/controllers/vdb/status_reconcile.go
+++ b/pkg/controllers/vdb/status_reconcile.go
@@ -68,6 +68,10 @@ func (s *StatusReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ct
 			if i == len(vdbChg.Status.Subclusters) {
 				vdbChg.Status.Subclusters = append(vdbChg.Status.Subclusters, vapi.SubclusterStatus{})
 			}
+			// Preserve the oid in case all of the subclusters pods are down
+			if i < len(s.Vdb.Status.Subclusters) {
+				vdbChg.Status.Subclusters[i].Oid = s.Vdb.Status.Subclusters[i].Oid
+			}
 			if err := s.calculateSubclusterStatus(ctx, subclusters[i], &vdbChg.Status.Subclusters[i]); err != nil {
 				return fmt.Errorf("failed to calculate subcluster status %s %w", subclusters[i].Name, err)
 			}
@@ -116,6 +120,9 @@ func (s *StatusReconciler) calculateSubclusterStatus(ctx context.Context, sc *va
 		curStat.Detail[podIndex].AddedToDB = pf.dbExists
 		if pf.vnodeName != "" {
 			curStat.Detail[podIndex].VNodeName = pf.vnodeName
+		}
+		if pf.subclusterOid != "" {
+			curStat.Oid = pf.subclusterOid
 		}
 	}
 	// Refresh the counts

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -118,6 +118,7 @@ func defaultPodFactOverrider(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFa
 	pf.dbExists = true
 	pf.startupInProgress = false
 	pf.upNode = true
+	pf.subclusterOid = "123456"
 	return nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -37,7 +37,7 @@ const (
 	// Names of the labels that we can apply to metrics.
 	NamespaceLabel        = "namespace"
 	VerticaDBLabel        = "verticadb"
-	SubclusterLabel       = "subcluster"
+	SubclusterOidLabel    = "subcluster_oid"
 	ReviveInstanceIDLabel = "revive_instance_id"
 )
 
@@ -124,7 +124,7 @@ var (
 			Name:      "total_nodes_count",
 			Help:      "The number of nodes that currently exist",
 		},
-		[]string{NamespaceLabel, VerticaDBLabel, ReviveInstanceIDLabel, SubclusterLabel},
+		[]string{NamespaceLabel, VerticaDBLabel, ReviveInstanceIDLabel, SubclusterOidLabel},
 	)
 	RunningNodeCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -132,7 +132,7 @@ var (
 			Name:      "running_nodes_count",
 			Help:      "The number of nodes that have a running pod associated with it",
 		},
-		[]string{NamespaceLabel, VerticaDBLabel, ReviveInstanceIDLabel, SubclusterLabel},
+		[]string{NamespaceLabel, VerticaDBLabel, ReviveInstanceIDLabel, SubclusterOidLabel},
 	)
 	UpNodeCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -140,7 +140,7 @@ var (
 			Name:      "up_nodes_count",
 			Help:      "The number of nodes that have vertica running and can accept connections",
 		},
-		[]string{NamespaceLabel, VerticaDBLabel, ReviveInstanceIDLabel, SubclusterLabel},
+		[]string{NamespaceLabel, VerticaDBLabel, ReviveInstanceIDLabel, SubclusterOidLabel},
 	)
 	// Add new metrics above this comment.
 	//
@@ -174,12 +174,12 @@ func init() {
 
 // HandleSubclusterDelete will cleanup metrics upon subcluster
 // deletion.  It will clear out any metrics that are subcluster specific.
-func HandleSubclusterDelete(vdb *vapi.VerticaDB, scName string, log logr.Logger) {
-	log.Info("Removing metrics with subcluster label", "subcluster", scName)
+func HandleSubclusterDelete(vdb *vapi.VerticaDB, scOid string, log logr.Logger) {
+	log.Info("Removing metrics with subcluster label", "subcluster oid", scOid)
 	labels := prometheus.Labels{
-		NamespaceLabel:  vdb.Namespace,
-		VerticaDBLabel:  vdb.Name,
-		SubclusterLabel: scName,
+		NamespaceLabel:     vdb.Namespace,
+		VerticaDBLabel:     vdb.Name,
+		SubclusterOidLabel: scOid,
 	}
 	TotalNodeCount.DeletePartialMatch(labels)
 	RunningNodeCount.DeletePartialMatch(labels)
@@ -235,12 +235,12 @@ func MakeVDBLabels(vdb *vapi.VerticaDB) prometheus.Labels {
 
 // MakeSubclusterLabels returns a prometheus.Labels that includes the VerticaDB
 // and subcluster name.
-func MakeSubclusterLabels(vdb *vapi.VerticaDB, scName string) prometheus.Labels {
+func MakeSubclusterLabels(vdb *vapi.VerticaDB, scOid string) prometheus.Labels {
 	return prometheus.Labels{
 		NamespaceLabel:        vdb.Namespace,
 		VerticaDBLabel:        vdb.Name,
 		ReviveInstanceIDLabel: getReviveInstanceID(vdb),
-		SubclusterLabel:       scName,
+		SubclusterOidLabel:    scOid,
 	}
 }
 

--- a/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
+++ b/tests/e2e-extra/operator-metrics/30-verify-metrics-endpoint.yaml
@@ -33,26 +33,20 @@ data:
     do
         curl http://$SVC_NAME:8443/metrics | grep $metric
     done
-    for sc in pri-sc sec-sc
-    do
-        curl http://$SVC_NAME:8443/metrics | grep "vertica_total_nodes_count{.*subcluster=\"$sc\".*} 1"
-        curl http://$SVC_NAME:8443/metrics | grep "vertica_running_nodes_count{.*verticadb=\"v-operator-metrics\".*} 1"
-        curl http://$SVC_NAME:8443/metrics | grep -e 'vertica_cluster_restart_failed_total{.*revive_instance_id="\([0-9a-f]\)*".*}'
-    done
+    curl http://$SVC_NAME:8443/metrics | grep "vertica_total_nodes_count{.*subcluster_oid=.*} 1"
+    curl http://$SVC_NAME:8443/metrics | grep "vertica_running_nodes_count{.*verticadb=\"v-operator-metrics\".*} 1"
+    curl http://$SVC_NAME:8443/metrics | grep -e 'vertica_cluster_restart_failed_total{.*revive_instance_id="\([0-9a-f]\)*".*}'
     # These is timing with the ready pod count.  The pod may be ready but the
     # metrics haven't yet been updated.  We check that a few times before
     # failing the test.
-    for sc in pri-sc sec-sc
+    for i in $(seq 1 5)
     do
-      for i in $(seq 1 5)
-      do
-        [ $i -gt 1 ] && sleep 10
-        curl http://$SVC_NAME:8443/metrics
-        curl http://$SVC_NAME:8443/metrics | grep "vertica_up_nodes_count{.*subcluster=\"$sc\".*} 1" \
-          && s=0 && break || s=$?
-      done
-      (exit $s)
+      [ $i -gt 1 ] && sleep 10
+      curl http://$SVC_NAME:8443/metrics
+      curl http://$SVC_NAME:8443/metrics | grep "vertica_up_nodes_count{.*subcluster_oid.*} 1" \
+        && s=0 && break || s=$?
     done
+    (exit $s)
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
This changes a few prometheus metrics to include the subcluster oid instead of the name. The subcluster name can change where as the oid stays constant. So, it's better to build a dashboard around. This is to sync with what the server is doing, so we will be able to combine metrics from the operator and the server in a single dashboard.

In order to include the subcluster oid, we needed to collect it. The podfacts were updated and a new status field was added to store the oid. The status field is necessary so that we know the oid if vertica is down and we can't query anything.