### PR TITLE
Allow workflow dispach to set the name of the e2e run

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -278,6 +278,7 @@ jobs:
 
     - name: Set up Go
       uses: ./.github/actions/setup-go
+      if: ${{ inputs.operator_image == '' }}
 
     - name: Build and optionally push operator image
       if: ${{ inputs.operator_image == '' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,12 @@ on:
         - none
         default: all
         required: false
+      reason:
+        description: 'Descriptive name of the workflow run'
+        required: false
+        default: ''
+
+run-name: ${{ inputs.reason || github.event.pull_request.title || github.event.head_commit.message || 'e2e tests' }}
 
 jobs:
   build:


### PR DESCRIPTION
This takes advantage of a new feature in GitHub workflows that allows you to set the name of the run. We'll be able to use this to distinguish the dispatched runs from the Vertica internal CI: is it a release we are testing, is it the daily server, developer branch, etc.