### PR TITLE
Include small tools in vertica container

### DIFF
--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -117,6 +117,7 @@ RUN set -x \
   gdb \
   iproute2 \
   krb5-user \
+  less \
   libkeyutils1\
   libz-dev \
   locales \
@@ -128,6 +129,7 @@ RUN set -x \
   procps \
   sysstat \
   sudo \
+  vim-tiny \
   # Install jre if not minimal
   && if [[ ($MINIMAL != "YES" && $MINIMAL != "yes") ]] ; then \
     apt-get install -y --no-install-recommends $JRE_PKG; \


### PR DESCRIPTION
This adds vi (not vim) and less for basic editing inside the vertica server container. It adds only 2MB to the overall container size.