### PR TITLE
Allow the readinessProbe to be configured

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -331,6 +331,13 @@ type VerticaDBSpec struct {
 	// - tls.crt: The signed certificate chain for the private key
 	// - ca.crt: The CA certificate
 	HTTPServerTLSSecret string `json:"httpServerTLSSecret,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// +kubebuilder:validation:Optional
+	// Allows tuning of the Vertica pods readiness probe. Each of the values
+	// here are applied to the default readiness probe we create. If this is
+	// omitted, we use the default probe.
+	ReadinessProbeOverride *corev1.Probe `json:"readinessProbeOverride,omitempty"`
 }
 
 // LocalObjectReference is used instead of corev1.LocalObjectReference and behaves the same.

--- a/changes/unreleased/Added-20230103-152056.yaml
+++ b/changes/unreleased/Added-20230103-152056.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Allow the readinessProbe to be configured
+time: 2023-01-03T15:20:56.222242752-04:00
+custom:
+  Issue: "309"

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -113,9 +112,9 @@ var _ = Describe("builder", func() {
 		const NewInitialDelaySeconds int32 = 7
 		const NewPeriodSeconds int32 = 8
 		const NewSuccessThreshold int32 = 9
-		vdb.Spec.ReadinessProbeOverride = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
+		vdb.Spec.ReadinessProbeOverride = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
 					Command: NewCommand,
 				},
 			},

--- a/tests/e2e-leg-3/readiness-probe-override/05-create-creds.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/05-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-3/readiness-probe-override/10-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-leg-3/readiness-probe-override/10-deploy-operator.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/10-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator WATCH_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-3/readiness-probe-override/15-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/15-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-readiness-probe-override
+status:
+  subclusterCount: 2
+  installCount: 2
+  subclusters:
+    - installCount: 1
+    - installCount: 1

--- a/tests/e2e-leg-3/readiness-probe-override/15-create-db.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/15-create-db.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl apply -n $NAMESPACE -f - "

--- a/tests/e2e-leg-3/readiness-probe-override/20-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/20-assert.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-readiness-probe-override-queries
+status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-readiness-probe-override-admin
+status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-readiness-probe-override
+status:
+  subclusterCount: 2
+  installCount: 2
+  addedToDBCount: 2
+  upNodeCount: 2

--- a/tests/e2e-leg-3/readiness-probe-override/20-wait-for-create-db.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/20-wait-for-create-db.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-3/readiness-probe-override/25-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/25-assert.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-readiness-probe-override-queries
+spec:
+  template:
+    spec:
+      containers:
+        - name: server
+          readinessProbe:
+            timeoutSeconds: 5
+            periodSeconds: 20
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-readiness-probe-override-admin
+spec:
+  template:
+    spec:
+      containers:
+        - name: server
+          readinessProbe:
+            timeoutSeconds: 5
+            periodSeconds: 20

--- a/tests/e2e-leg-3/readiness-probe-override/25-verify-readiness-probe-override.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/25-verify-readiness-probe-override.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-3/readiness-probe-override/30-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/30-assert.yaml
@@ -1,0 +1,46 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-readiness-probe-override-queries
+spec:
+  template:
+    spec:
+      containers:
+        - name: server
+          readinessProbe:
+            periodSeconds: 20
+            timeoutSeconds: 8
+            failureThreshold: 5
+status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-readiness-probe-override-admin
+spec:
+  template:
+    spec:
+      containers:
+        - name: server
+          readinessProbe:
+            periodSeconds: 20
+            timeoutSeconds: 8
+            failureThreshold: 5
+status:
+  currentReplicas: 1
+  readyReplicas: 1

--- a/tests/e2e-leg-3/readiness-probe-override/30-change-overrides.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/30-change-overrides.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-readiness-probe-override
+spec:
+  readinessProbeOverride:
+    timeoutSeconds: 8
+    failureThreshold: 5

--- a/tests/e2e-leg-3/readiness-probe-override/35-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/35-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -t 360"

--- a/tests/e2e-leg-3/readiness-probe-override/90-delete-clean-communal-pod.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/90-delete-clean-communal-pod.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: Pod
+    name: clean-communal

--- a/tests/e2e-leg-3/readiness-probe-override/90-errors.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/90-errors.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal

--- a/tests/e2e-leg-3/readiness-probe-override/95-delete-cr.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB

--- a/tests/e2e-leg-3/readiness-probe-override/95-errors.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-leg-3/readiness-probe-override/96-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-3/readiness-probe-override/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/96-cleanup-storage.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/readiness-probe-override/97-errors.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/97-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-leg-3/readiness-probe-override/97-uninstall-operator.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/97-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-3/readiness-probe-override/99-delete-ns.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-3/readiness-probe-override/README.txt
+++ b/tests/e2e-leg-3/readiness-probe-override/README.txt
@@ -1,0 +1,1 @@
+This will create a database with 3 subclusters

--- a/tests/e2e-leg-3/readiness-probe-override/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-3/readiness-probe-override/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,39 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-readiness-probe-override
+spec:
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  subclusters:
+    - name: queries
+      size: 1
+      isPrimary: false
+    - name: admin
+      size: 1
+      isPrimary: true
+  kSafety: "0"
+  readinessProbeOverride:
+    timeoutSeconds: 5
+    periodSeconds: 20
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
The VerticaDB currently has a hard coded timeout for the readiness probe of 1 second. It does a 'select 1' query to vertica to check that its up and ready to accept connections. If this does not respond in 1 second, and this happens 3 times in a row, then we assume the endpoint isn't up. Routing rules from the service object will no longer reach that pod until the readiness probe is successful again.

A new knob is added to the VerticaDB to allow the readiness probe to be altered. See the `readinessProbeOverride` parameter in the example below. The new parameter is the `corev1.Probe` type, so it can accept any values that are typically included with probes.

```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: v
spec:
...
  readinessProbeOverride:
    timeoutSeconds: 5
    periodSeconds: 20
```

Closes #302