### PR TITLE
Rename some fields added in current release

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -701,10 +701,10 @@ type Subcluster struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	// Like the nodePort parameter, except this controls the node port to use
-	// for the http server.  The same rules apply: it must be defined within the
-	// range allocated by the control plane, if omitted Kubernetes will choose
-	// the port automatically.
-	HTTPNodePort int32 `json:"httpNodePort,omitempty"`
+	// for the http endpoint in the Vertica server.  The same rules apply: it
+	// must be defined within the range allocated by the control plane, if
+	// omitted Kubernetes will choose the port automatically.
+	VerticaHTTPNodePort int32 `json:"verticaHTTPNodePort,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -456,9 +456,9 @@ func (v *VerticaDB) hasValidNodePort(allErrs field.ErrorList) field.ErrorList {
 				allErrs = v.genNodePortInvalidError(allErrs, pathPrefix,
 					"nodePort", v.Spec.Subclusters[i].NodePort)
 			}
-			if isNodePortNumberInvalid(sc.HTTPNodePort) {
+			if isNodePortNumberInvalid(sc.VerticaHTTPNodePort) {
 				allErrs = v.genNodePortInvalidError(allErrs, pathPrefix,
-					"httpNodePort", v.Spec.Subclusters[i].HTTPNodePort)
+					"verticaHttpNodePort", v.Spec.Subclusters[i].VerticaHTTPNodePort)
 			}
 		}
 	}

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -545,12 +545,12 @@ var _ = Describe("verticadb_webhook", func() {
 		validateSpecValuesHaveErr(vdb, false)
 	})
 
-	It("should verify range for httpNodePort", func() {
+	It("should verify range for verticaHTTPNodePort", func() {
 		vdb := MakeVDB()
 		vdb.Spec.Subclusters[0].ServiceType = v1.ServiceTypeNodePort
-		vdb.Spec.Subclusters[0].HTTPNodePort = 8443 // Too low
+		vdb.Spec.Subclusters[0].VerticaHTTPNodePort = 8443 // Too low
 		validateSpecValuesHaveErr(vdb, true)
-		vdb.Spec.Subclusters[0].HTTPNodePort = 30000 // Okay
+		vdb.Spec.Subclusters[0].VerticaHTTPNodePort = 30000 // Okay
 		validateSpecValuesHaveErr(vdb, false)
 	})
 

--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -90,15 +90,6 @@ spec:
           the service object. More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips'
         displayName: External IPs
         path: template.externalIPs
-      - description: 'Like the nodePort parameter, except this controls the node port
-          to use for the http server.  The same rules apply: it must be defined within
-          the range allocated by the control plane, if omitted Kubernetes will choose
-          the port automatically.'
-        displayName: HTTPNode Port
-        path: template.httpNodePort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: This allows a different image to be used for the subcluster than
           the one in VerticaDB.  This is intended to be used internally by the online
           image change process.
@@ -193,6 +184,15 @@ spec:
           a pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
         displayName: Tolerations
         path: template.tolerations
+      - description: 'Like the nodePort parameter, except this controls the node port
+          to use for the http endpoint in the Vertica server.  The same rules apply:
+          it must be defined within the range allocated by the control plane, if omitted
+          Kubernetes will choose the port automatically.'
+        displayName: Vertica HTTPNode Port
+        path: template.verticaHTTPNodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The name of the VerticaDB CR that this autoscaler is defined
           for.  The VerticaDB object must exist in the same namespace as this object.
         displayName: Vertica DBName
@@ -490,6 +490,13 @@ spec:
         path: local.storageClass
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Allows tuning of the Vertica pods readiness probe. Each of the
+          values here are applied to the default readiness probe we create. If this
+          is omitted, we use the default probe.
+        displayName: Readiness Probe Override
+        path: readinessProbeOverride
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: If a reconciliation iteration needs to be requeued this controls
           the amount of time in seconds to wait.  If this is set to 0, then the requeue
           time will increase using an exponential backoff algorithm.  Caution, when
@@ -599,15 +606,6 @@ spec:
           the service object. More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips'
         displayName: External IPs
         path: subclusters[0].externalIPs
-      - description: 'Like the nodePort parameter, except this controls the node port
-          to use for the http server.  The same rules apply: it must be defined within
-          the range allocated by the control plane, if omitted Kubernetes will choose
-          the port automatically.'
-        displayName: HTTPNode Port
-        path: subclusters[0].httpNodePort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: This allows a different image to be used for the subcluster than
           the one in VerticaDB.  This is intended to be used internally by the online
           image change process.
@@ -702,6 +700,15 @@ spec:
           a pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
         displayName: Tolerations
         path: subclusters[0].tolerations
+      - description: 'Like the nodePort parameter, except this controls the node port
+          to use for the http endpoint in the Vertica server.  The same rules apply:
+          it must be defined within the range allocated by the control plane, if omitted
+          Kubernetes will choose the port automatically.'
+        displayName: Vertica HTTPNode Port
+        path: subclusters[0].verticaHTTPNodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: An optional name for a secret that contains the password for
           the database's superuser. If this is not set, then we assume no such password
           is set for the database. If this is set, it is up the user to create this
@@ -756,15 +763,6 @@ spec:
           the service object. More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips'
         displayName: External IPs
         path: temporarySubclusterRouting.template.externalIPs
-      - description: 'Like the nodePort parameter, except this controls the node port
-          to use for the http server.  The same rules apply: it must be defined within
-          the range allocated by the control plane, if omitted Kubernetes will choose
-          the port automatically.'
-        displayName: HTTPNode Port
-        path: temporarySubclusterRouting.template.httpNodePort
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:number
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: This allows a different image to be used for the subcluster than
           the one in VerticaDB.  This is intended to be used internally by the online
           image change process.
@@ -859,6 +857,15 @@ spec:
           a pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
         displayName: Tolerations
         path: temporarySubclusterRouting.template.tolerations
+      - description: 'Like the nodePort parameter, except this controls the node port
+          to use for the http endpoint in the Vertica server.  The same rules apply:
+          it must be defined within the range allocated by the control plane, if omitted
+          Kubernetes will choose the port automatically.'
+        displayName: Vertica HTTPNode Port
+        path: temporarySubclusterRouting.template.verticaHTTPNodePort
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'Defines how upgrade will be managed.  Available values are:
           Offline, Online and Auto. - Offline: means we take down the entire cluster
           then bring it back up with the new image. - Online: will keep the cluster

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -53,7 +53,7 @@ func BuildExtSvc(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclust
 			Type:     sc.ServiceType,
 			Ports: []corev1.ServicePort{
 				{Port: 5433, Name: "vertica", NodePort: sc.NodePort},
-				{Port: 8443, Name: "http", NodePort: sc.HTTPNodePort},
+				{Port: 8443, Name: "vertica-http", NodePort: sc.VerticaHTTPNodePort},
 			},
 			ExternalIPs:    sc.ExternalIPs,
 			LoadBalancerIP: sc.LoadBalancerIP,

--- a/pkg/controllers/vdb/obj_reconcile.go
+++ b/pkg/controllers/vdb/obj_reconcile.go
@@ -310,7 +310,7 @@ func (o ObjReconciler) reconcileExtSvcFields(curSvc, expSvc *corev1.Service, sc 
 		// differs from what is currently in use. Otherwise, they must stay the
 		// same. This protects us from changing the k8s generated node port each
 		// time there is a Service object update.
-		explicitNodePortByIndex := []int32{sc.NodePort, sc.HTTPNodePort}
+		explicitNodePortByIndex := []int32{sc.NodePort, sc.VerticaHTTPNodePort}
 		for i := range curSvc.Spec.Ports {
 			if explicitNodePortByIndex[i] != 0 {
 				if expSvc.Spec.Ports[i].NodePort != curSvc.Spec.Ports[i].NodePort {

--- a/pkg/controllers/vdb/obj_reconcile_test.go
+++ b/pkg/controllers/vdb/obj_reconcile_test.go
@@ -706,8 +706,8 @@ var _ = Describe("obj_reconcile", func() {
 		It("should not change generated node port's if service object changes", func() {
 			vdb := vapi.MakeVDB()
 			vdb.Spec.Subclusters[0].ServiceType = corev1.ServiceTypeNodePort
-			vdb.Spec.Subclusters[0].NodePort = 0     // k8s to generate one
-			vdb.Spec.Subclusters[0].HTTPNodePort = 0 // k8s to generate one
+			vdb.Spec.Subclusters[0].NodePort = 0            // k8s to generate one
+			vdb.Spec.Subclusters[0].VerticaHTTPNodePort = 0 // k8s to generate one
 			createCrd(vdb, true)
 			defer deleteCrd(vdb)
 
@@ -739,7 +739,7 @@ var _ = Describe("obj_reconcile", func() {
 			vdb.Spec.Subclusters[0].ServiceType = corev1.ServiceTypeNodePort
 			vdb.Spec.Subclusters[0].NodePort = 0 // k8s to generate one
 			const HTTPNodePort int32 = 30000
-			vdb.Spec.Subclusters[0].HTTPNodePort = HTTPNodePort
+			vdb.Spec.Subclusters[0].VerticaHTTPNodePort = HTTPNodePort
 			createCrd(vdb, true)
 			defer deleteCrd(vdb)
 


### PR DESCRIPTION
Some new fields in the VerticaDB were added this release for the Vertica http server. There is going to be two http servers in the future, so changing the names of the fields to accomadate for this future change. This rename is fine because we haven't yet released a version of the operator that had the old names. They are new in this release.