### PR TITLE
Use container for helm ut

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,6 +82,9 @@ jobs:
 
   unittests:
     uses: ./.github/workflows/unittests.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   scorecardtests:
     uses: ./.github/workflows/scorecardtests.yml

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,15 @@
 name: Unit tests
 
-on: [workflow_call]
+on: 
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'Optional docker user to authenticate with. If empty docker access will be anonymous.'
+        required: false
+      DOCKERHUB_TOKEN:
+        description: 'If DOCKERHUB_USERNAME was set, this is the password for that use'
+        required: false
 
 jobs:
 
@@ -11,6 +20,17 @@ jobs:
 
     - name: Set up Go
       uses: ./.github/actions/setup-go
+
+    # We use a container hosted on docker to run the helm unittest. If
+    # provided, we login to avoid hitting rate limiting for anonymous access.
+    - name: Login to Docker Hub
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      if: ${{ env.DOCKERHUB_USERNAME != '' }}
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Run unit tests
       run: make test


### PR DESCRIPTION
Occasionally, we see failures when trying to install the unittest plugin for helm. Helm pulls it from github, but occasionally it can fail with errors such as this:
```
helm plugin install https://github.com/quintush/helm-unittest
Support linux-amd64
Retrieving https://api.github.com/repos/quintush/helm-unittest/releases/tags/v0.2.11
No download_url found only searching for linux
Downloading  to location /tmp/_dist/
curl: Remote file name has no length!
curl: (23) Failed writing received data to disk/application
```
Ideally, we would like to retry because this seems to be an intermittent problem. But the curl command is embedded in helm. So, instead I'm switching to use a container as that seems a bit more robust. As a side benefit, this also allows us to fix the version of the plugin we are using.