### PR TITLE
Fix intermittent network issues in e2e-udx

### DIFF
--- a/.github/workflows/e2e-udx.yml
+++ b/.github/workflows/e2e-udx.yml
@@ -63,8 +63,8 @@ jobs:
         java --version
         # Install system packages that some of the tests depend on.  Any
         # changes here need to be duplicated in udx-cpp/30-upload-files.yaml
-        sudo apt-get update
-        sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev
+        # We retry the command to avoid any interimittent network issues.
+        for i in $(seq 1 5); do sudo apt-get update && sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev && break || sleep 60; done
         scripts/setup-e2e-udx.sh -v
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-s3-ci.txt
 

--- a/tests/e2e-udx/udx-cpp/30-upload-files.yaml
+++ b/tests/e2e-udx/udx-cpp/30-upload-files.yaml
@@ -5,5 +5,6 @@ commands:
   - command: kubectl -n $NAMESPACE cp ../../../sdk/examples/build v-udx-cpp-sc1-0:/opt/vertica/sdk/examples
   # upload the expected outputs of executing sql files
   - command: kubectl -n $NAMESPACE cp ./expected-outputs v-udx-cpp-sc1-0:/opt/vertica/sdk/examples
-  # Install packages in the pod that are needed to run the C++ examples.
-  - command: kubectl -n $NAMESPACE exec -it v-udx-cpp-sc1-0 -- bash -c "sudo apt-get update && sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev"
+  # Install packages in the pod that are needed to run the C++ examples. We
+  # retry to resolve any intermittent network issues.
+  - command: kubectl -n $NAMESPACE exec -it v-udx-cpp-sc1-0 -- bash -c "for i in $(seq 1 5); do sudo apt-get update && sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev && break || sleep 60; done"


### PR DESCRIPTION
Occasionally, the apt-get will fail due to network issues causing the e2e-udx run to fail. This adds in a simple retry mechanism.