### PR TITLE
Use newer version of minio in e2e/sample

### DIFF
--- a/config/samples/minio.yaml
+++ b/config/samples/minio.yaml
@@ -16,7 +16,20 @@
 #   kubectl krew install minio
 #   kubectl minio init
 
-# Secret to be used as MinIO Root Credentials
+# MiniIO storage config. The access/secret key needs to be duplicated here
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-configuration
+stringData:
+  config.env: |-
+    export MINIO_ROOT_USER="minio"
+    export MINIO_ROOT_PASSWORD="minio123"
+type: Opaque
+---
+# Secret to be used as MinIO Root Credentials. We use this secret as access
+# credentials in v1beta1_verticadb.yaml. The accesskey/secretkey is duplicated
+# in the storage-configuration.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -34,10 +47,10 @@ kind: Tenant
 metadata:
   name: minio
 spec:
-  image: minio/minio:RELEASE.2021-09-03T03-56-13Z
+  configuration:
+    name: storage-configuration
+  image: quay.io/minio/minio:RELEASE.2023-01-12T02-06-16Z
   imagePullPolicy: IfNotPresent
-  credsSecret:
-    name: s3-auth
   pools:
     - servers: 1
       volumesPerServer: 4

--- a/scripts/setup-minio.sh
+++ b/scripts/setup-minio.sh
@@ -58,9 +58,9 @@ set -o xtrace
 
 # First setup the operator
 kubectl krew update
-kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/9ee1af89f729b999bcd37f90484c4d74c70a1df2/plugins/minio.yaml
+kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/d1817869b86fd040a923682b1392bdb232947bf5/plugins/minio.yaml
 # If these images ever change, they must be updated in tests/external-images-s3-ci.txt
-kubectl minio init --console-image minio/console:v0.9.8 --image minio/operator:v4.2.7
+kubectl minio init --console-image minio/console:v0.22.5 --image minio/operator:v4.5.7
 
 # The above command will create the CRD.  But there is a timing hole where the
 # CRD is not yet registered with k8s, causing the tenant creation below to

--- a/tests/external-images-s3-ci.txt
+++ b/tests/external-images-s3-ci.txt
@@ -1,6 +1,6 @@
 # List of additional images that are needed to run s3 endpoint in CI.
 # These are pushed to kind in run-k8s-int-tests.sh.
 #
-minio/minio:RELEASE.2021-09-03T03-56-13Z
-minio/operator:v4.2.7
-minio/console:v0.9.8
+quay.io/minio/minio:RELEASE.2023-01-12T02-06-16Z
+minio/operator:v4.5.7
+minio/console:v0.22.5

--- a/tests/manifests/minio/02-tenant.yaml
+++ b/tests/manifests/minio/02-tenant.yaml
@@ -11,6 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# MinIO storage config
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-configuration
+stringData:
+  config.env: |-
+    export MINIO_ROOT_USER="minio"
+    export MINIO_ROOT_PASSWORD="minio123"
+type: Opaque
+---
 # MinIO Tenant Definition
 apiVersion: minio.min.io/v2
 kind: Tenant
@@ -19,7 +30,9 @@ metadata:
   labels:
     stern: include
 spec:
-  image: minio/minio:RELEASE.2021-09-03T03-56-13Z
+  configuration:
+    name: storage-configuration
+  image: quay.io/minio/minio:RELEASE.2023-01-12T02-06-16Z
   imagePullPolicy: IfNotPresent
   credsSecret:
     name: communal-creds


### PR DESCRIPTION
This upgrades the minio version we use in e2e and in the samples. The tenant we create in the old sample didn't work with the latest minio version, so updating that so the samples work.