### PR TITLE
Increase the trivy scan timeout

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -132,7 +132,7 @@ jobs:
         exit-code: ${{ inputs.security_scan_exit_code }}
         ignore-unfixed: true
         security-checks: vuln
-        timeout: '10m0s'
+        timeout: '20m0s'
         format: 'sarif'
         output: 'trivy-results-vertica-image.sarif'
 
@@ -150,7 +150,7 @@ jobs:
         exit-code: ${{ inputs.security_scan_exit_code }}
         ignore-unfixed: true
         security-checks: vuln
-        timeout: '10m0s'
+        timeout: '20m0s'
         format: 'table'
         output: 'trivy-results-vertica-image.out'
 


### PR DESCRIPTION
Last nights e2e run hit a timeout issue with the trivy scanning. Doubling the timeout to make this less likely in the future.