### PR TITLE
Add startupProbe and livenessProbe for vertica server

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -338,6 +338,20 @@ type VerticaDBSpec struct {
 	// here are applied to the default readiness probe we create. If this is
 	// omitted, we use the default probe.
 	ReadinessProbeOverride *corev1.Probe `json:"readinessProbeOverride,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// +kubebuilder:validation:Optional
+	// Allows tuning of the Vertica pods liveness probe. Each of the values
+	// here are applied to the default liveness probe we create. If this is
+	// omitted, we use the default probe.
+	LivenessProbeOverride *corev1.Probe `json:"livenessProbeOverride,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// +kubebuilder:validation:Optional
+	// Allows tuning of the Vertica pods startup probe. Each of the values
+	// here are applied to the default startup probe we create. If this is
+	// omitted, we use the default probe.
+	StartupProbeOverride *corev1.Probe `json:"startupProbeOverride,omitempty"`
 }
 
 // LocalObjectReference is used instead of corev1.LocalObjectReference and behaves the same.

--- a/changes/unreleased/Added-20230127-150517.yaml
+++ b/changes/unreleased/Added-20230127-150517.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Add startupProbe and livenessProbe for the server
+time: 2023-01-27T15:05:17.526853602-04:00
+custom:
+  Issue: "325"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -520,7 +520,7 @@ func makeLivenessProbe(vdb *vapi.VerticaDB) *corev1.Probe {
 				Port: intstr.FromInt(VerticaClientPort),
 			},
 		},
-		// These values were picked to so that the vertica process has to be
+		// These values were picked so that the vertica process needs to be
 		// unresponsive for about 1.5-minutes before it gets killed. Formula is:
 		// InitialDelaySeconds + PeriodSeconds * FailureThreshold.
 		InitialDelaySeconds: 60,

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -133,6 +133,21 @@ var _ = Describe("builder", func() {
 		Expect(c.ReadinessProbe.SuccessThreshold).Should(Equal(NewSuccessThreshold))
 	})
 
+	It("should allow parts of the startupProbe and livenessProbe to be overridden", func() {
+		vdb := vapi.MakeVDB()
+		const NewTimeout int32 = 10
+		const NewPeriodSeconds int32 = 20
+		vdb.Spec.LivenessProbeOverride = &v1.Probe{
+			TimeoutSeconds: NewTimeout,
+		}
+		vdb.Spec.StartupProbeOverride = &v1.Probe{
+			PeriodSeconds: NewPeriodSeconds,
+		}
+		c := makeServerContainer(vdb, &vdb.Spec.Subclusters[0])
+		Expect(c.LivenessProbe.TimeoutSeconds).Should(Equal(NewTimeout))
+		Expect(c.StartupProbe.PeriodSeconds).Should(Equal(NewPeriodSeconds))
+	})
+
 	It("should have the fsGroup set for the dbadmin GID", func() {
 		vdb := vapi.MakeVDB()
 		c := buildPodSpec(vdb, &vdb.Spec.Subclusters[0], &DeploymentNames{})

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -273,31 +273,6 @@ var _ = Describe("podfacts", func() {
 		Expect(pf.setDepotDetails("not-a-number|blah")).ShouldNot(Succeed())
 	})
 
-	It("should detect startup in progress correctly", func() {
-		vdb := vapi.MakeVDB()
-		sc := &vdb.Spec.Subclusters[0]
-		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
-		defer test.DeletePods(ctx, k8sClient, vdb)
-
-		pn := names.GenPodName(vdb, sc, 0)
-		fpr := &cmds.FakePodRunner{}
-		pfs := MakePodFacts(vdbRec, fpr)
-		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs := &GatherState{VerticaPIDRunning: true, StartupComplete: false}
-		Expect(pfs.checkIfNodeIsDoingStartup(ctx, vdb, pf, gs)).Should(Succeed())
-		Expect(pf.startupInProgress).Should(BeTrue())
-
-		pf = &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs = &GatherState{VerticaPIDRunning: false, StartupComplete: true}
-		Expect(pfs.checkIfNodeIsDoingStartup(ctx, vdb, pf, gs)).Should(Succeed())
-		Expect(pf.startupInProgress).Should(BeFalse())
-
-		pf = &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs = &GatherState{VerticaPIDRunning: true, StartupComplete: true}
-		Expect(pfs.checkIfNodeIsDoingStartup(ctx, vdb, pf, gs)).Should(Succeed())
-		Expect(pf.startupInProgress).Should(BeFalse())
-	})
-
 	It("should handle subcluster oid lookup properly for enterprise db", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.ShardCount = 0

--- a/pkg/controllers/vdb/restart_reconcile.go
+++ b/pkg/controllers/vdb/restart_reconcile.go
@@ -521,10 +521,10 @@ func (r *RestartReconciler) killReadOnlyProcesses(ctx context.Context, pods []*P
 }
 
 // filterNonActiveStartupProbe returns a new pod list with the pods that
-// have already tried filtered out. It also returns the number of pods
-// that were removed. This is important because we don't want to restart any pod
-// that has an active livelinessProbe. The pods are likely to get deleted part way
-// through the restart.
+// have already finished the startupProbe filtered out. It also returns the
+// number of pods that were removed. This is important because we don't want to
+// restart any pod that has an active livelinessProbe. The pods are likely to
+// get deleted part way through the restart.
 func (r *RestartReconciler) filterNonActiveStartupProbe(ctx context.Context,
 	pods []*PodFact) (newPodList []*PodFact, removedCount int, err error) {
 	newPodList = []*PodFact{}
@@ -546,9 +546,8 @@ func (r *RestartReconciler) filterNonActiveStartupProbe(ctx context.Context,
 
 // filterSlowStartup removes any pods that are still in the process of starting
 // up. We want to not consider them as candidates to startup. We would need to
-// kill the vertica pid, which we let the health probes due. And if it takes a
-// long time, its usually best to wait it out since the lag is probably due to a
-// large catalog.
+// kill the vertica pid. Rather we let the health probes do that, which can be
+// tuned to how long you want to wait for.
 func (r *RestartReconciler) filterSlowStartup(pods []*PodFact) (newPodList []*PodFact, removedCount int) {
 	for i := range pods {
 		if pods[i].startupInProgress {
@@ -590,8 +589,8 @@ func (r *RestartReconciler) makeResultForLivenessProbeWait(ctx context.Context) 
 	}, nil
 }
 
-// isStartupProbeActive will check if the given pod name whether the
-// startupProbe is active.
+// isStartupProbeActive will check if the given pod name has an active
+// startupProbe.
 func (r *RestartReconciler) isStartupProbeActive(ctx context.Context, nm types.NamespacedName) (bool, error) {
 	pod := &corev1.Pod{}
 	if err := r.VRec.Client.Get(ctx, nm, pod); err != nil {

--- a/pkg/controllers/vdb/restart_reconcile.go
+++ b/pkg/controllers/vdb/restart_reconcile.go
@@ -18,6 +18,7 @@ package vdb
 import (
 	"context"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
 	"github.com/vertica/vertica-kubernetes/pkg/version"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -45,6 +47,8 @@ const (
 	AdminToolsMapFile = "/opt/vertica/config/ipMap.txt"
 	// Constant for an up node, this is taken from the STATE colume in NODES table
 	StateUp = "UP"
+	// Percent of livenessProbe time to wait when requeuing due to waiting on livenessProbe
+	PctOfLivenessProbeWait = 0.25
 )
 
 // A map that does a lookup of a vertica node name to an IP address
@@ -130,15 +134,37 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Kill any vertica process that may still be running.  This includes a rogue
-	// process that is no longer communicating with spread and process for
-	// read-only nodes.  This is needed before re_ip, as re_ip can only work if
-	// the database isn't running, which would be case if there are read-only
-	// nodes.
-	// Include transient nodes since we may need to run re-ip against them.
 	downPods := r.PFacts.findRestartablePods(r.RestartReadOnly, true)
-	if res, err := r.killOldProcesses(ctx, downPods); verrors.IsReconcileAborted(res, err) {
+
+	// Kill any read-only vertica process that may still be running. This does
+	// not include any rogue process that is no longer communicating with
+	// spread; these are killed by the liveness probe. Read-only nodes need to
+	// be killed because we need to restart vertica on them so they join the new
+	// cluster and can gain write access.
+	if res, err := r.killReadOnlyProcesses(ctx, downPods); verrors.IsReconcileAborted(res, err) {
 		return res, err
+	}
+
+	// If any of the pods have finished the startupProbe, we need to wait for
+	// the livenessProbe to kill them before starting. If we don't do this, we
+	// run the risk of having the livenessProbe delete the pod while we
+	// are doing the startup. The startupProbe has a much longer timeout and can
+	// accommodate a slow startup.
+	if _, pc, err := r.filterNonActiveStartupProbe(ctx, downPods); err != nil {
+		return ctrl.Result{}, err
+	} else if pc != 0 {
+		r.Log.Info("Some pods have active livenessProbes. Waiting for them to be rescheduled before trying a restart.",
+			"podCount", pc)
+		return r.makeResultForLivenessProbeWait(ctx)
+	}
+
+	// Similar to above, wait for any pods that are just slow starting. They
+	// probably have a large catalog. So, its best to wait it out. The health
+	// probes will eventually kill them if they can't make any progress.
+	if _, pc := r.filterSlowStartup(downPods); pc != 0 {
+		r.Log.Info("Some pods are slow starting up. Waiting for them to finish or abort before trying a cluster restart",
+			"podCount", pc)
+		return r.makeResultForLivenessProbeWait(ctx)
 	}
 
 	if err := r.acceptEulaIfMissing(ctx); err != nil {
@@ -226,18 +252,38 @@ func (r *RestartReconciler) restartPods(ctx context.Context, pods []*PodFact) (c
 		return ctrl.Result{}, err
 	}
 	if len(downPods) == 0 {
-		// Pods are down but the cluster doesn't yet know that.  Requeue the reconciliation.
-		return ctrl.Result{Requeue: true}, nil
+		r.Log.Info("Pods are down but the cluster state doesn't show that yet. Requeue the reconciliation.")
+		return r.makeResultForLivenessProbeWait(ctx)
 	}
-	vnodeList := genRestartVNodeList(downPods)
-	ipList := genRestartIPList(downPods)
 
-	if res, err := r.killOldProcesses(ctx, downPods); verrors.IsReconcileAborted(res, err) {
-		return res, err
+	// Kill any read-only vertica processes so we can restart them with full
+	// write access. If any pods are killed, we will requeue.
+	if res, err2 := r.killReadOnlyProcesses(ctx, downPods); verrors.IsReconcileAborted(res, err2) {
+		return res, err2
+	}
+
+	var pc int
+	downPods, pc, err = r.filterNonActiveStartupProbe(ctx, downPods)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(downPods) == 0 {
+		r.Log.Info("Some pod(s) have active livenessProbes. "+
+			"Waiting for them to be rescheduled before trying a restart.", "podCount", pc)
+		return r.makeResultForLivenessProbeWait(ctx)
+	}
+
+	downPods, _ = r.filterSlowStartup(downPods)
+	if len(downPods) == 0 {
+		r.Log.Info("Some pod(s) are still starting up. Waiting for them to " +
+			"finish or abort (via health probes) before trying to restart again")
+		return r.makeResultForLivenessProbeWait(ctx)
 	}
 
 	debugDumpAdmintoolsConf(ctx, r.PRunner, r.ATPod)
 
+	vnodeList := genRestartVNodeList(downPods)
+	ipList := genRestartIPList(downPods)
 	cmd := r.genRestartNodeCmd(vnodeList, ipList)
 	if stdout, err := r.execRestartPods(ctx, downPods, cmd); err != nil {
 		if strings.Contains(stdout, "All nodes in the input are not down, can't restart") {
@@ -254,7 +300,10 @@ func (r *RestartReconciler) restartPods(ctx context.Context, pods []*PodFact) (c
 
 	// Schedule a requeue if we detected some down pods aren't down according to
 	// the cluster state.
-	return ctrl.Result{Requeue: len(pods) > len(downPods)}, nil
+	if len(pods) > len(downPods) {
+		return r.makeResultForLivenessProbeWait(ctx)
+	}
+	return ctrl.Result{}, nil
 }
 
 // removePodsWithClusterUpState will see if the pods in the down list are
@@ -436,21 +485,17 @@ func genRestartIPList(downPods []*PodFact) []string {
 	return ipList
 }
 
-// killOldProcesses will remove any running vertica processes.  At this point,
-// we have determined the nodes are down, so we are cleaning up so that it
-// doesn't impact the restart.  This may include killing a pod that is in the
-// read-only state.  For this reason, we requeue the iteration if anything is
-// killed so that status is updated before starting a restart; this is done for
-// the benefit of PD purposes and stability in the restart test.
-func (r *RestartReconciler) killOldProcesses(ctx context.Context, pods []*PodFact) (ctrl.Result, error) {
+// killReadOnlyProcesses will remove any running vertica processes that are
+// currently in read-only.  At this point, we have determined that the read-only
+// nodes need to be shutdown so we can restart them to have full write access.
+// We requeue the iteration if anything is killed so that status is updated
+// before starting a restart; this is done for the benefit of PD purposes and
+// stability in the restart test.
+func (r *RestartReconciler) killReadOnlyProcesses(ctx context.Context, pods []*PodFact) (ctrl.Result, error) {
 	killedAtLeastOnePid := false
-	startupInProgressCount := 0
 	for _, pod := range pods {
-		// We will avoid killing pids that are in the process of starting up.
-		// Startup can be slow at times and killing the pid will just force the
-		// entire process to restart, which will likely timeout again.
-		if pod.startupInProgress {
-			startupInProgressCount++
+		// Only killing read-only vertica processes
+		if !pod.readOnly {
 			continue
 		}
 		const KillMarker = "Killing process"
@@ -469,18 +514,105 @@ func (r *RestartReconciler) killOldProcesses(ctx context.Context, pods []*PodFac
 		// We are going to requeue if killed at least one process.  This is for
 		// the benefit of the status reconciler, so that we don't treat it as
 		// an up node anymore.
-		r.Log.Info("Requeue.  Killed at least one vertica process.")
-		return ctrl.Result{Requeue: true}, nil
-	}
-	if startupInProgressCount > 0 {
-		r.VRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.SlowRestartDetected,
-			"Detected slow Vertica startup in %d pod(s). Continuing to wait.", startupInProgressCount)
-		// At least one pid was still in the middle of startup.  We are going to
-		// requeue to allow that process to complete startup.
-		r.Log.Info("Requeue. Found at least one vertica process still starting up.")
+		r.Log.Info("Requeue.  Killed at least one read-only vertica process.")
 		return ctrl.Result{Requeue: true}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// filterNonActiveStartupProbe returns a new pod list with the pods that
+// have already tried filtered out. It also returns the number of pods
+// that were removed. This is important because we don't want to restart any pod
+// that has an active livelinessProbe. The pods are likely to get deleted part way
+// through the restart.
+func (r *RestartReconciler) filterNonActiveStartupProbe(ctx context.Context,
+	pods []*PodFact) (newPodList []*PodFact, removedCount int, err error) {
+	newPodList = []*PodFact{}
+	var startupActive bool
+	for i := range pods {
+		startupActive, err = r.isStartupProbeActive(ctx, pods[i].name)
+		if err != nil {
+			return
+		} else if !startupActive {
+			r.Log.Info("Not restarting pod because its startupProbe is not active anymore. "+
+				"Wait for livenessProbe to reschedule the pod", "pod", pods[i].name)
+			continue
+		}
+		newPodList = append(newPodList, pods[i])
+	}
+	removedCount = len(pods) - len(newPodList)
+	return
+}
+
+// filterSlowStartup removes any pods that are still in the process of starting
+// up. We want to not consider them as candidates to startup. We would need to
+// kill the vertica pid, which we let the health probes due. And if it takes a
+// long time, its usually best to wait it out since the lag is probably due to a
+// large catalog.
+func (r *RestartReconciler) filterSlowStartup(pods []*PodFact) (newPodList []*PodFact, removedCount int) {
+	for i := range pods {
+		if pods[i].startupInProgress {
+			continue
+		}
+		newPodList = append(newPodList, pods[i])
+	}
+	removedCount = len(pods) - len(newPodList)
+	return
+}
+
+// getRequeueTimeoutForLivenessProbeWait will return the time to requeue if
+// waiting for a livenessProbe to reschedule a pod.
+func (r *RestartReconciler) makeResultForLivenessProbeWait(ctx context.Context) (ctrl.Result, error) {
+	// If the restart reconciler is going to requeue because it has to wait for
+	// the livenessProbe, we don't want to use the exponential backoff. That
+	// could result in waiting too long for the requeue. Instead, we are going
+	// to use a percentage of the total livenessProbe timeout.
+	pn := names.GenPodName(r.Vdb, &r.Vdb.Spec.Subclusters[0], 0)
+	pod := corev1.Pod{}
+	if err := r.VRec.Client.Get(ctx, pn, &pod); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			r.Log.Info("Could not read sample pod for livenessProbe timeout. Default to exponential backoff",
+				"podName", pn)
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	probe := pod.Spec.Containers[names.ServerContainerIndex].LivenessProbe
+	if probe == nil {
+		// For backwards compatibility, if the probe isn't set, then we just
+		// return a simple requeue with exponential backoff.
+		return ctrl.Result{Requeue: true}, nil
+	}
+	timeToWait := int(float32(probe.PeriodSeconds*probe.FailureThreshold) * PctOfLivenessProbeWait)
+	const MinWaitTime = 10
+	return ctrl.Result{
+		RequeueAfter: time.Second * time.Duration(int(math.Max(float64(timeToWait), MinWaitTime))),
+	}, nil
+}
+
+// isStartupProbeActive will check if the given pod name whether the
+// startupProbe is active.
+func (r *RestartReconciler) isStartupProbeActive(ctx context.Context, nm types.NamespacedName) (bool, error) {
+	pod := &corev1.Pod{}
+	if err := r.VRec.Client.Get(ctx, nm, pod); err != nil {
+		r.Log.Info("Failed to fetch the pod", "pod", nm, "err", err)
+		return false, err
+	}
+	// If the pod doesn't have a livenessProbe then we always return true. This
+	// can happen if we are in the middle of upgrading the operator.
+	if pod.Spec.Containers[names.ServerContainerIndex].LivenessProbe == nil {
+		r.Log.Info("Pod doesn't have a livenessProbe. Okay to restart", "pod", nm)
+		return true, nil
+	}
+	// Check the container status of the server. There is a state in there
+	// (Started) that indicates if the startupProbe is still active.
+	if len(pod.Status.ContainerStatuses) > names.ServerContainerIndex {
+		cstat := &pod.Status.ContainerStatuses[names.ServerContainerIndex]
+		r.Log.Info("Pod container status", "started", cstat.Started)
+		return cstat.Started == nil || !*cstat.Started, nil
+	}
+	// If no container status, then we assume startupProbe hasn't completed yet.
+	return true, nil
 }
 
 // genRestartNodeCmd returns the command to run to restart a pod

--- a/pkg/controllers/vdb/restart_reconcile.go
+++ b/pkg/controllers/vdb/restart_reconcile.go
@@ -47,7 +47,9 @@ const (
 	AdminToolsMapFile = "/opt/vertica/config/ipMap.txt"
 	// Constant for an up node, this is taken from the STATE colume in NODES table
 	StateUp = "UP"
-	// Percent of livenessProbe time to wait when requeuing due to waiting on livenessProbe
+	// Percent of livenessProbe time to wait when requeuing due to waiting on
+	// livenessProbe. This is just a heuristic we use to avoid going into a long
+	// exponential backoff wait for the livenessProbe to fail.
 	PctOfLivenessProbeWait = 0.25
 )
 

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -120,8 +120,8 @@ func defaultPodFactOverrider(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFa
 		paths.HTTPTLSConfFile: true,
 	}
 	pf.dbExists = true
-	pf.upNode = true
 	pf.startupInProgress = false
+	pf.upNode = true
 	pf.subclusterOid = "123456"
 	return nil
 }

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -59,6 +59,7 @@ type VerticaDBReconciler struct {
 // +kubebuilder:rbac:groups=apps,namespace=WATCH_NAMESPACE,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=pods,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=pods/exec,verbs=create
+// +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=pods/status,verbs=update
 // +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=secrets,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",namespace=WATCH_NAMESPACE,resources=persistentvolumeclaims,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;list;watch;update;patch
@@ -124,7 +125,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// Functions such as Upgrade may already set RequeueAfter and Requeue to false
 			if (res.Requeue || res.RequeueAfter > 0) && vdb.Spec.RequeueTime > 0 {
 				res.Requeue = false
-				res.RequeueAfter = time.Duration(vdb.Spec.RequeueTime)
+				res.RequeueAfter = time.Second * time.Duration(vdb.Spec.RequeueTime)
 			}
 			log.Info("aborting reconcile of VerticaDB", "result", res, "err", err)
 			return res, err

--- a/tests/e2e-leg-4/restart-kill-sts/35-assert.yaml
+++ b/tests/e2e-leg-4/restart-kill-sts/35-assert.yaml
@@ -23,6 +23,5 @@ metadata:
 status:
   containerStatuses:
   - ready: false
-    started: true
     name: server
 

--- a/tests/e2e-leg-4/restart-with-liveness-probe/05-create-communal-creds.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/05-create-communal-creds.yaml
@@ -11,26 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-4/restart-with-liveness-probe/10-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/10-assert.yaml
@@ -11,26 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-leg-4/restart-with-liveness-probe/10-deploy-operator.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/10-deploy-operator.yaml
@@ -11,26 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator WATCH_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-4/restart-with-liveness-probe/15-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/15-assert.yaml
@@ -14,23 +14,26 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-scale-up-and-down
+  name: v-restart-with-liveness-probe
+status:
+  installCount: 3
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri2-0
 spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  containers:
+  - name: server
+    livenessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 60
+      periodSeconds: 30
+      successThreshold: 1
+      timeoutSeconds: 1
+    startupProbe:
+      failureThreshold: 117
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5

--- a/tests/e2e-leg-4/restart-with-liveness-probe/15-create-cr.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/15-create-cr.yaml
@@ -11,26 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/restart-with-liveness-probe/20-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/20-assert.yaml
@@ -14,23 +14,9 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: v-restart-with-liveness-probe
+status:
+  installCount: 3
+  addedToDBCount: 3
+  upNodeCount: 3
+  subclusterCount: 2

--- a/tests/e2e-leg-4/restart-with-liveness-probe/20-wait-for-create-db.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/20-wait-for-create-db.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/restart-with-liveness-probe/25-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/25-wait-for-steady-state.yaml
@@ -11,26 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -t 360"

--- a/tests/e2e-leg-4/restart-with-liveness-probe/30-delete-vertica-pid.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/30-delete-vertica-pid.yaml
@@ -11,26 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl exec -n $NAMESPACE -i v-restart-with-liveness-probe-pri1-1 -- bash -c 'kill -n SIGKILL $(pgrep ^vertica)'

--- a/tests/e2e-leg-4/restart-with-liveness-probe/35-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/35-assert.yaml
@@ -11,26 +11,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: v-restart-with-liveness-probe-pri1-1
+status:
+  containerStatuses:
+  - name: server
+    ready: false
+    lastState:
+      terminated:
+        exitCode: 137
+        reason: Error
+    started: false
+    restartCount: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri1-0
+status:
+  containerStatuses:
+  - name: server
+    ready: true
+    started: true

--- a/tests/e2e-leg-4/restart-with-liveness-probe/35-wait-for-liveness-failure.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/35-wait-for-liveness-failure.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/restart-with-liveness-probe/40-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/40-assert.yaml
@@ -14,23 +14,37 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
+  name: v-restart-with-liveness-probe
+status:
   subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - addedToDBCount: 2
+      upNodeCount: 2
+    - addedToDBCount: 1
+      upNodeCount: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri1-0
+status:
+  containerStatuses:
+  - name: server
+    started: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri1-1
+status:
+  containerStatuses:
+  - name: server
+    started: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri2-0
+status:
+  containerStatuses:
+  - name: server
+    started: true

--- a/tests/e2e-leg-4/restart-with-liveness-probe/40-wait-for-restart.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/40-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/restart-with-liveness-probe/45-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/45-assert.yaml
@@ -11,26 +11,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: v-restart-with-liveness-probe-pri1-0
+status:
+  containerStatuses:
+  - name: server
+    started: false
+    ready: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri1-1
+status:
+  containerStatuses:
+  - name: server
+    started: true
+    ready: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri2-0
+status:
+  containerStatuses:
+  - name: server
+    started: true
+    ready: false

--- a/tests/e2e-leg-4/restart-with-liveness-probe/45-delete-pid-and-pod.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/45-delete-pid-and-pod.yaml
@@ -11,26 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Delete one pod entirely and delete the vertica pid in the other. This will
+  # cause us to lose quorum and restart all 3. The restart count for everything
+  # but pri1-0 should be non-zero.
+  - command: kubectl delete pod v-restart-with-liveness-probe-pri1-0
+    namespaced: true
+  - command: kubectl exec -n $NAMESPACE -i v-restart-with-liveness-probe-pri2-0 -- bash -c 'kill -n SIGKILL $(pgrep ^vertica)'

--- a/tests/e2e-leg-4/restart-with-liveness-probe/50-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/50-assert.yaml
@@ -14,23 +14,10 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
+  name: v-restart-with-liveness-probe
+status:
   subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - addedToDBCount: 2
+      upNodeCount: 0
+    - addedToDBCount: 1
+      upNodeCount: 0

--- a/tests/e2e-leg-4/restart-with-liveness-probe/50-wait-restart-begin.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/50-wait-restart-begin.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/restart-with-liveness-probe/55-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/55-assert.yaml
@@ -1,0 +1,65 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-with-liveness-probe
+status:
+  subclusters:
+    - addedToDBCount: 2
+      upNodeCount: 2
+    - addedToDBCount: 1
+      upNodeCount: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri1-0
+status:
+  containerStatuses:
+  - name: server
+    restartCount: 0
+    started: true
+    ready: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri1-1
+status:
+  containerStatuses:
+  - name: server
+    # Restarted twice. Once in step 40 and another in this step.
+    restartCount: 2
+    started: true
+    ready: true
+    lastState:
+      terminated:
+        exitCode: 137
+        reason: Error
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri2-0
+status:
+  containerStatuses:
+  - name: server
+    started: true
+    ready: true
+    restartCount: 1
+    lastState:
+      terminated:
+        exitCode: 137
+        reason: Error

--- a/tests/e2e-leg-4/restart-with-liveness-probe/55-wait-for-restart-end.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/55-wait-for-restart-end.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/restart-with-liveness-probe/60-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/60-assert.yaml
@@ -1,0 +1,52 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri2-0
+spec:
+  containers:
+  - name: server
+    livenessProbe:
+      initialDelaySeconds: 55
+      periodSeconds: 25
+      failureThreshold: 3
+      successThreshold: 1
+      timeoutSeconds: 1
+    startupProbe:
+      timeoutSeconds: 3
+      failureThreshold: 60
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      successThreshold: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-liveness-probe-pri1-1
+spec:
+  containers:
+  - name: server
+    livenessProbe:
+      initialDelaySeconds: 55
+      periodSeconds: 25
+      failureThreshold: 3
+      successThreshold: 1
+      timeoutSeconds: 1
+    startupProbe:
+      timeoutSeconds: 3
+      failureThreshold: 60
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      successThreshold: 1

--- a/tests/e2e-leg-4/restart-with-liveness-probe/60-change-probe.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/60-change-probe.yaml
@@ -14,23 +14,12 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-scale-up-and-down
+  name: v-restart-with-liveness-probe
 spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  startupProbeOverride:
+    timeoutSeconds: 3
+    failureThreshold: 60
+  livenessProbeOverride:
+    initialDelaySeconds: 55
+    periodSeconds: 25
+

--- a/tests/e2e-leg-4/restart-with-liveness-probe/95-delete-cr.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/95-delete-cr.yaml
@@ -11,26 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB

--- a/tests/e2e-leg-4/restart-with-liveness-probe/95-errors.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/95-errors.yaml
@@ -11,26 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: verticadb-operator
+---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []

--- a/tests/e2e-leg-4/restart-with-liveness-probe/96-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/96-assert.yaml
@@ -11,26 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-4/restart-with-liveness-probe/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/96-cleanup-storage.yaml
@@ -11,26 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/restart-with-liveness-probe/97-errors.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/97-errors.yaml
@@ -11,26 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-leg-4/restart-with-liveness-probe/97-uninstall-operator.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/97-uninstall-operator.yaml
@@ -11,26 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-4/restart-with-liveness-probe/99-delete-ns.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/99-delete-ns.yaml
@@ -11,26 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-4/restart-with-liveness-probe/README.txt
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/README.txt
@@ -1,0 +1,2 @@
+This does restart by letting the livenessProbe schedule the pod. It will invoke
+that method by killing the vertica PID rather than the entire pod.

--- a/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/kustomization.yaml
@@ -11,26 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-scale-up-and-down
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
-  communal:
-    includeUIDInPath: true
-  local:
-    requestSize: 100Mi
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/setup-vdb.yaml
@@ -14,22 +14,23 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-scale-up-and-down
+  name: v-restart-with-liveness-probe
 spec:
-  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
-  sidecars:
-    - name: vlogger
-      image: kustomize-vlogger-image
   communal:
     includeUIDInPath: true
   local:
     requestSize: 100Mi
-  encryptSpreadComm: vertica
+  dbName: db
+  initPolicy: CreateSkipPackageInstall
+  requeueTime: 5
   subclusters:
-    - name: main
-      size: 3
-  kSafety: "1"
+    - name: pri1
+      size: 2
+      isPrimary: true
+    - name: pri2
+      size: 1
+      isPrimary: true
   certSecrets: []
   imagePullSecrets: []
   volumes: []


### PR DESCRIPTION
This adds new health probes to better handle when vertica crashes or becomes unresponsive. This was handled before internally by the operator. It would kill vertica process that were no longer responsive. This approach wasn't configurable and didn't handle some edge cases well. Using health probes is better because it's a more idiomatic way of doing things in k8s. They can also be tuned with new parameters in the VerticaDB.

The following probes are added:
- startupProbe: We wait for up to 20-minutes for the vertica process to start. The probe will monitor the startup.log. This can be tuned using the `spec.startupProbeOverride` field in the VerticaDB.
- livenessProbe: This probe will wait for about 1.5-minutes before failing. The probe checks if the TCP client port is open. This differs from the readinessProbe, as that checks the 'select 1' canary query. We chose a different path to minimize variability as this probe isn't forgiving if it fails (we reschedule the pod). This can be tuned using the `spec.livenessProbeOverride` field in the VerticaDB

The operator will only ever restart vertica when the startupProbe is active. The livenessProbe is too short. If we started vertica when that probe is active, we risk having the pod get rescheduled during the restart.

When moving up to an operator with this fix, the operator will add the new probes. This requires restart of the pods. The operator will handle this automatically, but you will see a rolling update as the change is applied.
