### PR TITLE
Make disk full errors more prominent

### DIFF
--- a/changes/unreleased/Fixed-20230131-160542.yaml
+++ b/changes/unreleased/Fixed-20230131-160542.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Make disk full errors more prominent
+time: 2023-01-31T16:05:42.527232985-04:00
+custom:
+  Issue: "330"

--- a/pkg/controllers/vdb/localdatacheck_reconcile.go
+++ b/pkg/controllers/vdb/localdatacheck_reconcile.go
@@ -17,6 +17,7 @@ package vdb
 
 import (
 	"context"
+	"fmt"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
@@ -51,8 +52,9 @@ func (l *LocalDataCheckReconciler) Reconcile(ctx context.Context, req *ctrl.Requ
 	pods := l.PFacts.findPodsLowOnDiskSpace(FreeSpaceThreshold)
 	l.NumEvents = 0
 	for i := range pods {
-		l.VRec.Eventf(l.Vdb, corev1.EventTypeWarning, events.LowLocalDataAvailSpace,
-			"Low disk space in persistent volume attached to %s", pods[i].name.Name)
+		msg := fmt.Sprintf("Low disk space in persistent volume attached to %s", pods[i].name.Name)
+		l.VRec.Log.Info(msg)
+		l.VRec.Eventf(l.Vdb, corev1.EventTypeWarning, events.LowLocalDataAvailSpace, msg)
 		l.NumEvents++
 	}
 

--- a/pkg/controllers/vdb/localdatacheck_reconcile.go
+++ b/pkg/controllers/vdb/localdatacheck_reconcile.go
@@ -17,7 +17,6 @@ package vdb
 
 import (
 	"context"
-	"fmt"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
@@ -52,9 +51,8 @@ func (l *LocalDataCheckReconciler) Reconcile(ctx context.Context, req *ctrl.Requ
 	pods := l.PFacts.findPodsLowOnDiskSpace(FreeSpaceThreshold)
 	l.NumEvents = 0
 	for i := range pods {
-		msg := fmt.Sprintf("Low disk space in persistent volume attached to %s", pods[i].name.Name)
-		l.VRec.Log.Info(msg)
-		l.VRec.Eventf(l.Vdb, corev1.EventTypeWarning, events.LowLocalDataAvailSpace, msg)
+		l.VRec.Eventf(l.Vdb, corev1.EventTypeWarning, events.LowLocalDataAvailSpace,
+			"Low disk space in persistent volume attached to %s", pods[i].name.Name)
 		l.NumEvents++
 	}
 

--- a/pkg/controllers/vdb/localdatacheck_reconcile.go
+++ b/pkg/controllers/vdb/localdatacheck_reconcile.go
@@ -1,0 +1,60 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// LocalDataCheckReconciler will check the free space available in the PV and
+// log events if they it is too low.
+type LocalDataCheckReconciler struct {
+	VRec      *VerticaDBReconciler
+	Vdb       *vapi.VerticaDB
+	PFacts    *PodFacts
+	NumEvents int // Number of events written
+}
+
+// MakeLocalDataCheckReconciler will build a LocalDataCheckReconciler object
+func MakeLocalDataCheckReconciler(vdbrecon *VerticaDBReconciler, vdb *vapi.VerticaDB, pfacts *PodFacts) controllers.ReconcileActor {
+	return &LocalDataCheckReconciler{VRec: vdbrecon, Vdb: vdb, PFacts: pfacts}
+}
+
+// Reconcile will look at all pods to see if any have low disk space available.
+func (l *LocalDataCheckReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if err := l.PFacts.Collect(ctx, l.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// We report a warning for any pod that has less then this amount of free
+	// space in their local PV.
+	const FreeSpaceThreshold = 10 * 1024 * 1024 // 10mb
+	pods := l.PFacts.findPodsLowOnDiskSpace(FreeSpaceThreshold)
+	l.NumEvents = 0
+	for i := range pods {
+		l.VRec.Eventf(l.Vdb, corev1.EventTypeWarning, events.LowLocalDataAvailSpace,
+			"Low disk space in persistent volume attached to %s", pods[i].name.Name)
+		l.NumEvents++
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/vdb/localdatacheck_reconcile_test.go
+++ b/pkg/controllers/vdb/localdatacheck_reconcile_test.go
@@ -1,0 +1,58 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("localdatacheck_reconcile", func() {
+	ctx := context.Background()
+
+	It("should write events when disk space is low", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters[0].Size = 3
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		prunner := &cmds.FakePodRunner{}
+		// PodFacts should have 1 of 2 pods running low on space
+		pfacts := createPodFactsDefault(prunner)
+		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
+		sc := &vdb.Spec.Subclusters[0]
+		pn := names.GenPodName(vdb, sc, 0)
+		pfacts.Detail[pn].localDataAvail = 30 * 1024 * 1024
+		pn = names.GenPodName(vdb, sc, 1)
+		pfacts.Detail[pn].localDataAvail = 5 * 1024 * 1024
+		pn = names.GenPodName(vdb, sc, 1)
+		pfacts.Detail[pn].localDataAvail = 1 * 1024 * 1024 * 1024
+
+		actor := MakeLocalDataCheckReconciler(vdbRec, vdb, pfacts)
+		l := actor.(*LocalDataCheckReconciler)
+		Expect(l.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		Expect(l.NumEvents).Should(Equal(1))
+	})
+})

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -771,37 +771,4 @@ var _ = Describe("restart_reconciler", func() {
 		restart := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "restart_node")
 		Expect(len(restart)).Should(Equal(0))
 	})
-
-	It("should log a diskfull event", func() {
-		vdb := vapi.MakeVDB()
-		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
-		pfacts := createPodFactsWithSlowStartup(ctx, vdb, &vdb.Spec.Subclusters[0], fpr, []int32{2})
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly)
-		r := act.(*RestartReconciler)
-
-		sampleOutput := `Info: no password specified, using none
-*** Updating IP addresses for nodes of database vertdb ***
-    Start update IP addresses for nodes
-    Updating node IP addresses
-    Generating new configuration information and reloading spread
-
-
-Admintools was unable to complete a network operation while executing this request.
-Sometimes this can be caused by transient network issues.
-Please consider retrying the command.
-Details:
---- Logging error ---\r
-Traceback (most recent call last):\r
-  File \"/opt/vertica/oss/python3/lib/python3.9/logging/__init__.py\", line 1087, in emit\r
-    self.flush()\r
-  File \"/opt/vertica/oss/python3/lib/python3.9/logging/__init__.py\", line 1067, in flush\r
-    self.stream.flush()\r
-OSError: [Errno 28] No space left on device\r
-Call stack:\r
-  File \"/opt/vertica/oss/python3/lib/python3.9/runpy.py\", line 197, in _run_module_as_main\r
-    return _run_code(code, main_globals, None,\r
-		`
-		Expect(isDiskFull(sampleOutput)).Should(BeTrue())
-		r.logATFailureEvent("restart_db", sampleOutput)
-	})
 })

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -771,4 +771,37 @@ var _ = Describe("restart_reconciler", func() {
 		restart := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "restart_node")
 		Expect(len(restart)).Should(Equal(0))
 	})
+
+	It("should log a diskfull event", func() {
+		vdb := vapi.MakeVDB()
+		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
+		pfacts := createPodFactsWithSlowStartup(ctx, vdb, &vdb.Spec.Subclusters[0], fpr, []int32{2})
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly)
+		r := act.(*RestartReconciler)
+
+		sampleOutput := `Info: no password specified, using none
+*** Updating IP addresses for nodes of database vertdb ***
+    Start update IP addresses for nodes
+    Updating node IP addresses
+    Generating new configuration information and reloading spread
+
+
+Admintools was unable to complete a network operation while executing this request.
+Sometimes this can be caused by transient network issues.
+Please consider retrying the command.
+Details:
+--- Logging error ---\r
+Traceback (most recent call last):\r
+  File \"/opt/vertica/oss/python3/lib/python3.9/logging/__init__.py\", line 1087, in emit\r
+    self.flush()\r
+  File \"/opt/vertica/oss/python3/lib/python3.9/logging/__init__.py\", line 1067, in flush\r
+    self.stream.flush()\r
+OSError: [Errno 28] No space left on device\r
+Call stack:\r
+  File \"/opt/vertica/oss/python3/lib/python3.9/runpy.py\", line 197, in _run_module_as_main\r
+    return _run_code(code, main_globals, None,\r
+		`
+		Expect(isDiskFull(sampleOutput)).Should(BeTrue())
+		r.logATFailureEvent("restart_db", sampleOutput)
+	})
 })

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -148,6 +148,8 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Always start with a status reconcile in case the prior reconcile failed.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		MakeMetricReconciler(r, vdb, prunner, pfacts),
+		// Report any pods that have low disk space
+		MakeLocalDataCheckReconciler(r, vdb, pfacts),
 		// Handle upgrade actions for any k8s objects created in prior versions
 		// of the operator.
 		MakeUpgradeOperator120Reconciler(r, log, vdb),

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -42,10 +42,8 @@ const (
 	RemoveNodesSucceeded            = "RemoveNodesSucceeded"
 	RemoveNodesFailed               = "RemoveNodesFailed"
 	NodeRestartStarted              = "NodeRestartStarted"
-	NodeRestartFailed               = "NodeRestartFailed"
 	NodeRestartSucceeded            = "NodeRestartSucceeded"
 	ClusterRestartStarted           = "ClusterRestartStarted"
-	ClusterRestartFailed            = "ClusterRestartFailed"
 	ClusterRestartSucceeded         = "ClusterRestartSucceeded"
 	SlowRestartDetected             = "SlowRestartDetected"
 	SubclusterAdded                 = "SubclusterAdded"
@@ -76,6 +74,9 @@ const (
 	SkipPVCExpansion                = "SkipPVCExpansion"
 	SkipDepotResize                 = "SkipDepotResize"
 	DepotResized                    = "DepotResized"
+	ATFailed                        = "AdminToolsFailed"
+	ATFailedDiskFull                = "AdminToolsFailedDiskfull"
+	LowLocalDataAvailSpace          = "LowLocalDataAvailSpace"
 )
 
 // Constants for VerticaAutoscaler reconciler

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -74,8 +74,8 @@ const (
 	SkipPVCExpansion                = "SkipPVCExpansion"
 	SkipDepotResize                 = "SkipDepotResize"
 	DepotResized                    = "DepotResized"
-	ATFailed                        = "AdminToolsFailed"
-	ATFailedDiskFull                = "AdminToolsFailedDiskfull"
+	MgmtFailed                      = "MgmtFailed"
+	MgmtFailedDiskFull              = "MgmtFailedDiskfull"
 	LowLocalDataAvailSpace          = "LowLocalDataAvailSpace"
 )
 

--- a/pkg/mgmterrors/aterrors.go
+++ b/pkg/mgmterrors/aterrors.go
@@ -28,7 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// ATErrors handles event logging for errors that come back from admintools.
+// ATErrors handles event logging for errors that come back from admintools
 type ATErrors struct {
 	Writer               EVWriter
 	VDB                  *vapi.VerticaDB

--- a/pkg/mgmterrors/aterrors_test.go
+++ b/pkg/mgmterrors/aterrors_test.go
@@ -1,0 +1,129 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package mgmterrors
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("aterrors", func() {
+	It("should log a diskfull event", func() {
+		sampleOutput := `Info: no password specified, using none
+*** Updating IP addresses for nodes of database vertdb ***
+    Start update IP addresses for nodes
+    Updating node IP addresses
+    Generating new configuration information and reloading spread
+
+
+Admintools was unable to complete a network operation while executing this request.
+Sometimes this can be caused by transient network issues.
+Please consider retrying the command.
+Details:
+--- Logging error ---\r
+Traceback (most recent call last):\r
+  File \"/opt/vertica/oss/python3/lib/python3.9/logging/__init__.py\", line 1087, in emit\r
+    self.flush()\r
+  File \"/opt/vertica/oss/python3/lib/python3.9/logging/__init__.py\", line 1067, in flush\r
+    self.stream.flush()\r
+OSError: [Errno 28] No space left on device\r
+Call stack:\r
+  File \"/opt/vertica/oss/python3/lib/python3.9/runpy.py\", line 197, in _run_module_as_main\r
+    return _run_code(code, main_globals, None,\r
+		`
+		vdb := vapi.MakeVDB()
+		tw := TestEVWriter{}
+		evlogr := MakeATErrors(&tw, vdb, events.MgmtFailed)
+		Expect(evlogr.LogFailure("restart_db", sampleOutput, nil)).Should(Equal(ctrl.Result{Requeue: true}))
+		Expect(len(tw.RecordedEvents)).Should(Equal(1))
+		Expect(tw.RecordedEvents[0].Reason).Should(Equal(events.MgmtFailedDiskFull))
+	})
+
+	It("should handle generic error that has no special output", func() {
+		vdb := vapi.MakeVDB()
+		tw := TestEVWriter{}
+		const GenErrorReason = events.MgmtFailed
+		evlogr := MakeATErrors(&tw, vdb, GenErrorReason)
+		res, err := evlogr.LogFailure("test_cmd", "", nil)
+		Expect(err).ShouldNot(Succeed())
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(len(tw.RecordedEvents)).Should(Equal(1))
+		Expect(tw.RecordedEvents[0].Reason).Should(Equal(GenErrorReason))
+	})
+
+	It("should generate a requeue error for various known admintools errors", func() {
+		vdb := vapi.MakeVDB()
+
+		errStrings := []string{
+			"Unable to connect to endpoint",
+			"The specified bucket does not exist.",
+			"Communal location [s3://blah] is not empty",
+			"You are trying to access your S3 bucket using the wrong region. If you are using S3",
+			"The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-central-1'.",
+			"An error occurred during kerberos authentication",
+		}
+
+		for i := range errStrings {
+			tw := TestEVWriter{}
+			evlogr := MakeATErrors(&tw, vdb, events.CreateDBFailed)
+			Expect(evlogr.LogFailure("create_db", errStrings[i], fmt.Errorf("error"))).Should(Equal(ctrl.Result{Requeue: true}))
+		}
+	})
+
+	It("should requeue a short duration when admintools fails restart because some nodes are up", func() {
+		vdb := vapi.MakeVDB()
+		tw := TestEVWriter{}
+		const GenErrorReason = events.MgmtFailed
+		evlogr := MakeATErrors(&tw, vdb, GenErrorReason)
+		Expect(evlogr.LogFailure("test_cmd", "All nodes in the input are not down, can't restart", nil)).Should(Equal(ctrl.Result{
+			Requeue:      false,
+			RequeueAfter: time.Second * RestartNodesNotDownRequeueWaitTimeInSeconds,
+		}))
+		Expect(len(tw.RecordedEvents)).Should(Equal(1))
+		Expect(tw.RecordedEvents[0].Reason).Should(Equal(GenErrorReason))
+	})
+
+	It("should generate a requeue error for various known s3 errors", func() {
+		vdb := vapi.MakeVDB()
+		errStrings := []string{
+			"Error: The database vertdb cannot continue because the communal storage location\n\ts3://nimbusdb/db\n" +
+				"might still be in use.\n\nthe cluster lease will expire:\n\t2021-05-13 14:35:00.280925",
+			"Could not copy file [s3://nimbusdb/db/empty/metadata/newdb/cluster_config.json] to [/tmp/desc.json]: " +
+				"No such file or directory [s3://nimbusdb/db/empty/metadata/newdb/cluster_config.json]",
+			"Could not copy file [gs://vertica-fleeting/mspilchen/revivedb-failures/metadata/vertdb/cluster_conf] to [/tmp/desc.json]: " +
+				"File not found",
+			"Could not copy file [webhdfs://vertdb/cluster_config.json] to [/tmp/desc.json]: Seen WebHDFS exception: " +
+				"\nURL: [http://vertdb/cluster_config.json]\nHTTP response code: 404\nException type: FileNotFoundException",
+			"Could not copy file [azb://cluster_config.json] to [/tmp/desc.json]: : The specified blob does not exist",
+			"\n10.244.1.34 Permission Denied \n\n",
+			"Database could not be revived.\nError: Node count mismatch",
+			"Error: Primary node count mismatch:",
+			"Could not copy file [s3://nimbusdb/db/spilly/metadata/vertdb/cluster_config.json] to [/tmp/desc.json]: Unable to connect to endpoint\n",
+			"[/tmp/desc.json]: The specified bucket does not exist\nExit",
+		}
+		for i := range errStrings {
+			tw := TestEVWriter{}
+			evlogr := MakeATErrors(&tw, vdb, events.ReviveDBFailed)
+			Expect(evlogr.LogFailure("revive_db", errStrings[i], fmt.Errorf("error"))).Should(Equal(ctrl.Result{Requeue: true}))
+		}
+	})
+})

--- a/pkg/mgmterrors/interface.go
+++ b/pkg/mgmterrors/interface.go
@@ -1,0 +1,36 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package mgmterrors
+
+import (
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type EventLogger interface {
+	// LogFailure is called when the management SDK had attempted a command
+	// but failed. The command used, along with the output of the command are
+	// given. This function will parse the output and determine the appropriate
+	// Event and log message to write. It will also determine the appropriate
+	// ctrl.Result to bubble back up.
+	LogFailure(cmd, op string, err error) (ctrl.Result, error)
+}
+
+// EVWriter is an interface for writing k8s events
+type EVWriter interface {
+	Event(vdb *vapi.VerticaDB, eventtype, reason, message string)
+	Eventf(vdb *vapi.VerticaDB, eventtype, reason, messageFmt string, args ...interface{})
+}

--- a/pkg/mgmterrors/suite_test.go
+++ b/pkg/mgmterrors/suite_test.go
@@ -1,0 +1,61 @@
+/*
+ (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package mgmterrors
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"mgmterrors Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+type EventDetails struct {
+	EventType string
+	Reason    string
+	Message   string
+}
+
+type TestEVWriter struct {
+	RecordedEvents []EventDetails
+}
+
+func (t *TestEVWriter) Event(vdb *vapi.VerticaDB, eventtype, reason, message string) {
+	d := EventDetails{
+		EventType: eventtype,
+		Reason:    reason,
+		Message:   message,
+	}
+	if t.RecordedEvents == nil {
+		t.RecordedEvents = []EventDetails{}
+	}
+	t.RecordedEvents = append(t.RecordedEvents, d)
+}
+
+func (t *TestEVWriter) Eventf(vdb *vapi.VerticaDB, eventtype, reason, messageFmt string, args ...interface{}) {
+	msg := fmt.Sprintf(messageFmt, args...)
+	t.Event(vdb, eventtype, reason, msg)
+}


### PR DESCRIPTION
This change makes disk full errors more prominent in the operator. The focus is on checking the disk space for the local PV. We handle this with a couple of strategies:
- parsing the output from admintools. Sometimes, disk full errors will be seen in the output.
- add a reconcile actor that will check the disk space available in the local PV and log a k8s event if its below a threshold (currently 10mb)

I did the second approach because there are some times when vertica may have trouble starting and the error doesn't surface in the admintools output.