### PR TITLE
Change e2e http test to try different endpoint

### DIFF
--- a/tests/e2e-http-server/http-custom-certs/50-assert.yaml
+++ b/tests/e2e-http-server/http-custom-certs/50-assert.yaml
@@ -14,7 +14,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-verify-version
+  name: test-verify-metrics
 status:
   containerStatuses:
     - name: test

--- a/tests/e2e-http-server/http-custom-certs/50-verify-metrics.yaml
+++ b/tests/e2e-http-server/http-custom-certs/50-verify-metrics.yaml
@@ -19,21 +19,21 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: script-verify-version
+  name: script-verify-metrics
 data:
   entrypoint.sh: |-
     #!/bin/bash
     set -o xtrace
     set -o errexit
 
-    # Version can change only validate a portion of it
-    curl --insecure --fail --verbose --key /certs/tls.key --cert /certs/tls.crt https://v-http-custom-certs-main-0.v-http-custom-certs:8443/info/version | tee /tmp/curl.out
-    grep -cq 'Vertica Analytic Database' /tmp/curl.out
+    # metrics can change only validate a portion of it
+    curl --insecure --fail --verbose --key /certs/tls.key --cert /certs/tls.crt https://v-http-custom-certs-main-0.v-http-custom-certs:8443/metrics | tee /tmp/curl.out
+    grep -cq 'vertica_build_info' /tmp/curl.out
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test-verify-version
+  name: test-verify-metrics
   labels:
     stern: include
 spec:
@@ -53,7 +53,7 @@ spec:
     - name: entrypoint-volume
       configMap:
         defaultMode: 0777
-        name: script-verify-version
+        name: script-verify-metrics
     - name: certs
       secret:
         secretName: custom-certs


### PR DESCRIPTION
The overnight e2e test failed because it was testing an endpoint that was renamed. It was using /info/version, changed that to use /metrics.