### PR TITLE
Allow revive when local paths aren't known

### DIFF
--- a/changes/unreleased/Changed-20230206-091559.yaml
+++ b/changes/unreleased/Changed-20230206-091559.yaml
@@ -2,4 +2,4 @@ kind: Changed
 body: Allow revive when local paths aren't known
 time: 2023-02-06T09:15:59.25368159-04:00
 custom:
-  Issue: "330"
+  Issue: "332"

--- a/changes/unreleased/Changed-20230206-091559.yaml
+++ b/changes/unreleased/Changed-20230206-091559.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Allow revive when local paths aren't known
+time: 2023-02-06T09:15:59.25368159-04:00
+custom:
+  Issue: "330"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -41,6 +41,15 @@ const (
 	VerticaHTTPPort         = 8443
 	InternalVerticaCommPort = 5434
 	SSHPort                 = 22
+
+	// Standard environment variables that are set in each pod
+	PodIPEnv        = "POD_IP"
+	HostIPEnv       = "HOST_IP"
+	HostNameEnv     = "HOST_NODENAME"
+	DataPathEnv     = "DATA_PATH"
+	CatalogPathEnv  = "CATALOG_PATH"
+	DepotPathEnv    = "DEPOT_PATH"
+	DatabaseNameEnv = "DATABASE_NAME"
 )
 
 // BuildExtSvc creates desired spec for the external service.
@@ -444,19 +453,19 @@ func buildPodSecurityPolicy() *corev1.PodSecurityContext {
 func makeServerContainer(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.Container {
 	envVars := translateAnnotationsToEnvVars(vdb)
 	envVars = append(envVars, []corev1.EnvVar{
-		{Name: "POD_IP", ValueFrom: &corev1.EnvVarSource{
+		{Name: PodIPEnv, ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"}},
 		},
-		{Name: "HOST_IP", ValueFrom: &corev1.EnvVarSource{
+		{Name: HostIPEnv, ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"}},
 		},
-		{Name: "HOST_NODENAME", ValueFrom: &corev1.EnvVarSource{
+		{Name: HostNameEnv, ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}},
 		},
-		{Name: "DATA_PATH", Value: vdb.Spec.Local.DataPath},
-		{Name: "DEPOT_PATH", Value: vdb.Spec.Local.DepotPath},
-		{Name: "CATALOG_PATH", Value: vdb.Spec.Local.GetCatalogPath()},
-		{Name: "DATABASE_NAME", Value: vdb.Spec.DBName},
+		{Name: DataPathEnv, Value: vdb.Spec.Local.DataPath},
+		{Name: DepotPathEnv, Value: vdb.Spec.Local.DepotPath},
+		{Name: CatalogPathEnv, Value: vdb.Spec.Local.GetCatalogPath()},
+		{Name: DatabaseNameEnv, Value: vdb.Spec.DBName},
 	}...)
 	return corev1.Container{
 		Image:           pickImage(vdb, sc),

--- a/pkg/reviveplanner/analyze.go
+++ b/pkg/reviveplanner/analyze.go
@@ -1,0 +1,169 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reviveplanner
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+)
+
+// IsCompatible will check the vdb and extracted revive info to see if
+// everything is compatible. Returns a failure if an error is detected.
+func (a *ATPlanner) IsCompatible() (string, bool) {
+	// To see if the revive is compatible, we are going to check each of the
+	// paths of all the nodes. The prefix of each path needs to be the same. The
+	// operator assumes that all paths are homogeneous across all vertica hosts.
+	pathFuncs := []func() []string{
+		a.getDataPaths,
+		a.getDepotPaths,
+		a.getCatalogPaths,
+	}
+	for i := range pathFuncs {
+		_, err := a.getCommonPath(pathFuncs[i]())
+		if err != nil {
+			// Extract out the error message and return that.
+			return err.Error(), false
+		}
+	}
+	return "", true
+}
+
+// ApplyChanges will update the input vdb based on things it found during
+// analysis. Return true if the vdb was updated.
+func (a *ATPlanner) ApplyChanges(vdb *vapi.VerticaDB) (updated bool, err error) {
+	foundShardCount, err := strconv.Atoi(a.CommunalLocation.NumShards)
+	if err != nil {
+		a.Log.Info("Failed to convert shard in revive --display-only output to int",
+			"num_shards", a.CommunalLocation.NumShards)
+		// We won't be able to validate/update the shard count. Ignore the error and continue.
+	} else if foundShardCount != vdb.Spec.ShardCount {
+		a.Log.Info("Shard count changing to match revive output",
+			"oldShardCount", vdb.Spec.ShardCount, "newShardCount", foundShardCount)
+		vdb.Spec.ShardCount = foundShardCount
+		updated = true
+	}
+
+	dataPath, err := a.getCommonPath(a.getDataPaths())
+	if err != nil {
+		return
+	}
+	if dataPath != vdb.Spec.Local.DataPath {
+		a.logPathChange("data", vdb.Spec.Local.DataPath, dataPath)
+		vdb.Spec.Local.DataPath = dataPath
+		updated = true
+	}
+
+	depotPath, err := a.getCommonPath(a.getDepotPaths())
+	if err != nil {
+		return
+	}
+	if depotPath != vdb.Spec.Local.DepotPath {
+		a.logPathChange("depot", vdb.Spec.Local.DepotPath, depotPath)
+		vdb.Spec.Local.DepotPath = depotPath
+		updated = true
+	}
+
+	catPath, err := a.getCommonPath(a.getCatalogPaths())
+	if err != nil {
+		return
+	}
+	if catPath != vdb.Spec.Local.GetCatalogPath() {
+		a.logPathChange("catalog", vdb.Spec.Local.GetCatalogPath(), catPath)
+		vdb.Spec.Local.CatalogPath = catPath
+		updated = true
+	}
+
+	return updated, err
+}
+
+// logPathChange will add a log entry for a change to one of the vdb path changes
+func (a *ATPlanner) logPathChange(pathType, oldPath, newPath string) {
+	a.Log.Info(fmt.Sprintf("%s path has to change to match revive output", pathType),
+		"oldPath", oldPath, "newPath", newPath)
+}
+
+// getDataPaths will return the data paths for each node
+func (a *ATPlanner) getDataPaths() []string {
+	paths := []string{}
+	for i := range a.Database.Nodes {
+		p, ok := a.Database.Nodes[i].GetDataPath()
+		if !ok {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+// getDepotPaths will return the depot paths for each node
+func (a *ATPlanner) getDepotPaths() []string {
+	paths := []string{}
+	for i := range a.Database.Nodes {
+		p, ok := a.Database.Nodes[i].GetDepotPath()
+		if !ok {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+// getCatalogPaths will return the catalog paths that are set for each node.
+func (a *ATPlanner) getCatalogPaths() []string {
+	paths := []string{}
+	for i := range a.Database.Nodes {
+		paths = append(paths, a.Database.Nodes[i].CatalogPath)
+	}
+	return paths
+}
+
+// getCommonPath will look at a slice of paths, and return the common prefix for
+// all of them.
+func (a *ATPlanner) getCommonPath(paths []string) (string, error) {
+	if len(paths) == 0 {
+		return "", fmt.Errorf("no paths passed in")
+	}
+	commonPath := ""
+	for i := range paths {
+		p, err := a.extractPathPrefix(paths[i])
+		if err != nil {
+			return "", err
+		}
+		if commonPath == "" {
+			commonPath = p
+		} else if commonPath != p {
+			return "", fmt.Errorf("multiple vertica hosts don't have common paths: %s and %s", commonPath, p)
+		}
+	}
+	return commonPath, nil
+}
+
+// extractPathPrefix will extract out the prefix of a vertica POSIX path. This
+// path could be catalog, depot or data path.
+func (a *ATPlanner) extractPathPrefix(path string) (string, error) {
+	// Path will come in the form: <prefix>/<dbname>/v_<dbname>_<nodenum>_<pathType>
+	// This function will return <prefix>.
+	r := regexp.MustCompile(fmt.Sprintf(`(.*)/%s/v_%s_node[0-9]{4}_`, a.Database.Name, a.Database.Name))
+	m := r.FindStringSubmatch(path)
+	const ExpectedMatches = 2
+	if len(m) < ExpectedMatches {
+		return "", fmt.Errorf("path '%s' is not a valid vertica path", path)
+	}
+	return m[1], nil
+}

--- a/pkg/reviveplanner/analyze_test.go
+++ b/pkg/reviveplanner/analyze_test.go
@@ -1,0 +1,146 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reviveplanner
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+)
+
+var _ = Describe("analyze", func() {
+	It("should be able to extract out a common prefix", func() {
+		p := ATPlanner{
+			Database: Database{
+				Name: "vertdb",
+			},
+		}
+		Expect(p.extractPathPrefix("/data/vertdb/v_vertdb_node0001_catalog")).Should(Equal("/data"))
+		Expect(p.extractPathPrefix("/one/path/vertdb/v_vertdb_node0101_data")).Should(Equal("/one/path"))
+		_, err := p.extractPathPrefix("/data/not-valid")
+		Expect(err).ShouldNot(Succeed())
+	})
+
+	It("should be able to find common paths", func() {
+		p := ATPlanner{
+			Database: Database{
+				Name: "v",
+			},
+		}
+		Expect(p.getCommonPath([]string{
+			"/data/prefix/v/v_v_node0001_depot",
+			"/data/prefix/v/v_v_node0002_depot",
+			"/data/prefix/v/v_v_node0003_depot",
+		})).Should(Equal("/data/prefix"))
+		_, err := p.getCommonPath([]string{
+			"/p1/v/v_v_node0001_depot",
+			"/p2/v/v_v_node0002_depot",
+		})
+		Expect(err).ShouldNot(Succeed())
+		_, err = p.getCommonPath(nil)
+		Expect(err).ShouldNot(Succeed())
+		_, err = p.getCommonPath([]string{
+			"/p1/v/v_v_node0001_depot",
+			"/p1/v/invalid/path/no/vnode",
+		})
+		Expect(err).ShouldNot(Succeed())
+	})
+
+	It("should update vdb based on revive output", func() {
+		vdb := vapi.MakeVDB()
+		p := MakeATPlannerFromVDB(vdb, logger)
+
+		origVdb := vdb.DeepCopy()
+
+		// Change some things in vdb that the planner will change back
+		vdb.Spec.ShardCount = 50
+		vdb.Spec.Local.DataPath = "/new-data/location/is/here"
+		vdb.Spec.Local.CatalogPath = "/somewhere"
+		vdb.Spec.Local.DepotPath = "/depot-location_is_here/subdir"
+
+		Expect(p.ApplyChanges(vdb)).Should(BeTrue())
+		Expect(vdb.Spec.ShardCount).Should(Equal(origVdb.Spec.ShardCount))
+		Expect(vdb.Spec.Local.DataPath).Should(Equal(origVdb.Spec.Local.DataPath))
+		Expect(vdb.Spec.Local.GetCatalogPath()).Should(Equal(origVdb.Spec.Local.GetCatalogPath()))
+		Expect(vdb.Spec.Local.DepotPath).Should(Equal(origVdb.Spec.Local.DepotPath))
+	})
+
+	It("should say revive isn't compatible if paths differ among nodes", func() {
+		p := ATPlanner{
+			Database: Database{
+				Name: "mydb",
+				Nodes: []Node{
+					{
+						Name:        "v_mydb_node0001",
+						CatalogPath: "/cat/mydb/v_mydb_node0001_catalog",
+						VStorageLocations: []StorageLocation{
+							{
+								Path:  "/dep/mydb/v_mydb_node0001_depot",
+								Usage: UsageIsDepot,
+							},
+							{
+								Path:  "/dat/mydb/v_mydb_node0001_data",
+								Usage: UsageIsDataTemp,
+							},
+						},
+					}, {
+						Name:        "v_mydb_node0002",
+						CatalogPath: "/cat/mydb/v_mydb_node0002_catalog",
+						VStorageLocations: []StorageLocation{
+							{
+								Path:  "/dep/mydb/v_mydb_node0002_depot",
+								Usage: UsageIsDepot,
+							},
+							{
+								Path:  "/dat/mydb/v_mydb_node0002_data",
+								Usage: UsageIsDataTemp,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, ok := p.IsCompatible()
+		Expect(ok).Should(BeTrue())
+
+		origCatPath := p.Database.Nodes[1].CatalogPath
+		p.Database.Nodes[1].CatalogPath = fmt.Sprintf("/something-not-common%s", origCatPath)
+		msg, ok := p.IsCompatible()
+		Expect(ok).Should(BeFalse())
+		Expect(len(msg)).ShouldNot(Equal(0))
+		p.Database.Nodes[1].CatalogPath = origCatPath
+
+		origDepotPath := p.Database.Nodes[1].VStorageLocations[0].Path
+		p.Database.Nodes[1].VStorageLocations[0].Path = fmt.Sprintf("/a%s", origDepotPath)
+		msg, ok = p.IsCompatible()
+		Expect(ok).Should(BeFalse())
+		Expect(len(msg)).ShouldNot(Equal(0))
+		p.Database.Nodes[1].VStorageLocations[0].Path = origDepotPath
+
+		origDataPath := p.Database.Nodes[0].VStorageLocations[1].Path
+		p.Database.Nodes[0].VStorageLocations[1].Path = fmt.Sprintf("/b%s", origDataPath)
+		msg, ok = p.IsCompatible()
+		Expect(ok).Should(BeFalse())
+		Expect(len(msg)).ShouldNot(Equal(0))
+		p.Database.Nodes[0].VStorageLocations[1].Path = origDataPath
+
+		_, ok = p.IsCompatible()
+		Expect(ok).Should(BeTrue())
+	})
+})

--- a/pkg/reviveplanner/at.go
+++ b/pkg/reviveplanner/at.go
@@ -1,0 +1,33 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reviveplanner
+
+import "github.com/go-logr/logr"
+
+type ATPlanner struct {
+	Database         Database
+	CommunalLocation CommunalLocation
+	Log              logr.Logger
+	ParseComplete    bool
+}
+
+// MakeATPlanner is a factory function for the Planner interface. This makes one
+// specific to admintools output.
+func MakeATPlanner(log logr.Logger) Planner {
+	return &ATPlanner{
+		Log: log,
+	}
+}

--- a/pkg/reviveplanner/interface.go
+++ b/pkg/reviveplanner/interface.go
@@ -1,0 +1,34 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reviveplanner
+
+import (
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+)
+
+type Planner interface {
+	// Analyze will look at the given output, from revive --display-only, and
+	// parse it into Go structs.
+	Parse(op string) error
+
+	// IsCompatible will check if the revive will even work in k8s. A failure
+	// message is returned if it isn't compatible.
+	IsCompatible() (string, bool)
+
+	// ApplyChanges will update the input vdb based on things it found during
+	// analysis. Return true if the vdb was updated.
+	ApplyChanges(vdb *vapi.VerticaDB) (bool, error)
+}

--- a/pkg/reviveplanner/parser.go
+++ b/pkg/reviveplanner/parser.go
@@ -1,0 +1,195 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reviveplanner
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+)
+
+// The format of the next few struct's is implemented in the server. Do not add
+// new fields in here, unless those new fields are also exposed by the server's
+// 'admintools -t revive_db --display-only' output.
+
+const (
+	// The usage number for DATA,TEMP. Set internally by Vertica.
+	UsageIsDataTemp = 3
+	// The usage number for DEPOT. Set internally by Vertica.
+	UsageIsDepot = 5
+)
+
+// CommunalLocation shows information about the database's communal storage
+type CommunalLocation struct {
+	CommunalStorageURL string `json:"communal_storage_url"`
+	NumShards          string `json:"num_shards"`
+	DepotPath          string `json:"depot_path"`
+	DepotSize          string `json:"depot_size"`
+}
+
+// Database is a top-level database struct
+type Database struct {
+	Nodes                 []Node `json:"nodes"`
+	Name                  string `json:"name"`
+	Version               int    `json:"version"`
+	SpreadVersion         int    `json:"spreadversion"`
+	ControlMode           string `json:"controlmode"`
+	WillUgrade            bool   `json:"willupgrade"`
+	SpreadEncryption      string `json:"spreadEncryption"`
+	SpreadEncryptionInUse bool   `json:"spreadEncryptionInUse"`
+}
+
+// Node shows information about a single node
+type Node struct {
+	Name                    string            `json:"name"`
+	OID                     int64             `json:"oid"`
+	CatalogPath             string            `json:"catalogpath"`
+	StorageLocs             []string          `json:"storagelocs"`
+	VStorageLocations       []StorageLocation `json:"_vstorage_locations"`
+	CommunalStorageLocation StorageLocation   `json:"_communal_storage_location"`
+	Host                    string            `json:"host"`
+	Port                    int               `json:"port"`
+	ControlNode             int64             `json:"controlnode"`
+	Deps                    [][]string        `json:"deps"`
+	StartCmd                string            `json:"startcmd"`
+	IsPrimary               bool              `json:"isprimary"`
+}
+
+// StorageLocation has details about a single storage location
+type StorageLocation struct {
+	Name        string `json:"name"`
+	Label       string `json:"label"`
+	OID         int64  `json:"oid"`
+	Path        string `json:"path"`
+	SharingType int    `json:"sharing_type"`
+	Usage       int    `json:"usage"`
+	Size        int    `json:"size"`
+	Site        int64  `json:"site"`
+}
+
+// MakeATPPlannerFromVDB will make a Planner struct based on the passed in vdb.
+// This is used for tests only.
+func MakeATPlannerFromVDB(vdb *vapi.VerticaDB, logger logr.Logger) Planner {
+	db := Database{
+		Name: vdb.Spec.DBName,
+	}
+	nc := 1
+	for i := range vdb.Spec.Subclusters {
+		for j := 0; j < int(vdb.Spec.Subclusters[i].Size); j++ {
+			db.Nodes = append(db.Nodes, Node{
+				Name:        fmt.Sprintf("v_%s_node%04d", db.Name, nc),
+				CatalogPath: fmt.Sprintf("%s/v_%s_node%04d_catalog", vdb.GetDBCatalogPath(), db.Name, nc),
+				IsPrimary:   vdb.Spec.Subclusters[i].IsPrimary,
+				VStorageLocations: []StorageLocation{
+					{
+						Path:  fmt.Sprintf("%s/%s/v_%s_node%04d_data", vdb.Spec.Local.DataPath, db.Name, db.Name, nc),
+						Usage: UsageIsDataTemp,
+					}, {
+						Path:  fmt.Sprintf("%s/%s/v_%s_node%04d_depot", vdb.Spec.Local.DepotPath, db.Name, db.Name, nc),
+						Usage: UsageIsDepot,
+					},
+				},
+			})
+			nc++
+		}
+	}
+	communalLocation := CommunalLocation{
+		NumShards: fmt.Sprintf("%d", vdb.Spec.ShardCount),
+	}
+	return &ATPlanner{
+		Log:              logger,
+		Database:         db,
+		CommunalLocation: communalLocation,
+		ParseComplete:    true, // We mimiced parse by filling in Database and communal info
+	}
+}
+
+// GetDataPath returns the data path for the node
+func (n *Node) GetDataPath() (string, bool) {
+	return n.getPathByUsage(UsageIsDataTemp)
+}
+
+// GetDepotPath returns the depot path for the node
+func (n *Node) GetDepotPath() (string, bool) {
+	return n.getPathByUsage(UsageIsDepot)
+}
+
+// getPathByUsage returns the path for a given usage type. See Usage* const at
+// the top of this file.
+func (n *Node) getPathByUsage(usage int) (string, bool) {
+	for i := range n.VStorageLocations {
+		if n.VStorageLocations[i].Usage == usage {
+			return n.VStorageLocations[i].Path, true
+		}
+	}
+	return "", false
+}
+
+// Parse looks at the op string passed in and spits out Database and
+// CommunalLocation structs.
+func (a *ATPlanner) Parse(op string) error {
+	// We only parse once. No-op if parse already done.
+	if a.ParseComplete {
+		return nil
+	}
+	var rawJSON string
+	rawJSON = a.extractCommunalLocation(op)
+	if err := json.Unmarshal([]byte(rawJSON), &a.CommunalLocation); err != nil {
+		return err
+	}
+
+	rawJSON = a.extractDatabase(op)
+	return json.Unmarshal([]byte(rawJSON), &a.Database)
+}
+
+// extractDatabase parses the full output and returns the json portion that
+// pertains to the database.
+func (a *ATPlanner) extractDatabase(op string) string {
+	startingMarker := regexp.MustCompile(`^\s*== Database and node details: ==`)
+	endingMarker := regexp.MustCompile(`^\s*== `)
+	return a.extractGeneric(op, startingMarker, endingMarker)
+}
+
+// extractCommunalLocation parses the full output and returns only the portion
+// that is for the communal location information.
+func (a *ATPlanner) extractCommunalLocation(op string) string {
+	startingMarker := regexp.MustCompile(`^\s*== Communal location details: ==`)
+	endingMarker := regexp.MustCompile(`^\s*Cluster lease expiration:`)
+	return a.extractGeneric(op, startingMarker, endingMarker)
+}
+
+// extractGeneric is a general parsing function of the revive_db --display-only output.
+func (a *ATPlanner) extractGeneric(op string, startingMarker, endingMarker *regexp.Regexp) string {
+	scanner := bufio.NewScanner(strings.NewReader(op))
+	var sb strings.Builder
+	for scanner.Scan() {
+		if startingMarker.MatchString(scanner.Text()) {
+			for scanner.Scan() {
+				if endingMarker.MatchString(scanner.Text()) {
+					break
+				}
+				sb.WriteString(scanner.Text())
+			}
+			break
+		}
+	}
+	return sb.String()
+}

--- a/pkg/reviveplanner/parser_test.go
+++ b/pkg/reviveplanner/parser_test.go
@@ -1,0 +1,147 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reviveplanner
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parser", func() {
+	It("should parse the sample output", func() {
+		planner := ATPlanner{}
+		sampleOutput := `Attempting to retrieve file: [/db/cad47f8e-7cca-48dd-8d9c-a2403f6c457f/metadata/vertdb/cluster_config.json]
+
+		Validated 1-node database vertdb defined at communal storage /db/cad47f8e-7cca-48dd-8d9c-a2403f6c457f.
+		
+		Expected layout of database after reviving from communal storage: /db/cad47f8e-7cca-48dd-8d9c-a2403f6c457f
+		
+		== Communal location details: ==
+		{
+		 "communal_storage_url": "/db/cad47f8e-7cca-48dd-8d9c-a2403f6c457f",
+		 "num_shards": "6",
+		 "depot_path": "/depot",
+		 "depot_size": "287447467K"
+		}
+		
+		Cluster lease expiration: 2023-02-01 15:07:32.022759
+		
+		== Database and node details: ==
+		{
+		 "nodes": [
+		  {
+		   "name": "v_vertdb_node0001",
+		   "oid": 45035996273704986,
+		   "catalogpath": "/data/vertdb/v_vertdb_node0001_catalog",
+		   "storagelocs": [
+			"/db/cad47f8e-7cca-48dd-8d9c-a2403f6c457f",
+			"/data/vertdb/v_vertdb_node0001_data",
+			"/depot/vertdb/v_vertdb_node0001_depot"
+		   ],
+		   "_vstorage_locations": [
+			{
+			 "name": "__location_0_v_vertdb_node0001",
+			 "label": "",
+			 "oid": 45035996273705020,
+			 "path": "/data/vertdb/v_vertdb_node0001_data",
+			 "sharing_type": 0,
+			 "usage": 3,
+			 "size": 0,
+			 "site": 45035996273704986
+			},
+			{
+			 "name": "__location_1_v_vertdb_node0001",
+			 "label": "auto-data-depot",
+			 "oid": 45035996273705156,
+			 "path": "/depot/vertdb/v_vertdb_node0001_depot",
+			 "sharing_type": 0,
+			 "usage": 5,
+			 "size": 294346206208,
+			 "site": 45035996273704986
+			}
+		   ],
+		   "_communal_storage_location": {
+			"name": "__location_0_communal",
+			"label": "",
+			"oid": 45035996273705022,
+			"path": "/db/cad47f8e-7cca-48dd-8d9c-a2403f6c457f",
+			"sharing_type": 2,
+			"usage": 1,
+			"size": 0,
+			"site": 0
+		   },
+		   "host": "10.244.0.47",
+		   "port": 5433,
+		   "controlnode": 45035996273704986,
+		   "startcmd": null,
+		   "isprimary": true
+		  }
+		 ],
+		 "flags": {},
+		 "name": "vertdb",
+		 "version": 0,
+		 "spreadversion": 0,
+		 "controlmode": "pt2pt",
+		 "deps": [],
+		 "willupgrade": false,
+		 "spreadEncryption": null,
+		 "spreadEncryptionInUse": false
+		}
+		
+		== Storage locations: ==
+		[
+		 {
+		  "name": "__location_0_v_vertdb_node0001",
+		  "label": "",
+		  "oid": 45035996273705020,
+		  "path": "/data/vertdb/v_vertdb_node0001_data",
+		  "sharing_type": 0,
+		  "usage": 3,
+		  "size": 0,
+		  "site": 45035996273704986
+		 },
+		 {
+		  "name": "__location_0_communal",
+		  "label": "",
+		  "oid": 45035996273705022,
+		  "path": "/db/cad47f8e-7cca-48dd-8d9c-a2403f6c457f",
+		  "sharing_type": 2,
+		  "usage": 1,
+		  "size": 0,
+		  "site": 0
+		 },
+		 {
+		  "name": "__location_1_v_vertdb_node0001",
+		  "label": "auto-data-depot",
+		  "oid": 45035996273705156,
+		  "path": "/depot/vertdb/v_vertdb_node0001_depot",
+		  "sharing_type": 0,
+		  "usage": 5,
+		  "size": 294346206208,
+		  "site": 45035996273704986
+		 }
+		]
+		
+		Number of primary nodes: 1`
+		Expect(planner.Parse(sampleOutput)).Should(Succeed())
+		Expect(planner.Database.Name).Should(Equal("vertdb"))
+		Expect(len(planner.Database.Nodes)).Should(Equal(1))
+		Expect(planner.Database.Nodes[0].Host).Should(Equal("10.244.0.47"))
+		Expect(planner.Database.Nodes[0].Port).Should(Equal(5433))
+		Expect(planner.CommunalLocation.NumShards).Should(Equal("6"))
+		Expect(planner.CommunalLocation.DepotPath).Should(Equal("/depot"))
+	})
+})

--- a/pkg/reviveplanner/suite_test.go
+++ b/pkg/reviveplanner/suite_test.go
@@ -1,0 +1,40 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reviveplanner
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var logger logr.Logger
+
+var _ = BeforeSuite(func() {
+	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+}, 60)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"reviveplanner Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}

--- a/tests/e2e-enterprise/enterprise-sanity/README.txt
+++ b/tests/e2e-enterprise/enterprise-sanity/README.txt
@@ -1,3 +1,0 @@
-Tests access to the cluster from different kinds of clients.  These tests were
-originally the integration tests in 10.1.1 -- written with the octopus test framework.  
-They were ported over to kuttl in the 11.0.0 release.

--- a/tests/e2e-leg-3/revive-with-different-local-paths/05-create-communal-creds.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/05-create-communal-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-3/revive-with-different-local-paths/10-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-leg-3/revive-with-different-local-paths/10-deploy-operator.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/10-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator WATCH_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-3/revive-with-different-local-paths/15-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/15-assert.yaml
@@ -1,0 +1,27 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-3-node-main
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-create-3-node
+status:
+  subclusters:
+    - installCount: 3

--- a/tests/e2e-leg-3/revive-with-different-local-paths/15-create-crd.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/15-create-crd.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build vdb-to-create/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/revive-with-different-local-paths/20-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/20-assert.yaml
@@ -1,0 +1,36 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-3-node-main
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-create-3-node
+spec:
+  local:
+    dataPath: /vertica/data
+    depotPath: /vertica/depot
+    catalogPath: /vertica/catalog
+  shardCount: 32
+status:
+  subclusters:
+    - installCount: 3
+      addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-3/revive-with-different-local-paths/20-wait-for-create-db.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/20-wait-for-create-db.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-3/revive-with-different-local-paths/25-delete-cr.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/25-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB

--- a/tests/e2e-leg-3/revive-with-different-local-paths/25-errors.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/25-errors.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-3-node-main
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-leg-3/revive-with-different-local-paths/30-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/30-assert.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-3-node-main
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-revive-3-node
+spec:
+  local:
+    dataPath: /not/sure/data
+    depotPath: /not/sure/depot
+    catalogPath: /not/sure/catalog
+  shardCount: 5
+status:
+  subclusters:
+    - installCount: 3

--- a/tests/e2e-leg-3/revive-with-different-local-paths/30-revive-setup-sts.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/30-revive-setup-sts.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build vdb-to-revive/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/revive-with-different-local-paths/35-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/35-assert.yaml
@@ -1,0 +1,36 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-3-node-main
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-revive-3-node
+spec:
+  local:
+    dataPath: /vertica/data
+    depotPath: /vertica/depot
+    catalogPath: /vertica/catalog
+  shardCount: 32
+status:
+  subclusters:
+    - installCount: 3
+      addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-3/revive-with-different-local-paths/35-wait-for-revive.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/35-wait-for-revive.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-3/revive-with-different-local-paths/95-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/95-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-3/revive-with-different-local-paths/95-delete-cr.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/95-delete-cr.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/revive-with-different-local-paths/95-errors.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-leg-3/revive-with-different-local-paths/97-errors.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/97-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-leg-3/revive-with-different-local-paths/97-uninstall-operator.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/97-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-3/revive-with-different-local-paths/99-delete-ns.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-create/base/kustomization.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-create/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-create/base/setup-vdb.yaml
@@ -1,0 +1,37 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-create-3-node
+spec:
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: false
+  initPolicy: CreateSkipPackageInstall
+  local:
+    dataPath: /vertica/data
+    depotPath: /vertica/depot
+    catalogPath: /vertica/catalog
+    requestSize: 100Mi
+  dbName: entdb
+  shardCount: 32
+  requeueTime: 5
+  subclusters:
+    - name: main
+      size: 3
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-revive/base/kustomization.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-revive/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/vdb-to-revive/base/setup-vdb.yaml
@@ -1,0 +1,40 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-revive-3-node
+spec:
+  image: kustomize-vertica-image
+  ignoreClusterLease: true
+  communal:
+    includeUIDInPath: false
+  initPolicy: Revive
+  local:
+    # The operator will overwrite the paths with the correct ones. So put
+    # anything here.
+    dataPath: /not/sure/data
+    depotPath: /not/sure/depot
+    catalogPath: /not/sure/catalog
+    requestSize: 100Mi
+  dbName: entdb
+  shardCount: 5 # Operator should change this to match what was used at create
+  requeueTime: 5
+  subclusters:
+    - name: main
+      size: 3
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
This will make it easier to initialize a VerticaDB with revive. It takes the guesswork out of the local paths. It will do a pre-pass for the revive to get the local paths that existed for the database. If the paths differ from what is in the VerticaDB, the operator will update the paths to match.

The webhook had to be relaxed to allow changing of the paths. Before, this was strictly prevented. Now, we allow the local paths to change as long as the database hasn't been initialized yet.

There are no new externals for this change. The revive pre-pass is always done. If the paths are already correct, there is no change in behavior.