### PR TITLE
Revive to handle DB names that have capitals

### DIFF
--- a/pkg/reviveplanner/analyze.go
+++ b/pkg/reviveplanner/analyze.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 )
@@ -159,7 +160,7 @@ func (a *ATPlanner) getCommonPath(paths []string) (string, error) {
 func (a *ATPlanner) extractPathPrefix(path string) (string, error) {
 	// Path will come in the form: <prefix>/<dbname>/v_<dbname>_<nodenum>_<pathType>
 	// This function will return <prefix>.
-	r := regexp.MustCompile(fmt.Sprintf(`(.*)/%s/v_%s_node[0-9]{4}_`, a.Database.Name, a.Database.Name))
+	r := regexp.MustCompile(fmt.Sprintf(`(.*)/%s/v_%s_node[0-9]{4}_`, a.Database.Name, strings.ToLower(a.Database.Name)))
 	m := r.FindStringSubmatch(path)
 	const ExpectedMatches = 2
 	if len(m) < ExpectedMatches {

--- a/pkg/reviveplanner/analyze_test.go
+++ b/pkg/reviveplanner/analyze_test.go
@@ -37,6 +37,15 @@ var _ = Describe("analyze", func() {
 		Expect(err).ShouldNot(Succeed())
 	})
 
+	It("should be able to extract out a common prefix if db has capital letters", func() {
+		p := ATPlanner{
+			Database: Database{
+				Name: "Vertica_Dashboard",
+			},
+		}
+		Expect(p.extractPathPrefix("/vertica/dat/Vertica_Dashboard/v_vertica_dashboard_node0001_data")).Should(Equal("/vertica/dat"))
+	})
+
 	It("should be able to find common paths", func() {
 		p := ATPlanner{
 			Database: Database{

--- a/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
@@ -27,7 +27,7 @@ spec:
     dataPath: /data
     depotPath: /depot
     requestSize: 100Mi
-  dbName: vertdb
+  dbName: Vert_DB
   subclusters:
     - name: main
       isPrimary: true

--- a/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
@@ -35,7 +35,7 @@ spec:
     dataPath: /data
     depotPath: /depot
     requestSize: 100Mi
-  dbName: vertdb
+  dbName: Vert_DB
   subclusters:
     - name: main
       isPrimary: true


### PR DESCRIPTION
This fixes a regression in the new revive handler work. It wasn't handling database names that had capital letters in them. When we run the revive with --display-only option, we would erronously think the paths are bad because we weren't checking for the correct case.

Updates an e2e test to use capital letters in its db name that would have caught this sooner.

This regression exists only in the current release. So, no changie entry exists.