### PR TITLE
Add option to override pod-level securityContext

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -312,6 +312,12 @@ type VerticaDBSpec struct {
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// This can be used to override any pod-level securityContext for the
+	// Vertica pod. It will be merged with the default context. If omitted, then
+	// the default context is used.
+	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	// +kubebuilder:default:=""
 	// +kubebuilder:validation:Optional
 	// Control the Vertica's http server.  The http server provides a REST interface

--- a/changes/unreleased/Added-20230219-214900.yaml
+++ b/changes/unreleased/Added-20230219-214900.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Add config knob for pod-level securityContext of vertica pod's
+time: 2023-02-19T21:49:00.227765135-04:00
+custom:
+  Issue: "337"

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -153,6 +153,23 @@ var _ = Describe("builder", func() {
 		c := buildPodSpec(vdb, &vdb.Spec.Subclusters[0], &DeploymentNames{})
 		Expect(*c.SecurityContext.FSGroup).Should(Equal(int64(5000)))
 	})
+
+	It("should override some of the pod securityContext settings", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.PodSecurityContext = &v1.PodSecurityContext{
+			Sysctls: []v1.Sysctl{
+				{Name: "net.ipv4.tcp_keepalive_time", Value: "45"},
+				{Name: "net.ipv4.tcp_keepalive_intvl", Value: "5"},
+			},
+		}
+		c := buildPodSpec(vdb, &vdb.Spec.Subclusters[0], &DeploymentNames{})
+		Expect(*c.SecurityContext.FSGroup).Should(Equal(int64(5000)))
+		Expect(len(c.SecurityContext.Sysctls)).Should(Equal(2))
+		Expect(c.SecurityContext.Sysctls[0].Name).Should(Equal("net.ipv4.tcp_keepalive_time"))
+		Expect(c.SecurityContext.Sysctls[0].Value).Should(Equal("45"))
+		Expect(c.SecurityContext.Sysctls[1].Name).Should(Equal("net.ipv4.tcp_keepalive_intvl"))
+		Expect(c.SecurityContext.Sysctls[1].Value).Should(Equal("5"))
+	})
 })
 
 // makeSubPaths is a helper that extracts all of the subPaths from the volume mounts.


### PR DESCRIPTION
A new parameter is added to the VerticaDB CRD that will allow pod-level securityContext options be overridden. Any value put in spec.podSecurityContext will get merged in with the default pod securityContext.