### PR TITLE
Revive planner to handle data path without vnode in it

### DIFF
--- a/pkg/reviveplanner/parser.go
+++ b/pkg/reviveplanner/parser.go
@@ -122,25 +122,26 @@ func MakeATPlannerFromVDB(vdb *vapi.VerticaDB, logger logr.Logger) Planner {
 	}
 }
 
-// GetDataPath returns the data path for the node
-func (n *Node) GetDataPath() (string, bool) {
-	return n.getPathByUsage(UsageIsDataTemp)
+// GetDataPaths returns the data paths for the node
+func (n *Node) GetDataPaths() []string {
+	return n.getPathsByUsage(UsageIsDataTemp)
 }
 
-// GetDepotPath returns the depot path for the node
-func (n *Node) GetDepotPath() (string, bool) {
-	return n.getPathByUsage(UsageIsDepot)
+// GetDepotPath returns the depot paths for the node
+func (n *Node) GetDepotPath() []string {
+	return n.getPathsByUsage(UsageIsDepot)
 }
 
-// getPathByUsage returns the path for a given usage type. See Usage* const at
+// getPathsByUsage returns the path for a given usage type. See Usage* const at
 // the top of this file.
-func (n *Node) getPathByUsage(usage int) (string, bool) {
+func (n *Node) getPathsByUsage(usage int) []string {
+	paths := []string{}
 	for i := range n.VStorageLocations {
 		if n.VStorageLocations[i].Usage == usage {
-			return n.VStorageLocations[i].Path, true
+			paths = append(paths, n.VStorageLocations[i].Path)
 		}
 	}
-	return "", false
+	return paths
 }
 
 // Parse looks at the op string passed in and spits out Database and

--- a/tests/e2e-leg-3/revive-with-different-local-paths/22-create-storage-path.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/22-create-storage-path.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -- vsql -c "create location '/vertica/data/storage' ALL NODES; select retire_location('/vertica/data/entdb/v_entdb_node0001_data','v_entdb_node0001'); select drop_location('/vertica/data/entdb/v_entdb_node0001_data','v_entdb_node0001'); select sync_catalog();"


### PR DESCRIPTION
The pre-pass we do with revive now handles more scenarios with the data path:
- vertica hosts can have DATA,TEMP paths that don't end with the vnode name. The generated DATA,TEMP paths all end with the vnode (e.g. /data/db/v_db_node0001_data). But additional paths can be added that don't follow that format.
- vertica hosts can have multiple DATA,TEMP paths. Previously, it only assumed there was one.

Closes #335 