### PR TITLE
Duane/upgrade packages

### DIFF
--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -89,7 +89,20 @@ RUN set -x \
   fi
 
 ##############################################################################################
-FROM ubuntu:${BASE_OS_VERSION}
+FROM ubuntu:${BASE_OS_VERSION} as initial
+
+RUN set -x \
+  # Update is needed to be confident that we're picking up
+  # fixed libraries.
+  && apt-get -y update \
+  && apt-get -y upgrade \
+  && apt-get clean \
+  && apt-get autoremove \
+  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old
+
+# this squashes the image
+FROM scratch
+COPY --from=initial / /
 
 ARG DBADMIN_GID=5000
 ARG DBADMIN_UID=5000
@@ -124,8 +137,7 @@ COPY s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
-  # Update is needed to be confident that we're picking up
-  # fixed libraries. 
+  # update needed because we just did a clean
   && apt-get -y update \
   && apt-get install -y --no-install-recommends \
   ca-certificates \
@@ -151,7 +163,6 @@ RUN set -x \
   && if [[ ${MINIMAL^^} != "YES" ]] ; then \
     apt-get install -y --no-install-recommends $JRE_PKG; \
   fi \
-  && apt-get -y upgrade \
   && apt-get clean \
   && apt-get autoremove \
   && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 Vertica
 #
 
-ARG BASE_OS_VERSION="focal-20220801"
+ARG BASE_OS_VERSION="focal"
 ARG BUILDER_OS_VERSION="7.9.2009"
 ARG MINIMAL=""
 ARG NO_SSH_KEYS=""
@@ -152,7 +152,9 @@ RUN set -x \
     apt-get install -y --no-install-recommends $JRE_PKG; \
   fi \
   && apt-get -y upgrade \
-  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
+  && apt-get autoremove \
+  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
   # Make the "en_US.UTF-8" locale so vertica will be utf-8 enabled by default
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
   && mkdir -p /run/sshd \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -151,6 +151,7 @@ RUN set -x \
   && if [[ ${MINIMAL^^} != "YES" ]] ; then \
     apt-get install -y --no-install-recommends $JRE_PKG; \
   fi \
+  && apt-get -y upgrade \
   && rm -rf /var/lib/apt/lists/* \
   # Make the "en_US.UTF-8" locale so vertica will be utf-8 enabled by default
   && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -10,6 +10,7 @@ all: docker-build-vertica
 
 .PHONY: docker-build-vertica
 docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
+	docker pull ubuntu:focal ## make sure we use the latest focal image
 	docker build \
 		-f Dockerfile \
 		--label minimal=${MINIMAL_VERTICA_IMG} \


### PR DESCRIPTION
This seems to decrease the number of vulnerabilities

Before:
```
PS C:\Users\dbronson> powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://otscan.otxlab.net/otscan.ps1 | iex; otscan" twistlock -remote vertica/vertica-k8s:scanme-noupgrade
2023/03/01 20:03:27 starting scan
2023/03/01 20:03:27 images: [vertica/vertica-k8s:scanme-noupgrade]
2023/03/01 20:03:27 waiting for images to finish pulling on remote server
2023/03/01 20:04:09 waiting for scan to complete

Scan results for: image vertica/vertica-k8s:scanme-noupgrade sha256:719a0513a755e2cbf7f592fc98bac48710fefda91d1ef83d971050f929fbe7a7

Vulnerabilities found for image vertica/vertica-k8s:scanme-noupgrade: total - 123, critical - 1, high - 24, medium - 64, low - 34
Vulnerability threshold check results: FAIL
Scan failed due to vulnerability policy violations: Default - alert all components, 23 vulnerabilities. Blocking vulnerabilities by severity OR by risk factors. Severity distribution : [critical:1 high:22]

Compliance found for image vertica/vertica-k8s:scanme-noupgrade: total - 1, critical - 0, high - 1, medium - 0, low - 0
Compliance threshold check results: PASS
2023/03/01 20:04:19 scan status: fail
2023/03/01 20:04:19 scan results url: https://otscan.otxlab.net/api/v1/scan/0ef29e01-471d-4d5b-8876-760eb42f3580/report/html
2023/03/01 20:04:19 scan failed policy validation
```
After:
```
PS C:\Users\dbronson> powershell "[Net.ServicePointManager]::SecurityProtocol = 'tls12'; irm https://otscan.otxlab.net/otscan.ps1 | iex; otscan" twistlock -remote vertica/vertica-k8s:scanme
2023/03/01 19:45:56 starting scan
2023/03/01 19:45:57 images: [vertica/vertica-k8s:scanme]
2023/03/01 19:45:57 waiting for images to finish pulling on remote server
2023/03/01 19:46:19 waiting for scan to complete

Scan results for: image vertica/vertica-k8s:scanme sha256:8abc174bcd3f4c896289f86f6abdc4351d9343caaf6355c8d680253773d51dab

Vulnerabilities found for image vertica/vertica-k8s:scanme: total - 103, critical - 1, high - 24, medium - 55, low - 23
Vulnerability threshold check results: FAIL
Scan failed due to vulnerability policy violations: Default - alert all components, 23 vulnerabilities. Blocking vulnerabilities by severity OR by risk factors. Severity distribution : [critical:1 high:22]

Compliance found for image vertica/vertica-k8s:scanme: total - 1, critical - 0, high - 1, medium - 0, low - 0
Compliance threshold check results: PASS
2023/03/01 19:46:30 scan status: fail
2023/03/01 19:46:30 scan results url: https://otscan.otxlab.net/api/v1/scan/f11ca8ab-9fc4-4c33-9fe9-d88a5cdb3801/report/html
2023/03/01 19:46:30 scan failed policy validation
```