### PR TITLE
Fix bug preventing restart when pods have sidecars

### DIFF
--- a/changes/unreleased/Fixed-20230304-072028.yaml
+++ b/changes/unreleased/Fixed-20230304-072028.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Regression in 1.10.0 that prevents the operator from restarting vertica if the
+  pod has sidecars.
+time: 2023-03-04T07:20:28.674367987-04:00
+custom:
+  Issue: "345"

--- a/tests/e2e-leg-4/restart-with-sidecars/05-create-communal-creds.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/05-create-communal-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-4/restart-with-sidecars/10-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-leg-4/restart-with-sidecars/10-deploy-operator.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/10-deploy-operator.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && DEPLOY_WITH=helm HELM_OVERRIDES='--set prometheus.expose=EnableWithoutAuth' make deploy-operator NAMESPACE=$NAMESPACE"
+

--- a/tests/e2e-leg-4/restart-with-sidecars/15-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/15-assert.yaml
@@ -1,0 +1,31 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-with-sidecars
+status:
+  installCount: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-sidecars-main-0
+spec:
+  containers:
+  - name: server
+  - name: vlogger
+  - name: startup-log
+  - name: bootstrap-catalog-log
+  - name: db-log

--- a/tests/e2e-leg-4/restart-with-sidecars/15-create-cr.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/15-create-cr.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/restart-with-sidecars/20-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/20-assert.yaml
@@ -1,0 +1,34 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-with-sidecars
+status:
+  installCount: 1
+  addedToDBCount: 1
+  upNodeCount: 1
+  subclusterCount: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-restart-with-sidecars-main-0
+status:
+  containerStatuses:
+  - ready: true
+  - ready: true
+  - ready: true
+  - ready: true
+  - ready: true

--- a/tests/e2e-leg-4/restart-with-sidecars/20-wait-for-create-db.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/20-wait-for-create-db.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/restart-with-sidecars/25-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/25-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -t 360"

--- a/tests/e2e-leg-4/restart-with-sidecars/30-delete-vertica-pid.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/30-delete-vertica-pid.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl exec -n $NAMESPACE -i v-restart-with-sidecars-main-0 -c server -- bash -c 'pgrep ^vertica && kill -SIGKILL $(pgrep ^vertica)'

--- a/tests/e2e-leg-4/restart-with-sidecars/35-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/35-assert.yaml
@@ -1,0 +1,32 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-restart-in-metrics
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-with-sidecars
+status:
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-4/restart-with-sidecars/35-verify-restart-in-metrics.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/35-verify-restart-in-metrics.yaml
@@ -1,0 +1,59 @@
+# (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies restart by checking the prometheus metrics.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-restart-in-metrics
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o pipefail
+
+    SVC_NAME=verticadb-operator-metrics-service
+    EXPECTED_RESTART_COUNT=1
+    TIMEOUT=10m
+    trap "echo '*** ERROR: Timeout waiting for expected metric value'; curl http://$SVC_NAME:8443/metrics" EXIT
+    set -o xtrace
+    timeout $TIMEOUT bash -c -- "\
+         while ! curl http://$SVC_NAME:8443/metrics 2> /dev/null | grep -e 'vertica_cluster_restart_attempted_total{.*} $EXPECTED_RESTART_COUNT'; \
+         do \
+           sleep 0.1; \
+         done"
+    trap - EXIT
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-restart-in-metrics
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-restart-in-metrics

--- a/tests/e2e-leg-4/restart-with-sidecars/45-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/45-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -t 360"

--- a/tests/e2e-leg-4/restart-with-sidecars/95-delete-cr.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB

--- a/tests/e2e-leg-4/restart-with-sidecars/95-errors.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-leg-4/restart-with-sidecars/96-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-4/restart-with-sidecars/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/96-cleanup-storage.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/restart-with-sidecars/97-errors.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/97-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-leg-4/restart-with-sidecars/97-uninstall-operator.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/97-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-4/restart-with-sidecars/99-delete-ns.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-4/restart-with-sidecars/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-4/restart-with-sidecars/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,49 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-restart-with-sidecars
+spec:
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+    catalogPath: /vertica/catalog
+    dataPath: /ssd
+  dbName: Vertica_DB
+  initPolicy: CreateSkipPackageInstall
+  requeueTime: 5
+  kSafety: "0"
+  sidecars:
+  - name: vlogger
+    image: kustomize-vlogger-image
+  - name: startup-log
+    image: vertica/vertica-logger:latest
+    command: [ "sh", "-c", "FN=$DBPATH/v_*_catalog/startup.log; until [ -f $FN ]; do sleep 0.1; done; tail -n 1 -F $FN"]
+  - name: bootstrap-catalog-log
+    image: vertica/vertica-logger:latest
+    command: [ "sh", "-c", "FN=$DBPATH/v_*_catalog/bootstrap-catalog.log; until [ -f $FN ]; do sleep 0.1; done; tail -n 1 -F $FN"]
+  - name: db-log
+    image: vertica/vertica-logger:latest
+    command: [ "sh", "-c", "FN=$DBPATH/dbLog; until [ -f $FN ]; do sleep 0.1; done; tail -n 1 -F $FN"]
+  subclusters:
+    - name: main
+      size: 1
+      isPrimary: true
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
This fixes a regression that was introduced in 1.10.0 of the operator. If you ran your VertiacDB with sidecars, it is possible that the operator fails to restart vertica. It will be stuck in a loop waiting for the startupProbe to expire.

The operator was checking the pod's status.containerStatuses list to see if the startupProbe is active. It assumed (wrongly) that it only ever needed to look at the first entry in that list. So, it kept looking at the wrong entry and can make the wrong inference about whether the startupProbe is still active.

A new e2e test was added to mimic the error and verify the fix.