### PR TITLE
Always gen http cert if httpServerMode is auto

### DIFF
--- a/pkg/controllers/vdb/httpservercertgen_reconcile.go
+++ b/pkg/controllers/vdb/httpservercertgen_reconcile.go
@@ -47,8 +47,10 @@ func MakeHTTPServerCertGenReconciler(vdbrecon *VerticaDBReconciler, vdb *vapi.Ve
 // Reconcile will create a TLS secret for the http server if one is missing
 func (h *HTTPServerCertGenReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
 	const PKKeySize = 2048
-	// Early out if http server is not enabled, or we already have a TLS secret
-	if !h.Vdb.IsHTTPServerEnabled() || h.Vdb.Spec.HTTPServerTLSSecret != "" {
+	// Early out if http server is explicitly disabled or we already have a TLS secret.
+	// For auto, we continue even if the version may not support it. Assuming
+	// its needed will save a few reconcile iteration during bootstrap.
+	if h.Vdb.IsHTTPServerDisabled() || h.Vdb.Spec.HTTPServerTLSSecret != "" {
 		return ctrl.Result{}, nil
 	}
 	caCert, err := security.NewSelfSignedCACertificate(PKKeySize)

--- a/pkg/controllers/vdb/obj_reconcile.go
+++ b/pkg/controllers/vdb/obj_reconcile.go
@@ -132,7 +132,10 @@ func (o *ObjReconciler) checkMountedObjs(ctx context.Context) (ctrl.Result, erro
 		}
 	}
 
-	if o.Vdb.IsHTTPServerEnabled() {
+	// Skip if HTTP server is explicitly disabled. For auto, some of the work
+	// isn't needed here. But we don't know the version, so we assume we need
+	// it.
+	if !o.Vdb.IsHTTPServerDisabled() {
 		// When the HTTP server is enabled, a secret must exist that has the
 		// certs to use for it.  There is a reconciler that is run before this
 		// that will create the secret.  We will requeue if we find the Vdb


### PR DESCRIPTION
The http cert is needed if running httpServerMode. When this is set to Auto, we use to rely on the vertica version to know if it supports the http server. That was causing some issues in our e2e tests. A lot of reconcile iterations were needed for created db. Eventually some of the tests were going into a few minute lag between reconcile iterations due to the exponential backoff.

This change is to create the cert ahead of any version check. This may mean we generate the cert and put it in the sts more often. But this http server will be required at some point in the future, so this shouldn't be too much of a problem.