### PR TITLE
Add missing 's'

### DIFF
--- a/docker-vertica/packages/cleanup.sh
+++ b/docker-vertica/packages/cleanup.sh
@@ -23,7 +23,7 @@
 #
 # wander around in the image looking for things you can remove
 rm -r -f \
-   /opt/vertica/config/https_cert/*.key \
+   /opt/vertica/config/https_certs/*.key \
    /opt/vertica/config/share/agent* \
    /opt/vertica/examples \
    /opt/vertica/packages/*/examples \


### PR DESCRIPTION
There was a missing 's' to a folder name: /opt/vertica/config/https_cert -> /opt/vertica/config/https_certs