### PR TITLE
Add backdoor to run the agent

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -20,6 +20,7 @@ package v1beta1
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
@@ -964,6 +965,10 @@ const (
 	DefaultS3Region       = "us-east-1"
 	DefaultGCloudRegion   = "US-EAST1"
 	DefaultGCloudEndpoint = "https://storage.googleapis.com"
+
+	// VerticaDB.Spec.Annotation to enable the agent
+	StartAgent   = "start-agent"
+	AgentEnabled = "yes"
 )
 
 // ExtractNamespacedName gets the name and returns it as a NamespacedName
@@ -1252,4 +1257,10 @@ func (v *VerticaDB) IsHTTPServerEnabled() bool {
 // overridden to take affect.
 func (v *VerticaDB) IsEON() bool {
 	return v.Spec.ShardCount > 0
+}
+
+// IsAgentEnabled returns true if the annotation to enable the argent
+// has been set to the correct value
+func (v *VerticaDB) IsAgentEnabled() bool {
+	return strings.EqualFold(v.Spec.Annotations[StartAgent], AgentEnabled)
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -961,14 +961,13 @@ const (
 	BuildRefAnnotation  = "vertica.com/buildRef"
 	// Annotation for the database's revive_instance_id
 	ReviveInstanceIDAnnotation = "vertica.com/revive-instance-id"
+	// Annotation to enable the agent
+	RunAgentAnnotation             = "vertica.com/run-agent"
+	RunAgentAnnotationEnabledValue = "yes"
 
 	DefaultS3Region       = "us-east-1"
 	DefaultGCloudRegion   = "US-EAST1"
 	DefaultGCloudEndpoint = "https://storage.googleapis.com"
-
-	// VerticaDB.Spec.Annotation to enable the agent
-	StartAgent   = "start-agent"
-	AgentEnabled = "yes"
 )
 
 // ExtractNamespacedName gets the name and returns it as a NamespacedName
@@ -1259,8 +1258,8 @@ func (v *VerticaDB) IsEON() bool {
 	return v.Spec.ShardCount > 0
 }
 
-// IsAgentEnabled returns true if the annotation to enable the argent
+// IsAgentEnabled returns true if the annotation to enable the agent
 // has been set to the correct value
 func (v *VerticaDB) IsAgentEnabled() bool {
-	return strings.EqualFold(v.Spec.Annotations[StartAgent], AgentEnabled)
+	return strings.EqualFold(v.ObjectMeta.Annotations[RunAgentAnnotation], RunAgentAnnotationEnabledValue)
 }

--- a/changes/unreleased/Added-20230310-154628.yaml
+++ b/changes/unreleased/Added-20230310-154628.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Backdoor to run the Vertica agent. This is to be used for development purposes
+  only.
+time: 2023-03-10T15:46:28.916712564-04:00
+custom:
+  Issue: "349"

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -86,6 +86,7 @@ RUN set -x \
   && chmod go-w /etc/ssh/sshd_config.d/* /etc/ssh/ssh_config.d/* \
   && if [[ ${NO_SSH_KEYS^^} == "YES" ]] ; then \
     rm -rf /home/dbadmin/.ssh/*;  \
+    rm -rf /opt/vertica/config/share/agent*; \
   fi
 
 ##############################################################################################
@@ -193,6 +194,8 @@ ENTRYPOINT [ "/init" ]
 EXPOSE 5433
 # vertica-http port
 EXPOSE 8443
+# agent port
+EXPOSE 5444
 USER dbadmin
 LABEL os-family="ubuntu"
 LABEL image-name="vertica_k8s"

--- a/docker-vertica/packages/cleanup.sh
+++ b/docker-vertica/packages/cleanup.sh
@@ -24,7 +24,6 @@
 # wander around in the image looking for things you can remove
 rm -r -f \
    /opt/vertica/config/https_certs/*.key \
-   /opt/vertica/config/share/agent* \
    /opt/vertica/examples \
    /opt/vertica/packages/*/examples \
    /opt/vertica/oss/python*/lib/python*/test \

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -38,6 +38,7 @@ const (
 	SuperuserPasswordPath   = "superuser-passwd"
 	TestStorageClassName    = "test-storage-class"
 	VerticaClientPort       = 5433
+	VerticaAgentPort        = 5444
 	VerticaHTTPPort         = 8443
 	InternalVerticaCommPort = 5434
 	SSHPort                 = 22
@@ -68,6 +69,7 @@ func BuildExtSvc(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclust
 			Ports: []corev1.ServicePort{
 				{Port: VerticaClientPort, Name: "vertica", NodePort: sc.NodePort},
 				{Port: VerticaHTTPPort, Name: "vertica-http", NodePort: sc.VerticaHTTPNodePort},
+				{Port: VerticaAgentPort, Name: "agent"},
 			},
 			ExternalIPs:    sc.ExternalIPs,
 			LoadBalancerIP: sc.LoadBalancerIP,
@@ -483,6 +485,7 @@ func makeServerContainer(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.Contai
 			{ContainerPort: VerticaClientPort, Name: "vertica"},
 			{ContainerPort: InternalVerticaCommPort, Name: "vertica-int"},
 			{ContainerPort: SSHPort, Name: "ssh"},
+			{ContainerPort: VerticaAgentPort, Name: "agent"},
 		},
 		ReadinessProbe:  makeReadinessProbe(vdb),
 		LivenessProbe:   makeLivenessProbe(vdb),

--- a/pkg/controllers/vdb/agent_reconciler.go
+++ b/pkg/controllers/vdb/agent_reconciler.go
@@ -1,0 +1,88 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// AgentReconciler will ensure the agent is running
+type AgentReconciler struct {
+	VRec    *VerticaDBReconciler
+	Log     logr.Logger
+	Vdb     *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	PRunner cmds.PodRunner
+	PFacts  *PodFacts
+}
+
+// MakeAgentReconciler will build a AgentReonciler object
+func MakeAgentReconciler(vrec *VerticaDBReconciler, log logr.Logger,
+	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) controllers.ReconcileActor {
+	return &AgentReconciler{VRec: vrec, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
+}
+
+// Reconcile will ensure the agent is running and start it if it isn't
+func (a *AgentReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if !a.Vdb.IsAgentEnabled() {
+		return ctrl.Result{}, nil
+	}
+
+	if err := a.PFacts.Collect(ctx, a.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for _, pod := range a.PFacts.Detail {
+		if pod.agentRunning {
+			continue
+		}
+		// Only start the agent for pods that have been added to a database
+		if !pod.dbExists {
+			continue
+		}
+
+		if err := a.startAgentInPod(ctx, pod); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Invalidate the pod facts cache since its out of date due to the agent starting
+		a.PFacts.Invalidate()
+	}
+	return ctrl.Result{}, nil
+}
+
+// startAgentInPod will start the agent in the given pod.
+func (a *AgentReconciler) startAgentInPod(ctx context.Context, pod *PodFact) error {
+	cmd := []string{
+		"sudo", "/opt/vertica/sbin/vertica_agent", "start",
+	}
+	a.VRec.Event(a.Vdb, corev1.EventTypeNormal, events.StartAgentStart,
+		"Calling '/opt/vertica/sbin/vertica_agent start'")
+	if _, _, err := a.PRunner.ExecInPod(ctx, pod.name, ServerContainer, cmd...); err != nil {
+		a.VRec.Event(a.Vdb, corev1.EventTypeWarning, events.StartAgentFailed, "Failed to start the agent")
+		return err
+	}
+	a.VRec.Event(a.Vdb, corev1.EventTypeNormal, events.StartAgentSucceeded,
+		"The agent is now running")
+	return nil
+}

--- a/pkg/controllers/vdb/agent_reconciler_test.go
+++ b/pkg/controllers/vdb/agent_reconciler_test.go
@@ -1,0 +1,77 @@
+/*
+ (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("agent_reconcile", func() {
+	ctx := context.Background()
+
+	It("should start the agent if it isn't running", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Annotations[vapi.StartAgent] = vapi.AgentEnabled
+		vdb.Spec.Subclusters[0].Size = 2
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		cmds := reconcileAndFindVerticaAgentStart(ctx, vdb)
+		Expect(len(cmds)).Should(Equal(2))
+	})
+
+	It("should avoid starting the agent if vdb.spec.annotations[start-agent] is not set to 'yes'", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters[0].Size = 2
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		cmds := reconcileAndFindVerticaAgentStart(ctx, vdb)
+		Expect(len(cmds)).Should(Equal(0))
+	})
+
+	It("should avoid starting the agent if DB is not included", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Annotations[vapi.StartAgent] = vapi.AgentEnabled
+		vdb.Spec.Subclusters[0].Size = 1
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr)
+		pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)].dbExists = false
+		r := MakeAgentReconciler(vdbRec, logger, vdb, fpr, pfacts)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		cmds := fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
+		Expect(len(cmds)).Should(Equal(0))
+	})
+})
+
+func reconcileAndFindVerticaAgentStart(ctx context.Context, vdb *vapi.VerticaDB) []cmds.CmdHistory {
+	fpr := &cmds.FakePodRunner{}
+	pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr)
+	r := MakeAgentReconciler(vdbRec, logger, vdb, fpr, pfacts)
+	Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+	return fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
+}

--- a/pkg/controllers/vdb/agent_reconciler_test.go
+++ b/pkg/controllers/vdb/agent_reconciler_test.go
@@ -32,7 +32,7 @@ var _ = Describe("agent_reconcile", func() {
 
 	It("should start the agent if it isn't running", func() {
 		vdb := vapi.MakeVDB()
-		vdb.Spec.Annotations[vapi.StartAgent] = vapi.AgentEnabled
+		vdb.ObjectMeta.Annotations[vapi.RunAgentAnnotation] = vapi.RunAgentAnnotationEnabledValue
 		vdb.Spec.Subclusters[0].Size = 2
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
@@ -53,7 +53,7 @@ var _ = Describe("agent_reconcile", func() {
 
 	It("should avoid starting the agent if DB is not included", func() {
 		vdb := vapi.MakeVDB()
-		vdb.Spec.Annotations[vapi.StartAgent] = vapi.AgentEnabled
+		vdb.ObjectMeta.Annotations[vapi.RunAgentAnnotation] = vapi.RunAgentAnnotationEnabledValue
 		vdb.Spec.Subclusters[0].Size = 1
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
@@ -61,7 +61,7 @@ var _ = Describe("agent_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr)
 		pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)].dbExists = false
-		r := MakeAgentReconciler(vdbRec, logger, vdb, fpr, pfacts)
+		r := MakeAgentReconciler(vdbRec, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		cmds := fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
 		Expect(len(cmds)).Should(Equal(0))
@@ -71,7 +71,7 @@ var _ = Describe("agent_reconcile", func() {
 func reconcileAndFindVerticaAgentStart(ctx context.Context, vdb *vapi.VerticaDB) []cmds.CmdHistory {
 	fpr := &cmds.FakePodRunner{}
 	pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr)
-	r := MakeAgentReconciler(vdbRec, logger, vdb, fpr, pfacts)
+	r := MakeAgentReconciler(vdbRec, vdb, fpr, pfacts)
 	Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	return fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
 }

--- a/pkg/controllers/vdb/obj_reconcile.go
+++ b/pkg/controllers/vdb/obj_reconcile.go
@@ -313,7 +313,7 @@ func (o ObjReconciler) reconcileExtSvcFields(curSvc, expSvc *corev1.Service, sc 
 		// differs from what is currently in use. Otherwise, they must stay the
 		// same. This protects us from changing the k8s generated node port each
 		// time there is a Service object update.
-		explicitNodePortByIndex := []int32{sc.NodePort, sc.VerticaHTTPNodePort}
+		explicitNodePortByIndex := []int32{sc.NodePort, sc.VerticaHTTPNodePort, 0 /*to skip port agent*/}
 		for i := range curSvc.Spec.Ports {
 			if explicitNodePortByIndex[i] != 0 {
 				if expSvc.Spec.Ports[i].NodePort != curSvc.Spec.Ports[i].NodePort {

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -297,7 +297,6 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		p.checkForSimpleGatherStateMapping,
 		p.checkShardSubscriptions,
 		p.queryDepotDetails,
-		p.checkIfAgentRunning,
 		// Override function must be last one as we can use it to override any
 		// of the facts set earlier.
 		p.OverrideFunc,
@@ -477,6 +476,7 @@ func (p *PodFacts) checkForSimpleGatherStateMapping(ctx context.Context, vdb *va
 	pf.fileExists = gs.FileExists
 	pf.localDataSize = gs.LocalDataSize
 	pf.localDataAvail = gs.LocalDataAvail
+	pf.agentRunning = gs.AgentRunning
 	return nil
 }
 
@@ -605,16 +605,6 @@ func (p *PodFacts) checkIsDBCreated(ctx context.Context, vdb *vapi.VerticaDB, pf
 	}
 	pf.dbExists = gs.DBExists
 	pf.vnodeName = gs.VNodeName
-	return nil
-}
-
-// checkIfAgentRunning will check if the Vertica agent is running and set state in pf.agentRunning
-func (p *PodFacts) checkIfAgentRunning(ctx context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
-	pf.agentRunning = false
-	if !pf.isPodRunning || !pf.dbExists || !gs.VerticaPIDRunning {
-		return nil
-	}
-	pf.agentRunning = gs.AgentRunning
 	return nil
 }
 

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -193,6 +193,15 @@ func createPodFactsWithSlowStartup(ctx context.Context, vdb *vapi.VerticaDB, sc 
 	return pfacts
 }
 
+func createPodFactsWithAgentNotRunning(ctx context.Context, vdb *vapi.VerticaDB, fpr *cmds.FakePodRunner) *PodFacts {
+	pfacts := createPodFactsDefault(fpr)
+	ExpectWithOffset(1, pfacts.Collect(ctx, vdb)).Should(Succeed())
+	for _, pod := range pfacts.Detail {
+		pod.agentRunning = false
+	}
+	return pfacts
+}
+
 const testAccessKey = "dummy"
 const testSecretKey = "dummy"
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -211,7 +211,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Update the labels in pods so that Services route to nodes to them.
 		MakeClientRoutingLabelReconciler(r, vdb, pfacts, AddNodeApplyMethod, ""),
 		// Ensure the vertica agent is running on each pod
-		MakeAgentReconciler(r, log, vdb, prunner, pfacts),
+		MakeAgentReconciler(r, vdb, prunner, pfacts),
 		// Handle calls to admintools -t db_add_subcluster
 		MakeDBAddSubclusterReconciler(r, log, vdb, prunner, pfacts),
 		MakeMetricReconciler(r, vdb, prunner, pfacts),

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -210,6 +210,8 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Update the labels in pods so that Services route to nodes to them.
 		MakeClientRoutingLabelReconciler(r, vdb, pfacts, AddNodeApplyMethod, ""),
+		// Ensure the vertica agent is running on each pod
+		MakeAgentReconciler(r, log, vdb, prunner, pfacts),
 		// Handle calls to admintools -t db_add_subcluster
 		MakeDBAddSubclusterReconciler(r, log, vdb, prunner, pfacts),
 		MakeMetricReconciler(r, vdb, prunner, pfacts),

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -77,9 +77,9 @@ const (
 	MgmtFailed                      = "MgmtFailed"
 	MgmtFailedDiskFull              = "MgmtFailedDiskfull"
 	LowLocalDataAvailSpace          = "LowLocalDataAvailSpace"
-	StartAgentStart                 = "StartAgentStart"
-	StartAgentSucceeded             = "StartAgentSucceeded"
-	StartAgentFailed                = "StartAgentFailed"
+	RunAgentStart                   = "RunAgentStart"
+	RunAgentSucceeded               = "RunAgentSucceeded"
+	RunAgentFailed                  = "RunAgentFailed"
 )
 
 // Constants for VerticaAutoscaler reconciler

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -77,6 +77,9 @@ const (
 	MgmtFailed                      = "MgmtFailed"
 	MgmtFailedDiskFull              = "MgmtFailedDiskfull"
 	LowLocalDataAvailSpace          = "LowLocalDataAvailSpace"
+	StartAgentStart                 = "StartAgentStart"
+	StartAgentSucceeded             = "StartAgentSucceeded"
+	StartAgentFailed                = "StartAgentFailed"
 )
 
 // Constants for VerticaAutoscaler reconciler

--- a/tests/e2e-leg-2/shared-svc/21-wait-for-agent.yaml
+++ b/tests/e2e-leg-2/shared-svc/21-wait-for-agent.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2022] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # We are verifying that the agent is running in all pods  
+  - script: n=0 &&
+          until [ $n -eq 3]; do n=0; i=1; while[ $i -ne 4 ]; do sleep 2; n1=$(kubectl exec -n $NAMESPACE v-shared-svc-sc${i}-0 -- /opt/vertica/sbin/vertica_agent status 2> /dev/null | grep 'running' | wc -l); n=$((n+$n1)); i=$((i+1)); done; done &&
+          echo "Vertica Agent is running" &&
+          exit 0
+    timeout: 120

--- a/tests/e2e-leg-2/shared-svc/21-wait-for-agent.yaml
+++ b/tests/e2e-leg-2/shared-svc/21-wait-for-agent.yaml
@@ -16,7 +16,7 @@ kind: TestStep
 commands:
   # We are verifying that the agent is running in all pods  
   - script: n=0 &&
-          until [ $n -eq 3]; do n=0; i=1; while[ $i -ne 4 ]; do sleep 2; n1=$(kubectl exec -n $NAMESPACE v-shared-svc-sc${i}-0 -- /opt/vertica/sbin/vertica_agent status 2> /dev/null | grep 'running' | wc -l); n=$((n+$n1)); i=$((i+1)); done; done &&
+          until [ $n -eq 3 ]; do n=0; i=1; while [ $i -ne 4 ]; do sleep 2; n1=$(kubectl exec -n $NAMESPACE v-shared-svc-sc${i}-0 -- /opt/vertica/sbin/vertica_agent status 2> /dev/null | grep 'running' | wc -l); n=$((n+$n1)); i=$((i+1)); done; done &&
           echo "Vertica Agent is running" &&
           exit 0
     timeout: 120

--- a/tests/e2e-leg-2/shared-svc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-2/shared-svc/setup-vdb/base/setup-vdb.yaml
@@ -15,11 +15,11 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-shared-svc
+  annotations:
+    vertica.com/run-agent: "YES"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
-  annotations: 
-    start-agent: "YES"
   communal:
     includeUIDInPath: true
   local:

--- a/tests/e2e-leg-2/shared-svc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-2/shared-svc/setup-vdb/base/setup-vdb.yaml
@@ -18,6 +18,8 @@ metadata:
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
+  annotations: 
+    start-agent: "YES"
   communal:
     includeUIDInPath: true
   local:


### PR DESCRIPTION
This adds the agent for VA. 
- A new reconciler has been added.
- We start the agent only when this specific annotation is set in the CR: `vertica.com/run-agent: "yes"`
- We have added the agent key back to some of the images (not the nosshkeys version).
- The port 5444 will be added to the extsvc and  every vertica container
- An e2e test has been modified to check that agent is running when enabled.