### PR TITLE
Fix e2e test for catalog sync HTTP endpoint

### DIFF
--- a/tests/e2e-http-server/http-generated-certs/60-verify-sync-catalog.yaml
+++ b/tests/e2e-http-server/http-generated-certs/60-verify-sync-catalog.yaml
@@ -26,8 +26,14 @@ data:
     set -o errexit
     set -o xtrace
 
-    curl --insecure -X POST --fail --verbose --key /certs/tls.key --cert /certs/tls.crt https://v-http-generated-certs-sc-0.v-http-generated-certs:8443/manage/sync-catalog | tee /tmp/curl.out
-    grep -cq 'new_truncation_version' /tmp/curl.out
+    # The catalog sync endpoint changed in 23.3. Checking both for backwards
+    # compatibility. This test succeeds if one of the endpoints work. The curl
+    # command below relies on pipefail being off for this to work.
+    for endpoint in cluster/catalog/sync manage/sync-catalog
+    do
+      curl --insecure -X POST --fail --verbose --key /certs/tls.key --cert /certs/tls.crt https://v-http-generated-certs-sc-0.v-http-generated-certs:8443/$endpoint | tee /tmp/curl.out
+      grep -cq 'new_truncation_version' /tmp/curl.out && break
+    done
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
The catalog sync HTTP endpoint was renamed in Vertica 23.3. This updates the test to check the old and new endpoint name so that it can continue to work against different server versions.