### PR TITLE
UP node check needs to be made more resilient

### DIFF
--- a/changes/unreleased/Fixed-20230324-084145.yaml
+++ b/changes/unreleased/Fixed-20230324-084145.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Run rebalance shards on new subcluster created in a v11 database that was migrated
+  from enterprise
+time: 2023-03-24T08:41:45.635668943-03:00
+custom:
+  Issue: "360"

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -209,7 +209,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// status updates after both of them.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Update the labels in pods so that Services route to nodes to them.
-		MakeClientRoutingLabelReconciler(r, vdb, pfacts, AddNodeApplyMethod, ""),
+		MakeClientRoutingLabelReconciler(r, vdb, pfacts, PodRescheduleApplyMethod, ""),
 		// Ensure the vertica agent is running on each pod
 		MakeAgentReconciler(r, vdb, prunner, pfacts),
 		// Handle calls to admintools -t db_add_subcluster


### PR DESCRIPTION
This fixes an issue with subcluster creation. We weren't running the rebalance_shards() to add subscriptions to the new subcluster. To hit this you had to have a few specific things:
- had to use a v11 server
- the database has to be migrated from enterprise to eon

There was a server issue during migration, to be fixed separately, that set some wrong state for certain tables. Some tables were identified as being "shared", which to the server means we need active shard subscriptions to query them. If no subscriptions, then the query would fail with "ERROR 9099:  Cannot find participating nodes to run the query".

This was affecting queries the operator does to catalog tables -- key for this fix was it affected any query to the nodes table. Because of this, the operator deemed the new scaled out nodes as down. So, it would never run the rebalance.

The fix is to align the UP node check with the livenessProbe by looking to see if the vertica process is running. We still query out the node state from node, but it is used for information purposes now.

Closes #355 