### PR TITLE
Support subcluster names with underscore

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -1131,11 +1131,18 @@ func (s *Subcluster) GetType() string {
 	return SecondarySubclusterType
 }
 
+// GenNameWithoutUnderscore returns the subcluster name after
+// replacing all `_` occurrences with `-`
+func (s *Subcluster) GenNameWithoutUnderscore() string {
+	m := regexp.MustCompile(`_`)
+	return m.ReplaceAllString(s.Name, "-")
+}
+
 // GetServiceName returns the name of the service object that route traffic to
 // this subcluster.
 func (s *Subcluster) GetServiceName() string {
 	if s.ServiceName == "" {
-		return s.Name
+		return s.GenNameWithoutUnderscore()
 	}
 	return s.ServiceName
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -1051,7 +1051,7 @@ func (v *VerticaDB) GenSubclusterMap() map[string]*Subcluster {
 func IsValidSubclusterName(scName string) bool {
 	// Although `_` is not a valid k8s domain name's character, it is included
 	// here as we now have a better support for it
-	r := regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-\_]{0,61}[a-z0-9])?$`)
+	r := regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`)
 	return r.MatchString(scName)
 }
 
@@ -1133,9 +1133,9 @@ func (s *Subcluster) GetType() string {
 	return SecondarySubclusterType
 }
 
-// GenNameWithoutUnderscore returns the subcluster name after
-// replacing all `_` occurrences with `-`
-func (s *Subcluster) GenNameWithoutUnderscore() string {
+// GenCompatibleFQDN returns a name of the subcluster that is
+// compatible inside a fully-qualified domain name.
+func (s *Subcluster) GenCompatibleFQDN() string {
 	m := regexp.MustCompile(`_`)
 	return m.ReplaceAllString(s.Name, "-")
 }
@@ -1144,7 +1144,7 @@ func (s *Subcluster) GenNameWithoutUnderscore() string {
 // this subcluster.
 func (s *Subcluster) GetServiceName() string {
 	if s.ServiceName == "" {
-		return s.GenNameWithoutUnderscore()
+		return s.GenCompatibleFQDN()
 	}
 	return s.ServiceName
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -1049,8 +1049,6 @@ func (v *VerticaDB) GenSubclusterMap() map[string]*Subcluster {
 // about its name because it is included in the name of the statefulset, so we
 // must adhere to the Kubernetes rules for object names.
 func IsValidSubclusterName(scName string) bool {
-	// Although `_` is not a valid k8s domain name's character, it is included
-	// here as we now have a better support for it
 	r := regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`)
 	return r.MatchString(scName)
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -1049,7 +1049,9 @@ func (v *VerticaDB) GenSubclusterMap() map[string]*Subcluster {
 // about its name because it is included in the name of the statefulset, so we
 // must adhere to the Kubernetes rules for object names.
 func IsValidSubclusterName(scName string) bool {
-	r := regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`)
+	// Although `_` is not a valid k8s domain name's character, it is included
+	// here as we now have a better support for it
+	r := regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-\_]{0,61}[a-z0-9])?$`)
 	return r.MatchString(scName)
 }
 

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -401,7 +401,7 @@ func (v *VerticaDB) getClusterSize() int {
 func (v *VerticaDB) hasValidDomainName(allErrs field.ErrorList) field.ErrorList {
 	for i := range v.Spec.Subclusters {
 		sc := &v.Spec.Subclusters[i]
-		if !IsValidSubclusterName(sc.Name) {
+		if !IsValidSubclusterName(sc.GenCompatibleFQDN()) {
 			err := field.Invalid(field.NewPath("spec").Child("subcluster").Index(i).Child("name"),
 				v.Spec.Subclusters[i],
 				"is not a valid domain name")
@@ -481,7 +481,7 @@ func (v *VerticaDB) hasDuplicateScName(allErrs field.ErrorList) field.ErrorList 
 			sc2 := &v.Spec.Subclusters[j]
 			// subcluster names like default-subcluster and default_subcluster
 			// are considered identical
-			if sc1.GenNameWithoutUnderscore() == sc2.GenNameWithoutUnderscore() {
+			if sc1.GenCompatibleFQDN() == sc2.GenCompatibleFQDN() {
 				err := field.Invalid(field.NewPath("spec").Child("subclusters").Index(j).Child("name"),
 					v.Spec.Subclusters[j].Name,
 					fmt.Sprintf("duplicates the name of subcluster[%d]", i))

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -479,7 +479,9 @@ func (v *VerticaDB) hasDuplicateScName(allErrs field.ErrorList) field.ErrorList 
 		sc1 := &v.Spec.Subclusters[i]
 		for j := i + 1; j < countSc; j++ {
 			sc2 := &v.Spec.Subclusters[j]
-			if sc1.Name == sc2.Name {
+			// subcluster names like default-subcluster and default_subcluster
+			// are considered identical
+			if sc1.GenNameWithoutUnderscore() == sc2.GenNameWithoutUnderscore() {
 				err := field.Invalid(field.NewPath("spec").Child("subclusters").Index(j).Child("name"),
 					v.Spec.Subclusters[j].Name,
 					fmt.Sprintf("duplicates the name of subcluster[%d]", i))

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -84,7 +84,7 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Communal.Endpoint = "s3://minio"
 		validateSpecValuesHaveErr(vdb, true)
 	})
-	It("should have valid subcluster name", func() {
+	It("should have invalid subcluster name", func() {
 		vdb := createVDBHelper()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Name = "default-subcluster"
@@ -93,7 +93,7 @@ var _ = Describe("verticadb_webhook", func() {
 	It("should not have invalid subcluster name", func() {
 		vdb := createVDBHelper()
 		sc := &vdb.Spec.Subclusters[0]
-		sc.Name = "default_subcluster"
+		sc.Name = "defaultsubcluster_"
 		validateSpecValuesHaveErr(vdb, true)
 	})
 	It("should be allowed to have empty credentialsecret", func() {

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -84,7 +84,7 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Communal.Endpoint = "s3://minio"
 		validateSpecValuesHaveErr(vdb, true)
 	})
-	It("should have invalid subcluster name", func() {
+	It("should have valid subcluster name", func() {
 		vdb := createVDBHelper()
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Name = "default-subcluster"
@@ -291,6 +291,19 @@ var _ = Describe("verticadb_webhook", func() {
 		})
 		allErrs := vdb.validateImmutableFields(vdbUpdate)
 		Expect(allErrs).ShouldNot(BeNil())
+	})
+
+	It("should not have two or more subclusters whose names only differ by `-` and `_`", func() {
+		vdb := createVDBHelper()
+		vdb.Spec.Subclusters = append(vdb.Spec.Subclusters, Subcluster{
+			Name: "default_subcluster",
+			Size: 3,
+		})
+		vdb.Spec.Subclusters = append(vdb.Spec.Subclusters, Subcluster{
+			Name: "default-subcluster",
+			Size: 3,
+		})
+		validateSpecValuesHaveErr(vdb, true)
 	})
 
 	It("should only allow certain values for initPolicy", func() {

--- a/changes/unreleased/Fixed-20230403-102815.yaml
+++ b/changes/unreleased/Fixed-20230403-102815.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Support subcluster names with underscores, such as default_subcluster.
+time: 2023-04-03T10:28:15.600484948-03:00
+custom:
+  Issue: "362"

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -71,7 +71,7 @@ func GenSUPasswdSecretName(vdb *vapi.VerticaDB) types.NamespacedName {
 // The name of the pod is generated, this function is just a helper for when we need
 // to lookup a pod by its generated name.
 func GenPodName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%d", vdb.Name, sc.Name, podIndex))
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%d", vdb.Name, sc.GenNameWithoutUnderscore(), podIndex))
 }
 
 // GenPodNameFromSts returns the name of a specific pod in a statefulset
@@ -84,12 +84,12 @@ func GenPodNameFromSts(vdb *vapi.VerticaDB, sts *appsv1.StatefulSet, podIndex in
 
 // GenPVCName returns the name of a specific pod's PVC.  This is for test purposes only.
 func GenPVCName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.Name, podIndex))
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenNameWithoutUnderscore(), podIndex))
 }
 
 // GenPVName returns the name of a dummy PV for test purposes
 func GenPVName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
 	return types.NamespacedName{
-		Name: fmt.Sprintf("pv-%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.Name, podIndex),
+		Name: fmt.Sprintf("pv-%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenNameWithoutUnderscore(), podIndex),
 	}
 }

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -49,7 +49,7 @@ func GenHlSvcName(vdb *vapi.VerticaDB) types.NamespacedName {
 
 // GenStsName returns the name of the statefulset object
 func GenStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
-	return GenNamespacedName(vdb, vdb.Name+"-"+sc.Name)
+	return GenNamespacedName(vdb, vdb.Name+"-"+sc.GenNameWithoutUnderscore())
 }
 
 // GenCommunalCredSecretName returns the name of the secret that has the credentials to access s3

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -49,7 +49,7 @@ func GenHlSvcName(vdb *vapi.VerticaDB) types.NamespacedName {
 
 // GenStsName returns the name of the statefulset object
 func GenStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
-	return GenNamespacedName(vdb, vdb.Name+"-"+sc.GenNameWithoutUnderscore())
+	return GenNamespacedName(vdb, vdb.Name+"-"+sc.GenCompatibleFQDN())
 }
 
 // GenCommunalCredSecretName returns the name of the secret that has the credentials to access s3
@@ -71,7 +71,7 @@ func GenSUPasswdSecretName(vdb *vapi.VerticaDB) types.NamespacedName {
 // The name of the pod is generated, this function is just a helper for when we need
 // to lookup a pod by its generated name.
 func GenPodName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%d", vdb.Name, sc.GenNameWithoutUnderscore(), podIndex))
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%d", vdb.Name, sc.GenCompatibleFQDN(), podIndex))
 }
 
 // GenPodNameFromSts returns the name of a specific pod in a statefulset
@@ -84,12 +84,12 @@ func GenPodNameFromSts(vdb *vapi.VerticaDB, sts *appsv1.StatefulSet, podIndex in
 
 // GenPVCName returns the name of a specific pod's PVC.  This is for test purposes only.
 func GenPVCName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenNameWithoutUnderscore(), podIndex))
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenCompatibleFQDN(), podIndex))
 }
 
 // GenPVName returns the name of a dummy PV for test purposes
 func GenPVName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
 	return types.NamespacedName{
-		Name: fmt.Sprintf("pv-%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenNameWithoutUnderscore(), podIndex),
+		Name: fmt.Sprintf("pv-%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenCompatibleFQDN(), podIndex),
 	}
 }

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -44,4 +44,17 @@ var _ = Describe("k8s/names", func() {
 			types.NamespacedName{Namespace: "my-ns", Name: "name-test-my-sc-9"},
 		))
 	})
+
+	It("subcluster and external service generated names should not contain `_`", func() {
+		vdb := vapi.MakeVDB()
+		vdb.ObjectMeta.Name = "v"
+		vdb.ObjectMeta.Namespace = "v-ns"
+		vdb.Spec.Subclusters[0].Name = "my_sc"
+		Ω(GenStsName(vdb, &vdb.Spec.Subclusters[0])).Should(Equal(
+			types.NamespacedName{Namespace: "v-ns", Name: "v-my-sc"},
+		))
+		Ω(GenExtSvcName(vdb, &vdb.Spec.Subclusters[0])).Should(Equal(
+			types.NamespacedName{Namespace: "v-ns", Name: "v-my-sc"},
+		))
+	})
 })

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -590,7 +590,10 @@ func (d *DBGenerator) setSubclusterDetail(ctx context.Context) error {
 			return fmt.Errorf("failed running '%s': %w", q, err)
 		}
 
-		if !vapi.IsValidSubclusterName(name) {
+		sc := &vapi.Subcluster{
+			Name: name,
+		}
+		if !vapi.IsValidSubclusterName(sc.GenCompatibleFQDN()) {
 			return fmt.Errorf("subcluster names are included in the name of statefulsets, but the name "+
 				"'%s' cannot be used as it will violate Kubernetes naming.  Please rename the subcluster and "+
 				"retry this command again", name)

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -427,7 +427,7 @@ var _ = Describe("vdb", func() {
 
 		dbGen := DBGenerator{Conn: db}
 
-		for _, name := range []string{"default_subcluster", "scCapital", "sc!bang", "sc-"} {
+		for _, name := range []string{"scCapital", "sc!bang", "sc-"} {
 			mock.ExpectQuery(Queries[SubclusterQueryKey]).
 				WillReturnRows(sqlmock.NewRows([]string{"node_name", "location_path"}).AddRow(name, true))
 

--- a/tests/e2e-leg-1/create-and-del-crd/15-assert.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/15-assert.yaml
@@ -14,28 +14,28 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: verticadb-sample-defaultsubcluster-0
+  name: verticadb-sample-default-subcluster-0
 status:
   phase: Running
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: verticadb-sample-defaultsubcluster-1
+  name: verticadb-sample-default-subcluster-1
 status:
   phase: Running
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: verticadb-sample-defaultsubcluster-2
+  name: verticadb-sample-default-subcluster-2
 status:
   phase: Running
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: verticadb-sample-defaultsubcluster
+  name: verticadb-sample-default-subcluster
 ---
 apiVersion: v1
 kind: Service
@@ -45,6 +45,6 @@ metadata:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: verticadb-sample-defaultsubcluster
+  name: verticadb-sample-default-subcluster
 status:
   currentReplicas: 3

--- a/tests/e2e-leg-1/create-and-del-crd/20-custom-volume-mounts.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/20-custom-volume-mounts.yaml
@@ -14,7 +14,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c vlogger -n $NAMESPACE -- touch mymountpath/emptyfile"
-  - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c server -n $NAMESPACE -- test -f /tenants/emptyfile"
-  - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c server -n $NAMESPACE -- sh -c 'echo hello > /tenants/ack'"
-  - command: sh -c "kubectl exec verticadb-sample-defaultsubcluster-0 -c vlogger -n $NAMESPACE -- cat mymountpath/ack | grep hello"
+  - command: sh -c "kubectl exec verticadb-sample-default-subcluster-0 -c vlogger -n $NAMESPACE -- touch mymountpath/emptyfile"
+  - command: sh -c "kubectl exec verticadb-sample-default-subcluster-0 -c server -n $NAMESPACE -- test -f /tenants/emptyfile"
+  - command: sh -c "kubectl exec verticadb-sample-default-subcluster-0 -c server -n $NAMESPACE -- sh -c 'echo hello > /tenants/ack'"
+  - command: sh -c "kubectl exec verticadb-sample-default-subcluster-0 -c vlogger -n $NAMESPACE -- cat mymountpath/ack | grep hello"

--- a/tests/e2e-leg-1/create-and-del-crd/25-assert.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/25-assert.yaml
@@ -14,6 +14,6 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: verticadb-sample-defaultsubcluster
+  name: verticadb-sample-default-subcluster
 status:
   replicas: 5

--- a/tests/e2e-leg-1/create-and-del-crd/25-scale-out.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/25-scale-out.yaml
@@ -17,5 +17,5 @@ metadata:
   name: verticadb-sample
 spec:
   subclusters:
-    - name: defaultsubcluster
+    - name: default_subcluster
       size: 5

--- a/tests/e2e-leg-1/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/setup-vdb/base/setup-vdb.yaml
@@ -36,6 +36,6 @@ spec:
     - mountPath: /tenants
       name: my-extra-vol1
   subclusters:
-    - name: defaultsubcluster
+    - name: default_subcluster
   certSecrets: []
   imagePullSecrets: []


### PR DESCRIPTION
Before this, a subcluster's name couldn't contain the underscore character because it is part of sts and pod names and according to FQDN rules, an underscore is not a valid character. 

This adds better support by simply mapping '_' to a '-' before building pod/service/sts name. This will allow us to support the default subcluster name in vertica – default_subcluster. 

The webhook now allows subcluster name with '_'. However, two subclusters could have have identical sts names: e.g. default_subcluster and default-subcluster. We reject that case now in the webhook. 
