### PR TITLE
Fix udx-cpp due to python change in latest server

### DIFF
--- a/tests/e2e-udx/udx-cpp/70-verify-cpp-source.yaml
+++ b/tests/e2e-udx/udx-cpp/70-verify-cpp-source.yaml
@@ -22,7 +22,7 @@ data:
     set -o errexit
 
     POD_NAME=v-udx-cpp-sc1-0
-    UDX_OP=$(kubectl exec $POD_NAME -i -- bash -c "cd /opt/vertica/sdk/examples; vsql -U dbadmin -f SourceFunctions.sql 2>&1 > /tmp/SourceFunctionsOut.txt; cat /tmp/SourceFunctionsOut.txt")
+    UDX_OP=$(kubectl exec $POD_NAME -i -- bash -c "cd /opt/vertica/sdk/examples && sed -i 's/python2/python/g' SourceFunctions.sql && vsql -U dbadmin -f SourceFunctions.sql 2>&1 > /tmp/SourceFunctionsOut.txt; cat /tmp/SourceFunctionsOut.txt")
     echo "$UDX_OP"
     kubectl exec $POD_NAME -i -- bash -c "diff /tmp/SourceFunctionsOut.txt /opt/vertica/sdk/examples/expected-outputs/SourceFunctionsOut.txt"
 ---


### PR DESCRIPTION
The udx samples were changed in the latest server to call out to python2. This isn't present in the container that we use, nor do I want to add it. Rather, I'm simplying doing a sed in the samples to call python instead of python2.