### PR TITLE
Fix intermittent failure in schedule-only e2e test

### DIFF
--- a/tests/e2e-leg-2/schedule-only/60-wait-for-restart.yaml
+++ b/tests/e2e-leg-2/schedule-only/60-wait-for-restart.yaml
@@ -1,1 +1,19 @@
-# Intentionally empty to give this step a name in kuttl
+# (c) Copyright [2021-2023] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-schedule-only
+spec:
+  autoRestartVertica: true

--- a/tests/e2e-leg-2/schedule-only/setup-schedule-only-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-2/schedule-only/setup-schedule-only-vdb/base/setup-vdb.yaml
@@ -16,6 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-schedule-only
 spec:
+  autoRestartVertica: false
   initPolicy: ScheduleOnly
   communal: {}
   image: kustomize-vertica-image


### PR DESCRIPTION
The schedule-only test can fail occastionally. It's a combination of running add node outside of the operator and the operator attempting to restart the very same node we are adding. I'm avoiding this timing scenario in the test by setting autoRestartVertica to false until we specifically want to test restart (at step 60).