### PR TITLE
Fixes for server version change

### DIFF
--- a/.github/workflows/e2e-server-upgrade.yml
+++ b/.github/workflows/e2e-server-upgrade.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Run e2e tests
       run: |
-        export BASE_VERTICA_IMG=vertica/vertica-k8s:11.1.1-0-minimal
+        export BASE_VERTICA_IMG=vertica/vertica-k8s:12.0.2-0-minimal
         export E2E_TEST_DIRS=tests/e2e-server-upgrade
         export VERTICA_IMG=${{ inputs.vertica-image }}
         export OPERATOR_IMG=${{ inputs.operator-image }}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,6 +44,11 @@ var UpgradePaths = map[Components]Info{
 	{11, 0, 2}: {"v11.1.x", Components{11, 1, 0}},
 	{11, 1, 0}: {"v12.0.x", Components{12, 0, 0}},
 	{11, 1, 1}: {"v12.0.x", Components{12, 0, 0}},
+	{12, 0, 0}: {"v23.3.x", Components{23, 3, 0}},
+	{12, 0, 1}: {"v23.3.x", Components{23, 3, 0}},
+	{12, 0, 2}: {"v23.3.x", Components{23, 3, 0}},
+	{12, 0, 3}: {"v23.3.x", Components{23, 3, 0}},
+	{12, 0, 4}: {"v23.3.x", Components{23, 3, 0}},
 }
 
 // MakeInfoFromStr will construct an Info struct by parsing the version string

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -61,4 +61,15 @@ var _ = Describe("version", func() {
 		ok = cur.IsOlder("v13.1.1")
 		Expect(ok).Should(BeTrue())
 	})
+
+	It("should allow any v12 transitions to 23.3", func() {
+		const Server23_3 = "v23.3.0"
+		serverVersions := []string{"v12.0.1", "v12.0.2", "v12.0.3", "v12.0.4"}
+		for _, sver := range serverVersions {
+			cur, ok := MakeInfoFromStr(sver)
+			Expect(ok).Should(BeTrue())
+			ok, _ = cur.IsValidUpgradePath(Server23_3)
+			Expect(ok).Should(BeTrue())
+		}
+	})
 })

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/15-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/15-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,4 +25,4 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-start-vertica-upgrade.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/20-start-vertica-upgrade.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-defsc-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-defsc-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-upgrade-and-scale-up.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/35-upgrade-and-scale-up.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal
   subclusters:
   - name: defsc
     size: 3

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-upgrade-and-scale-down.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/40-upgrade-and-scale-down.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal
   subclusters:
   - name: defsc
     size: 1

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/50-upgrade-vertica.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/50-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/55-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/55-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-defsc-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/70-upgrade-vertica.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/70-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/75-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/75-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal
   imagePullPolicy: IfNotPresent
   superuserPasswordSecret: su-passwd
   communal:

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/25-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/25-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-sc1-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-sc1-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-assert.yaml
@@ -17,7 +17,7 @@ metadata:
   name: v-upgrade-vertica-sc1-0
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -25,7 +25,7 @@ metadata:
   name: v-upgrade-vertica-sc1-1
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: v1
 kind: Pod
@@ -33,7 +33,7 @@ metadata:
   name: v-upgrade-vertica-sc1-2
 spec:
   containers:
-    - image: vertica/vertica-k8s:11.1.1-0-minimal
+    - image: vertica/vertica-k8s:12.0.2-0-minimal
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-upgrade-vertica.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/35-upgrade-vertica.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/setup-vdb/base/setup-vdb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal
   imagePullPolicy: IfNotPresent
   communal:
     includeUIDInPath: true

--- a/tests/e2e-udx/udx-cpp/35-verify-cpp-aggregate.yaml
+++ b/tests/e2e-udx/udx-cpp/35-verify-cpp-aggregate.yaml
@@ -31,7 +31,7 @@ data:
     # In 23.3, we changed the aggregate examples.
     if [ "$MAJOR" -gt 12 ] \
         || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -gt 0 ]) \
-        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -eq 0 ] && [ "$PATCH" -ge 3 ])
+        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -eq 0 ] && [ "$PATCH" -gt 3 ])
     then
       EXP=/opt/vertica/sdk/examples/expected-outputs/23.3.0/AggregateFunctionsOut.txt
     else

--- a/tests/e2e-udx/udx-cpp/35-verify-cpp-aggregate.yaml
+++ b/tests/e2e-udx/udx-cpp/35-verify-cpp-aggregate.yaml
@@ -28,13 +28,12 @@ data:
     MAJOR=$(kubectl exec $POD_NAME -i -- bash -c "vertica --version | head -1 | perl -ne 'print \"\$1\n\" if /v([0-9]+).([0-9]+).([0-9]+)/'")
     MINOR=$(kubectl exec $POD_NAME -i -- bash -c "vertica --version | head -1 | perl -ne 'print \"\$2\n\" if /v([0-9]+).([0-9]+).([0-9]+)/'")
     PATCH=$(kubectl exec $POD_NAME -i -- bash -c "vertica --version | head -1 | perl -ne 'print \"\$3\n\" if /v([0-9]+).([0-9]+).([0-9]+)/'")
-    # In 23.3, we changed the aggregate examples. However, the nightly build
-    # still reports 12.0.4. And we have no way of knowing if it's really 23.3 or
-    # 12.0.4. So, we'll just stop running the test if it's 12.0.4. We need to come
-    # back to this and pick the proper exp file.
-    if [ "$MAJOR" -ge 12 ] && [ "$MINOR" -ge 0 ] && [ "$PATCH" -ge 3 ]
+    # In 23.3, we changed the aggregate examples.
+    if [ "$MAJOR" -gt 12 ] \
+        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -gt 0 ]) \
+        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -eq 0 ] && [ "$PATCH" -ge 3 ])
     then
-      exit 0
+      EXP=/opt/vertica/sdk/examples/expected-outputs/23.3.0/AggregateFunctionsOut.txt
     else
       EXP=/opt/vertica/sdk/examples/expected-outputs/12.0.3/AggregateFunctionsOut.txt
     fi

--- a/tests/e2e-udx/udx-cpp/expected-outputs/23.3.0/AggregateFunctionsOut.txt
+++ b/tests/e2e-udx/udx-cpp/expected-outputs/23.3.0/AggregateFunctionsOut.txt
@@ -1,0 +1,49 @@
+CREATE LIBRARY
+CREATE AGGREGATE FUNCTION
+CREATE AGGREGATE FUNCTION
+CREATE AGGREGATE FUNCTION
+CREATE AGGREGATE FUNCTION
+CREATE TABLE
+ x |  z   | average 
+---+------+---------
+ 1 | 'A'  |    2.50
+ 2 | 'A'  |    2.20
+ 2 | 'B'  |    2.30
+ 3 | 'B'  |    4.50
+ 3 | 'C'  |    2.00
+ 4 | 'AB' |    7.50
+ 4 | 'BC' |    5.50
+(7 rows)
+
+ x | agg_longest_string 
+---+--------------------
+ 1 | 'A'
+ 2 | 'B'
+ 3 | 'C'
+ 4 | 'BC'
+(4 rows)
+
+ x | agg_longest_string 
+---+--------------------
+ 1 | 'A'
+ 2 | 'B'
+ 3 | 'C'
+ 4 | 'BC'
+(4 rows)
+
+ num_occurences 
+----------------
+              4
+(1 row)
+
+  z   | num_occurences 
+------+----------------
+ 'A'  |              2
+ 'AB' |              0
+ 'C'  |              0
+ 'B'  |              2
+ 'BC' |              0
+(5 rows)
+
+DROP TABLE
+DROP LIBRARY

--- a/tests/e2e-udx/udx-python/40-verify-python-transform.yaml
+++ b/tests/e2e-udx/udx-python/40-verify-python-transform.yaml
@@ -29,7 +29,9 @@ data:
     MINOR=$(kubectl exec $POD_NAME -i -- bash -c "vertica --version | head -1 | perl -ne 'print \"\$2\n\" if /v([0-9]+).([0-9]+).([0-9]+)/'")
     PATCH=$(kubectl exec $POD_NAME -i -- bash -c "vertica --version | head -1 | perl -ne 'print \"\$3\n\" if /v([0-9]+).([0-9]+).([0-9]+)/'")
     # In 12.0.4, we changed the PythonTransformFunction. So pick the correct output.
-    if [ "$MAJOR" -ge 12 ] && [ "$MINOR" -ge 0 ] && [ "$PATCH" -ge 4 ]
+    if [ "$MAJOR" -gt 12 ] \
+        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -gt 0 ]) \
+        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -eq 0 ] && [ "$PATCH" -ge 4 ])
     then
       EXP=/opt/vertica/sdk/examples/expected-outputs/12.0.4/PythonTransformFunctionsOut.txt
     else

--- a/tests/external-images-server-upgrade-ci.txt
+++ b/tests/external-images-server-upgrade-ci.txt
@@ -1,3 +1,3 @@
 # List of images that we pull during the e2e tests for server-upgrade.
 #
-vertica/vertica-k8s:11.1.1-0-minimal
+vertica/vertica-k8s:12.0.2-0-minimal

--- a/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
+++ b/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
@@ -16,4 +16,4 @@ kind: ConfigMap
 metadata:
   name: upgrade-vertica-1
 data:
-  image: vertica/vertica-k8s:11.1.1-0-minimal
+  image: vertica/vertica-k8s:12.0.2-0-minimal


### PR DESCRIPTION
This is a fix for the e2e tests related to the nightly vertica server test. The latest server builds updated it's version to 23.3.0. This broke a few things:
- all of the upgrade tests were from 11.1.1. As per the upgrade path, you cannot go from 11.1.1 to 23.3.0 as you are skipping the 12.0.x release. The fix here is to change all of the upgrade tests to start from 12.0.2.
- some of the udx tests have different expected results based on the server version. The server version check wasn't quite right, so we were picking the wrong expected result for 23.3.0.