### PR TITLE
Additional ports added to headless service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,14 @@ $(OPERATOR_SDK):
 	curl --silent --show-error --retry 10 --retry-max-time 1800 --location --fail "https://github.com/operator-framework/operator-sdk/releases/download/v$(OPERATOR_SDK_VERSION)/operator-sdk_linux_amd64" --output $(OPERATOR_SDK)
 	chmod +x $(OPERATOR_SDK)
 
+ISTIOCTL = $(shell pwd)/bin/istioctl
+ISTIOCTL_VERSION = 1.17.2
+istioctl: $(ISTIOCTL)  ## Download istioctl locally if necessary
+$(ISTIOCTL):
+	curl --silent --show-error --retry 10 --retry-max-time 1800 --location --fail "https://github.com/istio/istio/releases/download/$(ISTIOCTL_VERSION)/istio-$(ISTIOCTL_VERSION)-linux-amd64.tar.gz" | tar xvfz - istio-1.17.2/bin/istioctl -O > $(ISTIOCTL)
+	chmod +x $(ISTIOCTL)
+
+
 ##@ Release
 
 change-operator-version: ## Change the operator version in source files. Override VERSION on command line to change the value in the Makefile.

--- a/changes/unreleased/Added-20230509-105206.yaml
+++ b/changes/unreleased/Added-20230509-105206.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Additional ports added to headless service. This is to support istio with TPROXY
+  and strict mTLS.
+time: 2023-05-09T10:52:06.236086735-03:00
+custom:
+  Issue: "392"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -42,6 +42,8 @@ const (
 	VerticaHTTPPort         = 8443
 	InternalVerticaCommPort = 5434
 	SSHPort                 = 22
+	VerticaClusterCommPort  = 5434
+	SpreadClientPort        = 4803
 
 	// Standard environment variables that are set in each pod
 	PodIPEnv        = "POD_IP"
@@ -92,7 +94,9 @@ func BuildHlSvc(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.Service {
 			Type:                     "ClusterIP",
 			PublishNotReadyAddresses: true,
 			Ports: []corev1.ServicePort{
-				{Port: SSHPort, Name: "ssh"},
+				{Port: SSHPort, Name: "tcp-ssh"},
+				{Port: VerticaClusterCommPort, Name: "tcp-verticaclustercomm"},
+				{Port: SpreadClientPort, Name: "tcp-spreadclient"},
 			},
 		},
 	}

--- a/tests/e2e-leg-3/istio/05-setup-istio.yaml
+++ b/tests/e2e-leg-3/istio/05-setup-istio.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: sh -c "cd ../../.. && make istioctl"
+- command: sh -c "../../../bin/istioctl operator init"
+- command: sh -c "../../../bin/istioctl uninstall --purge --skip-confirmation || true"
+- command: sh -c "../../../bin/istioctl install --set profile=demo --skip-confirmation"
+- command: kubectl label namespace $NAMESPACE istio-injection=enabled

--- a/tests/e2e-leg-3/istio/10-assert.yaml
+++ b/tests/e2e-leg-3/istio/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running

--- a/tests/e2e-leg-3/istio/10-deploy-operator.yaml
+++ b/tests/e2e-leg-3/istio/10-deploy-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make deploy-operator DEPLOY_WITH=helm WATCH_NAMESPACE=$NAMESPACE HELM_OVERRIDES='--set webhook.enable=false'"

--- a/tests/e2e-leg-3/istio/15-enable-strict-mTLS.yaml
+++ b/tests/e2e-leg-3/istio/15-enable-strict-mTLS.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+spec:
+  mtls:
+    mode: STRICT

--- a/tests/e2e-leg-3/istio/20-assert.yaml
+++ b/tests/e2e-leg-3/istio/20-assert.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-istio-tproxy-main
+  annotations:
+    sidecar.istio.io/interceptionMode: TPROXY
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-istio-tproxy
+spec:
+  annotations:
+    sidecar.istio.io/interceptionMode: TPROXY
+status:
+  subclusters:
+    - installCount: 3
+

--- a/tests/e2e-leg-3/istio/20-create-cr-tproxy.yaml
+++ b/tests/e2e-leg-3/istio/20-create-cr-tproxy.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb-tproxy/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/istio/25-assert.yaml
+++ b/tests/e2e-leg-3/istio/25-assert.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-istio-tproxy-main
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-istio-tproxy
+status:
+  subclusters:
+    - installCount: 3
+      upNodeCount: 3
+

--- a/tests/e2e-leg-3/istio/25-wait-for-create-db.yaml
+++ b/tests/e2e-leg-3/istio/25-wait-for-create-db.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-3/istio/30-kill-sts.yaml
+++ b/tests/e2e-leg-3/istio/30-kill-sts.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete sts v-istio-tproxy-main
+    namespaced: true

--- a/tests/e2e-leg-3/istio/35-assert.yaml
+++ b/tests/e2e-leg-3/istio/35-assert.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-istio-tproxy-main
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-istio-tproxy
+status:
+  subclusters:
+    - upNodeCount: 3
+

--- a/tests/e2e-leg-3/istio/35-wait-for-restart.yaml
+++ b/tests/e2e-leg-3/istio/35-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-3/istio/90-cleanup-istio.yaml
+++ b/tests/e2e-leg-3/istio/90-cleanup-istio.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- command: kubectl label namespace $NAMESPACE istio-injection-
+- command: sh -c "../../../bin/istioctl uninstall --purge --skip-confirmation"

--- a/tests/e2e-leg-3/istio/90-errors.yaml
+++ b/tests/e2e-leg-3/istio/90-errors.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal

--- a/tests/e2e-leg-3/istio/95-delete-cr.yaml
+++ b/tests/e2e-leg-3/istio/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB

--- a/tests/e2e-leg-3/istio/95-errors.yaml
+++ b/tests/e2e-leg-3/istio/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-leg-3/istio/96-assert.yaml
+++ b/tests/e2e-leg-3/istio/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-3/istio/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/istio/96-cleanup-storage.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/istio/97-errors.yaml
+++ b/tests/e2e-leg-3/istio/97-errors.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    control-plane: controller-manager

--- a/tests/e2e-leg-3/istio/97-uninstall-operator.yaml
+++ b/tests/e2e-leg-3/istio/97-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-3/istio/99-delete-ns.yaml
+++ b/tests/e2e-leg-3/istio/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-3/istio/setup-vdb-tproxy/base/kustomization.yaml
+++ b/tests/e2e-leg-3/istio/setup-vdb-tproxy/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-3/istio/setup-vdb-tproxy/base/setup-vdb.yaml
+++ b/tests/e2e-leg-3/istio/setup-vdb-tproxy/base/setup-vdb.yaml
@@ -1,0 +1,35 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-istio-tproxy
+spec:
+  annotations:
+    sidecar.istio.io/interceptionMode: TPROXY
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  communal:
+    includeUIDInPath: true
+  local:
+    requestSize: 100Mi
+  subclusters:
+    - name: main
+      size: 3
+      isPrimary: true
+  kSafety: "1"
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
This adds new ports to the headless service. This was done for compatibility with istio. When istio is enabled with TPROXY redirection and strict mTLS, the ports are needed to ensure vertica pods can continue to communicate with each other. See this for more info: https://istio.io/latest/docs/ops/configuration/traffic-management/traffic-routing/#headless-services

The headless service previously only had the ssh port. That was renamed from ssh to tcp-ssh to follow the istio port naming guidelines (see https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/)