### PR TITLE
Move vertica-k8s to Ubuntu 23.04 (Lunar Lobster)

### DIFF
--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -3,12 +3,12 @@
 # Copyright (c) 2021 Vertica
 #
 
-ARG BASE_OS_VERSION="focal"
-ARG BUILDER_OS_VERSION="7.9.2009"
+ARG BASE_OS_VERSION="lunar"
+ARG BUILDER_OS_VERSION="stream8"
 ARG MINIMAL=""
 ARG NO_KEYS=""
 ARG S6_OVERLAY_VERSION=3.1.2.1
-FROM centos:centos${BUILDER_OS_VERSION} as builder
+FROM quay.io/centos/centos:${BUILDER_OS_VERSION} as builder
 
 ARG VERTICA_RPM="vertica-x86_64.RHEL6.latest.rpm"
 ARG MINIMAL
@@ -32,8 +32,9 @@ RUN set -x \
   && yum install -y \
   cronie \
   dialog \
+  glibc \
+  glibc-langpack-en \
   iproute \
-  mcelog \
   openssh-server \
   openssh-clients \
   openssl \

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -1,6 +1,6 @@
 VERTICA_RPM?=vertica-x86_64.RHEL6.latest.rpm
-BUILDER_OS_VERSION?=7.9.2009
-BASE_OS_VERSION?=focal-20220316
+BUILDER_OS_VERSION?=stream8
+BASE_OS_VERSION?=lunar
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 NO_KEYS?=
@@ -10,7 +10,7 @@ all: docker-build-vertica
 
 .PHONY: docker-build-vertica
 docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
-	docker pull ubuntu:focal ## make sure we use the latest focal image
+	docker pull ubuntu:lunar ## make sure we use the latest ubuntu image
 	docker build \
 		--platform linux/amd64 \
 		-f Dockerfile \

--- a/docker-vertica/packages/cleanup.sh
+++ b/docker-vertica/packages/cleanup.sh
@@ -29,7 +29,8 @@ rm -r -f \
    /opt/vertica/oss/python*/lib/python*/test \
    /opt/vertica/oss/python*/lib/python*/unittest/test \
    /opt/vertica/oss/python*/lib/python*/pip \
-   /opt/vertica/oss/python*/lib/python*/site-packages/pip \
+   /opt/vertica/oss/python*/lib/python*/site-packages/pip* \
+   /opt/vertica/oss/python*/bin/pip* \
    /opt/vertica/oss/python*/lib/python*/config-[0-9]* \
    /opt/vertica/oss/python*/lib/python*/tkinter \
    /opt/vertica/oss/python*/lib/python*/idlelib

--- a/tests/e2e-udx/udx-cpp/30-upload-files.yaml
+++ b/tests/e2e-udx/udx-cpp/30-upload-files.yaml
@@ -7,4 +7,4 @@ commands:
   - command: kubectl -n $NAMESPACE cp ./expected-outputs v-udx-cpp-sc1-0:/opt/vertica/sdk/examples
   # Install packages in the pod that are needed to run the C++ examples. We
   # retry to resolve any intermittent network issues.
-  - command: kubectl -n $NAMESPACE exec -it v-udx-cpp-sc1-0 -- bash -c "for i in $(seq 1 5); do sudo apt-get update && sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev && break || sleep 60; done"
+  - command: kubectl -n $NAMESPACE exec -it v-udx-cpp-sc1-0 -- bash -c "for i in $(seq 1 5); do sudo apt-get update && sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev bzip2 && break || sleep 60; done"

--- a/tests/e2e-udx/udx-cpp/50-verify-cpp-filter.yaml
+++ b/tests/e2e-udx/udx-cpp/50-verify-cpp-filter.yaml
@@ -24,7 +24,10 @@ data:
     POD_NAME=v-udx-cpp-sc1-0
     UDX_OP=$(kubectl exec $POD_NAME -i -- bash -c "cd /opt/vertica/sdk/examples; vsql -U dbadmin -f FilterFunctions.sql 2>&1")
     echo "$UDX_OP"
-    kubectl exec $POD_NAME -i -- bash -c "echo \"$UDX_OP\" | diff - /opt/vertica/sdk/examples/expected-outputs/FilterFunctionsOut.txt"
+    # the row orders in the output might be unstable, so sort the entire output and then compare
+    kubectl exec $POD_NAME -i -- bash -c "\
+        cd /opt/vertica/sdk/examples/expected-outputs; sort ./FilterFunctionsOut.txt > ./FilterFunctionsOutSorted.txt; \
+        echo \"$UDX_OP\" | sort | diff - /opt/vertica/sdk/examples/expected-outputs/FilterFunctionsOutSorted.txt"
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
An image change for vertica-k8s that addresses some security vulnerabilities that we found internally:

- change the OS of the final stage of the image to Ubuntu 23.04 (Lunar Lobster). This newer version gets security updates quicker than the previous version we were using. Moving to this version addressed a few vulnerabilities that we had
- remove pip from the image. We had an earlier attempt at doing this, but there was remnents still around.
- change the builder os version, an early stage in the container, from centos:centos7.9.2009 to quay.io/centos/centos:stream8. The old image we were using was deprecated. If you try building the vertica container on a new mac, it would complain. Switching to a new centos.