### PR TITLE
Allow app.kubernetes.io/name to be set in the VerticaDB CR

### DIFF
--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -1,0 +1,67 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package v1beta1
+
+const (
+	SvcTypeLabel              = "vertica.com/svc-type"
+	SubclusterNameLabel       = "vertica.com/subcluster-name"
+	SubclusterLegacyNameLabel = "vertica.com/subcluster"
+	SubclusterTypeLabel       = "vertica.com/subcluster-type"
+	SubclusterSvcNameLabel    = "vertica.com/subcluster-svc"
+	SubclusterTransientLabel  = "vertica.com/subcluster-transient"
+
+	// ClientRoutingLabel is a label that must exist on the pod in
+	// order for Service objects to route to the pod.  This label isn't part of
+	// the template in the StatefulSet.  This label is added after the pod is
+	// scheduled.  There are a couple of uses for it:
+	// - after an add node, we only add the labels once the node has at least
+	// one shard subscription.  This saves routing to a pod that cannot fulfill
+	// a query request.
+	// - before we remove a node.  It allows us to drain out pods that are going
+	// to be removed by a pending node removal.
+	ClientRoutingLabel = "vertica.com/client-routing"
+	ClientRoutingVal   = "true"
+
+	VDBInstanceLabel     = "app.kubernetes.io/instance"
+	OperatorVersionLabel = "app.kubernetes.io/version"
+	ManagedByLabel       = "app.kubernetes.io/managed-by"
+	ComponentLabel       = "app.kubernetes.io/component"
+	DataBaseLabel        = "vertica.com/database"
+
+	CurOperatorVersion = "1.11.0" // The version number of the operator
+	// If any of the operator versions are used in the code, add a const here.
+	// But it isn't necessary to create a const for each version.
+	OperatorVersion100 = "1.0.0"
+	OperatorVersion110 = "1.1.0"
+	OperatorVersion120 = "1.2.0"
+	OperatorVersion130 = "1.3.0"
+)
+
+// ProtectedLabels lists all of the internally used label.
+var ProtectedLabels = []string{
+	ManagedByLabel,
+	VDBInstanceLabel,
+	ComponentLabel,
+	OperatorVersionLabel,
+	DataBaseLabel,
+	SubclusterNameLabel,
+	SubclusterTypeLabel,
+	SubclusterTransientLabel,
+	SubclusterSvcNameLabel,
+	SubclusterLegacyNameLabel,
+	SvcTypeLabel,
+	ClientRoutingLabel,
+}

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -390,9 +391,7 @@ func (v *VerticaDB) validateAdditionalConfigParms(allErrs field.ErrorList) field
 }
 
 func (v *VerticaDB) validateCustomLabels(allErrs field.ErrorList) field.ErrorList {
-	invalidLabels := make([]string, len(ProtectedLabels))
-	copy(invalidLabels, ProtectedLabels)
-	for _, invalidLabel := range invalidLabels {
+	for _, invalidLabel := range vmeta.ProtectedLabels {
 		_, ok := v.Spec.Labels[invalidLabel]
 		if ok {
 			err := field.Invalid(field.NewPath("spec").Child("labels"),

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -271,6 +271,7 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.validateCommunalPath(allErrs)
 	allErrs = v.validateS3ServerSideEncryption(allErrs)
 	allErrs = v.validateAdditionalConfigParms(allErrs)
+	allErrs = v.validateCustomLabels(allErrs)
 	allErrs = v.validateEndpoint(allErrs)
 	allErrs = v.hasValidDomainName(allErrs)
 	allErrs = v.hasValidNodePort(allErrs)
@@ -383,6 +384,21 @@ func (v *VerticaDB) validateAdditionalConfigParms(allErrs field.ErrorList) field
 			allErrs = append(allErrs, err)
 		}
 		additionalConfigKeysCopy[strings.ToLower(k)] = ""
+	}
+	return allErrs
+}
+
+func (v *VerticaDB) validateCustomLabels(allErrs field.ErrorList) field.ErrorList {
+	invalidLabels := make([]string, len(ProtectedLabels))
+	copy(invalidLabels, ProtectedLabels)
+	for _, invalidLabel := range invalidLabels {
+		_, ok := v.Spec.Labels[invalidLabel]
+		if ok {
+			err := field.Invalid(field.NewPath("spec").Child("labels"),
+				v.Spec.Labels,
+				fmt.Sprintf("'%s' is a restricted label.", invalidLabel))
+			allErrs = append(allErrs, err)
+		}
 	}
 	return allErrs
 }

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -660,15 +661,15 @@ var _ = Describe("verticadb_webhook", func() {
 	It("should prevent internally generated labels to be overridden", func() {
 		vdb := MakeVDB()
 		vdb.Spec.Labels = map[string]string{
-			SubclusterNameLabel: "sc-name",
+			vmeta.SubclusterNameLabel: "sc-name",
 		}
 		validateSpecValuesHaveErr(vdb, true)
 		vdb.Spec.Labels = map[string]string{
-			VDBInstanceLabel: "v",
+			vmeta.VDBInstanceLabel: "v",
 		}
 		validateSpecValuesHaveErr(vdb, true)
 		vdb.Spec.Labels = map[string]string{
-			ClientRoutingLabel: ClientRoutingVal,
+			vmeta.ClientRoutingLabel: vmeta.ClientRoutingVal,
 		}
 		validateSpecValuesHaveErr(vdb, true)
 		vdb.Spec.Labels = map[string]string{

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -657,6 +657,26 @@ var _ = Describe("verticadb_webhook", func() {
 		validateSpecValuesHaveErr(vdb, true)
 	})
 
+	It("should prevent internally generated labels to be overridden", func() {
+		vdb := MakeVDB()
+		vdb.Spec.Labels = map[string]string{
+			SubclusterNameLabel: "sc-name",
+		}
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.Labels = map[string]string{
+			VDBInstanceLabel: "v",
+		}
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.Labels = map[string]string{
+			ClientRoutingLabel: ClientRoutingVal,
+		}
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.Labels = map[string]string{
+			"vertica.com/good-label": "val",
+		}
+		validateSpecValuesHaveErr(vdb, false)
+	})
+
 	It("should verify httpServerMode is valid", func() {
 		vdb := MakeVDB()
 		vdb.Spec.HTTPServerMode = "bad-server-mode"

--- a/changes/unreleased/Fixed-20230511-141746.yaml
+++ b/changes/unreleased/Fixed-20230511-141746.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Allow app.kubernetes.io/name to be overridden
+time: 2023-05-11T14:17:46.053871313-03:00
+custom:
+  Issue: "394"

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers/et"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers/vas"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers/vdb"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/opcfg"
 	"github.com/vertica/vertica-kubernetes/pkg/security"
 	//+kubebuilder:scaffold:imports
@@ -105,7 +106,7 @@ func addReconcilersToManager(mgr manager.Manager, restCfg *rest.Config, oc *opcf
 		Log:    ctrl.Log.WithName("controllers").WithName("VerticaDB"),
 		Scheme: mgr.GetScheme(),
 		Cfg:    restCfg,
-		EVRec:  mgr.GetEventRecorderFor(builder.OperatorName),
+		EVRec:  mgr.GetEventRecorderFor(vmeta.OperatorName),
 		OpCfg:  *oc,
 		DeploymentNames: builder.DeploymentNames{
 			ServiceAccountName: oc.ServiceAccountName,
@@ -119,7 +120,7 @@ func addReconcilersToManager(mgr manager.Manager, restCfg *rest.Config, oc *opcf
 	if err := (&vas.VerticaAutoscalerReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		EVRec:  mgr.GetEventRecorderFor(builder.OperatorName),
+		EVRec:  mgr.GetEventRecorderFor(vmeta.OperatorName),
 		Log:    ctrl.Log.WithName("controllers").WithName("VerticaAutoscaler"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VerticaAutoscaler")

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -24,6 +24,7 @@ import (
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cloud"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	appsv1 "k8s.io/api/apps/v1"
@@ -331,19 +332,19 @@ func buildDownwardAPIProjection() *corev1.DownwardAPIProjection {
 			{
 				Path: "k8s-version",
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: fmt.Sprintf("metadata.annotations['%s']", KubernetesVersionAnnotation),
+					FieldPath: fmt.Sprintf("metadata.annotations['%s']", vmeta.KubernetesVersionAnnotation),
 				},
 			},
 			{
 				Path: "k8s-git-commit",
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: fmt.Sprintf("metadata.annotations['%s']", KubernetesGitCommitAnnotation),
+					FieldPath: fmt.Sprintf("metadata.annotations['%s']", vmeta.KubernetesGitCommitAnnotation),
 				},
 			},
 			{
 				Path: "k8s-build-date",
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: fmt.Sprintf("metadata.annotations['%s']", KubernetesBuildDateAnnotation),
+					FieldPath: fmt.Sprintf("metadata.annotations['%s']", vmeta.KubernetesBuildDateAnnotation),
 				},
 			},
 		},
@@ -774,9 +775,9 @@ func BuildPod(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) *corev1.
 	// added by the AnnotationAndLabelPodReconciler.  However, this function is for test
 	// purposes, and we have a few dependencies on these annotations.  Rather
 	// than having many tests run the reconciler, we will add in sample values.
-	pod.Annotations[KubernetesBuildDateAnnotation] = "2022-03-16T15:58:47Z"
-	pod.Annotations[KubernetesGitCommitAnnotation] = "c285e781331a3785a7f436042c65c5641ce8a9e9"
-	pod.Annotations[KubernetesVersionAnnotation] = "v1.23.5"
+	pod.Annotations[vmeta.KubernetesBuildDateAnnotation] = "2022-03-16T15:58:47Z"
+	pod.Annotations[vmeta.KubernetesGitCommitAnnotation] = "c285e781331a3785a7f436042c65c5641ce8a9e9"
+	pod.Annotations[vmeta.KubernetesVersionAnnotation] = "v1.23.5"
 	// Set a few things in the spec that are normally done by the statefulset
 	// controller. Again, this is for testing purposes only as the statefulset
 	// controller handles adding of the PVC to the volume list.

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -22,37 +22,8 @@ import (
 )
 
 const (
-	SvcTypeLabel              = "vertica.com/svc-type"
-	SubclusterNameLabel       = "vertica.com/subcluster-name"
-	SubclusterLegacyNameLabel = "vertica.com/subcluster"
-	SubclusterTypeLabel       = "vertica.com/subcluster-type"
-	SubclusterSvcNameLabel    = "vertica.com/subcluster-svc"
-	SubclusterTransientLabel  = "vertica.com/subcluster-transient"
-
-	// ClientRoutingLabel is a label that must exist on the pod in
-	// order for Service objects to route to the pod.  This label isn't part of
-	// the template in the StatefulSet.  This label is added after the pod is
-	// scheduled.  There are a couple of uses for it:
-	// - after an add node, we only add the labels once the node has at least
-	// one shard subscription.  This saves routing to a pod that cannot fulfill
-	// a query request.
-	// - before we remove a node.  It allows us to drain out pods that are going
-	// to be removed by a pending node removal.
-	ClientRoutingLabel = "vertica.com/client-routing"
-	ClientRoutingVal   = "true"
-
-	VDBInstanceLabel     = "app.kubernetes.io/instance"
-	OperatorVersionLabel = "app.kubernetes.io/version"
-	ManagedByLabel       = "app.kubernetes.io/managed-by"
-	OperatorName         = "verticadb-operator" // The name of the operator
-
-	CurOperatorVersion = "1.11.0" // The version number of the operator
-	// If any of the operator versions are used in the code, add a const here.
-	// But it isn't necessary to create a const for each version.
-	OperatorVersion100 = "1.0.0"
-	OperatorVersion110 = "1.1.0"
-	OperatorVersion120 = "1.2.0"
-	OperatorVersion130 = "1.3.0"
+	NameLabel    = "app.kubernetes.io/name"
+	OperatorName = "verticadb-operator" // The name of the operator
 
 	// Annotations that we set in each of the pod.  These are set by the
 	// AnnotateAndLabelPodReconciler.  They are available in the pod with the
@@ -65,14 +36,14 @@ const (
 // MakeSubclusterLabels returns the labels added for the subcluster
 func MakeSubclusterLabels(sc *vapi.Subcluster) map[string]string {
 	m := map[string]string{
-		SubclusterNameLabel:      sc.Name,
-		SubclusterTypeLabel:      sc.GetType(),
-		SubclusterTransientLabel: strconv.FormatBool(sc.IsTransient),
+		vapi.SubclusterNameLabel:      sc.Name,
+		vapi.SubclusterTypeLabel:      sc.GetType(),
+		vapi.SubclusterTransientLabel: strconv.FormatBool(sc.IsTransient),
 	}
 	// Transient subclusters never have the service name label set.  At various
 	// parts of the upgrade, it will accept traffic from all of the subclusters.
 	if !sc.IsTransient {
-		m[SubclusterSvcNameLabel] = sc.GetServiceName()
+		m[vapi.SubclusterSvcNameLabel] = sc.GetServiceName()
 	}
 	return m
 }
@@ -80,11 +51,10 @@ func MakeSubclusterLabels(sc *vapi.Subcluster) map[string]string {
 // MakeOperatorLabels returns the labels that all objects created by this operator will have
 func MakeOperatorLabels(vdb *vapi.VerticaDB) map[string]string {
 	return map[string]string{
-		ManagedByLabel:                OperatorName,
-		"app.kubernetes.io/name":      "vertica",
-		VDBInstanceLabel:              vdb.Name,
-		"app.kubernetes.io/component": "database",
-		"vertica.com/database":        vdb.Spec.DBName,
+		vapi.ManagedByLabel:   OperatorName,
+		vapi.VDBInstanceLabel: vdb.Name,
+		vapi.ComponentLabel:   "database",
+		vapi.DataBaseLabel:    vdb.Spec.DBName,
 	}
 }
 
@@ -97,7 +67,7 @@ func MakeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map
 		// set this for pods in the template.  We set the operator version in
 		// the pods as part of a reconciler so that we don't have to reschedule
 		// the pods.
-		labels[OperatorVersionLabel] = CurOperatorVersion
+		labels[vapi.OperatorVersionLabel] = vapi.CurOperatorVersion
 	}
 
 	// Remaining labels are for objects that are subcluster specific
@@ -115,6 +85,10 @@ func MakeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map
 // MakeLabelsForObjects constructs the labels for a new k8s object
 func makeLabelsForObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map[string]string {
 	labels := MakeCommonLabels(vdb, sc, forPod)
+
+	// This can be overridden if a different value is specified
+	// for this label on custom labels
+	labels[NameLabel] = "vertica"
 
 	// Add any custom labels that were in the spec.
 	for k, v := range vdb.Spec.Labels {
@@ -137,7 +111,7 @@ func MakeLabelsForStsObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string
 // MakeLabelsForSvcObject will create the set of labels for use with service objects
 func MakeLabelsForSvcObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, svcType string) map[string]string {
 	labels := makeLabelsForObject(vdb, sc, false)
-	labels[SvcTypeLabel] = svcType
+	labels[vapi.SvcTypeLabel] = svcType
 	return labels
 }
 
@@ -158,7 +132,7 @@ func MakeBaseSvcSelectorLabels(vdb *vapi.VerticaDB) map[string]string {
 	// pods created from an older operator, we need to be more selective in the
 	// labels we choose.
 	return map[string]string{
-		VDBInstanceLabel: vdb.Name,
+		vapi.VDBInstanceLabel: vdb.Name,
 	}
 }
 
@@ -167,10 +141,10 @@ func MakeBaseSvcSelectorLabels(vdb *vapi.VerticaDB) map[string]string {
 // allows us to combine multiple subcluster under a single service object.
 func MakeSvcSelectorLabelsForServiceNameRouting(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
 	m := MakeBaseSvcSelectorLabels(vdb)
-	m[SubclusterSvcNameLabel] = sc.GetServiceName()
+	m[vapi.SubclusterSvcNameLabel] = sc.GetServiceName()
 	// Only route to nodes that have verified they own at least one shard and
 	// aren't pending delete
-	m[ClientRoutingLabel] = ClientRoutingVal
+	m[vapi.ClientRoutingLabel] = vapi.ClientRoutingVal
 	return m
 }
 
@@ -179,8 +153,8 @@ func MakeSvcSelectorLabelsForServiceNameRouting(vdb *vapi.VerticaDB, sc *vapi.Su
 func MakeSvcSelectorLabelsForSubclusterNameRouting(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
 	m := MakeBaseSvcSelectorLabels(vdb)
 	// Routing is done using the subcluster name rather than the service name.
-	m[SubclusterNameLabel] = sc.Name
-	m[ClientRoutingLabel] = ClientRoutingVal
+	m[vapi.SubclusterNameLabel] = sc.Name
+	m[vapi.ClientRoutingLabel] = vapi.ClientRoutingVal
 
 	return m
 }
@@ -188,7 +162,7 @@ func MakeSvcSelectorLabelsForSubclusterNameRouting(vdb *vapi.VerticaDB, sc *vapi
 // MakeStsSelectorLabels will create the selector labels for use within a StatefulSet
 func MakeStsSelectorLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
 	m := MakeBaseSvcSelectorLabels(vdb)
-	m[SubclusterNameLabel] = sc.Name
+	m[vapi.SubclusterNameLabel] = sc.Name
 	return m
 }
 

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -61,6 +61,8 @@ func MakeOperatorLabels(vdb *vapi.VerticaDB) map[string]string {
 // MakeCommonLabels returns the labels that are common to all objects.
 func MakeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map[string]string {
 	labels := MakeOperatorLabels(vdb)
+	// This can be overridden through 'labels' in the CR.
+	labels[NameLabel] = "vertica"
 	if !forPod {
 		// Apply a label to indicate a version of the operator that created the
 		// object.  This is separate from MakeOperatorLabels as we don't want to
@@ -85,10 +87,6 @@ func MakeCommonLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map
 // MakeLabelsForObjects constructs the labels for a new k8s object
 func makeLabelsForObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map[string]string {
 	labels := MakeCommonLabels(vdb, sc, forPod)
-
-	// This can be overridden if a different value is specified
-	// for this label on custom labels
-	labels[NameLabel] = "vertica"
 
 	// Add any custom labels that were in the spec.
 	for k, v := range vdb.Spec.Labels {

--- a/pkg/controllers/vas/suite_test.go
+++ b/pkg/controllers/vas/suite_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 		Client: k8sClient,
 		Log:    logger,
 		Scheme: scheme.Scheme,
-		EVRec:  mgr.GetEventRecorderFor(builder.OperatorName),
+		EVRec:  mgr.GetEventRecorderFor(vmeta.OperatorName),
 	}
 })
 

--- a/pkg/controllers/vdb/annotateandlabelpod_reconciler.go
+++ b/pkg/controllers/vdb/annotateandlabelpod_reconciler.go
@@ -100,7 +100,7 @@ func (s *AnnotateAndLabelPodReconciler) generateAnnotations() (map[string]string
 // generateLabels will generate static labels that will be applied to each running pod
 func (s *AnnotateAndLabelPodReconciler) generateLabels() map[string]string {
 	return map[string]string{
-		builder.OperatorVersionLabel: builder.CurOperatorVersion,
+		vapi.OperatorVersionLabel: vapi.CurOperatorVersion,
 	}
 }
 

--- a/pkg/controllers/vdb/annotateandlabelpod_reconciler.go
+++ b/pkg/controllers/vdb/annotateandlabelpod_reconciler.go
@@ -19,8 +19,8 @@ import (
 	"context"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -91,16 +91,16 @@ func (s *AnnotateAndLabelPodReconciler) generateAnnotations() (map[string]string
 	s.VRec.Log.Info("Kubernetes server version", "version", ver.GitVersion, "gitCommit", ver.GitCommit, "buildDate", ver.BuildDate)
 
 	return map[string]string{
-		builder.KubernetesVersionAnnotation:   ver.GitVersion,
-		builder.KubernetesGitCommitAnnotation: ver.GitCommit,
-		builder.KubernetesBuildDateAnnotation: ver.BuildDate,
+		vmeta.KubernetesVersionAnnotation:   ver.GitVersion,
+		vmeta.KubernetesGitCommitAnnotation: ver.GitCommit,
+		vmeta.KubernetesBuildDateAnnotation: ver.BuildDate,
 	}, nil
 }
 
 // generateLabels will generate static labels that will be applied to each running pod
 func (s *AnnotateAndLabelPodReconciler) generateLabels() map[string]string {
 	return map[string]string{
-		vapi.OperatorVersionLabel: vapi.CurOperatorVersion,
+		vmeta.OperatorVersionLabel: vmeta.CurOperatorVersion,
 	}
 }
 

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -118,7 +117,7 @@ func (c *ClientRoutingLabelReconciler) reconcilePod(ctx context.Context, pn type
 }
 
 func (c *ClientRoutingLabelReconciler) manipulateRoutingLabelInPod(pod *corev1.Pod, pf *PodFact) {
-	_, labelExists := pod.Labels[builder.ClientRoutingLabel]
+	_, labelExists := pod.Labels[vapi.ClientRoutingLabel]
 
 	// There are 4 cases this reconciler is used:
 	// 1) Called after add node
@@ -139,15 +138,15 @@ func (c *ClientRoutingLabelReconciler) manipulateRoutingLabelInPod(pod *corev1.P
 	switch c.ApplyMethod {
 	case AddNodeApplyMethod, PodRescheduleApplyMethod:
 		if !labelExists && pf.upNode && (pf.shardSubscriptions > 0 || !c.Vdb.IsEON()) && !pf.pendingDelete {
-			pod.Labels[builder.ClientRoutingLabel] = builder.ClientRoutingVal
+			pod.Labels[vapi.ClientRoutingLabel] = vapi.ClientRoutingVal
 			c.VRec.Log.Info("Adding client routing label", "pod",
-				pod.Name, "label", fmt.Sprintf("%s=%s", builder.ClientRoutingLabel, builder.ClientRoutingVal))
+				pod.Name, "label", fmt.Sprintf("%s=%s", vapi.ClientRoutingLabel, vapi.ClientRoutingVal))
 		}
 	case DelNodeApplyMethod:
 		if labelExists && pf.pendingDelete {
-			delete(pod.Labels, builder.ClientRoutingLabel)
+			delete(pod.Labels, vapi.ClientRoutingLabel)
 			c.VRec.Log.Info("Removing client routing label", "pod",
-				pod.Name, "label", fmt.Sprintf("%s=%s", builder.ClientRoutingLabel, builder.ClientRoutingVal))
+				pod.Name, "label", fmt.Sprintf("%s=%s", vapi.ClientRoutingLabel, vapi.ClientRoutingVal))
 		}
 	}
 }

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler.go
@@ -22,6 +22,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -117,7 +118,7 @@ func (c *ClientRoutingLabelReconciler) reconcilePod(ctx context.Context, pn type
 }
 
 func (c *ClientRoutingLabelReconciler) manipulateRoutingLabelInPod(pod *corev1.Pod, pf *PodFact) {
-	_, labelExists := pod.Labels[vapi.ClientRoutingLabel]
+	_, labelExists := pod.Labels[vmeta.ClientRoutingLabel]
 
 	// There are 4 cases this reconciler is used:
 	// 1) Called after add node
@@ -138,15 +139,15 @@ func (c *ClientRoutingLabelReconciler) manipulateRoutingLabelInPod(pod *corev1.P
 	switch c.ApplyMethod {
 	case AddNodeApplyMethod, PodRescheduleApplyMethod:
 		if !labelExists && pf.upNode && (pf.shardSubscriptions > 0 || !c.Vdb.IsEON()) && !pf.pendingDelete {
-			pod.Labels[vapi.ClientRoutingLabel] = vapi.ClientRoutingVal
+			pod.Labels[vmeta.ClientRoutingLabel] = vmeta.ClientRoutingVal
 			c.VRec.Log.Info("Adding client routing label", "pod",
-				pod.Name, "label", fmt.Sprintf("%s=%s", vapi.ClientRoutingLabel, vapi.ClientRoutingVal))
+				pod.Name, "label", fmt.Sprintf("%s=%s", vmeta.ClientRoutingLabel, vmeta.ClientRoutingVal))
 		}
 	case DelNodeApplyMethod:
 		if labelExists && pf.pendingDelete {
-			delete(pod.Labels, vapi.ClientRoutingLabel)
+			delete(pod.Labels, vmeta.ClientRoutingLabel)
 			c.VRec.Log.Info("Removing client routing label", "pod",
-				pod.Name, "label", fmt.Sprintf("%s=%s", vapi.ClientRoutingLabel, vapi.ClientRoutingVal))
+				pod.Name, "label", fmt.Sprintf("%s=%s", vmeta.ClientRoutingLabel, vmeta.ClientRoutingVal))
 		}
 	}
 }

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
@@ -55,12 +54,12 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 
 		pod := &corev1.Pod{}
 		Expect(k8sClient.Get(ctx, pfn1, pod)).Should(Succeed())
-		_, ok := pod.Labels[builder.ClientRoutingLabel]
+		_, ok := pod.Labels[vapi.ClientRoutingLabel]
 		Expect(ok).Should(BeFalse())
 		Expect(k8sClient.Get(ctx, pfn2, pod)).Should(Succeed())
-		v, ok := pod.Labels[builder.ClientRoutingLabel]
+		v, ok := pod.Labels[vapi.ClientRoutingLabel]
 		Expect(ok).Should(BeTrue())
-		Expect(v).Should(Equal(builder.ClientRoutingVal))
+		Expect(v).Should(Equal(vapi.ClientRoutingVal))
 	})
 
 	It("should ignore second subcluster when sc filter is used", func() {
@@ -86,11 +85,11 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 
 		pod := &corev1.Pod{}
 		Expect(k8sClient.Get(ctx, pfn1, pod)).Should(Succeed())
-		v, ok := pod.Labels[builder.ClientRoutingLabel]
+		v, ok := pod.Labels[vapi.ClientRoutingLabel]
 		Expect(ok).Should(BeTrue())
-		Expect(v).Should(Equal(builder.ClientRoutingVal))
+		Expect(v).Should(Equal(vapi.ClientRoutingVal))
 		Expect(k8sClient.Get(ctx, pfn2, pod)).Should(Succeed())
-		_, ok = pod.Labels[builder.ClientRoutingLabel]
+		_, ok = pod.Labels[vapi.ClientRoutingLabel]
 		Expect(ok).Should(BeFalse())
 	})
 
@@ -118,12 +117,12 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		for i := int32(0); i < sc.Size; i++ {
 			pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], i)
 			Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-			v, ok := pod.Labels[builder.ClientRoutingLabel]
+			v, ok := pod.Labels[vapi.ClientRoutingLabel]
 			if i == 0 {
 				Expect(ok).Should(BeFalse())
 			} else {
 				Expect(ok).Should(BeTrue())
-				Expect(v).Should(Equal(builder.ClientRoutingVal))
+				Expect(v).Should(Equal(vapi.ClientRoutingVal))
 			}
 		}
 	})
@@ -148,16 +147,16 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 
 		pod := &corev1.Pod{}
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		v, ok := pod.Labels[builder.ClientRoutingLabel]
+		v, ok := pod.Labels[vapi.ClientRoutingLabel]
 		Expect(ok).Should(BeTrue())
-		Expect(v).Should(Equal(builder.ClientRoutingVal))
+		Expect(v).Should(Equal(vapi.ClientRoutingVal))
 
 		pfacts.Detail[pn].pendingDelete = true
 		r.ApplyMethod = DelNodeApplyMethod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		_, ok = pod.Labels[builder.ClientRoutingLabel]
+		_, ok = pod.Labels[vapi.ClientRoutingLabel]
 		Expect(ok).Should(BeFalse())
 	})
 })

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	corev1 "k8s.io/api/core/v1"
@@ -54,12 +55,12 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 
 		pod := &corev1.Pod{}
 		Expect(k8sClient.Get(ctx, pfn1, pod)).Should(Succeed())
-		_, ok := pod.Labels[vapi.ClientRoutingLabel]
+		_, ok := pod.Labels[vmeta.ClientRoutingLabel]
 		Expect(ok).Should(BeFalse())
 		Expect(k8sClient.Get(ctx, pfn2, pod)).Should(Succeed())
-		v, ok := pod.Labels[vapi.ClientRoutingLabel]
+		v, ok := pod.Labels[vmeta.ClientRoutingLabel]
 		Expect(ok).Should(BeTrue())
-		Expect(v).Should(Equal(vapi.ClientRoutingVal))
+		Expect(v).Should(Equal(vmeta.ClientRoutingVal))
 	})
 
 	It("should ignore second subcluster when sc filter is used", func() {
@@ -85,11 +86,11 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 
 		pod := &corev1.Pod{}
 		Expect(k8sClient.Get(ctx, pfn1, pod)).Should(Succeed())
-		v, ok := pod.Labels[vapi.ClientRoutingLabel]
+		v, ok := pod.Labels[vmeta.ClientRoutingLabel]
 		Expect(ok).Should(BeTrue())
-		Expect(v).Should(Equal(vapi.ClientRoutingVal))
+		Expect(v).Should(Equal(vmeta.ClientRoutingVal))
 		Expect(k8sClient.Get(ctx, pfn2, pod)).Should(Succeed())
-		_, ok = pod.Labels[vapi.ClientRoutingLabel]
+		_, ok = pod.Labels[vmeta.ClientRoutingLabel]
 		Expect(ok).Should(BeFalse())
 	})
 
@@ -117,12 +118,12 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		for i := int32(0); i < sc.Size; i++ {
 			pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], i)
 			Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-			v, ok := pod.Labels[vapi.ClientRoutingLabel]
+			v, ok := pod.Labels[vmeta.ClientRoutingLabel]
 			if i == 0 {
 				Expect(ok).Should(BeFalse())
 			} else {
 				Expect(ok).Should(BeTrue())
-				Expect(v).Should(Equal(vapi.ClientRoutingVal))
+				Expect(v).Should(Equal(vmeta.ClientRoutingVal))
 			}
 		}
 	})
@@ -147,16 +148,16 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 
 		pod := &corev1.Pod{}
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		v, ok := pod.Labels[vapi.ClientRoutingLabel]
+		v, ok := pod.Labels[vmeta.ClientRoutingLabel]
 		Expect(ok).Should(BeTrue())
-		Expect(v).Should(Equal(vapi.ClientRoutingVal))
+		Expect(v).Should(Equal(vmeta.ClientRoutingVal))
 
 		pfacts.Detail[pn].pendingDelete = true
 		r.ApplyMethod = DelNodeApplyMethod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		_, ok = pod.Labels[vapi.ClientRoutingLabel]
+		_, ok = pod.Labels[vmeta.ClientRoutingLabel]
 		Expect(ok).Should(BeFalse())
 	})
 })

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/metrics"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	corev1 "k8s.io/api/core/v1"
@@ -150,7 +151,7 @@ func (d *DBRemoveSubclusterReconciler) resetDefaultSubcluster(ctx context.Contex
 		// remove the default subcluster that we do later will fail.  That
 		// provides a better error message than anything we do here.
 		if len(svcs.Items) > 0 {
-			return d.changeDefaultSubcluster(ctx, svcs.Items[0].Labels[vapi.SubclusterNameLabel])
+			return d.changeDefaultSubcluster(ctx, svcs.Items[0].Labels[vmeta.SubclusterNameLabel])
 		}
 	}
 	return nil

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
@@ -151,7 +150,7 @@ func (d *DBRemoveSubclusterReconciler) resetDefaultSubcluster(ctx context.Contex
 		// remove the default subcluster that we do later will fail.  That
 		// provides a better error message than anything we do here.
 		if len(svcs.Items) > 0 {
-			return d.changeDefaultSubcluster(ctx, svcs.Items[0].Labels[builder.SubclusterNameLabel])
+			return d.changeDefaultSubcluster(ctx, svcs.Items[0].Labels[vapi.SubclusterNameLabel])
 		}
 	}
 	return nil

--- a/pkg/controllers/vdb/httpservercertgen_reconciler.go
+++ b/pkg/controllers/vdb/httpservercertgen_reconciler.go
@@ -84,7 +84,7 @@ func (h *HTTPServerCertGenReconciler) createSecret(ctx context.Context, cert, ca
 			GenerateName: fmt.Sprintf("%s-http-server-tls-", h.Vdb.Name),
 			Namespace:    h.Vdb.Namespace,
 			Annotations:  builder.MakeAnnotationsForObject(h.Vdb),
-			Labels:       builder.MakeOperatorLabels(h.Vdb),
+			Labels:       builder.MakeCommonLabels(h.Vdb, nil, false),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         vapi.GroupVersion.String(),

--- a/pkg/controllers/vdb/obj_reconciler_test.go
+++ b/pkg/controllers/vdb/obj_reconciler_test.go
@@ -193,7 +193,7 @@ var _ = Describe("obj_reconcile", func() {
 				Expect(objectMeta.Annotations["gitRef"]).Should(Equal("1234abc"))
 				Expect(objectMeta.Labels["vertica.com/database"]).Should(Equal(vdb.Spec.DBName))
 				if isScSpecific {
-					Expect(objectMeta.Labels[builder.SubclusterNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].Name))
+					Expect(objectMeta.Labels[vapi.SubclusterNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].Name))
 				}
 			}
 
@@ -218,10 +218,10 @@ var _ = Describe("obj_reconcile", func() {
 
 			svc := &corev1.Service{}
 			Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-			svc.Labels[builder.OperatorVersionLabel] = builder.OperatorVersion100
+			svc.Labels[vapi.OperatorVersionLabel] = vapi.OperatorVersion100
 			Expect(k8sClient.Update(ctx, svc)).Should(Succeed())
 			Expect(k8sClient.Get(ctx, names.GenHlSvcName(vdb), svc)).Should(Succeed())
-			svc.Labels[builder.OperatorVersionLabel] = builder.OperatorVersion100
+			svc.Labels[vapi.OperatorVersionLabel] = vapi.OperatorVersion100
 			Expect(k8sClient.Update(ctx, svc)).Should(Succeed())
 
 			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
@@ -229,9 +229,9 @@ var _ = Describe("obj_reconcile", func() {
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 			Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-			Expect(svc.Labels[builder.OperatorVersionLabel]).Should(Equal(builder.CurOperatorVersion))
+			Expect(svc.Labels[vapi.OperatorVersionLabel]).Should(Equal(vapi.CurOperatorVersion))
 			Expect(k8sClient.Get(ctx, names.GenHlSvcName(vdb), svc)).Should(Succeed())
-			Expect(svc.Labels[builder.OperatorVersionLabel]).Should(Equal(builder.CurOperatorVersion))
+			Expect(svc.Labels[vapi.OperatorVersionLabel]).Should(Equal(vapi.CurOperatorVersion))
 		})
 
 		It("should create a statefulset with the configured size", func() {

--- a/pkg/controllers/vdb/obj_reconciler_test.go
+++ b/pkg/controllers/vdb/obj_reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	appsv1 "k8s.io/api/apps/v1"
@@ -193,7 +194,7 @@ var _ = Describe("obj_reconcile", func() {
 				Expect(objectMeta.Annotations["gitRef"]).Should(Equal("1234abc"))
 				Expect(objectMeta.Labels["vertica.com/database"]).Should(Equal(vdb.Spec.DBName))
 				if isScSpecific {
-					Expect(objectMeta.Labels[vapi.SubclusterNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].Name))
+					Expect(objectMeta.Labels[vmeta.SubclusterNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].Name))
 				}
 			}
 
@@ -218,10 +219,10 @@ var _ = Describe("obj_reconcile", func() {
 
 			svc := &corev1.Service{}
 			Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-			svc.Labels[vapi.OperatorVersionLabel] = vapi.OperatorVersion100
+			svc.Labels[vmeta.OperatorVersionLabel] = vmeta.OperatorVersion100
 			Expect(k8sClient.Update(ctx, svc)).Should(Succeed())
 			Expect(k8sClient.Get(ctx, names.GenHlSvcName(vdb), svc)).Should(Succeed())
-			svc.Labels[vapi.OperatorVersionLabel] = vapi.OperatorVersion100
+			svc.Labels[vmeta.OperatorVersionLabel] = vmeta.OperatorVersion100
 			Expect(k8sClient.Update(ctx, svc)).Should(Succeed())
 
 			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
@@ -229,9 +230,9 @@ var _ = Describe("obj_reconcile", func() {
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 			Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-			Expect(svc.Labels[vapi.OperatorVersionLabel]).Should(Equal(vapi.CurOperatorVersion))
+			Expect(svc.Labels[vmeta.OperatorVersionLabel]).Should(Equal(vmeta.CurOperatorVersion))
 			Expect(k8sClient.Get(ctx, names.GenHlSvcName(vdb), svc)).Should(Succeed())
-			Expect(svc.Labels[vapi.OperatorVersionLabel]).Should(Equal(vapi.CurOperatorVersion))
+			Expect(svc.Labels[vmeta.OperatorVersionLabel]).Should(Equal(vmeta.CurOperatorVersion))
 		})
 
 		It("should create a statefulset with the configured size", func() {

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -29,6 +29,7 @@ import (
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -146,7 +147,7 @@ func (o *OnlineUpgradeReconciler) precomputeStatusMsgs(ctx context.Context) (ctr
 
 	// Function we call for each secondary subcluster
 	procFunc := func(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
-		scName := sts.Labels[vapi.SubclusterNameLabel]
+		scName := sts.Labels[vmeta.SubclusterNameLabel]
 		o.StatusMsgs = append(o.StatusMsgs,
 			fmt.Sprintf("Draining secondary subcluster '%s'", scName),
 			fmt.Sprintf("Recreating pods for secondary subcluster '%s'", scName),
@@ -390,11 +391,11 @@ func (o *OnlineUpgradeReconciler) processSecondary(ctx context.Context, sts *app
 // isMatchingSubclusterType will return true if the subcluster type matches the
 // input string.  Always returns false for the transient subcluster.
 func (o *OnlineUpgradeReconciler) isMatchingSubclusterType(sts *appsv1.StatefulSet, scType string) (bool, error) {
-	isTransient, err := strconv.ParseBool(sts.Labels[vapi.SubclusterTransientLabel])
+	isTransient, err := strconv.ParseBool(sts.Labels[vmeta.SubclusterTransientLabel])
 	if err != nil {
-		return false, fmt.Errorf("could not parse label %s: %w", vapi.SubclusterTransientLabel, err)
+		return false, fmt.Errorf("could not parse label %s: %w", vmeta.SubclusterTransientLabel, err)
 	}
-	return sts.Labels[vapi.SubclusterTypeLabel] == scType && !isTransient, nil
+	return sts.Labels[vmeta.SubclusterTypeLabel] == scType && !isTransient, nil
 }
 
 // drainSubcluster will reroute traffic away from a subcluster and wait for it to be idle.
@@ -403,7 +404,7 @@ func (o *OnlineUpgradeReconciler) drainSubcluster(ctx context.Context, sts *apps
 	img := sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image
 
 	if img != o.Vdb.Spec.Image {
-		scName := sts.Labels[vapi.SubclusterNameLabel]
+		scName := sts.Labels[vmeta.SubclusterNameLabel]
 		o.Log.Info("rerouting client traffic from subcluster", "name", scName)
 		if err := o.routeClientTraffic(ctx, scName, true); err != nil {
 			return ctrl.Result{}, err
@@ -428,7 +429,7 @@ func (o *OnlineUpgradeReconciler) recreateSubclusterWithNewImage(ctx context.Con
 		o.PFacts.Invalidate()
 	}
 
-	scName := sts.Labels[vapi.SubclusterNameLabel]
+	scName := sts.Labels[vmeta.SubclusterNameLabel]
 	podsDeleted, err := o.Manager.deletePodsRunningOldImage(ctx, scName)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -450,7 +451,7 @@ func (o *OnlineUpgradeReconciler) checkVersion(ctx context.Context, sts *appsv1.
 	// We use a custom lookup function to only find pods for the subcluster we
 	// are working on.
 	vr := a.(*VersionReconciler)
-	scName := sts.Labels[vapi.SubclusterNameLabel]
+	scName := sts.Labels[vmeta.SubclusterNameLabel]
 	vr.FindPodFunc = func() (*PodFact, bool) {
 		for _, v := range o.PFacts.Detail {
 			if v.isPodRunning && v.subclusterName == scName {
@@ -508,7 +509,7 @@ func (o *OnlineUpgradeReconciler) bringSubclusterOnline(ctx context.Context, sts
 		return res, err
 	}
 
-	scName := sts.Labels[vapi.SubclusterNameLabel]
+	scName := sts.Labels[vmeta.SubclusterNameLabel]
 
 	actor = MakeClientRoutingLabelReconciler(o.VRec, o.Vdb, o.PFacts, PodRescheduleApplyMethod, scName)
 	res, err = actor.Reconcile(ctx, &ctrl.Request{})
@@ -606,7 +607,7 @@ func (o *OnlineUpgradeReconciler) cachePrimaryImages(ctx context.Context) error 
 	}
 	for i := range stss.Items {
 		sts := &stss.Items[i]
-		if sts.Labels[vapi.SubclusterTypeLabel] == vapi.PrimarySubclusterType {
+		if sts.Labels[vmeta.SubclusterTypeLabel] == vapi.PrimarySubclusterType {
 			img := sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image
 			imageFound := false
 			for j := range o.PrimaryImages {

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -146,7 +146,7 @@ func (o *OnlineUpgradeReconciler) precomputeStatusMsgs(ctx context.Context) (ctr
 
 	// Function we call for each secondary subcluster
 	procFunc := func(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
-		scName := sts.Labels[builder.SubclusterNameLabel]
+		scName := sts.Labels[vapi.SubclusterNameLabel]
 		o.StatusMsgs = append(o.StatusMsgs,
 			fmt.Sprintf("Draining secondary subcluster '%s'", scName),
 			fmt.Sprintf("Recreating pods for secondary subcluster '%s'", scName),
@@ -390,11 +390,11 @@ func (o *OnlineUpgradeReconciler) processSecondary(ctx context.Context, sts *app
 // isMatchingSubclusterType will return true if the subcluster type matches the
 // input string.  Always returns false for the transient subcluster.
 func (o *OnlineUpgradeReconciler) isMatchingSubclusterType(sts *appsv1.StatefulSet, scType string) (bool, error) {
-	isTransient, err := strconv.ParseBool(sts.Labels[builder.SubclusterTransientLabel])
+	isTransient, err := strconv.ParseBool(sts.Labels[vapi.SubclusterTransientLabel])
 	if err != nil {
-		return false, fmt.Errorf("could not parse label %s: %w", builder.SubclusterTransientLabel, err)
+		return false, fmt.Errorf("could not parse label %s: %w", vapi.SubclusterTransientLabel, err)
 	}
-	return sts.Labels[builder.SubclusterTypeLabel] == scType && !isTransient, nil
+	return sts.Labels[vapi.SubclusterTypeLabel] == scType && !isTransient, nil
 }
 
 // drainSubcluster will reroute traffic away from a subcluster and wait for it to be idle.
@@ -403,7 +403,7 @@ func (o *OnlineUpgradeReconciler) drainSubcluster(ctx context.Context, sts *apps
 	img := sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image
 
 	if img != o.Vdb.Spec.Image {
-		scName := sts.Labels[builder.SubclusterNameLabel]
+		scName := sts.Labels[vapi.SubclusterNameLabel]
 		o.Log.Info("rerouting client traffic from subcluster", "name", scName)
 		if err := o.routeClientTraffic(ctx, scName, true); err != nil {
 			return ctrl.Result{}, err
@@ -428,7 +428,7 @@ func (o *OnlineUpgradeReconciler) recreateSubclusterWithNewImage(ctx context.Con
 		o.PFacts.Invalidate()
 	}
 
-	scName := sts.Labels[builder.SubclusterNameLabel]
+	scName := sts.Labels[vapi.SubclusterNameLabel]
 	podsDeleted, err := o.Manager.deletePodsRunningOldImage(ctx, scName)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -450,7 +450,7 @@ func (o *OnlineUpgradeReconciler) checkVersion(ctx context.Context, sts *appsv1.
 	// We use a custom lookup function to only find pods for the subcluster we
 	// are working on.
 	vr := a.(*VersionReconciler)
-	scName := sts.Labels[builder.SubclusterNameLabel]
+	scName := sts.Labels[vapi.SubclusterNameLabel]
 	vr.FindPodFunc = func() (*PodFact, bool) {
 		for _, v := range o.PFacts.Detail {
 			if v.isPodRunning && v.subclusterName == scName {
@@ -508,7 +508,7 @@ func (o *OnlineUpgradeReconciler) bringSubclusterOnline(ctx context.Context, sts
 		return res, err
 	}
 
-	scName := sts.Labels[builder.SubclusterNameLabel]
+	scName := sts.Labels[vapi.SubclusterNameLabel]
 
 	actor = MakeClientRoutingLabelReconciler(o.VRec, o.Vdb, o.PFacts, PodRescheduleApplyMethod, scName)
 	res, err = actor.Reconcile(ctx, &ctrl.Request{})
@@ -606,7 +606,7 @@ func (o *OnlineUpgradeReconciler) cachePrimaryImages(ctx context.Context) error 
 	}
 	for i := range stss.Items {
 		sts := &stss.Items[i]
-		if sts.Labels[builder.SubclusterTypeLabel] == vapi.PrimarySubclusterType {
+		if sts.Labels[vapi.SubclusterTypeLabel] == vapi.PrimarySubclusterType {
 			img := sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image
 			imageFound := false
 			for j := range o.PrimaryImages {

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	appsv1 "k8s.io/api/apps/v1"
@@ -142,14 +143,14 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(r.routeClientTraffic(ctx, ScName, true)).Should(Succeed())
 		svc := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, sc), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(TransientScName))
+		Expect(svc.Spec.Selector[vmeta.SubclusterSvcNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vmeta.SubclusterNameLabel]).Should(Equal(TransientScName))
 
 		// Route back to original subcluster
 		Expect(r.routeClientTraffic(ctx, ScName, false)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, sc), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(sc.GetServiceName()))
-		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vmeta.SubclusterSvcNameLabel]).Should(Equal(sc.GetServiceName()))
+		Expect(svc.Spec.Selector[vmeta.SubclusterNameLabel]).Should(Equal(""))
 	})
 
 	It("should not route client traffic to transient subcluster since it doesn't exist", func() {
@@ -179,9 +180,9 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(r.routeClientTraffic(ctx, ScName, true)).Should(Succeed())
 		svc := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, sc), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(ScName))
-		Expect(svc.Spec.Selector[vapi.ClientRoutingLabel]).Should(Equal(vapi.ClientRoutingVal))
+		Expect(svc.Spec.Selector[vmeta.SubclusterSvcNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vmeta.SubclusterNameLabel]).Should(Equal(ScName))
+		Expect(svc.Spec.Selector[vmeta.ClientRoutingLabel]).Should(Equal(vmeta.ClientRoutingVal))
 	})
 
 	It("should avoid creating transient if the cluster is down", func() {
@@ -226,7 +227,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 
 		svc := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(PriScName))
+		Expect(svc.Spec.Selector[vmeta.SubclusterSvcNameLabel]).Should(Equal(PriScName))
 
 		r := createOnlineUpgradeReconciler(ctx, vdb)
 		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{}))
@@ -234,22 +235,22 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		// Route for primary subcluster
 		Expect(r.routeClientTraffic(ctx, PriScName, true)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterTransientLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(SecScName))
+		Expect(svc.Spec.Selector[vmeta.SubclusterTransientLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vmeta.SubclusterSvcNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vmeta.SubclusterNameLabel]).Should(Equal(SecScName))
 		Expect(r.routeClientTraffic(ctx, PriScName, false)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterTransientLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].GetServiceName()))
-		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vmeta.SubclusterTransientLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vmeta.SubclusterSvcNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].GetServiceName()))
+		Expect(svc.Spec.Selector[vmeta.SubclusterNameLabel]).Should(Equal(""))
 
 		// Route for secondary subcluster
 		Expect(r.routeClientTraffic(ctx, SecScName, true)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[1]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(PriScName))
+		Expect(svc.Spec.Selector[vmeta.SubclusterNameLabel]).Should(Equal(PriScName))
 		Expect(r.routeClientTraffic(ctx, SecScName, false)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[1]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(SecScName))
+		Expect(svc.Spec.Selector[vmeta.SubclusterSvcNameLabel]).Should(Equal(SecScName))
 	})
 
 	It("should not match transient subclusters", func() {
@@ -279,7 +280,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(r.isMatchingSubclusterType(sts, vapi.PrimarySubclusterType)).Should(BeFalse())
 		Expect(r.isMatchingSubclusterType(sts, vapi.SecondarySubclusterType)).Should(BeTrue())
 
-		sts.Labels[vapi.SubclusterTypeLabel] = "true" // Fake a transient subcluster
+		sts.Labels[vmeta.SubclusterTypeLabel] = "true" // Fake a transient subcluster
 		Expect(r.isMatchingSubclusterType(sts, vapi.PrimarySubclusterType)).Should(BeFalse())
 		Expect(r.isMatchingSubclusterType(sts, vapi.SecondarySubclusterType)).Should(BeFalse())
 	})

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
@@ -143,14 +142,14 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(r.routeClientTraffic(ctx, ScName, true)).Should(Succeed())
 		svc := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, sc), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterSvcNameLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[builder.SubclusterNameLabel]).Should(Equal(TransientScName))
+		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(TransientScName))
 
 		// Route back to original subcluster
 		Expect(r.routeClientTraffic(ctx, ScName, false)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, sc), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterSvcNameLabel]).Should(Equal(sc.GetServiceName()))
-		Expect(svc.Spec.Selector[builder.SubclusterNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(sc.GetServiceName()))
+		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(""))
 	})
 
 	It("should not route client traffic to transient subcluster since it doesn't exist", func() {
@@ -180,9 +179,9 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(r.routeClientTraffic(ctx, ScName, true)).Should(Succeed())
 		svc := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, sc), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterSvcNameLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[builder.SubclusterNameLabel]).Should(Equal(ScName))
-		Expect(svc.Spec.Selector[builder.ClientRoutingLabel]).Should(Equal(builder.ClientRoutingVal))
+		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(ScName))
+		Expect(svc.Spec.Selector[vapi.ClientRoutingLabel]).Should(Equal(vapi.ClientRoutingVal))
 	})
 
 	It("should avoid creating transient if the cluster is down", func() {
@@ -227,7 +226,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 
 		svc := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterSvcNameLabel]).Should(Equal(PriScName))
+		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(PriScName))
 
 		r := createOnlineUpgradeReconciler(ctx, vdb)
 		Expect(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{}))
@@ -235,22 +234,22 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		// Route for primary subcluster
 		Expect(r.routeClientTraffic(ctx, PriScName, true)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterTransientLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[builder.SubclusterSvcNameLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[builder.SubclusterNameLabel]).Should(Equal(SecScName))
+		Expect(svc.Spec.Selector[vapi.SubclusterTransientLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(SecScName))
 		Expect(r.routeClientTraffic(ctx, PriScName, false)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[0]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterTransientLabel]).Should(Equal(""))
-		Expect(svc.Spec.Selector[builder.SubclusterSvcNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].GetServiceName()))
-		Expect(svc.Spec.Selector[builder.SubclusterNameLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vapi.SubclusterTransientLabel]).Should(Equal(""))
+		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(vdb.Spec.Subclusters[0].GetServiceName()))
+		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(""))
 
 		// Route for secondary subcluster
 		Expect(r.routeClientTraffic(ctx, SecScName, true)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[1]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterNameLabel]).Should(Equal(PriScName))
+		Expect(svc.Spec.Selector[vapi.SubclusterNameLabel]).Should(Equal(PriScName))
 		Expect(r.routeClientTraffic(ctx, SecScName, false)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, names.GenExtSvcName(vdb, &vdb.Spec.Subclusters[1]), svc)).Should(Succeed())
-		Expect(svc.Spec.Selector[builder.SubclusterSvcNameLabel]).Should(Equal(SecScName))
+		Expect(svc.Spec.Selector[vapi.SubclusterSvcNameLabel]).Should(Equal(SecScName))
 	})
 
 	It("should not match transient subclusters", func() {
@@ -280,7 +279,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(r.isMatchingSubclusterType(sts, vapi.PrimarySubclusterType)).Should(BeFalse())
 		Expect(r.isMatchingSubclusterType(sts, vapi.SecondarySubclusterType)).Should(BeTrue())
 
-		sts.Labels[builder.SubclusterTypeLabel] = "true" // Fake a transient subcluster
+		sts.Labels[vapi.SubclusterTypeLabel] = "true" // Fake a transient subcluster
 		Expect(r.isMatchingSubclusterType(sts, vapi.PrimarySubclusterType)).Should(BeFalse())
 		Expect(r.isMatchingSubclusterType(sts, vapi.SecondarySubclusterType)).Should(BeFalse())
 	})

--- a/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
+++ b/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
@@ -21,8 +21,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	corev1 "k8s.io/api/core/v1"
@@ -45,9 +45,9 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 		pod := &corev1.Pod{}
 		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		Expect(pod.Annotations[builder.KubernetesBuildDateAnnotation]).ShouldNot(Equal(""))
-		Expect(pod.Annotations[builder.KubernetesGitCommitAnnotation]).ShouldNot(Equal(""))
-		Expect(pod.Annotations[builder.KubernetesVersionAnnotation]).ShouldNot(Equal(""))
+		Expect(pod.Annotations[vmeta.KubernetesBuildDateAnnotation]).ShouldNot(Equal(""))
+		Expect(pod.Annotations[vmeta.KubernetesGitCommitAnnotation]).ShouldNot(Equal(""))
+		Expect(pod.Annotations[vmeta.KubernetesVersionAnnotation]).ShouldNot(Equal(""))
 	})
 
 	It("should include operator version in the pod", func() {
@@ -61,7 +61,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
 		pod.SetAnnotations(map[string]string{
-			vapi.OperatorVersionLabel: "1.0.0",
+			vmeta.OperatorVersionLabel: "1.0.0",
 		})
 		Expect(k8sClient.Update(ctx, pod)).Should(Succeed())
 
@@ -71,6 +71,6 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		Expect(pod.Labels[vapi.OperatorVersionLabel]).Should(Equal(vapi.CurOperatorVersion))
+		Expect(pod.Labels[vmeta.OperatorVersionLabel]).Should(Equal(vmeta.CurOperatorVersion))
 	})
 })

--- a/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
+++ b/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
 		pod.SetAnnotations(map[string]string{
-			builder.OperatorVersionLabel: "1.0.0",
+			vapi.OperatorVersionLabel: "1.0.0",
 		})
 		Expect(k8sClient.Update(ctx, pod)).Should(Succeed())
 
@@ -71,6 +71,6 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())
-		Expect(pod.Labels[builder.OperatorVersionLabel]).Should(Equal(builder.CurOperatorVersion))
+		Expect(pod.Labels[vapi.OperatorVersionLabel]).Should(Equal(vapi.CurOperatorVersion))
 	})
 })

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -284,7 +284,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		pf.isPodRunning = pod.Status.Phase == corev1.PodRunning
 		pf.dnsName = pod.Spec.Hostname + "." + pod.Spec.Subdomain
 		pf.podIP = pod.Status.PodIP
-		pf.isTransient, _ = strconv.ParseBool(pod.Labels[builder.SubclusterTransientLabel])
+		pf.isTransient, _ = strconv.ParseBool(pod.Labels[vapi.SubclusterTransientLabel])
 		pf.pendingDelete = podIndex >= sc.Size
 		pf.image = pod.Spec.Containers[ServerContainerIndex].Image
 		pf.hasDCTableAnnotations = p.checkDCTableAnnotations(pod)

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	appsv1 "k8s.io/api/apps/v1"
@@ -288,7 +289,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		pf.isPodRunning = pod.Status.Phase == corev1.PodRunning
 		pf.dnsName = pod.Spec.Hostname + "." + pod.Spec.Subdomain
 		pf.podIP = pod.Status.PodIP
-		pf.isTransient, _ = strconv.ParseBool(pod.Labels[vapi.SubclusterTransientLabel])
+		pf.isTransient, _ = strconv.ParseBool(pod.Labels[vmeta.SubclusterTransientLabel])
 		pf.pendingDelete = podIndex >= sc.Size
 		pf.image = pod.Spec.Containers[ServerContainerIndex].Image
 		pf.hasDCTableAnnotations = p.checkDCTableAnnotations(pod)
@@ -578,7 +579,7 @@ func (p *PodFact) setDepotDetails(op string) error {
 // to populate the DC tables that we log at vertica start.
 func (p *PodFacts) checkDCTableAnnotations(pod *corev1.Pod) bool {
 	// We just look for one annotation.  This works because they are always added together.
-	_, ok := pod.Annotations[builder.KubernetesVersionAnnotation]
+	_, ok := pod.Annotations[vmeta.KubernetesVersionAnnotation]
 	return ok
 }
 

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -28,6 +28,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +79,7 @@ var _ = BeforeSuite(func() {
 		Log:             logger,
 		Scheme:          scheme.Scheme,
 		Cfg:             restCfg,
-		EVRec:           mgr.GetEventRecorderFor(builder.OperatorName),
+		EVRec:           mgr.GetEventRecorderFor(vmeta.OperatorName),
 		DeploymentNames: *builder.DefaultDeploymentNames(),
 	}
 })

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -24,6 +24,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/metrics"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
@@ -175,7 +176,7 @@ func (i *UpgradeManager) updateImageInStatefulSets(ctx context.Context) (int, ct
 	for inx := range stss.Items {
 		sts := &stss.Items[inx]
 
-		isTransient, err := strconv.ParseBool(sts.Labels[vapi.SubclusterTransientLabel])
+		isTransient, err := strconv.ParseBool(sts.Labels[vmeta.SubclusterTransientLabel])
 		if err != nil {
 			return numStsChanged, ctrl.Result{}, err
 		}
@@ -232,7 +233,7 @@ func (i *UpgradeManager) deletePodsRunningOldImage(ctx context.Context, scName s
 
 		// If scName was passed in, we only delete for a specific subcluster
 		if scName != "" {
-			scNameFromLabel, ok := pod.Labels[vapi.SubclusterNameLabel]
+			scNameFromLabel, ok := pod.Labels[vmeta.SubclusterNameLabel]
 			if ok && scNameFromLabel != scName {
 				continue
 			}

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	"github.com/vertica/vertica-kubernetes/pkg/metrics"
@@ -176,7 +175,7 @@ func (i *UpgradeManager) updateImageInStatefulSets(ctx context.Context) (int, ct
 	for inx := range stss.Items {
 		sts := &stss.Items[inx]
 
-		isTransient, err := strconv.ParseBool(sts.Labels[builder.SubclusterTransientLabel])
+		isTransient, err := strconv.ParseBool(sts.Labels[vapi.SubclusterTransientLabel])
 		if err != nil {
 			return numStsChanged, ctrl.Result{}, err
 		}
@@ -233,7 +232,7 @@ func (i *UpgradeManager) deletePodsRunningOldImage(ctx context.Context, scName s
 
 		// If scName was passed in, we only delete for a specific subcluster
 		if scName != "" {
-			scNameFromLabel, ok := pod.Labels[builder.SubclusterNameLabel]
+			scNameFromLabel, ok := pod.Labels[vapi.SubclusterNameLabel]
 			if ok && scNameFromLabel != scName {
 				continue
 			}

--- a/pkg/controllers/vdb/upgradeoperator120_reconciler.go
+++ b/pkg/controllers/vdb/upgradeoperator120_reconciler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -55,15 +56,15 @@ func (u *UpgradeOperator120Reconciler) Reconcile(ctx context.Context, req *ctrl.
 	// delete any sts created in prior releases.
 	for i := range stss.Items {
 		sts := &stss.Items[i]
-		opVer, ok := sts.ObjectMeta.Labels[vapi.OperatorVersionLabel]
+		opVer, ok := sts.ObjectMeta.Labels[vmeta.OperatorVersionLabel]
 		if !ok {
 			continue
 		}
 		switch opVer {
-		case vapi.OperatorVersion120, vapi.OperatorVersion110, vapi.OperatorVersion100:
+		case vmeta.OperatorVersion120, vmeta.OperatorVersion110, vmeta.OperatorVersion100:
 			u.VRec.Event(u.Vdb, corev1.EventTypeNormal, events.OperatorUpgrade,
 				fmt.Sprintf("Deleting statefulset '%s' because it was created by an old operator (pre-%s)",
-					sts.Name, vapi.OperatorVersion130))
+					sts.Name, vmeta.OperatorVersion130))
 			if err := u.VRec.Client.Delete(ctx, sts); err != nil {
 				u.Log.Info("Error deleting old statefulset", "opVer", opVer)
 				return ctrl.Result{}, err

--- a/pkg/controllers/vdb/upgradeoperator120_reconciler.go
+++ b/pkg/controllers/vdb/upgradeoperator120_reconciler.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
@@ -56,15 +55,15 @@ func (u *UpgradeOperator120Reconciler) Reconcile(ctx context.Context, req *ctrl.
 	// delete any sts created in prior releases.
 	for i := range stss.Items {
 		sts := &stss.Items[i]
-		opVer, ok := sts.ObjectMeta.Labels[builder.OperatorVersionLabel]
+		opVer, ok := sts.ObjectMeta.Labels[vapi.OperatorVersionLabel]
 		if !ok {
 			continue
 		}
 		switch opVer {
-		case builder.OperatorVersion120, builder.OperatorVersion110, builder.OperatorVersion100:
+		case vapi.OperatorVersion120, vapi.OperatorVersion110, vapi.OperatorVersion100:
 			u.VRec.Event(u.Vdb, corev1.EventTypeNormal, events.OperatorUpgrade,
 				fmt.Sprintf("Deleting statefulset '%s' because it was created by an old operator (pre-%s)",
-					sts.Name, builder.OperatorVersion130))
+					sts.Name, vapi.OperatorVersion130))
 			if err := u.VRec.Client.Delete(ctx, sts); err != nil {
 				u.Log.Info("Error deleting old statefulset", "opVer", opVer)
 				return ctrl.Result{}, err

--- a/pkg/controllers/vdb/upgradeoperator120_reconciler_test.go
+++ b/pkg/controllers/vdb/upgradeoperator120_reconciler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("k8s/upgradeoperator120_reconciler", func() {
 		nm := names.GenStsName(vdb, sc)
 		sts := builder.BuildStsSpec(nm, vdb, sc, builder.DefaultDeploymentNames())
 		// Set an old operator version to force the upgrade
-		sts.Labels[builder.OperatorVersionLabel] = builder.OperatorVersion110
+		sts.Labels[vapi.OperatorVersionLabel] = vapi.OperatorVersion110
 		Expect(k8sClient.Create(ctx, sts)).Should(Succeed())
 		defer func() {
 			delSts := &appsv1.StatefulSet{}

--- a/pkg/controllers/vdb/upgradeoperator120_reconciler_test.go
+++ b/pkg/controllers/vdb/upgradeoperator120_reconciler_test.go
@@ -20,6 +20,7 @@ import (
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +39,7 @@ var _ = Describe("k8s/upgradeoperator120_reconciler", func() {
 		nm := names.GenStsName(vdb, sc)
 		sts := builder.BuildStsSpec(nm, vdb, sc, builder.DefaultDeploymentNames())
 		// Set an old operator version to force the upgrade
-		sts.Labels[vapi.OperatorVersionLabel] = vapi.OperatorVersion110
+		sts.Labels[vmeta.OperatorVersionLabel] = vmeta.OperatorVersion110
 		Expect(k8sClient.Create(ctx, sts)).Should(Succeed())
 		defer func() {
 			delSts := &appsv1.StatefulSet{}

--- a/pkg/iter/sc_finder.go
+++ b/pkg/iter/sc_finder.go
@@ -129,7 +129,7 @@ func (m *SubclusterFinder) FindSubclusters(ctx context.Context, flags FindFlags)
 		// only fill in the name.  Size is intentionally left zero as this is an
 		// indication the subcluster is being removed.
 		for i := range missingSts.Items {
-			scName := missingSts.Items[i].Labels[builder.SubclusterNameLabel]
+			scName := missingSts.Items[i].Labels[vapi.SubclusterNameLabel]
 			subclusters = append(subclusters, &vapi.Subcluster{Name: scName, Size: 0})
 		}
 	}
@@ -158,7 +158,7 @@ func (m *SubclusterFinder) listObjectsOwnedByOperator(ctx context.Context, list 
 
 // hasSubclusterLabelFromVdb returns true if the given set of labels include a subcluster that is in the vdb
 func (m *SubclusterFinder) hasSubclusterLabelFromVdb(objLabels map[string]string) bool {
-	scName := objLabels[builder.SubclusterNameLabel]
+	scName := objLabels[vapi.SubclusterNameLabel]
 	_, ok := m.Subclusters[scName]
 	return ok
 }
@@ -206,14 +206,14 @@ func (m *SubclusterFinder) buildObjList(ctx context.Context, list client.ObjectL
 // hasSubclusterNameLabel returns true if there exists a label that indicates
 // the object is for a subcluster
 func hasSubclusterNameLabel(l map[string]string) bool {
-	_, ok := l[builder.SubclusterNameLabel]
+	_, ok := l[vapi.SubclusterNameLabel]
 	if ok {
 		return true
 	}
 	// Prior to 1.3.0, we had a different name for the subcluster name.  We
-	// renamed it as we added additional subcluster attributes to the labele.
+	// renamed it as we added additional subcluster attributes to the label.
 	// Check for this one too.
-	_, ok = l[builder.SubclusterLegacyNameLabel]
+	_, ok = l[vapi.SubclusterLegacyNameLabel]
 	return ok
 }
 

--- a/pkg/iter/sc_finder.go
+++ b/pkg/iter/sc_finder.go
@@ -22,6 +22,7 @@ import (
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -129,7 +130,7 @@ func (m *SubclusterFinder) FindSubclusters(ctx context.Context, flags FindFlags)
 		// only fill in the name.  Size is intentionally left zero as this is an
 		// indication the subcluster is being removed.
 		for i := range missingSts.Items {
-			scName := missingSts.Items[i].Labels[vapi.SubclusterNameLabel]
+			scName := missingSts.Items[i].Labels[vmeta.SubclusterNameLabel]
 			subclusters = append(subclusters, &vapi.Subcluster{Name: scName, Size: 0})
 		}
 	}
@@ -158,7 +159,7 @@ func (m *SubclusterFinder) listObjectsOwnedByOperator(ctx context.Context, list 
 
 // hasSubclusterLabelFromVdb returns true if the given set of labels include a subcluster that is in the vdb
 func (m *SubclusterFinder) hasSubclusterLabelFromVdb(objLabels map[string]string) bool {
-	scName := objLabels[vapi.SubclusterNameLabel]
+	scName := objLabels[vmeta.SubclusterNameLabel]
 	_, ok := m.Subclusters[scName]
 	return ok
 }
@@ -206,14 +207,14 @@ func (m *SubclusterFinder) buildObjList(ctx context.Context, list client.ObjectL
 // hasSubclusterNameLabel returns true if there exists a label that indicates
 // the object is for a subcluster
 func hasSubclusterNameLabel(l map[string]string) bool {
-	_, ok := l[vapi.SubclusterNameLabel]
+	_, ok := l[vmeta.SubclusterNameLabel]
 	if ok {
 		return true
 	}
 	// Prior to 1.3.0, we had a different name for the subcluster name.  We
 	// renamed it as we added additional subcluster attributes to the label.
 	// Check for this one too.
-	_, ok = l[vapi.SubclusterLegacyNameLabel]
+	_, ok = l[vmeta.SubclusterLegacyNameLabel]
 	return ok
 }
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -1,0 +1,25 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package meta
+
+const (
+	// Annotations that we set in each of the pod.  These are set by the
+	// AnnotateAndLabelPodReconciler.  They are available in the pod with the
+	// downwardAPI so they can be picked up by the Vertica data collector (DC).
+	KubernetesVersionAnnotation   = "kubernetes.io/version"   // Version of the k8s server
+	KubernetesGitCommitAnnotation = "kubernetes.io/gitcommit" // Git commit of the k8s server
+	KubernetesBuildDateAnnotation = "kubernetes.io/buildDate" // Build date of the k8s server
+)

--- a/pkg/meta/labels.go
+++ b/pkg/meta/labels.go
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-package v1beta1
+package meta
 
 const (
 	SvcTypeLabel              = "vertica.com/svc-type"
@@ -40,6 +40,9 @@ const (
 	ManagedByLabel       = "app.kubernetes.io/managed-by"
 	ComponentLabel       = "app.kubernetes.io/component"
 	DataBaseLabel        = "vertica.com/database"
+
+	NameLabel    = "app.kubernetes.io/name"
+	OperatorName = "verticadb-operator" // The name of the operator
 
 	CurOperatorVersion = "1.11.0" // The version number of the operator
 	// If any of the operator versions are used in the code, add a const here.

--- a/pkg/vasstatus/status.go
+++ b/pkg/vasstatus/status.go
@@ -110,11 +110,11 @@ func vasStatusUpdater(ctx context.Context, c client.Client, log logr.Logger,
 // getLabelSelector will generate the label for use in the vas status field
 func getLabelSelector(vas *vapi.VerticaAutoscaler) string {
 	return fmt.Sprintf("%s=%s,%s=%s,%s=%s",
-		builder.SubclusterSvcNameLabel,
+		vapi.SubclusterSvcNameLabel,
 		vas.Spec.ServiceName,
-		builder.VDBInstanceLabel,
+		vapi.VDBInstanceLabel,
 		vas.Spec.VerticaDBName,
-		builder.ManagedByLabel,
+		vapi.ManagedByLabel,
 		builder.OperatorName,
 	)
 }

--- a/pkg/vasstatus/status.go
+++ b/pkg/vasstatus/status.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -110,11 +110,11 @@ func vasStatusUpdater(ctx context.Context, c client.Client, log logr.Logger,
 // getLabelSelector will generate the label for use in the vas status field
 func getLabelSelector(vas *vapi.VerticaAutoscaler) string {
 	return fmt.Sprintf("%s=%s,%s=%s,%s=%s",
-		vapi.SubclusterSvcNameLabel,
+		vmeta.SubclusterSvcNameLabel,
 		vas.Spec.ServiceName,
-		vapi.VDBInstanceLabel,
+		vmeta.VDBInstanceLabel,
 		vas.Spec.VerticaDBName,
-		vapi.ManagedByLabel,
-		builder.OperatorName,
+		vmeta.ManagedByLabel,
+		vmeta.OperatorName,
 	)
 }

--- a/scripts/change-operator-version.sh
+++ b/scripts/change-operator-version.sh
@@ -57,7 +57,7 @@ logInfo "Changing Makefile"
 perl -i -0777 -pe "s/^(VERSION \?= ).*/\${1}$VERSION/gm" $REPO_DIR/Makefile
 
 logInfo "Changing version in the operator controller"
-perl -i -0777 -pe "s/(CurOperatorVersion = \")[0-9\.]+(\")/\${1}$VERSION\${2}/g" $REPO_DIR/pkg/builder/labels_annotations.go
+perl -i -0777 -pe "s/(CurOperatorVersion = \")[0-9\.]+(\")/\${1}$VERSION\${2}/g" $REPO_DIR/pkg/meta/labels.go
 cd $REPO_DIR
 make fmt
 

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-assert.yaml
@@ -19,3 +19,31 @@ status:
   installCount: 3
   addedToDBCount: 3
   upNodeCount: 3
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-base-upgrade-pri-0
+  labels:
+    app.kubernetes.io/name: e2e-server-upgrade
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-base-upgrade-pri-1
+  labels:
+    app.kubernetes.io/name: e2e-server-upgrade
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-base-upgrade-pri-2
+  labels:
+    app.kubernetes.io/name: e2e-server-upgrade
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-pri
+  labels:
+    app.kubernetes.io/name: e2e-server-upgrade

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
@@ -22,6 +22,8 @@ spec:
   local:
     requestSize: 100Mi
   kSafety: "1"
+  labels:
+    app.kubernetes.io/name: "e2e-server-upgrade"
   upgradePolicy: Offline
   subclusters:
     - name: pri


### PR DESCRIPTION
We can now set the following label in the CR:
```
spec:
  labels:
    app.kubernetes.io/name: "org-name"
```
All k8s created object will have it. If it is not set in the CR, it will assume the default value which is `vertica`.

A webhook has also been added to prevent other internally used labels to be overridden.

Closes #384