### PR TITLE
Avoid mounting dbadmin password if not needed

### DIFF
--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -288,6 +288,7 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.validateLocalStorage(allErrs)
 	allErrs = v.validateHTTPServerMode(allErrs)
 	allErrs = v.hasValidShardCount(allErrs)
+	allErrs = v.hasValidProbeOverrides(allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -921,6 +922,39 @@ func (v *VerticaDB) hasValidShardCount(allErrs field.ErrorList) field.ErrorList 
 		v.Spec.ShardCount,
 		"Shard count must be > 0")
 	return append(allErrs, err)
+}
+
+func (v *VerticaDB) hasValidProbeOverrides(allErrs field.ErrorList) field.ErrorList {
+	parentField := field.NewPath("spec")
+	allErrs = v.hasValidProbeOverride(allErrs, parentField.Child("readinessProbeOverride"), v.Spec.ReadinessProbeOverride)
+	allErrs = v.hasValidProbeOverride(allErrs, parentField.Child("startupProbeOverride"), v.Spec.StartupProbeOverride)
+	allErrs = v.hasValidProbeOverride(allErrs, parentField.Child("livenessProbeOverride"), v.Spec.LivenessProbeOverride)
+	return allErrs
+}
+
+func (v *VerticaDB) hasValidProbeOverride(allErrs field.ErrorList, fieldPath *field.Path, probe *v1.Probe) field.ErrorList {
+	if probe == nil {
+		return allErrs
+	}
+	// There are different kinds of handlers. You are only allowed to specify no more than one.
+	handlerCount := 0
+	if probe.Exec != nil {
+		handlerCount++
+	}
+	if probe.TCPSocket != nil {
+		handlerCount++
+	}
+	if probe.GRPC != nil {
+		handlerCount++
+	}
+	if probe.HTTPGet != nil {
+		handlerCount++
+	}
+	if handlerCount > 1 {
+		err := field.Invalid(fieldPath, probe, "can only specify one handler in the override")
+		allErrs = append(allErrs, err)
+	}
+	return allErrs
 }
 
 func (v *VerticaDB) isImageChangeInProgress() bool {

--- a/api/v1beta1/verticadb_webhook_test.go
+++ b/api/v1beta1/verticadb_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _ = Describe("verticadb_webhook", func() {
@@ -676,6 +677,33 @@ var _ = Describe("verticadb_webhook", func() {
 		validateSpecValuesHaveErr(vdb, true)
 		vdb.Spec.Subclusters[0].VerticaHTTPNodePort = 30000 // Okay
 		validateSpecValuesHaveErr(vdb, false)
+	})
+
+	It("should only allow a single handler to be overidden", func() {
+		vdb := MakeVDB()
+		vdb.Spec.ReadinessProbeOverride = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"vsql", "-c", "select 1"},
+				},
+				TCPSocket: &v1.TCPSocketAction{
+					Port: intstr.FromInt(5433),
+				},
+			},
+		}
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.ReadinessProbeOverride = nil
+		vdb.Spec.LivenessProbeOverride = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				GRPC: &v1.GRPCAction{
+					Port: 5433,
+				},
+				HTTPGet: &v1.HTTPGetAction{
+					Path: "/health",
+				},
+			},
+		}
+		validateSpecValuesHaveErr(vdb, true)
 	})
 
 	It("should verify the shard count", func() {

--- a/changes/unreleased/Fixed-20230511-151513.yaml
+++ b/changes/unreleased/Fixed-20230511-151513.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Avoid mounting dbadmin password if not needed
+time: 2023-05-11T15:15:13.987801525-03:00
+custom:
+  Issue: "396"

--- a/tests/e2e-leg-2/restart-sanity/01-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/01-assert.yaml
@@ -11,26 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: v-restart
-status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 3
-      upNodeCount: 3
+  name: integration-test-role
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  name: v-restart-defsc-0
-spec:
-  containers:
-  - name: server
-    readinessProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
-    startupProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
+  name: integration-test-rb
+

--- a/tests/e2e-leg-2/restart-sanity/01-rbac.yaml
+++ b/tests/e2e-leg-2/restart-sanity/01-rbac.yaml
@@ -11,26 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-restart
-status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 3
-      upNodeCount: 3
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: v-restart-defsc-0
-spec:
-  containers:
-  - name: server
-    readinessProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
-    startupProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-2/restart-sanity/12-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/12-assert.yaml
@@ -43,3 +43,10 @@ metadata:
 status:
   containerStatuses:
     - ready: true
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grant-dbadmin-local-access
+status:
+  succeeded: 1

--- a/tests/e2e-leg-2/restart-sanity/13-verify-passwd-mounted.yaml
+++ b/tests/e2e-leg-2/restart-sanity/13-verify-passwd-mounted.yaml
@@ -11,26 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-restart
-status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 3
-      upNodeCount: 3
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: v-restart-defsc-0
-spec:
-  containers:
-  - name: server
-    readinessProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
-    startupProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: kubectl exec -n $NAMESPACE v-restart-defsc-0 -- bash -c "ls /etc/podinfo"
+  # dbadmin password should be mounted because we reference it in probes.
+  - command: kubectl exec -n $NAMESPACE v-restart-defsc-0 -- bash -c "test -f /etc/podinfo/superuser-passwd"
+

--- a/tests/e2e-leg-2/restart-sanity/33-change-probes.yaml
+++ b/tests/e2e-leg-2/restart-sanity/33-change-probes.yaml
@@ -15,22 +15,13 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-restart
-status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 3
-      upNodeCount: 3
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: v-restart-defsc-0
 spec:
-  containers:
-  - name: server
-    readinessProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
-    startupProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
+  # Change the probes so that they no longer reference password. This will
+  # cause the operator to change the sts so that we don't mount the password
+  # anymore .
+  readinessProbeOverride:
+    exec:
+      command: ["vsql", "-c", "select 1"]
+  startupProbeOverride:
+    exec:
+      command: ["vsql", "-c", "select 1"]

--- a/tests/e2e-leg-2/restart-sanity/43-verify-passwd-not-mounted.yaml
+++ b/tests/e2e-leg-2/restart-sanity/43-verify-passwd-not-mounted.yaml
@@ -11,26 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-restart
-status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 3
-      upNodeCount: 3
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: v-restart-defsc-0
-spec:
-  containers:
-  - name: server
-    readinessProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
-    startupProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: kubectl exec -n $NAMESPACE v-restart-defsc-0 -- bash -c "ls /etc/podinfo"
+  # dbadmin password should be mounted because we reference it in probes.
+  - command: kubectl exec -n $NAMESPACE v-restart-defsc-0 -- bash -c "! test -f /etc/podinfo/superuser-passwd"
+

--- a/tests/e2e-leg-2/restart-sanity/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-2/restart-sanity/setup-vdb/base/setup-vdb.yaml
@@ -35,3 +35,60 @@ spec:
   imagePullSecrets: []
   volumes: []
   volumeMounts: []
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-grant-dbadmin-local-access
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    # Allow local dbadmin access without a password
+    kubectl exec -it svc/v-restart-defsc -- vsql -w superuser -c "\
+          CREATE AUTHENTICATION v_dbadmin_trust METHOD 'trust' LOCAL; \
+          GRANT AUTHENTICATION v_dbadmin_trust TO dbadmin; \
+          ALTER AUTHENTICATION v_dbadmin_trust PRIORITY 10000; \
+          select sync_catalog(); "
+---
+apiVersion: vertica.com/v1beta1
+kind: EventTrigger
+metadata:
+  name: grant-dbadmin-local-access
+spec:
+  references:
+  - object:
+      apiVersion: vertica.com/v1beta1
+      kind: VerticaDB
+      name: v-restart
+  matches:
+  - condition:
+      type: DBInitialized
+      status: "True"
+  template:
+    metadata:
+      name: grant-dbadmin-local-access
+      labels:
+        stern: include
+      annotations:
+        test-name: v-restart
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: test
+              image: bitnami/kubectl:1.20.4
+              command: ["/bin/entrypoint.sh"]
+              volumeMounts:
+                - name: entrypoint-volume
+                  mountPath: /bin/entrypoint.sh
+                  readOnly: true
+                  subPath: entrypoint.sh
+          volumes:
+            - name: entrypoint-volume
+              configMap:
+                defaultMode: 0777
+                name: script-grant-dbadmin-local-access

--- a/tests/e2e-leg-3/multi-sc-sanity/10-assert.yaml
+++ b/tests/e2e-leg-3/multi-sc-sanity/10-assert.yaml
@@ -11,6 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-multi-sc-sc-1
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        livenessProbe:
+          periodSeconds: 10
+          initialDelaySeconds: 5
+        readinessProbe:
+          tcpSocket:
+            port: 5433
+        startupProbe:
+          tcpSocket:
+            port: 5433
+---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:

--- a/tests/e2e-leg-3/multi-sc-sanity/13-verify-passwd-not-mounted.yaml
+++ b/tests/e2e-leg-3/multi-sc-sanity/13-verify-passwd-not-mounted.yaml
@@ -11,26 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-restart
-status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 3
-      upNodeCount: 3
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: v-restart-defsc-0
-spec:
-  containers:
-  - name: server
-    readinessProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
-    startupProbe:
-      exec:
-        command: ["vsql", "-c", "select 1"]
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: kubectl exec -n $NAMESPACE v-multi-sc-sc-1-0 -- bash -c "ls /etc/podinfo"
+  # dbadmin password should not be mounted because we don't reference it in probes.
+  - command: kubectl exec -n $NAMESPACE v-multi-sc-sc-1-0 -- bash -c "! test -f /etc/podinfo/superuser-passwd"

--- a/tests/e2e-leg-3/multi-sc-sanity/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-3/multi-sc-sanity/setup-vdb/base/setup-vdb.yaml
@@ -31,6 +31,17 @@ spec:
       size: 1
       isPrimary: true
   kSafety: "0"
+  # Override the readiness/startup probes to not use the dbadmin password. This
+  # will cause the dbadmin password not to be mounted in the container.
+  readinessProbeOverride:
+    tcpSocket:
+      port: 5433
+  startupProbeOverride:
+    tcpSocket:
+      port: 5433
+  livenessProbeOverride:
+    periodSeconds: 10
+    initialDelaySeconds: 5
   encryptSpreadComm: vertica
   certSecrets: []
   imagePullSecrets: []


### PR DESCRIPTION
Currently, the dbadmin password is mounted in the container at /etc/podinfo/superuser-passwd. This is needed so that readiness/startup probes can log into vertica and run the 'select 1' canary query. This change is to satisfy a request to avoid mounting the password if the probes are change to not refer to the password.

There are two ways you can change the probes:

1. Check if the client port is open.

Instead of checking the canary query. Just check if the client port is opened. Include overrides for the readiness and startup probes in the vdb like this:

```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: v
spec:
  ...
  readinessProbeOverride:
    tcpSocket:
      port: 5433
  startupProbeOverride:
    tcpSocket:
      port: 5433
```

2. Setup local trust for the dbadmin

Keep using the canary query but setup local trust for dbadmin so a password isn't needed. After the database is up, setup a local trust using SQL like the following:

```
CREATE AUTHENTICATION v_dbadmin_trust METHOD 'trust' LOCAL;
GRANT AUTHENTICATION v_dbadmin_trust TO dbadmin;
ALTER AUTHENTICATION v_dbadmin_trust PRIORITY 10000;
SELECT sync_catalog();
```

This can be included in an EventTrigger so that it's done automatically after a DB was created. Then create the vdb with an override for the command.

```
apiVersion: vertica.com/v1beta1
kind: VerticaDB
metadata:
  name: v
spec:
  readinessProbeOverride:
    exec:
      command: ["vsql", "-c", "select 1"]
  startupProbeOverride:
    exec:
      command: ["vsql", "-c", "select 1"]
```

In both cases, the operator was changed to not include the mount if we no longer reference dbadmin password in any of the probes.