### PR TITLE
Fix http testcases on nightly build

### DIFF
--- a/tests/e2e-http-server/http-custom-certs/55-verify-nodes.yaml
+++ b/tests/e2e-http-server/http-custom-certs/55-verify-nodes.yaml
@@ -26,8 +26,11 @@ data:
     set -o xtrace
     set -o errexit
 
-    curl --insecure --fail --verbose --key /certs/tls.key --cert /certs/tls.crt https://v-http-custom-certs-main-0.v-http-custom-certs:8443/nodes | tee /tmp/curl.out
-    grep -cq 'v_vertdb_node0001' /tmp/curl.out
+    for endpoint in v1/nodes nodes
+    do
+      curl --insecure --fail --verbose --key /certs/tls.key --cert /certs/tls.crt https://v-http-custom-certs-main-0.v-http-custom-certs:8443/$endpoint | tee /tmp/curl.out
+      grep -cq 'v_vertdb_node0001' /tmp/curl.out && break
+    done
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e-http-server/http-generated-certs/55-verify-listtable.yaml
+++ b/tests/e2e-http-server/http-generated-certs/55-verify-listtable.yaml
@@ -28,8 +28,11 @@ data:
 
     kubectl exec -it svc/v-http-generated-certs-sc -- vsql -w superuser -c "create table IF NOT EXISTS t1 (c1 int)"
 
-    curl -k --user dbadmin:superuser https://v-http-generated-certs-sc-0.v-http-generated-certs:8443/test/listtable | tee /tmp/curl.out
-    grep -cq "public.t1" /tmp/curl.out
+    for endpoint in test/listtable v1/test/listtable
+    do
+      curl -k --user dbadmin:superuser https://v-http-generated-certs-sc-0.v-http-generated-certs:8443/$endpoint | tee /tmp/curl.out
+      grep -cq "public.t1" /tmp/curl.out && break
+    done
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e-http-server/http-generated-certs/60-verify-sync-catalog.yaml
+++ b/tests/e2e-http-server/http-generated-certs/60-verify-sync-catalog.yaml
@@ -29,7 +29,7 @@ data:
     # The catalog sync endpoint changed in 23.3. Checking both for backwards
     # compatibility. This test succeeds if one of the endpoints work. The curl
     # command below relies on pipefail being off for this to work.
-    for endpoint in cluster/catalog/sync manage/sync-catalog
+    for endpoint in cluster/catalog/sync manage/sync-catalog v1/cluster/catalog/sync
     do
       curl --insecure -X POST --fail --verbose --key /certs/tls.key --cert /certs/tls.crt https://v-http-generated-certs-sc-0.v-http-generated-certs:8443/$endpoint | tee /tmp/curl.out
       grep -cq 'new_truncation_version' /tmp/curl.out && break


### PR DESCRIPTION
The http endpoints changed in the latest server build. Updating the http testcases to allow for the new endpoint names.