### PR TITLE
Reuse node names when installing new k8s pods

### DIFF
--- a/changes/unreleased/Fixed-20230512-095131.yaml
+++ b/changes/unreleased/Fixed-20230512-095131.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Reuse node names when installing new k8s pods
+time: 2023-05-12T09:51:31.690484607-03:00
+custom:
+  Issue: "398"


### PR DESCRIPTION
This corrects node name reuse when the operator installs new hosts in the admintools.conf. The old reuse logic was a bit too simple and could end up skip reusing a name under certain circumstances. 

Note, there are two kinds of node names in vertica. The node name before a node is added to the cluster -- in the format of node####. And the vnode name, which is the name after its added to the cluster -- in the format of v_<dbname>_node####. This impacts only the first format.
