### PR TITLE
Fix udx-cpp e2e test when run against a 12.0.4

### DIFF
--- a/tests/e2e-udx/udx-cpp/35-verify-cpp-aggregate.yaml
+++ b/tests/e2e-udx/udx-cpp/35-verify-cpp-aggregate.yaml
@@ -31,7 +31,7 @@ data:
     # In 23.3, we changed the aggregate examples.
     if [ "$MAJOR" -gt 12 ] \
         || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -gt 0 ]) \
-        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -eq 0 ] && [ "$PATCH" -gt 3 ])
+        || ([ "$MAJOR" -eq 12 ] && [ "$MINOR" -eq 0 ] && [ "$PATCH" -gt 4 ])
     then
       EXP=/opt/vertica/sdk/examples/expected-outputs/23.3.0/AggregateFunctionsOut.txt
     else


### PR DESCRIPTION
The udx-cpp e2e test has different expected output depending on the server version. For 12.0.4, we mistakenly picked the 23.3.x output.