### PR TITLE
Auto delete PVC on VerticaDB deletion

### DIFF
--- a/changes/unreleased/Added-20230525-131134.yaml
+++ b/changes/unreleased/Added-20230525-131134.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Auto delete PVC on VerticaDB deletion
+time: 2023-05-25T13:11:34.683066801-03:00
+custom:
+  Issue: "407"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -778,6 +778,7 @@ func getStorageClassName(vdb *vapi.VerticaDB) *string {
 
 // BuildStsSpec builds manifest for a subclusters statefulset
 func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster, deployNames *DeploymentNames) *appsv1.StatefulSet {
+	isControllerRef := true
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
@@ -804,6 +805,16 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: vapi.LocalDataPVC,
+						// Set the ownerReference so that we get auto-deletion
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: vapi.GroupVersion.String(),
+								Kind:       vapi.VerticaDBKind,
+								Name:       vdb.Name,
+								UID:        vdb.UID,
+								Controller: &isControllerRef,
+							},
+						},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/tests/e2e-http-server/http-custom-certs/96-cleanup-storage.yaml
+++ b/tests/e2e-http-server/http-custom-certs/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-http-server/http-custom-certs/96-errors.yaml
+++ b/tests/e2e-http-server/http-custom-certs/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-http-server/http-generated-certs/96-cleanup-storage.yaml
+++ b/tests/e2e-http-server/http-generated-certs/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-http-server/http-generated-certs/96-errors.yaml
+++ b/tests/e2e-http-server/http-generated-certs/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-http-server/http-server-start/96-cleanup-storage.yaml
+++ b/tests/e2e-http-server/http-server-start/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-http-server/http-server-start/96-errors.yaml
+++ b/tests/e2e-http-server/http-server-start/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/auto-restart-vertica/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/auto-restart-vertica/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/auto-restart-vertica/98-errors.yaml
+++ b/tests/e2e-leg-1/auto-restart-vertica/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/autoscale-by-pod/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/autoscale-by-pod/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/autoscale-by-pod/96-errors.yaml
+++ b/tests/e2e-leg-1/autoscale-by-pod/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/autoscale-by-subcluster/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/autoscale-by-subcluster/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/autoscale-by-subcluster/96-errors.yaml
+++ b/tests/e2e-leg-1/autoscale-by-subcluster/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/client-access/66-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/client-access/66-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/client-access/66-errors.yaml
+++ b/tests/e2e-leg-1/client-access/66-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/crash-before-createdb/36-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/crash-before-createdb/36-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/crash-before-createdb/36-errors.yaml
+++ b/tests/e2e-leg-1/crash-before-createdb/36-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/create-and-del-crd/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/create-and-del-crd/96-errors.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/custom-cert-webhook-cabundle-as-parm/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/custom-cert-webhook-cabundle-as-parm/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/custom-cert-webhook-cabundle-as-parm/98-errors.yaml
+++ b/tests/e2e-leg-1/custom-cert-webhook-cabundle-as-parm/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/custom-cert-webhook-cabundle-in-secret/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/custom-cert-webhook-cabundle-in-secret/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/custom-cert-webhook-cabundle-in-secret/98-errors.yaml
+++ b/tests/e2e-leg-1/custom-cert-webhook-cabundle-in-secret/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/custom-operator-log-path/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/custom-operator-log-path/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/custom-operator-log-path/98-errors.yaml
+++ b/tests/e2e-leg-1/custom-operator-log-path/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/k-safety-0-scaling/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/k-safety-0-scaling/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/k-safety-0-scaling/96-errors.yaml
+++ b/tests/e2e-leg-1/k-safety-0-scaling/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/k-safety-1-scaling/21-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/k-safety-1-scaling/21-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/k-safety-1-scaling/21-errors.yaml
+++ b/tests/e2e-leg-1/k-safety-1-scaling/21-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/kill-controller/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/kill-controller/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/kill-controller/98-errors.yaml
+++ b/tests/e2e-leg-1/kill-controller/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-1/kill-during-add-node/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-1/kill-during-add-node/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-1/kill-during-add-node/96-errors.yaml
+++ b/tests/e2e-leg-1/kill-during-add-node/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/restart-node-multi-sc/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/restart-node-multi-sc/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/restart-node-multi-sc/98-errors.yaml
+++ b/tests/e2e-leg-2/restart-node-multi-sc/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/restart-sanity/51-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/restart-sanity/51-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/restart-sanity/51-errors.yaml
+++ b/tests/e2e-leg-2/restart-sanity/51-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/revivedb-failures/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/revivedb-failures/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/revivedb-failures/96-errors.yaml
+++ b/tests/e2e-leg-2/revivedb-failures/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/scale-down-drain/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/scale-down-drain/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/scale-down-drain/98-errors.yaml
+++ b/tests/e2e-leg-2/scale-down-drain/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/schedule-only/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/schedule-only/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/schedule-only/98-errors.yaml
+++ b/tests/e2e-leg-2/schedule-only/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/shared-svc/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/shared-svc/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/shared-svc/98-errors.yaml
+++ b/tests/e2e-leg-2/shared-svc/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/update-strategy/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/update-strategy/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/update-strategy/96-errors.yaml
+++ b/tests/e2e-leg-2/update-strategy/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/use-preexisting-sa-incl-rbac/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/use-preexisting-sa-incl-rbac/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/use-preexisting-sa-incl-rbac/98-errors.yaml
+++ b/tests/e2e-leg-2/use-preexisting-sa-incl-rbac/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/use-preexisting-sa-skip-rbac/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/use-preexisting-sa-skip-rbac/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/use-preexisting-sa-skip-rbac/98-errors.yaml
+++ b/tests/e2e-leg-2/use-preexisting-sa-skip-rbac/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-2/webhook/211-cleanup-storage.yaml
+++ b/tests/e2e-leg-2/webhook/211-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-2/webhook/211-errors.yaml
+++ b/tests/e2e-leg-2/webhook/211-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-3/istio/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/istio/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/istio/96-errors.yaml
+++ b/tests/e2e-leg-3/istio/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-3/labels-annotations/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/labels-annotations/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/labels-annotations/98-errors.yaml
+++ b/tests/e2e-leg-3/labels-annotations/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-3/mount-certs/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/mount-certs/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/mount-certs/96-errors.yaml
+++ b/tests/e2e-leg-3/mount-certs/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-3/multi-sc-sanity/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/multi-sc-sanity/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/multi-sc-sanity/96-errors.yaml
+++ b/tests/e2e-leg-3/multi-sc-sanity/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/96-errors.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-3/readiness-probe-override/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/readiness-probe-override/96-errors.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-3/revive-with-different-local-paths/95-delete-cr.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/95-delete-cr.yaml
@@ -16,7 +16,5 @@ kind: TestStep
 delete:
   - apiVersion: vertica.com/v1beta1
     kind: VerticaDB
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-3/revive-with-different-local-paths/95-errors.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/95-errors.yaml
@@ -22,3 +22,6 @@ metadata:
 ---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/createdb-failures/95-delete-crd.yaml
+++ b/tests/e2e-leg-4/createdb-failures/95-delete-crd.yaml
@@ -16,7 +16,5 @@ kind: TestStep
 delete:
   - apiVersion: vertica.com/v1beta1
     kind: VerticaDB
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/createdb-failures/95-errors.yaml
+++ b/tests/e2e-leg-4/createdb-failures/95-errors.yaml
@@ -22,3 +22,6 @@ metadata:
 ---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/disable-webhook/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/disable-webhook/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/disable-webhook/96-errors.yaml
+++ b/tests/e2e-leg-4/disable-webhook/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/helm-nameoverride/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/helm-nameoverride/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/helm-nameoverride/96-errors.yaml
+++ b/tests/e2e-leg-4/helm-nameoverride/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/operator-metrics/46-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/operator-metrics/46-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/operator-metrics/46-errors.yaml
+++ b/tests/e2e-leg-4/operator-metrics/46-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/pending-pod/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/pending-pod/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/pending-pod/96-errors.yaml
+++ b/tests/e2e-leg-4/pending-pod/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/pvc-expansion/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/pvc-expansion/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/pvc-expansion/96-errors.yaml
+++ b/tests/e2e-leg-4/pvc-expansion/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/restart-kill-sts/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/restart-kill-sts/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/restart-kill-sts/96-errors.yaml
+++ b/tests/e2e-leg-4/restart-kill-sts/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/restart-with-liveness-probe/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/restart-with-liveness-probe/96-errors.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/restart-with-sidecars/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/restart-with-sidecars/96-errors.yaml
+++ b/tests/e2e-leg-4/restart-with-sidecars/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/revivedb-1-node/95-delete-crd.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/95-delete-crd.yaml
@@ -16,8 +16,6 @@ kind: TestStep
 delete:
   - apiVersion: vertica.com/v1beta1
     kind: VerticaDB
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
   - apiVersion: vertica.com/v1beta1
     kind: EventTrigger
 commands:

--- a/tests/e2e-leg-4/revivedb-1-node/95-errors.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/95-errors.yaml
@@ -28,3 +28,6 @@ kind: Job
 ---
 apiVersion: vertica.com/v1beta1
 kind: EventTrigger
+---
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/revivedb-3-node/95-delete-crd.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/95-delete-crd.yaml
@@ -16,7 +16,5 @@ kind: TestStep
 delete:
   - apiVersion: vertica.com/v1beta1
     kind: VerticaDB
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/revivedb-3-node/95-errors.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/95-errors.yaml
@@ -22,3 +22,6 @@ metadata:
 ---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/revivedb-multi-sc/95-delete-crd.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/95-delete-crd.yaml
@@ -16,7 +16,5 @@ kind: TestStep
 delete:
   - apiVersion: vertica.com/v1beta1
     kind: VerticaDB
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/revivedb-multi-sc/95-errors.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/95-errors.yaml
@@ -22,3 +22,6 @@ metadata:
 ---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/vdb-gen/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-4/vdb-gen/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/vdb-gen/98-errors.yaml
+++ b/tests/e2e-leg-4/vdb-gen/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-operator-upgrade-template/template/96-errors.yaml
+++ b/tests/e2e-operator-upgrade-template/template/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/98-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/98-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/98-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/98-errors.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-block-downgrade/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-block-downgrade/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-block-downgrade/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-block-downgrade/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-down-cluster/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-down-cluster/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-down-cluster/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-down-cluster/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-drain/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-drain/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-kill-transient/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-kill-transient/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-kill-transient/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-kill-transient/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-server-upgrade/online-upgrade-with-transient/98-cleanup-storage.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-transient/98-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-server-upgrade/online-upgrade-with-transient/98-errors.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-transient/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-udx/udx-cpp/96-cleanup-storage.yaml
+++ b/tests/e2e-udx/udx-cpp/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-udx/udx-cpp/96-errors.yaml
+++ b/tests/e2e-udx/udx-cpp/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-udx/udx-java/96-cleanup-storage.yaml
+++ b/tests/e2e-udx/udx-java/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-udx/udx-java/96-errors.yaml
+++ b/tests/e2e-udx/udx-java/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-udx/udx-python/96-cleanup-storage.yaml
+++ b/tests/e2e-udx/udx-python/96-cleanup-storage.yaml
@@ -13,8 +13,5 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
 commands:
   - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-udx/udx-python/96-errors.yaml
+++ b/tests/e2e-udx/udx-python/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim


### PR DESCRIPTION
When the VerticaDB is deleted, we will also delete all of the PVCs too. We get this behaviour automatically by filling in the ownerReferences in the PVC template.

Only new StatefulSet's created by the operator will get this behaviour. If upgrading the operator to this version, and the StatefulSet isn't recreated, then auto delete won't happen. We did this because you cannot change the PVC template in the StatefulSet after it is created.