### PR TITLE
Enable EventTrigger webhook

### DIFF
--- a/api/v1beta1/eventtrigger_webhook_test.go
+++ b/api/v1beta1/eventtrigger_webhook_test.go
@@ -57,4 +57,16 @@ var _ = Describe("eventtrigger_webhook", func() {
 		Expect(et.ValidateCreate()).ShouldNot(Succeed())
 		Expect(et.ValidateUpdate(et)).ShouldNot(Succeed())
 	})
+
+	It("should fail if job name is not specified", func() {
+		et := MakeET()
+		et.Spec.Template.Metadata.Name = ""
+		et.Spec.Template.Metadata.GenerateName = ""
+		Expect(et.ValidateCreate()).ShouldNot(Succeed())
+		et.Spec.Template.Metadata.GenerateName = "job1-"
+		Expect(et.ValidateCreate()).Should(Succeed())
+		et.Spec.Template.Metadata.Name = "job1"
+		et.Spec.Template.Metadata.GenerateName = ""
+		Expect(et.ValidateCreate()).Should(Succeed())
+	})
 })

--- a/changes/unreleased/Fixed-20230526-115323.yaml
+++ b/changes/unreleased/Fixed-20230526-115323.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Enable EventTrigger webhook
+time: 2023-05-26T11:53:23.725801268-03:00
+custom:
+  Issue: "409"

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -57,6 +57,31 @@ webhooks:
     resources:
     - verticaautoscalers
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-vertica-com-v1beta1-eventtrigger
+  failurePolicy: Fail
+  name: meventtrigger.kb.io
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: "In"
+        values: [verticadb-operator-system]
+  rules:
+  - apiGroups:
+    - vertica.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eventtriggers
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -113,4 +138,29 @@ webhooks:
     - UPDATE
     resources:
     - verticadbs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-vertica-com-v1beta1-eventtrigger
+  failurePolicy: Fail
+  name: veventtrigger.kb.io
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: "In"
+        values: [verticadb-operator-system]
+  rules:
+  - apiGroups:
+    - vertica.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - eventtriggers
   sideEffects: None


### PR DESCRIPTION
We built out a webhook for the EventTrigger CRD, but we didn't include it within the webhook config file. This hooks it up so that create/update for EventTrigger CRs go through the webhook for validation.

This also adds a new webhook rule to ensure the job template has a name set.