### PR TITLE
Fix for centos:stream8 package issue

### DIFF
--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -29,7 +29,10 @@ RUN set -x \
   # Update is needed to be confident that we're picking up
   # fixed libraries.
   && yum -q -y update \
-  && yum install -y \
+  # Using --nobest to make it easier yum install to work. This stage isn't used
+  # for the final image, so any package is good enough. We just need to install
+  # the vertica rpm and copy that over.
+  && yum install -y --nobest \
   cronie \
   dialog \
   glibc \


### PR DESCRIPTION
Hitting this while installing packages for the first stage of the vertica-k8s container:

```
#0 77.36 + yum install -y cronie dialog glibc glibc-langpack-en iproute openssh-server openssh-clients openssl which zlib-devel
#0 77.84 Last metadata expiration check: 0:00:05 ago on Wed May 31 19:43:14 2023.
#0 78.97 Package glibc-2.28-228.el8.x86_64 is already installed.
#0 78.97 Package iproute-6.2.0-2.el8.x86_64 is already installed.
#0 79.07 Error:
#0 79.07  Problem: cannot install both glibc-common-2.28-226.el8.x86_64 from baseos and glibc-common-2.28-228.el8.x86_64 from @System
#0 79.07   - package glibc-langpack-en-2.28-226.el8.x86_64 from baseos requires glibc-common = 2.28-226.el8, but none of the providers can be installed
#0 79.07   - package glibc-2.28-228.el8.x86_64 from @System requires glibc-common = 2.28-228.el8, but none of the providers can be installed
#0 79.07   - cannot install the best candidate for the job
#0 79.07 (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

The container that we are using for the first stage doesn't have a static tag. So, it's susceptible to breaks. I'm using '--nobest' to solve the issue.