### PR TITLE
SSH secret mounting improvements

### DIFF
--- a/changes/unreleased/Changed-20230608-170424.yaml
+++ b/changes/unreleased/Changed-20230608-170424.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: SSH secret mounting improvements
+time: 2023-06-08T17:04:24.719180023-03:00
+custom:
+  Issue: "414"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -186,15 +186,17 @@ func buildKerberosVolumeMounts() []corev1.VolumeMount {
 }
 
 func buildSSHVolumeMounts() []corev1.VolumeMount {
-	mnts := []corev1.VolumeMount{}
-	for _, p := range paths.SSHKeyPaths {
-		mnts = append(mnts, corev1.VolumeMount{
+	// Mount the ssh key in both the dbadmin and root account. Root is needed
+	// for any calls in the pod from the installer.
+	return []corev1.VolumeMount{
+		{
 			Name:      vapi.SSHMountName,
-			MountPath: fmt.Sprintf("%s/%s", paths.SSHPath, p),
-			SubPath:   p,
-		})
+			MountPath: paths.DBAdminSSHPath,
+		}, {
+			Name:      vapi.SSHMountName,
+			MountPath: paths.RootSSHPath,
+		},
 	}
-	return mnts
 }
 
 func buildHTTPServerVolumeMount() []corev1.VolumeMount {

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -239,9 +239,14 @@ var _ = Describe("builder", func() {
 		cnt := &c.Containers[0]
 		i, ok := getFirstSSHSecretVolumeMountIndex(cnt)
 		Expect(ok).Should(BeTrue())
-		Expect(cnt.VolumeMounts[i].MountPath).Should(Equal(paths.DBAdminSSHPath))
-		Expect(len(cnt.VolumeMounts)).Should(BeNumerically(">", i+1))
-		Expect(cnt.VolumeMounts[i+1].MountPath).Should(Equal(paths.RootSSHPath))
+		const ExpectedPathsPerMount = 3
+		Expect(len(cnt.VolumeMounts)).Should(BeNumerically(">=", i+2*ExpectedPathsPerMount))
+		for j := 0; i < ExpectedPathsPerMount; i++ {
+			Expect(cnt.VolumeMounts[i+j].MountPath).Should(ContainSubstring(paths.DBAdminSSHPath))
+		}
+		for j := 0; i < ExpectedPathsPerMount; i++ {
+			Expect(cnt.VolumeMounts[i+ExpectedPathsPerMount+j].MountPath).Should(ContainSubstring(paths.RootSSHPath))
+		}
 	})
 })
 

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -57,7 +57,8 @@ const (
 	HTTPServerCertsRoot       = "/certs/http-server"
 	Krb5Conf                  = "/etc/krb5.conf"
 	Krb5Keytab                = "/etc/krb5/krb5.keytab"
-	SSHPath                   = "/home/dbadmin/.ssh"
+	DBAdminSSHPath            = "/home/dbadmin/.ssh"
+	RootSSHPath               = "/root/.ssh"
 	HTTPServerCACrtName       = "ca.crt"
 )
 
@@ -65,7 +66,7 @@ const (
 var MountPaths = []string{LocalDataPath, CELicensePath, MountedLicensePath,
 	HadoopConfPath, ConfigPath, ConfigSharePath, ConfigLogrotatePath,
 	LogPath, PodInfoPath, AdminToolsConf, AuthParmsFile, EulaAcceptanceFile,
-	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, SSHPath}
+	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, DBAdminSSHPath}
 
 // SSHKeyPaths is a list of keys that must exist in the SSHSecret
 var SSHKeyPaths = []string{"id_rsa", "id_rsa.pub", "authorized_keys"}

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -66,7 +66,7 @@ const (
 var MountPaths = []string{LocalDataPath, CELicensePath, MountedLicensePath,
 	HadoopConfPath, ConfigPath, ConfigSharePath, ConfigLogrotatePath,
 	LogPath, PodInfoPath, AdminToolsConf, AuthParmsFile, EulaAcceptanceFile,
-	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, DBAdminSSHPath}
+	EulaAcceptanceScript, CertsRoot, Krb5Conf, Krb5Keytab, DBAdminSSHPath, RootSSHPath}
 
 // SSHKeyPaths is a list of keys that must exist in the SSHSecret
 var SSHKeyPaths = []string{"id_rsa", "id_rsa.pub", "authorized_keys"}


### PR DESCRIPTION
When using your own ssh keys through a ssh secret, we now mount the secret for the root user too. This comes in handy if you are running a hybrid k8s server and need to run update_vertica from within the pod. Prior to this change you couldn't do that because the ssh key for the root user was unrecognized.