### PR TITLE
Fix to ensure vbr can find rsync

### DIFF
--- a/changes/unreleased/Fixed-20230616-085300.yaml
+++ b/changes/unreleased/Fixed-20230616-085300.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Ensure vbr can find rsync. This will be available in server versions 23.3.0 and higher.
+time: 2023-06-16T08:53:00.755543732-03:00
+custom:
+  Issue: "418"

--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -200,7 +200,10 @@ RUN set -x \
   && tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz \
   && tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
   # delete old host keys
-  && rm -rf /etc/ssh/ssh_host*
+  && rm -rf /etc/ssh/ssh_host* \
+  # Create a symlink to the rsync for use with vbr. This works around a problem
+  # seen in some deployments where vbr cannot find rsync.
+  && ln -s /opt/vertica/bin/rsync /usr/bin/rsync
 
 ENTRYPOINT [ "/init" ]
 

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -200,7 +200,10 @@ RUN set -x \
   && tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz \
   && tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
   # delete old host keys
-  && rm -rf /etc/ssh/ssh_host*
+  && rm -rf /etc/ssh/ssh_host* \
+  # Create a symlink to the rsync for use with vbr. This works around a problem
+  # seen in some deployments where vbr cannot find rsync.
+  && ln -s /opt/vertica/bin/rsync /usr/bin/rsync
 
 ENTRYPOINT [ "/init" ]
 


### PR DESCRIPTION
In some deployments, we have seen vbr fail because it cannot find rsync. This creates a symlink in /usr/bin to the rsync binary in /opt/vertica/bin. This ensures that rsync will be found.