### PR TITLE
Add dispatch abstraction for admintools -t re_ip

### DIFF
--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -33,9 +33,6 @@ import (
 
 var _ = Describe("restart_reconciler", func() {
 	ctx := context.Background()
-	const Node1OldIP = "10.10.1.1"
-	const Node2OldIP = "10.10.1.2"
-	const Node3OldIP = "10.10.1.3"
 	const RestartProcessReadOnly = true
 	const RestartSkipReadOnly = false
 	const PodNotReadOnly = false

--- a/pkg/vadmin/create_db_at_test.go
+++ b/pkg/vadmin/create_db_at_test.go
@@ -20,9 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/cmds"
-	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -31,10 +28,7 @@ var _ = Describe("create_db_at", func() {
 	ctx := context.Background()
 
 	It("should call admintools with create_db task", func() {
-		vdb := vapi.MakeVDB()
-		fpr := &cmds.FakePodRunner{}
-		evWriter := mgmterrors.TestEVWriter{}
-		dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter)
+		dispatcher, _, fpr := mockAdmintoolsDispatcher()
 		Ω(dispatcher.CreateDB(ctx,
 			createdb.WithHosts([]string{"pod-1", "pod-2", "pod-3"}),
 			createdb.WithCommunalPath("/communal"),

--- a/pkg/vadmin/describe_db_at_test.go
+++ b/pkg/vadmin/describe_db_at_test.go
@@ -20,9 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/cmds"
-	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/describedb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -31,10 +28,7 @@ var _ = Describe("describe_db_at", func() {
 	ctx := context.Background()
 
 	It("should call admintools -t revive_db with --display-only", func() {
-		vdb := vapi.MakeVDB()
-		fpr := &cmds.FakePodRunner{}
-		evWriter := mgmterrors.TestEVWriter{}
-		dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter)
+		dispatcher, _, fpr := mockAdmintoolsDispatcher()
 		_, res, err := dispatcher.DescribeDB(ctx,
 			describedb.WithCommunalPath("/communal"),
 			describedb.WithDBName("blah"),

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/describedb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -44,6 +45,9 @@ type Dispatcher interface {
 	// FetchNodeState will determine if the given set of nodes are considered UP
 	// or DOWN in our consensous state. It returns a map of vnode to its node state.
 	FetchNodeState(ctx context.Context, opts ...fetchnodestate.Option) (map[string]string, ctrl.Result, error)
+
+	// ReIP will update the catalog on disk with new IPs for all of the nodes given.
+	ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error)
 }
 
 const (

--- a/pkg/vadmin/opts/reip/opts.go
+++ b/pkg/vadmin/opts/reip/opts.go
@@ -1,0 +1,62 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package reip
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Parms holds all of the option for a re_ip invocation.
+type Parms struct {
+	Initiator   types.NamespacedName
+	InitiatorIP string
+	Hosts       []Host
+}
+
+type Host struct {
+	VNode        string // Vertica node. In the format of v_<db>_node####
+	Compat21Node string // node name without the v_<db>_* prefix
+	IP           string // Current IP address of this host/pod
+}
+
+type Option func(*Parms)
+
+// Make will fill in the Parms based on the options chosen
+func (s *Parms) Make(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
+func WithInitiator(nm types.NamespacedName, ip string) Option {
+	return func(s *Parms) {
+		s.Initiator = nm
+		s.InitiatorIP = ip
+	}
+}
+
+func WithHost(vnode, compat21node, ip string) Option {
+	return func(s *Parms) {
+		if s.Hosts == nil {
+			s.Hosts = make([]Host, 1)
+		}
+		s.Hosts = append(s.Hosts, Host{
+			VNode:        vnode,
+			Compat21Node: compat21node,
+			IP:           ip,
+		})
+	}
+}

--- a/pkg/vadmin/re_ip_at.go
+++ b/pkg/vadmin/re_ip_at.go
@@ -1,0 +1,175 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/paths"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// The name of the IP map file that is used by re_ip.  re_ip is only ever used if the entire cluster is down.
+	AdminToolsMapFile = "/opt/vertica/config/ipMap.txt"
+)
+
+// A map that does a lookup of a vertica node name to an IP address
+type verticaIPLookup map[string]string
+
+// ReIP will update the catalog on disk with new IPs for all of the nodes given.
+func (a Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error) {
+	s := reip.Parms{}
+	s.Make(opts...)
+
+	if len(s.Hosts) == 0 {
+		return ctrl.Result{}, fmt.Errorf("you must specify at least one host for re-ip")
+	}
+
+	// We always use the compat21 nodes when generating the IP map.  We cannot
+	// use the vnode because they are only set _after_ a node is added to a DB.
+	// ReIP can be dealing with a mix -- some nodes that have been added to the
+	// db and some that aren't.
+	oldIPs, err := a.fetchOldIPsFromNode(ctx, s.Initiator)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	mapFileContents, ipChanging := a.genMapFile(oldIPs, &s)
+	if !ipChanging {
+		// no re-ip is necessary, the IP are not changing
+		return ctrl.Result{}, nil
+	}
+
+	cmd := a.genMapFileUploadCmd(mapFileContents)
+	if _, _, err := a.PRunner.ExecInPod(ctx, s.Initiator, names.ServerContainer, cmd...); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Prior to calling re_ip, dump out the state of admintools.conf for PD purposes
+	a.debugDumpAdmintoolsConf(ctx, s.Initiator)
+
+	cmd = a.genReIPCommand()
+	if _, _, err := a.PRunner.ExecAdmintools(ctx, s.Initiator, names.ServerContainer, cmd...); err != nil {
+		// Log an event as failure to re_ip means we won't be able to bring up the database.
+		a.EVWriter.Event(a.VDB, corev1.EventTypeWarning, events.ReipFailed,
+			"Attempt to run 'admintools -t re_ip' failed")
+		return ctrl.Result{}, err
+	}
+
+	// Now that re_ip is done, dump out the state of admintools.conf to the log.
+	a.debugDumpAdmintoolsConf(ctx, s.Initiator)
+
+	return ctrl.Result{}, nil
+}
+
+// genMapFile generates the map file used by re_ip
+// The list of old IPs are passed in. We combine that with the new IPs in the
+// podfacts to generate the map file. The map file is returned as a list of
+// strings. Its format is what is expected by admintools -t re_ip.
+func (a Admintools) genMapFile(oldIPs verticaIPLookup, s *reip.Parms) (mapContents []string, ipChanging bool) {
+	mapContents = []string{}
+	ipChanging = false
+
+	for _, host := range s.Hosts {
+		nodeName := host.Compat21Node
+		oldIP, ok := oldIPs[nodeName]
+		// If we are missing the old IP, we skip and don't fail.  Re-ip allows
+		// for a subset of the nodes and the host may already be removed from
+		// the cluster anyway.
+		if !ok {
+			continue
+		}
+		if oldIP != host.IP {
+			ipChanging = true
+		}
+		mapContents = append(mapContents, fmt.Sprintf("%s %s", oldIP, host.IP))
+	}
+	return mapContents, ipChanging
+}
+
+// genReIPCommand will return the command to run for the re_ip command
+func (a Admintools) genReIPCommand() []string {
+	cmd := []string{
+		"-t", "re_ip",
+		"--file=" + AdminToolsMapFile,
+		"--noprompt",
+	}
+
+	// In 11.1, we added a --force option to re_ip to allow us to run it while
+	// some nodes are up.  This was done to support doing a reip while there are
+	// read-only secondary nodes.
+	vinf, ok := a.VDB.MakeVersionInfo()
+	if ok && vinf.IsEqualOrNewer(vapi.ReIPAllowedWithUpNodesVersion) {
+		cmd = append(cmd, "--force")
+	}
+
+	return cmd
+}
+
+// genMapFileUploadCmd returns the command to run to upload the map file
+func (a Admintools) genMapFileUploadCmd(mapFileContents []string) []string {
+	return []string{
+		"bash", "-c", "cat > " + AdminToolsMapFile + "<<< '" + strings.Join(mapFileContents, "\n") + "'",
+	}
+}
+
+// fetchOldIPsFromNode will read a local admintools.conf and get the IPs from it.
+// The IPs from an admintools.conf represent the *old* IPs. We store them in a
+// map, where the lookup is by the node name. This function only handles
+// compat21 node names.
+func (a Admintools) fetchOldIPsFromNode(ctx context.Context, atPod types.NamespacedName) (verticaIPLookup, error) {
+	cmd := a.genGrepNodeCmd()
+	stdout, _, err := a.PRunner.ExecInPod(ctx, atPod, names.ServerContainer, cmd...)
+	if err != nil {
+		return verticaIPLookup{}, err
+	}
+	return parseNodesFromAdmintoolConf(stdout), nil
+}
+
+// genGrepNodeCmd returns the command to run to get the nodes from admintools.conf
+// This function only handles grepping compat21 nodes.
+func (a Admintools) genGrepNodeCmd() []string {
+	return []string{
+		"bash", "-c", fmt.Sprintf("grep --regexp='^node[0-9]' %s", paths.AdminToolsConf),
+	}
+}
+
+// parseNodesFromAdmintoolConf will parse out the vertica node and IP from admintools.conf output.
+// The nodeText passed in is taken from a grep output of the node columns. As
+// such, multiple lines are concatenated together with '\n'.
+func parseNodesFromAdmintoolConf(nodeText string) verticaIPLookup {
+	ips := make(verticaIPLookup)
+	rs := `^(node\d{4}) = ([\d.:a-fA-F]+),`
+
+	re := regexp.MustCompile(rs)
+	for _, line := range strings.Split(nodeText, "\n") {
+		match := re.FindAllStringSubmatch(line, 1)
+		if len(match) > 0 && len(match[0]) >= 3 {
+			ips[match[0][1]] = match[0][2]
+		}
+	}
+	return ips
+}

--- a/pkg/vadmin/re_ip_at_test.go
+++ b/pkg/vadmin/re_ip_at_test.go
@@ -1,0 +1,100 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
+)
+
+var _ = Describe("re_ip_at", func() {
+	ctx := context.Background()
+
+	It("should parse admintools.conf correctly in parseNodesFromAdmintoolsConf", func() {
+		ips := parseNodesFromAdmintoolConf(
+			"node0001 = 10.244.1.95,/home/dbadmin/local-data/data/ee65657f-a5f3,/home/dbadmin/local-data/data/ee65657f-a5f3\n" +
+				"node0002 = 10.244.1.96,/home/dbadmin/local-data/data/ee65657f-a5f3,/home/dbadmin/local-data/data/ee65657f-a5f3\n" +
+				"node0003 = 10.244.1.97,/home/dbadmin/local-data/data/ee65657f-a5f3,/home/dbadmin/local-data/data/ee65657f-a5f3\n" +
+				"node0blah = no-ip,/data,/data\n" +
+				"node0000 =badly formed\n",
+		)
+		Expect(ips["node0001"]).Should(Equal("10.244.1.95"))
+		Expect(ips["node0002"]).Should(Equal("10.244.1.96"))
+		Expect(ips["node0003"]).Should(Equal("10.244.1.97"))
+		_, ok := ips["node0004"] // Will not find
+		Expect(ok).Should(BeFalse())
+		_, ok = ips["node0000"] // Will not find since it was badly formed
+		Expect(ok).Should(BeFalse())
+	})
+
+	It("should use --force option in reip if on version that supports it", func() {
+		at, vdb, _ := mockAdmintoolsDispatcher()
+		vdb.Annotations[vapi.VersionAnnotation] = vapi.MinimumVersion
+		Expect(at.genReIPCommand()).ShouldNot(ContainElement("--force"))
+		vdb.Annotations[vapi.VersionAnnotation] = vapi.ReIPAllowedWithUpNodesVersion
+		Expect(at.genReIPCommand()).Should(ContainElement("--force"))
+	})
+
+	It("should detect that map file has no IPs that are changing", func() {
+		at, vdb, fpr := mockAdmintoolsDispatcher()
+
+		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		fpr.Results = cmds.CmdResults{
+			atPod: []cmds.CmdResult{
+				{Stdout: "node0001 = 10.10.10.10"},
+			},
+		}
+		Ω(at.ReIP(ctx,
+			reip.WithInitiator(atPod, "10.10.10.10"),
+			reip.WithHost("v_db_node0001", "node0001", "10.10.10.10"))).Should(Equal(ctrl.Result{}))
+	})
+
+	It("should only generate a map file for installed pods", func() {
+		at, vdb, fpr := mockAdmintoolsDispatcher()
+
+		const oldIP = "10.10.2.1"
+		const newIP = "10.10.2.2"
+		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		fpr.Results = cmds.CmdResults{
+			atPod: []cmds.CmdResult{
+				{Stdout: fmt.Sprintf("node0001 = %s,/data,/data", oldIP)},
+			},
+		}
+		Ω(at.ReIP(ctx,
+			reip.WithInitiator(atPod, "10.10.10.10"),
+			reip.WithHost("v_db_node0001", "node0001", newIP))).Should(Equal(ctrl.Result{}))
+		c := fpr.FindCommands(fmt.Sprintf("%s %s", oldIP, newIP))
+		Ω(len(c)).Should(Equal(1))
+	})
+
+	It("should fail if you supply no hosts", func() {
+		at, vdb, _ := mockAdmintoolsDispatcher()
+		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		_, err := at.ReIP(ctx,
+			reip.WithInitiator(atPod, "10.10.10.11"))
+		Ω(err).ShouldNot(Succeed())
+
+	})
+})

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -1,0 +1,32 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ReIP will update the catalog on disk with new IPs for all of the nodes given.
+func (v VClusterOps) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error) {
+	v.Log.Info("Starting vcluster ReIP")
+	s := reip.Parms{}
+	s.Make(opts...)
+	return ctrl.Result{}, fmt.Errorf("not implemented")
+}

--- a/pkg/vadmin/revive_db_at_test.go
+++ b/pkg/vadmin/revive_db_at_test.go
@@ -20,9 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/cmds"
-	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -31,10 +28,7 @@ var _ = Describe("revive_db_at", func() {
 	ctx := context.Background()
 
 	It("should call admintools -t revive_db", func() {
-		vdb := vapi.MakeVDB()
-		fpr := &cmds.FakePodRunner{}
-		evWriter := mgmterrors.TestEVWriter{}
-		dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter)
+		dispatcher, _, fpr := mockAdmintoolsDispatcher()
 		Ω(dispatcher.ReviveDB(ctx,
 			revivedb.WithCommunalPath("/communal-1"),
 			revivedb.WithDBName("testdb"),

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -43,7 +43,7 @@ func TestAPIs(t *testing.T) {
 // purposes.
 func mockAdmintoolsDispatcher() (Admintools, *vapi.VerticaDB, *cmds.FakePodRunner) {
 	vdb := vapi.MakeVDB()
-	fpr := &cmds.FakePodRunner{}
+	fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 	evWriter := mgmterrors.TestEVWriter{}
 	dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter)
 	return dispatcher.(Admintools), vdb, fpr

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -21,6 +21,9 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -34,4 +37,14 @@ func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "vadmin Suite")
+}
+
+// mockAdmintoolsDispatcher will create an admintools dispatcher for test
+// purposes.
+func mockAdmintoolsDispatcher() (Admintools, *vapi.VerticaDB, *cmds.FakePodRunner) {
+	vdb := vapi.MakeVDB()
+	fpr := &cmds.FakePodRunner{}
+	evWriter := mgmterrors.TestEVWriter{}
+	dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter)
+	return dispatcher.(Admintools), vdb, fpr
 }


### PR DESCRIPTION
More work to hide admintools commands behind an abstraction so that we can replace them with the vclusterOps library. This PR handles the admintools -t re_ip command. There is setup for a map file that re_ip needs. This was pushed into the abstraction too. When we create the re_ip API for vclusterOps we won't be specifying the mapping in a file.