### PR TITLE
Dispatch abstractions for 5 more APIs

### DIFF
--- a/pkg/controllers/vdb/dbaddnode_reconciler.go
+++ b/pkg/controllers/vdb/dbaddnode_reconciler.go
@@ -174,7 +174,6 @@ func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pods []*PodF
 		addnode.WithSubcluster(pods[0].subclusterName),
 	}
 	for i := range pods {
-		d.Log.Info("adding pod", "dnsName", pods[i].dnsName, "name", pods[i].name) // SPILLY
 		opts = append(opts, addnode.WithHost(pods[i].dnsName))
 	}
 	err := d.Dispatcher.AddNode(ctx, opts...)

--- a/pkg/controllers/vdb/dbaddnode_reconciler.go
+++ b/pkg/controllers/vdb/dbaddnode_reconciler.go
@@ -18,7 +18,6 @@ package vdb
 import (
 	"context"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -27,24 +26,34 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // DBAddNodeReconciler will ensure each pod is added to the database.
 type DBAddNodeReconciler struct {
-	VRec    *VerticaDBReconciler
-	Log     logr.Logger
-	Vdb     *vapi.VerticaDB // Vdb is the CRD we are acting on.
-	PRunner cmds.PodRunner
-	PFacts  *PodFacts
+	VRec       *VerticaDBReconciler
+	Log        logr.Logger
+	Vdb        *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	PRunner    cmds.PodRunner
+	PFacts     *PodFacts
+	Dispatcher vadmin.Dispatcher
 }
 
 // MakeDBAddNodeReconciler will build a DBAddNodeReconciler object
 func MakeDBAddNodeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
-	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) controllers.ReconcileActor {
-	return &DBAddNodeReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts}
+	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts, dispatcher vadmin.Dispatcher,
+) controllers.ReconcileActor {
+	return &DBAddNodeReconciler{
+		VRec:       vdbrecon,
+		Log:        log,
+		Vdb:        vdb,
+		PRunner:    prunner,
+		PFacts:     pfacts,
+		Dispatcher: dispatcher,
+	}
 }
 
 // Reconcile will ensure a DB exists and create one if it doesn't
@@ -121,7 +130,7 @@ func (d *DBAddNodeReconciler) reconcileSubcluster(ctx context.Context, sc *vapi.
 
 // runAddNode will add nodes to the given subcluster
 func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, pods []*PodFact) (ctrl.Result, error) {
-	atPod, ok := d.PFacts.findPodToRunVsql(false, "")
+	initiatorPod, ok := d.PFacts.findPodToRunVsql(false, "")
 	if !ok {
 		d.Log.Info("No pod found to run vsql and admintools from. Requeue reconciliation.")
 		return ctrl.Result{Requeue: true}, nil
@@ -136,23 +145,15 @@ func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, pods []*PodFact) (
 		}
 	}
 
-	if d.VRec.OpCfg.DevMode {
-		debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
-	}
-
-	if stdout, err := d.runAddNodeForPod(ctx, pods, atPod); err != nil {
+	if err := d.runAddNodeForPod(ctx, pods, initiatorPod); err != nil {
 		// If we reached the node limit according to the license, end this
 		// reconcile successfully. We don't want to fail and requeue because
 		// this isn't going to get fixed until someone manually adds a new
 		// license.
-		if isLicenseLimitError(stdout) {
+		if _, ok := err.(*addnode.LicenseLimitError); ok {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
-	}
-
-	if d.VRec.OpCfg.DevMode {
-		debugDumpAdmintoolsConf(ctx, d.PRunner, atPod.name)
 	}
 
 	// Invalidate the cached pod facts now that some pods have a DB now.
@@ -163,46 +164,23 @@ func (d *DBAddNodeReconciler) runAddNode(ctx context.Context, pods []*PodFact) (
 
 // runAddNodeForPod will execute the command to add a single node to the cluster
 // Returns the stdout from the command.
-func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pods []*PodFact, atPod *PodFact) (string, error) {
+func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pods []*PodFact, initiatorPod *PodFact) error {
 	podNames := genPodNames(pods)
 	d.VRec.Eventf(d.Vdb, corev1.EventTypeNormal, events.AddNodeStart,
 		"Calling 'admintools -t db_add_node' for pod(s) '%s'", podNames)
 	start := time.Now()
-	cmd := d.genAddNodeCommand(pods)
-	stdout, _, err := d.PRunner.ExecAdmintools(ctx, atPod.name, names.ServerContainer, cmd...)
+	opts := []addnode.Option{
+		addnode.WithInitiator(initiatorPod.name, initiatorPod.podIP),
+		addnode.WithSubcluster(pods[0].subclusterName),
+	}
+	for i := range pods {
+		d.Log.Info("adding pod", "dnsName", pods[i].dnsName, "name", pods[i].name) // SPILLY
+		opts = append(opts, addnode.WithHost(pods[i].dnsName))
+	}
+	err := d.Dispatcher.AddNode(ctx, opts...)
 	if err != nil {
-		switch {
-		case isLicenseLimitError(stdout):
-			d.VRec.Event(d.Vdb, corev1.EventTypeWarning, events.AddNodeLicenseFail,
-				"You cannot add more nodes to the database.  You have reached the limit allowed by your license.")
-		default:
-			d.VRec.Eventf(d.Vdb, corev1.EventTypeWarning, events.AddNodeFailed,
-				"Failed when calling 'admintools -t db_add_node' for pod(s) '%s'", podNames)
-		}
-	} else {
 		d.VRec.Eventf(d.Vdb, corev1.EventTypeNormal, events.AddNodeSucceeded,
 			"Successfully called 'admintools -t db_add_node' and it took %s", time.Since(start))
 	}
-	return stdout, err
-}
-
-// isLicenseLimitError returns true if the stdout contains the error about not enough licenses
-func isLicenseLimitError(stdout string) bool {
-	return strings.Contains(stdout, "Cannot create another node. The current license permits")
-}
-
-// genAddNodeCommand returns the command to run to add nodes to the cluster.
-func (d *DBAddNodeReconciler) genAddNodeCommand(pods []*PodFact) []string {
-	hostNames := make([]string, 0, len(pods))
-	for _, pod := range pods {
-		hostNames = append(hostNames, pod.dnsName)
-	}
-
-	return []string{
-		"-t", "db_add_node",
-		"--hosts", strings.Join(hostNames, ","),
-		"--database", d.Vdb.Spec.DBName,
-		"--subcluster", pods[0].subclusterName,
-		"--noprompt",
-	}
+	return err
 }

--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
@@ -87,9 +87,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		))
 	})
 
-	It("should use the proper subcluster type switch for v10.1.1 versions", func() {
+	It("should use the proper subcluster type switch", func() {
 		vdb := vapi.MakeVDB()
-		vdb.ObjectMeta.Annotations[vapi.VersionAnnotation] = "v10.1.1-0"
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
@@ -112,7 +111,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		Expect(r.createSubcluster(ctx, &vdb.Spec.Subclusters[0])).Should(Succeed())
 		hists = fpr.FindCommands("db_add_subcluster")
 		Expect(len(hists)).Should(Equal(1))
-		Expect(hists[0].Command).ShouldNot(ContainElement("--is-primary"))
+		Expect(hists[0].Command).Should(ContainElement("--is-primary"))
 	})
 
 	It("should exit without error if not using an EON database", func() {

--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
@@ -38,7 +38,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		a := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		a := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := a.(*DBAddSubclusterReconciler)
 		subclusters := r.parseFetchSubclusterVsql(
 			" sc1\n" +
@@ -76,7 +77,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 				{Stdout: " sc1\n"},
 			},
 		}
-		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// Last command should be AT -t db_add_subcluster
 		atCmdHistory := fpr.Histories[len(fpr.Histories)-1]
@@ -93,7 +95,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		act := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		act := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*DBAddSubclusterReconciler)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		r.ATPod = pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)]
@@ -121,7 +124,8 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		Expect(vdb.IsEON()).Should(BeFalse())
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
 })

--- a/pkg/controllers/vdb/dbremovenode_reconciler.go
+++ b/pkg/controllers/vdb/dbremovenode_reconciler.go
@@ -18,7 +18,6 @@ package vdb
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -29,30 +28,33 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DBRemoveNodeReconciler will handle removing a node from the database during scale down.
 type DBRemoveNodeReconciler struct {
-	VRec    *VerticaDBReconciler
-	Log     logr.Logger
-	Vdb     *vapi.VerticaDB // Vdb is the CRD we are acting on.
-	PRunner cmds.PodRunner
-	PFacts  *PodFacts
+	VRec       *VerticaDBReconciler
+	Log        logr.Logger
+	Vdb        *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	PRunner    cmds.PodRunner
+	PFacts     *PodFacts
+	Dispatcher vadmin.Dispatcher
 }
 
 // MakeDBRemoveNodeReconciler will build and return the DBRemoveNodeReconciler object.
 func MakeDBRemoveNodeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
-	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) controllers.ReconcileActor {
+	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts, dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
 	return &DBRemoveNodeReconciler{
-		VRec:    vdbrecon,
-		Log:     log,
-		Vdb:     vdb,
-		PRunner: prunner,
-		PFacts:  pfacts,
+		VRec:       vdbrecon,
+		Log:        log,
+		Vdb:        vdb,
+		PRunner:    prunner,
+		PFacts:     pfacts,
+		Dispatcher: dispatcher,
 	}
 }
 
@@ -112,7 +114,6 @@ func (d *DBRemoveNodeReconciler) removeNodesInSubcluster(ctx context.Context, sc
 	startPodIndex, endPodIndex int32) (ctrl.Result, error) {
 	podsToRemove, requeueNeeded := d.findPodsSuitableForScaleDown(sc, startPodIndex, endPodIndex)
 	if len(podsToRemove) > 0 {
-		cmd := d.genCmdRemoveNode(podsToRemove)
 		atPod, ok := d.PFacts.findPodToRunAdmintoolsAny()
 		if !ok {
 			// Requeue since we couldn't find a running pod
@@ -120,8 +121,8 @@ func (d *DBRemoveNodeReconciler) removeNodesInSubcluster(ctx context.Context, sc
 			return ctrl.Result{Requeue: true}, nil
 		}
 
-		if err := d.execATCmd(ctx, atPod.name, genPodNames(podsToRemove), cmd); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to call admintools -t db_remove_node: %w", err)
+		if err := d.execAdminCmd(ctx, atPod, podsToRemove); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to call remove node: %w", err)
 		}
 
 		// We successfully called db_remove_node, invalidate the pod facts cache
@@ -135,13 +136,20 @@ func (d *DBRemoveNodeReconciler) removeNodesInSubcluster(ctx context.Context, sc
 	return ctrl.Result{Requeue: requeueNeeded}, nil
 }
 
-// execATCmd will run the admintools command to remove the node
+// execAdminCmd will run the admin command to remove the node
 // This handles recording of the events.
-func (d *DBRemoveNodeReconciler) execATCmd(ctx context.Context, atPod types.NamespacedName, podNames string, cmd []string) error {
+func (d *DBRemoveNodeReconciler) execAdminCmd(ctx context.Context, atPod *PodFact, pods []*PodFact) error {
+	podNames := genPodNames(pods)
 	d.VRec.Eventf(d.Vdb, corev1.EventTypeNormal, events.RemoveNodesStart,
 		"Calling 'admintools -t db_remove_node' for pods '%s'", podNames)
 	start := time.Now()
-	if _, _, err := d.PRunner.ExecAdmintools(ctx, atPod, names.ServerContainer, cmd...); err != nil {
+	opts := []removenode.Option{
+		removenode.WithInitiator(atPod.name, atPod.podIP),
+	}
+	for i := range pods {
+		opts = append(opts, removenode.WithHost(pods[i].dnsName))
+	}
+	if err := d.Dispatcher.RemoveNode(ctx, opts...); err != nil {
 		d.VRec.Event(d.Vdb, corev1.EventTypeWarning, events.RemoveNodesFailed,
 			"Failed when calling 'admintools -t db_remove_node'")
 		return err
@@ -178,18 +186,4 @@ func (d *DBRemoveNodeReconciler) findPodsSuitableForScaleDown(sc *vapi.Subcluste
 		pods = append(pods, podFact)
 	}
 	return pods, requeueNeeded
-}
-
-// genCmdUninstall generates the command to use to uninstall a single host
-func (d *DBRemoveNodeReconciler) genCmdRemoveNode(pods []*PodFact) []string {
-	hostNames := make([]string, 0, len(pods))
-	for _, pod := range pods {
-		hostNames = append(hostNames, pod.dnsName)
-	}
-	return []string{
-		"-t", "db_remove_node",
-		"--database", d.Vdb.Spec.DBName,
-		"--hosts=" + strings.Join(hostNames, ","),
-		"--noprompts",
-	}
 }

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
@@ -34,7 +34,8 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
 
@@ -62,7 +63,8 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, lookupVdb, fpr, pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, lookupVdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// One command should be AT -t db_remove_subcluster and one should be
 		// changing the default subcluster

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -576,7 +576,7 @@ func (o *OnlineUpgradeReconciler) removeTransientSubclusters(ctx context.Context
 		return ctrl.Result{}, nil
 	}
 
-	actor := MakeDBRemoveSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	actor := MakeDBRemoveSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, o.Dispatcher)
 	o.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -279,7 +279,7 @@ func (o *OnlineUpgradeReconciler) addTransientNodes(ctx context.Context) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	actor := MakeDBAddNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	actor := MakeDBAddNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, o.Dispatcher)
 	o.traceActorReconcile(actor)
 	if err := o.PFacts.Collect(ctx, o.Vdb); err != nil {
 		return ctrl.Result{}, err

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -263,7 +263,7 @@ func (o *OnlineUpgradeReconciler) addTransientSubcluster(ctx context.Context) (c
 		return ctrl.Result{}, nil
 	}
 
-	actor := MakeDBAddSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
+	actor := MakeDBAddSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, o.Dispatcher)
 	o.traceActorReconcile(actor)
 	if err := o.PFacts.Collect(ctx, o.Vdb); err != nil {
 		return ctrl.Result{}, err

--- a/pkg/controllers/vdb/stopdb_reconciler.go
+++ b/pkg/controllers/vdb/stopdb_reconciler.go
@@ -46,11 +46,10 @@ func MakeStopDBReconciler(
 	dispatcher vadmin.Dispatcher,
 ) controllers.ReconcileActor {
 	return &StopDBReconciler{
-		VRec:    vdbrecon,
-		Vdb:     vdb,
-		PRunner: prunner,
-		PFacts:  pfacts,
-		// SPILLY - use a pointer??
+		VRec:       vdbrecon,
+		Vdb:        vdb,
+		PRunner:    prunner,
+		PFacts:     pfacts,
 		Dispatcher: dispatcher,
 	}
 }

--- a/pkg/controllers/vdb/stopdb_reconciler_test.go
+++ b/pkg/controllers/vdb/stopdb_reconciler_test.go
@@ -38,7 +38,8 @@ var _ = Describe("stopdb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(len(fpr.Histories)).Should(Equal(0))
 	})
@@ -52,7 +53,8 @@ var _ = Describe("stopdb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, &pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, &pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		hist := fpr.FindCommands("stop_db")
 		Expect(len(hist)).Should(Equal(0))
@@ -72,7 +74,8 @@ var _ = Describe("stopdb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		hist := fpr.FindCommands("stop_db")
 		Expect(len(hist)).Should(Equal(1))

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -175,7 +175,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeOfflineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeOnlineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		// Stop vertica if the status condition indicates
-		MakeStopDBReconciler(r, vdb, prunner, pfacts),
+		MakeStopDBReconciler(r, vdb, prunner, pfacts, dispatcher),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true, dispatcher),
 		MakeMetricReconciler(r, vdb, prunner, pfacts),

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -224,7 +224,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to admintools -t db_add_node
-		MakeDBAddNodeReconciler(r, log, vdb, prunner, pfacts),
+		MakeDBAddNodeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to rebalance_shards
 		MakeRebalanceShardsReconciler(r, log, vdb, prunner, pfacts, "" /* all subclusters */),
@@ -284,7 +284,7 @@ func (r *VerticaDBReconciler) makeDispatcher(log logr.Logger, vdb *vapi.VerticaD
 	if vmeta.UseVClusterOps(vdb.Annotations) {
 		return vadmin.MakeVClusterOps(log, vdb)
 	}
-	return vadmin.MakeAdmintools(log, vdb, prunner, r.EVRec)
+	return vadmin.MakeAdmintools(log, vdb, prunner, r.EVRec, r.OpCfg.DevMode)
 }
 
 // Event a wrapper for Event() that also writes a log entry

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -188,10 +188,10 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Wait for any nodes that are pending delete with active connections to leave.
 		MakeDrainNodeReconciler(r, vdb, prunner, pfacts),
 		// Handles calls to admintools -t db_remove_subcluster
-		MakeDBRemoveSubclusterReconciler(r, log, vdb, prunner, pfacts),
+		MakeDBRemoveSubclusterReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handles calls to admintools -t db_remove_node
-		MakeDBRemoveNodeReconciler(r, log, vdb, prunner, pfacts),
+		MakeDBRemoveNodeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to remove hosts from admintools.conf

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -220,7 +220,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Ensure http server is running on each pod
 		MakeHTTPServerCtrlReconciler(r, vdb, prunner, pfacts),
 		// Handle calls to admintools -t db_add_subcluster
-		MakeDBAddSubclusterReconciler(r, log, vdb, prunner, pfacts),
+		MakeDBAddSubclusterReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeMetricReconciler(r, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to admintools -t db_add_node

--- a/pkg/vadmin/add_node_at.go
+++ b/pkg/vadmin/add_node_at.go
@@ -1,0 +1,77 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"strings"
+
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AddNode will add a new vertica node to the cluster. If add node fails due to
+// a license limit, the error will be of type addnode.LicenseLimitError.
+func (a Admintools) AddNode(ctx context.Context, opts ...addnode.Option) error {
+	s := addnode.Parms{}
+	s.Make(opts...)
+	cmd := a.genAddNodeCommand(&s)
+
+	if a.DevMode {
+		a.debugDumpAdmintoolsConf(ctx, s.InitiatorName)
+	}
+
+	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	if err != nil {
+		switch {
+		case isLicenseLimitError(stdout):
+			a.EVWriter.Event(a.VDB, corev1.EventTypeWarning, events.AddNodeLicenseFail,
+				"You cannot add more nodes to the database.  You have reached the limit allowed by your license.")
+			// Remap the error to this type so the caller can do a type check to
+			// know it was a license limit error.
+			err = &addnode.LicenseLimitError{
+				Msg: stdout,
+			}
+		default:
+			a.EVWriter.Eventf(a.VDB, corev1.EventTypeWarning, events.AddNodeFailed,
+				"Failed when calling 'admintools -t db_add_node' for pod(s) '%s'", strings.Join(s.Hosts, ","))
+		}
+	}
+
+	if a.DevMode {
+		a.debugDumpAdmintoolsConf(ctx, s.InitiatorName)
+	}
+
+	return err
+}
+
+// isLicenseLimitError returns true if the stdout contains the error about not enough licenses
+func isLicenseLimitError(stdout string) bool {
+	return strings.Contains(stdout, "Cannot create another node. The current license permits")
+}
+
+// genAddNodeCommand returns the command to run to add nodes to the cluster.
+func (a Admintools) genAddNodeCommand(s *addnode.Parms) []string {
+	return []string{
+		"-t", "db_add_node",
+		"--hosts", strings.Join(s.Hosts, ","),
+		"--database", a.VDB.Spec.DBName,
+		"--subcluster", s.Subcluster,
+		"--noprompt",
+	}
+}

--- a/pkg/vadmin/add_node_at_test.go
+++ b/pkg/vadmin/add_node_at_test.go
@@ -1,0 +1,64 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
+)
+
+var _ = Describe("add_node_at", func() {
+	ctx := context.Background()
+
+	It("should call admintools -t db_add_node", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		Ω(dispatcher.AddNode(ctx,
+			addnode.WithInitiator(nm, "10.9.1.1"),
+			addnode.WithHost("v-main-1"),
+			addnode.WithHost("v-main-2"),
+		)).Should(Succeed())
+		hist := fpr.FindCommands("-t db_add_node")
+		Ω(len(hist)).Should(Equal(1))
+		Ω(hist[0].Command).Should(ContainElement("v-main-1,v-main-2"))
+	})
+
+	It("should return a special error when the licenese limit was reached", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		fpr.Results[nm] = []cmds.CmdResult{
+			{
+				Err: errors.New("admintools command failed"),
+				Stdout: "There was an error adding the nodes to the database: DB client operation \"create nodes\" failed during `ddl`: " +
+					"Severity: ROLLBACK, Message: Cannot create another node. The current license permits 3 node(s) and the database catalog " +
+					"already contains 3 node(s), Sqlstate: V2001",
+			},
+		}
+		err := dispatcher.AddNode(ctx,
+			addnode.WithInitiator(nm, "10.9.1.2"),
+			addnode.WithHost("v-main-0"),
+		)
+		Ω(err).ShouldNot(Succeed())
+		_, ok := err.(*addnode.LicenseLimitError)
+		Ω(ok).Should(BeTrue())
+	})
+})

--- a/pkg/vadmin/add_node_at_test.go
+++ b/pkg/vadmin/add_node_at_test.go
@@ -42,7 +42,7 @@ var _ = Describe("add_node_at", func() {
 		Ω(hist[0].Command).Should(ContainElement("v-main-1,v-main-2"))
 	})
 
-	It("should return a special error when the licenese limit was reached", func() {
+	It("should return a special error when the license limit was reached", func() {
 		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
 		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr.Results[nm] = []cmds.CmdResult{

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -19,13 +19,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
 )
 
-// StopDB will stop all the vertica hosts of a running cluster
-func (v VClusterOps) StopDB(ctx context.Context, opts ...stopdb.Option) error {
-	v.Log.Info("Starting vcluster StopDB")
-	s := stopdb.Parms{}
+// AddNode will add a new vertica node to the cluster
+func (v VClusterOps) AddNode(ctx context.Context, opts ...addnode.Option) error {
+	v.Log.Info("Starting vcluster AddNode")
+	s := addnode.Parms{}
 	s.Make(opts...)
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/vadmin/add_sc_at.go
+++ b/pkg/vadmin/add_sc_at.go
@@ -1,0 +1,52 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addsc"
+)
+
+// AddSubcluster will create a subcluster in the vertica cluster.
+func (a Admintools) AddSubcluster(ctx context.Context, opts ...addsc.Option) error {
+	s := addsc.Parms{}
+	s.Make(opts...)
+	cmd := []string{
+		"-t", "db_add_subcluster",
+		"--database", a.VDB.Spec.DBName,
+		"--subcluster", s.Subcluster,
+	}
+
+	// In v11, when adding a subcluster it defaults to a secondary.  Prior
+	// versions default to a primary.  Use the correct switch, depending on what
+	// version we are using.
+	vinf, ok := a.VDB.MakeVersionInfo()
+	const DefaultSecondarySubclusterCreationVersion = "v11.0.0"
+	if ok && vinf.IsEqualOrNewer(DefaultSecondarySubclusterCreationVersion) {
+		if s.IsPrimary {
+			cmd = append(cmd, "--is-primary")
+		}
+	} else {
+		if !s.IsPrimary {
+			cmd = append(cmd, "--is-secondary")
+		}
+	}
+
+	_, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	return err
+}

--- a/pkg/vadmin/add_sc_at.go
+++ b/pkg/vadmin/add_sc_at.go
@@ -32,19 +32,10 @@ func (a Admintools) AddSubcluster(ctx context.Context, opts ...addsc.Option) err
 		"--subcluster", s.Subcluster,
 	}
 
-	// In v11, when adding a subcluster it defaults to a secondary.  Prior
-	// versions default to a primary.  Use the correct switch, depending on what
-	// version we are using.
-	vinf, ok := a.VDB.MakeVersionInfo()
-	const DefaultSecondarySubclusterCreationVersion = "v11.0.0"
-	if ok && vinf.IsEqualOrNewer(DefaultSecondarySubclusterCreationVersion) {
-		if s.IsPrimary {
-			cmd = append(cmd, "--is-primary")
-		}
+	if s.IsPrimary {
+		cmd = append(cmd, "--is-primary")
 	} else {
-		if !s.IsPrimary {
-			cmd = append(cmd, "--is-secondary")
-		}
+		cmd = append(cmd, "--is-secondary")
 	}
 
 	_, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)

--- a/pkg/vadmin/add_sc_at_test.go
+++ b/pkg/vadmin/add_sc_at_test.go
@@ -1,0 +1,41 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addsc"
+)
+
+var _ = Describe("remove_sc_at", func() {
+	ctx := context.Background()
+
+	It("should call admintools -t db_add_subcluster", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		Ω(dispatcher.AddSubcluster(ctx,
+			addsc.WithInitiator(nm, "10.9.1.93"),
+			addsc.WithSubcluster(vdb.Spec.Subclusters[0].Name),
+		)).Should(Succeed())
+		hist := fpr.FindCommands("-t db_add_subcluster")
+		Ω(len(hist)).Should(Equal(1))
+		Ω(hist[0].Command).Should(ContainElement(vdb.Spec.Subclusters[0].Name))
+	})
+})

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -1,0 +1,30 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addsc"
+)
+
+// AddSubcluster will create a subcluster in the vertica cluster.
+func (v VClusterOps) AddSubcluster(ctx context.Context, opts ...addsc.Option) error {
+	s := addsc.Parms{}
+	s.Make(opts...)
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addsc"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/describedb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
@@ -53,12 +54,15 @@ type Dispatcher interface {
 	// ReIP will update the catalog on disk with new IPs for all of the nodes given.
 	ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error)
 
-	// StopDB will stop all the vertica hosts of a running cluster
+	// StopDB will stop all the vertica hosts of a running cluster.
 	StopDB(ctx context.Context, opts ...stopdb.Option) error
 
 	// AddNode will add a new vertica node to the cluster. If add node fails due to
 	// a license limit, the error will be of type addnode.LicenseLimitError.
 	AddNode(ctx context.Context, opts ...addnode.Option) error
+
+	// AddSubcluster will create a subcluster in the vertica cluster.
+	AddSubcluster(ctx context.Context, opts ...addsc.Option) error
 
 	// RemoveNode will remove an existng vertica node from the cluster.
 	RemoveNode(ctx context.Context, opts ...removenode.Option) error

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -27,6 +27,8 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/describedb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -57,6 +59,12 @@ type Dispatcher interface {
 	// AddNode will add a new vertica node to the cluster. If add node fails due to
 	// a license limit, the error will be of type addnode.LicenseLimitError.
 	AddNode(ctx context.Context, opts ...addnode.Option) error
+
+	// RemoveNode will remove an existng vertica node from the cluster.
+	RemoveNode(ctx context.Context, opts ...removenode.Option) error
+
+	// RemoveSubcluster will remove the given subcluster from the vertica cluster.
+	RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error
 }
 
 const (

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -48,6 +49,9 @@ type Dispatcher interface {
 
 	// ReIP will update the catalog on disk with new IPs for all of the nodes given.
 	ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error)
+
+	// StopDB will stop all the vertica hosts of a running cluster
+	StopDB(ctx context.Context, opts ...stopdb.Option) error
 }
 
 const (

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -22,6 +22,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/describedb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
@@ -52,6 +53,10 @@ type Dispatcher interface {
 
 	// StopDB will stop all the vertica hosts of a running cluster
 	StopDB(ctx context.Context, opts ...stopdb.Option) error
+
+	// AddNode will add a new vertica node to the cluster. If add node fails due to
+	// a license limit, the error will be of type addnode.LicenseLimitError.
+	AddNode(ctx context.Context, opts ...addnode.Option) error
 }
 
 const (
@@ -67,16 +72,18 @@ type Admintools struct {
 	Log      logr.Logger
 	EVWriter mgmterrors.EVWriter
 	VDB      *vapi.VerticaDB
+	DevMode  bool // true to include verbose logging for some operations
 }
 
 // MakeAdmintools will create a dispatcher that uses admintools to call the
 // admin commands.
-func MakeAdmintools(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner, evWriter mgmterrors.EVWriter) Dispatcher {
+func MakeAdmintools(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner, evWriter mgmterrors.EVWriter, devMode bool) Dispatcher {
 	return Admintools{
 		PRunner:  prunner,
 		VDB:      vdb,
 		Log:      log,
 		EVWriter: evWriter,
+		DevMode:  devMode,
 	}
 }
 

--- a/pkg/vadmin/opts/addnode/error.go
+++ b/pkg/vadmin/opts/addnode/error.go
@@ -13,19 +13,10 @@
  limitations under the License.
 */
 
-package vadmin
+package addnode
 
-import (
-	"context"
-	"fmt"
-
-	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
-)
-
-// StopDB will stop all the vertica hosts of a running cluster
-func (v VClusterOps) StopDB(ctx context.Context, opts ...stopdb.Option) error {
-	v.Log.Info("Starting vcluster StopDB")
-	s := stopdb.Parms{}
-	s.Make(opts...)
-	return fmt.Errorf("not implemented")
+type LicenseLimitError struct {
+	Msg string // description of error
 }
+
+func (e *LicenseLimitError) Error() string { return e.Msg }

--- a/pkg/vadmin/opts/addnode/opts.go
+++ b/pkg/vadmin/opts/addnode/opts.go
@@ -13,23 +13,18 @@
  limitations under the License.
 */
 
-package reip
+package addnode
 
 import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Parms holds all of the option for a re_ip invocation.
+// Parms holds all of the option for a revive DB invocation.
 type Parms struct {
-	Initiator   types.NamespacedName
-	InitiatorIP string
-	Hosts       []Host
-}
-
-type Host struct {
-	VNode        string // Vertica node. In the format of v_<db>_node####
-	Compat21Node string // node name without the v_<db>_* prefix
-	IP           string // Current IP address of this host/pod
+	InitiatorName types.NamespacedName
+	InitiatorIP   string
+	Hosts         []string
+	Subcluster    string
 }
 
 type Option func(*Parms)
@@ -43,20 +38,22 @@ func (s *Parms) Make(opts ...Option) {
 
 func WithInitiator(nm types.NamespacedName, ip string) Option {
 	return func(s *Parms) {
-		s.Initiator = nm
+		s.InitiatorName = nm
 		s.InitiatorIP = ip
 	}
 }
 
-func WithHost(vnode, compat21node, ip string) Option {
+func WithHost(fqdn string) Option {
 	return func(s *Parms) {
 		if s.Hosts == nil {
-			s.Hosts = make([]Host, 0)
+			s.Hosts = make([]string, 0)
 		}
-		s.Hosts = append(s.Hosts, Host{
-			VNode:        vnode,
-			Compat21Node: compat21node,
-			IP:           ip,
-		})
+		s.Hosts = append(s.Hosts, fqdn)
+	}
+}
+
+func WithSubcluster(subcluster string) Option {
+	return func(s *Parms) {
+		s.Subcluster = subcluster
 	}
 }

--- a/pkg/vadmin/opts/addsc/opts.go
+++ b/pkg/vadmin/opts/addsc/opts.go
@@ -1,0 +1,56 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package addsc
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Parms holds all of the option for a revive DB invocation.
+type Parms struct {
+	InitiatorName types.NamespacedName
+	InitiatorIP   string
+	Subcluster    string
+	IsPrimary     bool
+}
+
+type Option func(*Parms)
+
+// Make will fill in the Parms based on the options chosen
+func (s *Parms) Make(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
+func WithInitiator(nm types.NamespacedName, ip string) Option {
+	return func(s *Parms) {
+		s.InitiatorName = nm
+		s.InitiatorIP = ip
+	}
+}
+
+func WithSubcluster(scName string) Option {
+	return func(s *Parms) {
+		s.Subcluster = scName
+	}
+}
+
+func WithIsPrimary(isPrimary bool) Option {
+	return func(s *Parms) {
+		s.IsPrimary = isPrimary
+	}
+}

--- a/pkg/vadmin/opts/fetchnodestate/opts.go
+++ b/pkg/vadmin/opts/fetchnodestate/opts.go
@@ -72,7 +72,7 @@ func WithInitiator(nm types.NamespacedName, ip string) Option {
 func WithHost(vnode, ip string) Option {
 	return func(s *Parms) {
 		if s.Hosts == nil {
-			s.Hosts = make([]Host, 1)
+			s.Hosts = make([]Host, 0)
 		}
 		s.Hosts = append(s.Hosts, Host{VNode: vnode, IP: ip})
 	}

--- a/pkg/vadmin/opts/removenode/opts.go
+++ b/pkg/vadmin/opts/removenode/opts.go
@@ -1,0 +1,52 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package removenode
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Parms holds all of the option for a revive DB invocation.
+type Parms struct {
+	InitiatorName types.NamespacedName
+	InitiatorIP   string
+	Hosts         []string
+}
+
+type Option func(*Parms)
+
+// Make will fill in the Parms based on the options chosen
+func (s *Parms) Make(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
+func WithInitiator(nm types.NamespacedName, ip string) Option {
+	return func(s *Parms) {
+		s.InitiatorName = nm
+		s.InitiatorIP = ip
+	}
+}
+
+func WithHost(fqdn string) Option {
+	return func(s *Parms) {
+		if s.Hosts == nil {
+			s.Hosts = make([]string, 0)
+		}
+		s.Hosts = append(s.Hosts, fqdn)
+	}
+}

--- a/pkg/vadmin/opts/removesc/opts.go
+++ b/pkg/vadmin/opts/removesc/opts.go
@@ -1,0 +1,49 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package removesc
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Parms holds all of the option for a revive DB invocation.
+type Parms struct {
+	InitiatorName types.NamespacedName
+	InitiatorIP   string
+	Subcluster    string
+}
+
+type Option func(*Parms)
+
+// Make will fill in the Parms based on the options chosen
+func (s *Parms) Make(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
+func WithInitiator(nm types.NamespacedName, ip string) Option {
+	return func(s *Parms) {
+		s.InitiatorName = nm
+		s.InitiatorIP = ip
+	}
+}
+
+func WithSubcluster(scName string) Option {
+	return func(s *Parms) {
+		s.Subcluster = scName
+	}
+}

--- a/pkg/vadmin/opts/stopdb/opts.go
+++ b/pkg/vadmin/opts/stopdb/opts.go
@@ -1,0 +1,42 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package stopdb
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Parms holds all of the option for a revive DB invocation.
+type Parms struct {
+	InitiatorName types.NamespacedName
+	InitiatorIP   string
+}
+
+type Option func(*Parms)
+
+// Make will fill in the Parms based on the options chosen
+func (s *Parms) Make(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
+func WithInitiator(nm types.NamespacedName, ip string) Option {
+	return func(s *Parms) {
+		s.InitiatorName = nm
+		s.InitiatorIP = ip
+	}
+}

--- a/pkg/vadmin/remove_node_at.go
+++ b/pkg/vadmin/remove_node_at.go
@@ -1,0 +1,38 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"strings"
+
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
+)
+
+// RemoveNode will remove an existng vrtica node from the cluster.
+func (a Admintools) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
+	s := removenode.Parms{}
+	s.Make(opts...)
+	cmd := []string{
+		"-t", "db_remove_node",
+		"--database", a.VDB.Spec.DBName,
+		"--hosts", strings.Join(s.Hosts, ","),
+		"--noprompts",
+	}
+	_, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	return err
+}

--- a/pkg/vadmin/remove_node_at_test.go
+++ b/pkg/vadmin/remove_node_at_test.go
@@ -1,0 +1,42 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
+)
+
+var _ = Describe("remove_node_at", func() {
+	ctx := context.Background()
+
+	It("should call admintools -t db_remove_node", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		Ω(dispatcher.RemoveNode(ctx,
+			removenode.WithInitiator(nm, "10.9.1.91"),
+			removenode.WithHost("v-main-1"),
+			removenode.WithHost("v-main-2"),
+		)).Should(Succeed())
+		hist := fpr.FindCommands("-t db_remove_node")
+		Ω(len(hist)).Should(Equal(1))
+		Ω(hist[0].Command).Should(ContainElement("v-main-1,v-main-2"))
+	})
+})

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -1,0 +1,30 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
+)
+
+// RemoveNode will remove an existng vertica node from the cluster.
+func (v VClusterOps) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
+	s := removenode.Parms{}
+	s.Make(opts...)
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/vadmin/remove_sc_at.go
+++ b/pkg/vadmin/remove_sc_at.go
@@ -1,0 +1,45 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"strings"
+
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
+)
+
+// RemoveSubcluster will remove the given subcluster from the vertica cluster.
+func (a Admintools) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
+	s := removesc.Parms{}
+	s.Make(opts...)
+	cmd := []string{
+		"-t", "db_remove_subcluster",
+		"--database", a.VDB.Spec.DBName,
+		"--subcluster", s.Subcluster,
+		"--noprompts",
+	}
+	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	if err != nil {
+		if strings.Contains(stdout, "No subcluster found") {
+			// Nothing to do if the subcluster is already gone.
+			a.Log.Info("Attempted to remove a subcluster that was already gone", "subcluster", s.Subcluster)
+			return nil
+		}
+	}
+	return err
+}

--- a/pkg/vadmin/remove_sc_at_test.go
+++ b/pkg/vadmin/remove_sc_at_test.go
@@ -31,14 +31,17 @@ var _ = Describe("remove_sc_at", func() {
 
 	It("should call admintools -t db_remove_subcluster", func() {
 		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
-		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 1)
 		Ω(dispatcher.RemoveSubcluster(ctx,
 			removesc.WithInitiator(nm, "10.9.1.92"),
 			removesc.WithSubcluster(vdb.Spec.Subclusters[0].Name),
 		)).Should(Succeed())
 		hist := fpr.FindCommands("-t db_remove_subcluster")
 		Ω(len(hist)).Should(Equal(1))
-		Ω(hist[0].Command).Should(ContainElement(vdb.Spec.Subclusters[0].Name))
+		Ω(hist[0].Command).Should(ContainElements(
+			"--subcluster",
+			vdb.Spec.Subclusters[0].Name,
+		))
 	})
 
 	It("should be a no-op if the subcluster is already gone", func() {

--- a/pkg/vadmin/remove_sc_at_test.go
+++ b/pkg/vadmin/remove_sc_at_test.go
@@ -1,0 +1,61 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
+)
+
+var _ = Describe("remove_sc_at", func() {
+	ctx := context.Background()
+
+	It("should call admintools -t db_remove_subcluster", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		Ω(dispatcher.RemoveSubcluster(ctx,
+			removesc.WithInitiator(nm, "10.9.1.92"),
+			removesc.WithSubcluster(vdb.Spec.Subclusters[0].Name),
+		)).Should(Succeed())
+		hist := fpr.FindCommands("-t db_remove_subcluster")
+		Ω(len(hist)).Should(Equal(1))
+		Ω(hist[0].Command).Should(ContainElement(vdb.Spec.Subclusters[0].Name))
+	})
+
+	It("should be a no-op if the subcluster is already gone", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		fpr.Results[nm] = []cmds.CmdResult{
+			{
+				Err:    errors.New("admintools command failed"),
+				Stdout: "No subcluster found for the given name",
+			},
+		}
+		Ω(dispatcher.RemoveSubcluster(ctx,
+			removesc.WithInitiator(nm, "10.9.1.92"),
+			removesc.WithSubcluster("notexist"),
+		)).Should(Succeed())
+		hist := fpr.FindCommands("-t db_remove_subcluster")
+		Ω(len(hist)).Should(Equal(1))
+		Ω(hist[0].Command).Should(ContainElement("notexist"))
+	})
+})

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -1,0 +1,30 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
+)
+
+// RemoveSubcluster will remove the given subcluster from the vertica cluster.
+func (v VClusterOps) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
+	s := removesc.Parms{}
+	s.Make(opts...)
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/vadmin/stop_db_at.go
+++ b/pkg/vadmin/stop_db_at.go
@@ -1,0 +1,37 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
+)
+
+// ReviveDB will initialize a database from an existing communal path.
+// Admintools is used to run the revive.
+func (a Admintools) StopDB(ctx context.Context, opts ...stopdb.Option) error {
+	s := stopdb.Parms{}
+	s.Make(opts...)
+	cmd := []string{
+		"-t", "stop_db",
+		"--database", a.VDB.Spec.DBName,
+		"--force",
+	}
+	_, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	return err
+}

--- a/pkg/vadmin/stop_db_at.go
+++ b/pkg/vadmin/stop_db_at.go
@@ -22,8 +22,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 )
 
-// ReviveDB will initialize a database from an existing communal path.
-// Admintools is used to run the revive.
+// StopDB will stop all the vertica hosts of a running cluster
 func (a Admintools) StopDB(ctx context.Context, opts ...stopdb.Option) error {
 	s := stopdb.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/stop_db_at_test.go
+++ b/pkg/vadmin/stop_db_at_test.go
@@ -1,0 +1,39 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
+)
+
+var _ = Describe("stop_db_at", func() {
+	ctx := context.Background()
+
+	It("should call admintools -t stop_db", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		Ω(dispatcher.StopDB(ctx,
+			stopdb.WithInitiator(nm, "10.9.1.1"),
+		)).Should(Succeed())
+		hist := fpr.FindCommands("-t stop_db")
+		Ω(len(hist)).Should(Equal(1))
+	})
+})

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -1,0 +1,32 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
+)
+
+// ReviveDB will initialized a database using an existing communal path. It does
+// this using the vclusterops library.
+func (v VClusterOps) StopDB(ctx context.Context, opts ...stopdb.Option) error {
+	v.Log.Info("Starting vcluster StopDB")
+	s := stopdb.Parms{}
+	s.Make(opts...)
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -45,6 +45,6 @@ func mockAdmintoolsDispatcher() (Admintools, *vapi.VerticaDB, *cmds.FakePodRunne
 	vdb := vapi.MakeVDB()
 	fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 	evWriter := mgmterrors.TestEVWriter{}
-	dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter)
+	dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter, false)
 	return dispatcher.(Admintools), vdb, fpr
 }


### PR DESCRIPTION
More work to move admintools commands behind the dispatch abstraction. This is work needed for our vclusterOps integration. This PR adds the following interfaces:
- stop DB
- db add node.
- db remove node
- remove subcluster
- add subcluster