### PR TITLE
Automatically start the NMA in v2 vertica-k8s image

### DIFF
--- a/docker-vertica-v2/s6-rc.d/nma/up
+++ b/docker-vertica-v2/s6-rc.d/nma/up
@@ -1,2 +1,5 @@
 #!/command/execlineb -P
+# explicitly load container environment
+with-contenv
+# start node_management_agent
 /opt/vertica/bin/manage_node_agent.sh start


### PR DESCRIPTION
In the v2 vertica-k8s image, the NMA wasn't automatically starting up. The issue was that it wasn't finding the certs because the environment variables it depended on were no loaded. This PR fixes that so it can now find the certs through the environment variables and start.