### PR TITLE
Refactor dumping of admintools.conf

### DIFF
--- a/pkg/cmds/fake.go
+++ b/pkg/cmds/fake.go
@@ -98,6 +98,11 @@ func (f *FakePodRunner) CopyToPod(ctx context.Context, podName types.NamespacedN
 	return f.ExecInPod(ctx, podName, contName, executeCmd...)
 }
 
+// DumpAdmintoolsConf will log relenvant portions of the admintools.conf for debug purposes.
+func (f *FakePodRunner) DumpAdmintoolsConf(ctx context.Context, podName types.NamespacedName) {
+	// no-op
+}
+
 // FindCommands will search through the command history for any command that
 // contains the given partial command.
 func (f *FakePodRunner) FindCommands(partialCmd ...string) []CmdHistory {

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -113,17 +113,9 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{}, err
 	}
 
-	if g.VRec.OpCfg.DevMode {
-		debugDumpAdmintoolsConf(ctx, g.PRunner, initiatorPod)
-	}
-
 	if res, err := g.initializer.execCmd(ctx, initiatorPod,
 		getHostList(podList)); verrors.IsReconcileAborted(res, err) {
 		return res, err
-	}
-
-	if g.VRec.OpCfg.DevMode {
-		debugDumpAdmintoolsConf(ctx, g.PRunner, initiatorPod)
 	}
 
 	cond := vapi.VerticaDBCondition{Type: vapi.DBInitialized, Status: corev1.ConditionTrue}

--- a/pkg/controllers/vdb/install_reconciler.go
+++ b/pkg/controllers/vdb/install_reconciler.go
@@ -401,3 +401,10 @@ func (d *InstallReconciler) createConfigDirsForPodIfNecessary(ctx context.Contex
 	}
 	return nil
 }
+
+// debugDumpAdmintoolsConfForPods will dump debug information for admintools.conf for a list of pods
+func debugDumpAdmintoolsConfForPods(ctx context.Context, prunner cmds.PodRunner, pods []*PodFact) {
+	for _, pod := range pods {
+		prunner.DumpAdmintoolsConf(ctx, pod.name)
+	}
+}

--- a/pkg/controllers/vdb/paths.go
+++ b/pkg/controllers/vdb/paths.go
@@ -55,23 +55,3 @@ func prepLocalData(ctx context.Context, vdb *vapi.VerticaDB, prunner cmds.PodRun
 	}
 	return nil
 }
-
-// debugDumpAdmintoolsConf will dump specific info from admintools.conf for logging purposes
-// +nolint
-func debugDumpAdmintoolsConf(ctx context.Context, prunner cmds.PodRunner, atPod types.NamespacedName) {
-	// Dump out vital informating from admintools.conf for logging purposes. We
-	// rely on the logging that is done inside ExecInPod.
-	cmd := []string{
-		"bash", "-c",
-		fmt.Sprintf(`ls -l %s && grep '^node\|^v_\|^host' %s`, paths.AdminToolsConf, paths.AdminToolsConf),
-	}
-	// Since this is for debugging purposes all errors are ignored
-	prunner.ExecInPod(ctx, atPod, names.ServerContainer, cmd...) //nolint:errcheck
-}
-
-// debugDumpAdmintoolsConfForPods will dump debug information for admintools.conf for a list of pods
-func debugDumpAdmintoolsConfForPods(ctx context.Context, prunner cmds.PodRunner, pods []*PodFact) {
-	for _, pod := range pods {
-		debugDumpAdmintoolsConf(ctx, prunner, pod.name)
-	}
-}

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -288,16 +288,12 @@ func (r *RestartReconciler) restartPods(ctx context.Context, pods []*PodFact) (c
 		return r.makeResultForLivenessProbeWait(ctx)
 	}
 
-	debugDumpAdmintoolsConf(ctx, r.PRunner, r.InitiatorPod)
-
 	vnodeList := genRestartVNodeList(downPods)
 	ipList := genRestartIPList(downPods)
 	cmd := r.genRestartNodeCmd(vnodeList, ipList)
 	if res, err := r.execRestartPods(ctx, downPods, cmd); verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
-
-	debugDumpAdmintoolsConf(ctx, r.PRunner, r.InitiatorPod)
 
 	// Invalidate the cached pod facts now that some pods have restarted.
 	r.PFacts.Invalidate()

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -130,7 +130,6 @@ var _ = Describe("restart_reconciler", func() {
 		initiatorPod := names.GenPodName(vdb, sc, 3)
 		fpr.Results[initiatorPod] = []cmds.CmdResult{
 			{}, // check up node status via -t list_allnodes
-			{}, // command that will dump admintools.conf vitals
 			{
 				Err:    errors.New("all nodes are not down"),
 				Stdout: "All nodes in the input are not down, can't restart",

--- a/pkg/vadmin/add_node_at.go
+++ b/pkg/vadmin/add_node_at.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -32,11 +31,7 @@ func (a Admintools) AddNode(ctx context.Context, opts ...addnode.Option) error {
 	s.Make(opts...)
 	cmd := a.genAddNodeCommand(&s)
 
-	if a.DevMode {
-		a.debugDumpAdmintoolsConf(ctx, s.InitiatorName)
-	}
-
-	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	stdout, err := a.execAdmintools(ctx, s.InitiatorName, cmd...)
 	if err != nil {
 		switch {
 		case isLicenseLimitError(stdout):
@@ -51,10 +46,6 @@ func (a Admintools) AddNode(ctx context.Context, opts ...addnode.Option) error {
 			a.EVWriter.Eventf(a.VDB, corev1.EventTypeWarning, events.AddNodeFailed,
 				"Failed when calling 'admintools -t db_add_node' for pod(s) '%s'", strings.Join(s.Hosts, ","))
 		}
-	}
-
-	if a.DevMode {
-		a.debugDumpAdmintoolsConf(ctx, s.InitiatorName)
 	}
 
 	return err

--- a/pkg/vadmin/add_sc_at.go
+++ b/pkg/vadmin/add_sc_at.go
@@ -18,7 +18,6 @@ package vadmin
 import (
 	"context"
 
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addsc"
 )
 
@@ -38,6 +37,6 @@ func (a Admintools) AddSubcluster(ctx context.Context, opts ...addsc.Option) err
 		cmd = append(cmd, "--is-secondary")
 	}
 
-	_, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	_, err := a.execAdmintools(ctx, s.InitiatorName, cmd...)
 	return err
 }

--- a/pkg/vadmin/at.go
+++ b/pkg/vadmin/at.go
@@ -17,11 +17,9 @@ package vadmin
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
-	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -35,15 +33,18 @@ func (a Admintools) logFailure(cmd, genericFailureReason, op string, err error) 
 	return evLogr.LogFailure(cmd, op, err)
 }
 
-// debugDumpAdmintoolsConf will dump specific info from admintools.conf for logging purposes
-// +nolint
-func (a Admintools) debugDumpAdmintoolsConf(ctx context.Context, atPod types.NamespacedName) {
-	// Dump out vital informating from admintools.conf for logging purposes. We
-	// rely on the logging that is done inside ExecInPod.
-	cmd := []string{
-		"bash", "-c",
-		fmt.Sprintf(`ls -l %s && grep '^node\|^v_\|^host' %s`, paths.AdminToolsConf, paths.AdminToolsConf),
+// execAdmintools is a wrapper for admintools tools that handles logging of
+// debug information. The stdout and error of the AT call is returned.
+func (a Admintools) execAdmintools(ctx context.Context, initiatorPod types.NamespacedName, cmd ...string) (string, error) {
+	// Dump relevant contents of the admintools.conf before and after the
+	// admintools calls. We do this for PD purposes to see what changes occurred
+	// in the file.
+	if a.DevMode {
+		a.PRunner.DumpAdmintoolsConf(ctx, initiatorPod)
 	}
-	// Since this is for debugging purposes all errors are ignored
-	a.PRunner.ExecInPod(ctx, atPod, names.ServerContainer, cmd...) //nolint:errcheck
+	stdout, _, err := a.PRunner.ExecAdmintools(ctx, initiatorPod, names.ServerContainer, cmd...)
+	if a.DevMode {
+		a.PRunner.DumpAdmintoolsConf(ctx, initiatorPod)
+	}
+	return stdout, err
 }

--- a/pkg/vadmin/create_db_at.go
+++ b/pkg/vadmin/create_db_at.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,7 +31,7 @@ func (a Admintools) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl
 	s := createdb.Parms{}
 	s.Make(opts...)
 	cmd := a.genCreateDBCmd(&s)
-	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.Initiator, names.ServerContainer, cmd...)
+	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
 	if err != nil {
 		return a.logFailure("create_db", events.CreateDBFailed, stdout, err)
 	}

--- a/pkg/vadmin/describe_db_at.go
+++ b/pkg/vadmin/describe_db_at.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/describedb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,7 +32,7 @@ func (a Admintools) DescribeDB(ctx context.Context, opts ...describedb.Option) (
 	s := describedb.Parms{}
 	s.Make(opts...)
 	cmd := a.genDescribeCmd(&s)
-	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.Initiator, names.ServerContainer, cmd...)
+	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
 	if err != nil {
 		res, err2 := a.logFailure("revive_db", events.ReviveDBFailed, stdout, err)
 		return "", res, err2

--- a/pkg/vadmin/fetch_node_state_at.go
+++ b/pkg/vadmin/fetch_node_state_at.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -35,7 +34,7 @@ func (a Admintools) FetchNodeState(ctx context.Context, opts ...fetchnodestate.O
 	cmd := []string{
 		"-t", "list_allnodes",
 	}
-	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.Initiator, names.ServerContainer, cmd...)
+	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
 	if err != nil {
 		res, err2 := a.logFailure("list_allnodes", events.MgmtFailed, stdout, err)
 		return nil, res, err2

--- a/pkg/vadmin/re_ip_at.go
+++ b/pkg/vadmin/re_ip_at.go
@@ -68,19 +68,13 @@ func (a Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result,
 		return ctrl.Result{}, err
 	}
 
-	// Prior to calling re_ip, dump out the state of admintools.conf for PD purposes
-	a.debugDumpAdmintoolsConf(ctx, s.Initiator)
-
 	cmd = a.genReIPCommand()
-	if _, _, err := a.PRunner.ExecAdmintools(ctx, s.Initiator, names.ServerContainer, cmd...); err != nil {
+	if _, err := a.execAdmintools(ctx, s.Initiator, cmd...); err != nil {
 		// Log an event as failure to re_ip means we won't be able to bring up the database.
 		a.EVWriter.Event(a.VDB, corev1.EventTypeWarning, events.ReipFailed,
 			"Attempt to run 'admintools -t re_ip' failed")
 		return ctrl.Result{}, err
 	}
-
-	// Now that re_ip is done, dump out the state of admintools.conf to the log.
-	a.debugDumpAdmintoolsConf(ctx, s.Initiator)
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/vadmin/remove_node_at.go
+++ b/pkg/vadmin/remove_node_at.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
 )
 
@@ -33,6 +32,6 @@ func (a Admintools) RemoveNode(ctx context.Context, opts ...removenode.Option) e
 		"--hosts", strings.Join(s.Hosts, ","),
 		"--noprompts",
 	}
-	_, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	_, err := a.execAdmintools(ctx, s.InitiatorName, cmd...)
 	return err
 }

--- a/pkg/vadmin/remove_sc_at.go
+++ b/pkg/vadmin/remove_sc_at.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
 )
 
@@ -33,7 +32,7 @@ func (a Admintools) RemoveSubcluster(ctx context.Context, opts ...removesc.Optio
 		"--subcluster", s.Subcluster,
 		"--noprompts",
 	}
-	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	stdout, err := a.execAdmintools(ctx, s.InitiatorName, cmd...)
 	if err != nil {
 		if strings.Contains(stdout, "No subcluster found") {
 			// Nothing to do if the subcluster is already gone.

--- a/pkg/vadmin/revive_db_at.go
+++ b/pkg/vadmin/revive_db_at.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,7 +32,7 @@ func (a Admintools) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ctrl
 	s := revivedb.Parms{}
 	s.Make(opts...)
 	cmd := a.genReviveCmd(&s)
-	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.Initiator, names.ServerContainer, cmd...)
+	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
 	if err != nil {
 		return a.logFailure("revive_db", events.ReviveDBFailed, stdout, err)
 	}

--- a/pkg/vadmin/stop_db_at.go
+++ b/pkg/vadmin/stop_db_at.go
@@ -18,7 +18,6 @@ package vadmin
 import (
 	"context"
 
-	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 )
 
@@ -31,6 +30,6 @@ func (a Admintools) StopDB(ctx context.Context, opts ...stopdb.Option) error {
 		"--database", a.VDB.Spec.DBName,
 		"--force",
 	}
-	_, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	_, err := a.execAdmintools(ctx, s.InitiatorName, cmd...)
 	return err
 }

--- a/scripts/dockerfile-lint
+++ b/scripts/dockerfile-lint
@@ -27,7 +27,7 @@ set -o pipefail
 LINT_IMAGE=hadolint/hadolint:2.12.0
 docker pull $LINT_IMAGE
 
-for dir in docker-operator docker-vertica docker-vlogger
+for dir in docker-operator docker-vertica docker-vlogger docker-vertica-v2
 do
     F=$dir/Dockerfile
     printf "Checking ${YELLOW}$F${NC}\n"


### PR DESCRIPTION
This is a refactor for the debugDumpAdmintoolsConfg() function. This is called to dump relevant portions of admintools.conf before and after an admintools call. Moving this to call to a common wrapper so we don't have to duplicate the calls so often. This also gets moves it into the admintools version of the Dispatcher interface.