### PR TITLE
Move restart_node and start_db behind dispatcher abstraction

### DIFF
--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -34,6 +34,8 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -288,10 +290,7 @@ func (r *RestartReconciler) restartPods(ctx context.Context, pods []*PodFact) (c
 		return r.makeResultForLivenessProbeWait(ctx)
 	}
 
-	vnodeList := genRestartVNodeList(downPods)
-	ipList := genRestartIPList(downPods)
-	cmd := r.genRestartNodeCmd(vnodeList, ipList)
-	if res, err := r.execRestartPods(ctx, downPods, cmd); verrors.IsReconcileAborted(res, err) {
+	if res, err := r.execRestartPods(ctx, downPods); verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 
@@ -343,23 +342,30 @@ func (r *RestartReconciler) fetchClusterNodeStatus(ctx context.Context, pods []*
 }
 
 // execRestartPods will execute the AT command and event recording for restart pods.
-func (r *RestartReconciler) execRestartPods(ctx context.Context, downPods []*PodFact, cmd []string) (ctrl.Result, error) {
+func (r *RestartReconciler) execRestartPods(ctx context.Context, downPods []*PodFact) (ctrl.Result, error) {
 	podNames := make([]string, 0, len(downPods))
 	for _, pods := range downPods {
 		podNames = append(podNames, pods.name.Name)
+	}
+
+	opts := []restartnode.Option{
+		restartnode.WithInitiator(r.InitiatorPod, r.InitiatorPodIP),
+	}
+	for i := range downPods {
+		opts = append(opts, restartnode.WithHost(downPods[i].vnodeName, downPods[i].podIP))
 	}
 
 	r.VRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.NodeRestartStarted,
 		"Calling 'admintools -t restart_node' to restart the following pods: %s", strings.Join(podNames, ", "))
 	start := time.Now()
 	labels := metrics.MakeVDBLabels(r.Vdb)
-	stdout, _, err := r.PRunner.ExecAdmintools(ctx, r.InitiatorPod, names.ServerContainer, cmd...)
+	res, err := r.Dispatcher.RestartNode(ctx, opts...)
 	elapsedTimeInSeconds := time.Since(start).Seconds()
 	metrics.NodesRestartDuration.With(labels).Observe(elapsedTimeInSeconds)
 	metrics.NodesRestartAttempt.With(labels).Inc()
-	if err != nil {
+	if verrors.IsReconcileAborted(res, err) {
 		metrics.NodesRestartFailed.With(labels).Inc()
-		return r.EVLogr.LogFailure("restart_node", stdout, err)
+		return res, err
 	}
 	r.VRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.NodeRestartSucceeded,
 		"Successfully called 'admintools -t restart_node' and it took %ds", int(elapsedTimeInSeconds))
@@ -392,40 +398,27 @@ func (r *RestartReconciler) reipNodes(ctx context.Context, pods []*PodFact) (ctr
 // restartCluster will call admintools -t start_db
 // It is assumed that the cluster has already run re_ip.
 func (r *RestartReconciler) restartCluster(ctx context.Context, downPods []*PodFact) (ctrl.Result, error) {
-	cmd := r.genStartDBCommand(downPods)
+	opts := []startdb.Option{
+		startdb.WithInitiator(r.InitiatorPod, r.InitiatorPodIP),
+	}
+	for i := range downPods {
+		opts = append(opts, startdb.WithHost(downPods[i].podIP))
+	}
 	r.VRec.Event(r.Vdb, corev1.EventTypeNormal, events.ClusterRestartStarted,
 		"Calling 'admintools -t start_db' to restart the cluster")
 	start := time.Now()
 	labels := metrics.MakeVDBLabels(r.Vdb)
-	stdout, _, err := r.PRunner.ExecAdmintools(ctx, r.InitiatorPod, names.ServerContainer, cmd...)
+	res, err := r.Dispatcher.StartDB(ctx, opts...)
 	elapsedTimeInSeconds := time.Since(start).Seconds()
 	metrics.ClusterRestartDuration.With(labels).Observe(elapsedTimeInSeconds)
 	metrics.ClusterRestartAttempt.With(labels).Inc()
-	if err != nil {
+	if verrors.IsReconcileAborted(res, err) {
 		metrics.ClusterRestartFailure.With(labels).Inc()
-		return r.EVLogr.LogFailure("start_db", stdout, err)
+		return res, err
 	}
 	r.VRec.Eventf(r.Vdb, corev1.EventTypeNormal, events.ClusterRestartSucceeded,
 		"Successfully called 'admintools -t start_db' and it took %ds", int(elapsedTimeInSeconds))
 	return ctrl.Result{}, err
-}
-
-// genRestartVNodeList returns the vnodes of all of the hosts in downPods
-func genRestartVNodeList(downPods []*PodFact) []string {
-	hostList := []string{}
-	for _, v := range downPods {
-		hostList = append(hostList, v.vnodeName)
-	}
-	return hostList
-}
-
-// genRestartIPList returns the IPs of all of the hosts in downPods
-func genRestartIPList(downPods []*PodFact) []string {
-	ipList := []string{}
-	for _, v := range downPods {
-		ipList = append(ipList, v.podIP)
-	}
-	return ipList
 }
 
 // killReadOnlyProcesses will remove any running vertica processes that are
@@ -559,47 +552,6 @@ func (r *RestartReconciler) isStartupProbeActive(ctx context.Context, nm types.N
 	}
 	// If no container status, then we assume startupProbe hasn't completed yet.
 	return true, nil
-}
-
-// genRestartNodeCmd returns the command to run to restart a pod
-func (r *RestartReconciler) genRestartNodeCmd(vnodeList, ipList []string) []string {
-	cmd := []string{
-		"-t", "restart_node",
-		"--database=" + r.Vdb.Spec.DBName,
-		"--hosts=" + strings.Join(vnodeList, ","),
-		"--new-host-ips=" + strings.Join(ipList, ","),
-		"--noprompt",
-	}
-	if r.Vdb.Spec.RestartTimeout != 0 {
-		cmd = append(cmd, fmt.Sprintf("--timeout=%d", r.Vdb.Spec.RestartTimeout))
-	}
-	return cmd
-}
-
-// genStartDBCommand will return the command for start_db
-func (r *RestartReconciler) genStartDBCommand(downPods []*PodFact) []string {
-	cmd := []string{
-		"-t", "start_db",
-		"--database=" + r.Vdb.Spec.DBName,
-		"--noprompt",
-	}
-	if r.Vdb.Spec.IgnoreClusterLease {
-		cmd = append(cmd, "--ignore-cluster-lease")
-	}
-	if r.Vdb.Spec.RestartTimeout != 0 {
-		cmd = append(cmd, fmt.Sprintf("--timeout=%d", r.Vdb.Spec.RestartTimeout))
-	}
-
-	// In all versions that we support we can include a list of hosts to start.
-	// This parameter becomes important for online upgrade as we use this to
-	// start the primaries while the secondary are in read-only.
-	hostNames := []string{}
-	for _, pod := range downPods {
-		hostNames = append(hostNames, pod.podIP)
-	}
-	cmd = append(cmd, "--hosts", strings.Join(hostNames, ","))
-
-	return cmd
 }
 
 // setATPod will set r.ATPod if not already set.

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -430,20 +430,6 @@ var _ = Describe("restart_reconciler", func() {
 		Expect(len(restart)).Should(Equal(0))
 	})
 
-	It("should use --hosts option in start_db if on earliest version that we support", func() {
-		vdb := vapi.MakeVDB()
-		fpr := &cmds.FakePodRunner{}
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, &PodFacts{}, RestartProcessReadOnly, dispatcher)
-		r := act.(*RestartReconciler)
-		downPods := []*PodFact{
-			{podIP: "9.10.1.1"},
-			{podIP: "9.10.1.2"},
-		}
-		vdb.Annotations[vapi.VersionAnnotation] = vapi.MinimumVersion
-		Expect(r.genStartDBCommand(downPods)).Should(ContainElements("--hosts", "9.10.1.1,9.10.1.2"))
-	})
-
 	It("should requeue if k-safety is 0, there are no UP nodes and some pods aren't running", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters[0].Size = 3

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -24,6 +24,7 @@ import (
 
 // AddSubcluster will create a subcluster in the vertica cluster.
 func (v VClusterOps) AddSubcluster(ctx context.Context, opts ...addsc.Option) error {
+	v.Log.Info("Starting vcluster AddSubcluster")
 	s := addsc.Parms{}
 	s.Make(opts...)
 	return fmt.Errorf("not implemented")

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -30,7 +30,9 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -69,6 +71,16 @@ type Dispatcher interface {
 
 	// RemoveSubcluster will remove the given subcluster from the vertica cluster.
 	RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error
+
+	// RestartNode will restart a subset of nodes. Use this when vertica has not
+	// lost cluster quorum. The IP given for each vnode may not match the current IP
+	// in the vertica catalogs.
+	RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error)
+
+	// StartDB will start a subset of nodes. Use this when vertica has lost
+	// cluster quorum. The IP given for each vnode *must* match the current IP
+	// in the vertica catalog. If they aren't a call to ReIP is necessary.
+	StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error)
 }
 
 const (

--- a/pkg/vadmin/opts/restartnode/opts.go
+++ b/pkg/vadmin/opts/restartnode/opts.go
@@ -1,0 +1,57 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package restartnode
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Parms holds all of the option for a revive DB invocation.
+type Parms struct {
+	InitiatorName types.NamespacedName
+	InitiatorIP   string
+	HostVNodes    []string
+	HostIPs       []string
+}
+
+type Option func(*Parms)
+
+// Make will fill in the Parms based on the options chosen
+func (s *Parms) Make(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
+func WithInitiator(nm types.NamespacedName, ip string) Option {
+	return func(s *Parms) {
+		s.InitiatorName = nm
+		s.InitiatorIP = ip
+	}
+}
+
+func WithHost(vnode, ip string) Option {
+	return func(s *Parms) {
+		if s.HostVNodes == nil {
+			s.HostVNodes = make([]string, 0)
+		}
+		if s.HostIPs == nil {
+			s.HostIPs = make([]string, 0)
+		}
+		s.HostVNodes = append(s.HostVNodes, vnode)
+		s.HostIPs = append(s.HostIPs, ip)
+	}
+}

--- a/pkg/vadmin/opts/startdb/opts.go
+++ b/pkg/vadmin/opts/startdb/opts.go
@@ -1,0 +1,52 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package startdb
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Parms holds all of the option for a revive DB invocation.
+type Parms struct {
+	InitiatorName types.NamespacedName
+	InitiatorIP   string
+	Hosts         []string
+}
+
+type Option func(*Parms)
+
+// Make will fill in the Parms based on the options chosen
+func (s *Parms) Make(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
+func WithInitiator(nm types.NamespacedName, ip string) Option {
+	return func(s *Parms) {
+		s.InitiatorName = nm
+		s.InitiatorIP = ip
+	}
+}
+
+func WithHost(hostName string) Option {
+	return func(s *Parms) {
+		if s.Hosts == nil {
+			s.Hosts = make([]string, 0)
+		}
+		s.Hosts = append(s.Hosts, hostName)
+	}
+}

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -24,6 +24,7 @@ import (
 
 // RemoveSubcluster will remove the given subcluster from the vertica cluster.
 func (v VClusterOps) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
+	v.Log.Info("Starting vcluster RemoveSubcluster")
 	s := removesc.Parms{}
 	s.Make(opts...)
 	return fmt.Errorf("not implemented")

--- a/pkg/vadmin/restart_node_at.go
+++ b/pkg/vadmin/restart_node_at.go
@@ -1,0 +1,55 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// RestartNode will restart a subset of nodes. Use this when vertica has not
+// lost cluster quorum. The IP given for each vnode may not match the current IP
+// in the vertica catalogs.
+func (a Admintools) RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error) {
+	s := restartnode.Parms{}
+	s.Make(opts...)
+	cmd := a.genRestartNodeCmd(&s)
+	stdout, err := a.execAdmintools(ctx, s.InitiatorName, cmd...)
+	if err != nil {
+		return a.logFailure("restart_node", events.MgmtFailed, stdout, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// genRestartNodeCmd returns the command to run to restart a pod
+func (a Admintools) genRestartNodeCmd(s *restartnode.Parms) []string {
+	cmd := []string{
+		"-t", "restart_node",
+		"--database=" + a.VDB.Spec.DBName,
+		"--hosts=" + strings.Join(s.HostVNodes, ","),
+		"--new-host-ips=" + strings.Join(s.HostIPs, ","),
+		"--noprompt",
+	}
+	if a.VDB.Spec.RestartTimeout != 0 {
+		cmd = append(cmd, fmt.Sprintf("--timeout=%d", a.VDB.Spec.RestartTimeout))
+	}
+	return cmd
+}

--- a/pkg/vadmin/restart_node_at_test.go
+++ b/pkg/vadmin/restart_node_at_test.go
@@ -1,0 +1,48 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("restart_node_at", func() {
+	ctx := context.Background()
+
+	It("should call admintools -t restart_node", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		res, err := dispatcher.RestartNode(ctx,
+			restartnode.WithInitiator(nm, "10.8.1.1"),
+			restartnode.WithHost("v_db_node0001", "10.8.1.10"),
+			restartnode.WithHost("v_db_node0002", "10.8.1.11"),
+		)
+		Ω(err).Should(Succeed())
+		Ω(res).Should(Equal(ctrl.Result{}))
+		hist := fpr.FindCommands("-t restart_node")
+		Ω(len(hist)).Should(Equal(1))
+		Ω(hist[0].Command).Should(ContainElements(
+			"--hosts=v_db_node0001,v_db_node0002",
+			"--new-host-ips=10.8.1.10,10.8.1.11",
+		))
+	})
+})

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -19,13 +19,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// RemoveNode will remove an existng vertica node from the cluster.
-func (v VClusterOps) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
-	v.Log.Info("Starting vcluster RemoveNode")
-	s := removenode.Parms{}
+// RestartNode will restart a subset of nodes. Use this when vertica has not
+// lost cluster quorum. The IP given for each vnode may not match the current IP
+// in the vertica catalogs.
+func (v VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error) {
+	v.Log.Info("Starting vcluster RestartNode")
+	s := restartnode.Parms{}
 	s.Make(opts...)
-	return fmt.Errorf("not implemented")
+	return ctrl.Result{}, fmt.Errorf("not implemented")
 }

--- a/pkg/vadmin/start_db_at.go
+++ b/pkg/vadmin/start_db_at.go
@@ -1,0 +1,63 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// StartDB will start a subset of nodes. Use this when vertica has lost
+// cluster quorum. The IP given for each vnode *must* match the current IP
+// in the vertica catalog. If they aren't a call to ReIP is necessary.
+func (a Admintools) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
+	s := startdb.Parms{}
+	s.Make(opts...)
+	cmd := a.genStartDBCommand(&s)
+	stdout, _, err := a.PRunner.ExecAdmintools(ctx, s.InitiatorName, names.ServerContainer, cmd...)
+	if err != nil {
+		return a.logFailure("start_db", events.MgmtFailed, stdout, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// genStartDBCommand will return the command for start_db
+func (a Admintools) genStartDBCommand(s *startdb.Parms) []string {
+	cmd := []string{
+		"-t", "start_db",
+		"--database=" + a.VDB.Spec.DBName,
+		"--noprompt",
+	}
+	if a.VDB.Spec.IgnoreClusterLease {
+		cmd = append(cmd, "--ignore-cluster-lease")
+	}
+	if a.VDB.Spec.RestartTimeout != 0 {
+		cmd = append(cmd, fmt.Sprintf("--timeout=%d", a.VDB.Spec.RestartTimeout))
+	}
+
+	// In all versions that we support we can include a list of hosts to start.
+	// This parameter becomes important for online upgrade as we use this to
+	// start the primaries while the secondary are in read-only.
+	cmd = append(cmd, "--hosts", strings.Join(s.Hosts, ","))
+
+	return cmd
+}

--- a/pkg/vadmin/start_db_at_test.go
+++ b/pkg/vadmin/start_db_at_test.go
@@ -1,0 +1,52 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("start_db_at", func() {
+	ctx := context.Background()
+
+	It("should call admintools -t start_db", func() {
+		dispatcher, vdb, fpr := mockAdmintoolsDispatcher()
+		vdb.Spec.IgnoreClusterLease = true
+		vdb.Spec.RestartTimeout = 10
+		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		res, err := dispatcher.StartDB(ctx,
+			startdb.WithInitiator(nm, "11.8.1.1"),
+			startdb.WithHost("11.8.1.1"),
+			startdb.WithHost("11.8.1.2"),
+			startdb.WithHost("11.8.1.3"),
+		)
+		Ω(err).Should(Succeed())
+		Ω(res).Should(Equal(ctrl.Result{}))
+		hist := fpr.FindCommands("-t start_db")
+		Ω(len(hist)).Should(Equal(1))
+		Ω(hist[0].Command).Should(ContainElements(
+			"11.8.1.1,11.8.1.2,11.8.1.3",
+			"--ignore-cluster-lease",
+			"--timeout=10",
+		))
+	})
+})

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -17,15 +17,16 @@ package vadmin
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// RemoveNode will remove an existng vertica node from the cluster.
-func (v VClusterOps) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
-	v.Log.Info("Starting vcluster RemoveNode")
-	s := removenode.Parms{}
+// StartDB will start a subset of nodes. Use this when vertica has lost
+// cluster quorum. The IP given for each vnode *must* match the current IP
+// in the vertica catalog. If they aren't a call to ReIP is necessary.
+func (v VClusterOps) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
+	s := startdb.Parms{}
 	s.Make(opts...)
-	return fmt.Errorf("not implemented")
+	return ctrl.Result{}, nil
 }

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -17,6 +17,7 @@ package vadmin
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -28,5 +29,5 @@ import (
 func (v VClusterOps) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
 	s := startdb.Parms{}
 	s.Make(opts...)
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, fmt.Errorf("not implemented")
 }


### PR DESCRIPTION
This is a continuation of building out the dispatcher interface. The dispatcher interface will be used to switch between admintools and vcluster library. This adds the final two calls: RestartNode and StartDB. 