### PR TITLE
Implemented VClusterOps.CreateDB()

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -1104,10 +1104,11 @@ func MakeVDB() *VerticaDB {
 
 // MakeVDBForHTTP is a helper that constructs a VerticaDB struct with http enabled.
 // This is intended for test purposes.
-func MakeVDBForHTTP() *VerticaDB {
+func MakeVDBForHTTP(name string) *VerticaDB {
 	vdb := MakeVDB()
 	vdb.Annotations[VersionAnnotation] = HTTPServerMinVersion
 	vdb.Spec.HTTPServerMode = HTTPServerModeEnabled
+	vdb.Spec.HTTPServerTLSSecret = name
 	return vdb
 }
 

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -447,6 +447,9 @@ const (
 	AutoUpgrade UpgradePolicyType = "Auto"
 )
 
+// SuperUser is an automatically-created user in database creation
+const SuperUser = "dbadmin"
+
 type HTTPServerModeType string
 
 const (
@@ -1104,11 +1107,11 @@ func MakeVDB() *VerticaDB {
 
 // MakeVDBForHTTP is a helper that constructs a VerticaDB struct with http enabled.
 // This is intended for test purposes.
-func MakeVDBForHTTP(name string) *VerticaDB {
+func MakeVDBForHTTP(httpServerTLSSecretName string) *VerticaDB {
 	vdb := MakeVDB()
 	vdb.Annotations[VersionAnnotation] = HTTPServerMinVersion
 	vdb.Spec.HTTPServerMode = HTTPServerModeEnabled
-	vdb.Spec.HTTPServerTLSSecret = name
+	vdb.Spec.HTTPServerTLSSecret = httpServerTLSSecretName
 	return vdb
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
+	github.com/vertica/vcluster v0.0.0-20230626111548-d9d8c0dd50db
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -54,9 +55,10 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
-	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -275,7 +275,9 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/vertica/vcluster v0.0.0-20230626111548-d9d8c0dd50db h1:R9IVk9DTRg+CXrYOrSsWoCYj6Iv3Og/p0EbuTdHS8M4=
+github.com/vertica/vcluster v0.0.0-20230626111548-d9d8c0dd50db/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -312,6 +314,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -424,8 +428,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=

--- a/pkg/controllers/vdb/createdb_reconciler.go
+++ b/pkg/controllers/vdb/createdb_reconciler.go
@@ -248,6 +248,7 @@ func (c *CreateDBReconciler) genOptions(ctx context.Context, initiatorPod types.
 		createdb.WithDBName(c.Vdb.Spec.DBName),
 		createdb.WithLicensePath(licPath),
 		createdb.WithDepotPath(c.Vdb.Spec.Local.DepotPath),
+		createdb.WithDataPath(c.Vdb.Spec.Local.DataPath),
 	}
 
 	// If a communal path is set, include all of the EON parameters.

--- a/pkg/controllers/vdb/createdb_reconciler_test.go
+++ b/pkg/controllers/vdb/createdb_reconciler_test.go
@@ -30,6 +30,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+const TestPassword = "test-pw"
+
 var _ = Describe("createdb_reconciler", func() {
 	ctx := context.Background()
 
@@ -43,7 +45,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.Histories[len(fpr.Histories)-1]
@@ -62,7 +64,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 3)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		hist := fpr.FindCommands("/opt/vertica/bin/admintools -t create_db")
@@ -80,7 +82,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		r := act.(*CreateDBReconciler)
 		hostList, ok := r.getPodList()
@@ -108,7 +110,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(len(fpr.Histories)).Should(Equal(0))
@@ -126,7 +128,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		hist := fpr.FindCommands("alter database default set parameter EncryptSpreadComm")
@@ -144,7 +146,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*CreateDBReconciler)
 		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
@@ -198,7 +200,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size+vdb.Spec.Subclusters[1].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(len(fpr.Histories)).Should(BeNumerically(">", 0))
@@ -220,7 +222,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(len(fpr.Histories)).Should(BeNumerically(">", 0))
@@ -240,7 +242,7 @@ var _ = Describe("createdb_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(len(fpr.Histories)).Should(BeNumerically(">", 0))
@@ -260,7 +262,7 @@ func createMultiPodSubclusterForKsafe(ctx context.Context, ksafe vapi.KSafetyTyp
 
 	fpr := &cmds.FakePodRunner{}
 	pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
-	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 	act := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 	r := act.(*CreateDBReconciler)
 	hostList, ok := r.getPodList()

--- a/pkg/controllers/vdb/dbaddnode_reconciler_test.go
+++ b/pkg/controllers/vdb/dbaddnode_reconciler_test.go
@@ -39,7 +39,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.Histories[len(fpr.Histories)-1]
@@ -54,7 +54,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 3)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		lastCall := fpr.Histories[len(fpr.Histories)-1]
@@ -69,7 +69,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("db_add_node")
@@ -101,7 +101,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 					"already contains 3 node(s), Sqlstate: V2001",
 			},
 		}
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
@@ -116,7 +116,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 1)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("select rebalance_shards('defaultsubcluster')")
@@ -131,7 +131,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		atCmd := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
@@ -155,7 +155,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		pfacts.Detail[podWithNoDB].upNode = false
 		pfacts.Detail[podWithNoDB].isPodRunning = false
 		pfacts.Detail[podWithNoDB].isInstalled = false
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")
@@ -183,7 +183,7 @@ var _ = Describe("dbaddnode_reconcile", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 2)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")

--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		a := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := a.(*DBAddSubclusterReconciler)
 		subclusters := r.parseFetchSubclusterVsql(
@@ -77,7 +77,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 				{Stdout: " sc1\n"},
 			},
 		}
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// Last command should be AT -t db_add_subcluster
@@ -94,7 +94,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*DBAddSubclusterReconciler)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
@@ -123,7 +123,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		Expect(vdb.IsEON()).Should(BeFalse())
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})

--- a/pkg/controllers/vdb/dbremovenode_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovenode_reconciler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		recon := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
@@ -54,7 +54,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		actor := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		recon := actor.(*DBRemoveNodeReconciler)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
@@ -82,7 +82,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
@@ -110,7 +110,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())
@@ -132,7 +132,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		removePod := names.GenPodName(vdb, sc, 2)
 		pfacts.Detail[removePod].dbExists = false
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
 		Expect(err).Should(Succeed())

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
@@ -34,7 +34,7 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 		vdb := vapi.MakeVDB()
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
@@ -63,7 +63,7 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, lookupVdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// One command should be AT -t db_remove_subcluster and one should be

--- a/pkg/controllers/vdb/install_reconciler_test.go
+++ b/pkg/controllers/vdb/install_reconciler_test.go
@@ -121,13 +121,13 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 	})
 
 	It("should have a successful installer reconcile when running vclusterOps feature flag", func() {
-		vdb := vapi.MakeVDBForHTTP()
+		secretName := "tls-1"
+		vdb := vapi.MakeVDBForHTTP(secretName)
 		vdb.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationTrue
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
-		secret := createTLSSecret(ctx, vdb, "tls-1")
+		secret := createTLSSecret(ctx, vdb, secretName)
 		defer test.DeleteSecret(ctx, k8sClient, secret.Name)
-		vdb.Spec.HTTPServerTLSSecret = secret.Name
 
 		fpr := &cmds.FakePodRunner{}
 		pfact := MakePodFacts(vdbRec, fpr)
@@ -136,13 +136,13 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 	})
 
 	It("should not wait for all pods to be running to install when vclusterOps is set", func() {
-		vdb := vapi.MakeVDBForHTTP()
+		secretName := "tls-2"
+		vdb := vapi.MakeVDBForHTTP(secretName)
 		vdb.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationTrue
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
-		secret := createTLSSecret(ctx, vdb, "tls-2")
+		secret := createTLSSecret(ctx, vdb, secretName)
 		defer test.DeleteSecret(ctx, k8sClient, secret.Name)
-		vdb.Spec.HTTPServerTLSSecret = secret.Name
 
 		sc := &vdb.Spec.Subclusters[0]
 		fpr := &cmds.FakePodRunner{}

--- a/pkg/controllers/vdb/offlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconciler_test.go
@@ -165,7 +165,7 @@ func updateVdbToCauseUpgrade(ctx context.Context, vdb *vapi.VerticaDB, newImage 
 func createOfflineUpgradeReconciler(vdb *vapi.VerticaDB) (*OfflineUpgradeReconciler, *cmds.FakePodRunner, *PodFacts) {
 	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
 	pfacts := createPodFactsDefault(fpr)
-	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 	actor := MakeOfflineUpgradeReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 	return actor.(*OfflineUpgradeReconciler), fpr, pfacts
 }

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -471,7 +471,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 func createOnlineUpgradeReconciler(ctx context.Context, vdb *vapi.VerticaDB) *OnlineUpgradeReconciler {
 	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
 	pfacts := MakePodFacts(vdbRec, fpr)
-	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 	actor := MakeOnlineUpgradeReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 	r := actor.(*OnlineUpgradeReconciler)
 

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -45,7 +45,7 @@ var _ = Describe("restart_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		recon := MakeRestartReconciler(vdbRec, logger, vdb, fpr, &pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
@@ -66,7 +66,7 @@ var _ = Describe("restart_reconciler", func() {
 		downPodNm := names.GenPodName(vdb, sc, 1)
 		Expect(k8sClient.Get(ctx, downPodNm, downPod)).Should(Succeed())
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		restartCmd := fpr.FindCommands("restart_node")
@@ -96,7 +96,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{1}, PodNotReadOnly)
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(k8sClient.Get(ctx, nm, vdb)).Should(Succeed())
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -136,7 +136,7 @@ var _ = Describe("restart_reconciler", func() {
 			},
 		}
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
@@ -164,7 +164,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1}, PodNotReadOnly)
 		setVerticaNodeNameInPodFacts(vdb, sc, pfacts)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 	})
@@ -191,7 +191,7 @@ var _ = Describe("restart_reconciler", func() {
 			},
 		}
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
@@ -226,7 +226,7 @@ var _ = Describe("restart_reconciler", func() {
 			pfacts.Detail[downPodNm].isInstalled = true
 		}
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		listCmd := fpr.FindCommands("start_db")
@@ -258,7 +258,7 @@ var _ = Describe("restart_reconciler", func() {
 			},
 		}
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
@@ -279,7 +279,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1}, PodNotReadOnly)
 		initiatorPod := names.GenPodName(vdb, sc, 0)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
@@ -302,7 +302,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0}, PodNotReadOnly)
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
 		Expect(r.reconcileNodes(ctx)).Should(Equal(ctrl.Result{}))
@@ -339,7 +339,7 @@ var _ = Describe("restart_reconciler", func() {
 			},
 		}
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
@@ -372,7 +372,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		const DownPodIndex = 1
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{DownPodIndex}, PodNotReadOnly)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
@@ -390,7 +390,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		const DownPodIndex = 0
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{DownPodIndex}, PodReadOnly)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartSkipReadOnly, dispatcher)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -423,7 +423,7 @@ var _ = Describe("restart_reconciler", func() {
 		const DownPodIndex = 0
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, transientSc, fpr, []int32{DownPodIndex}, PodReadOnly)
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		restart := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "restart_node")
@@ -452,7 +452,7 @@ var _ = Describe("restart_reconciler", func() {
 			pfacts.Detail[downPodNm].isPodRunning = podIndex != 0
 		}
 
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		listCmd := fpr.FindCommands("start_db")
@@ -480,7 +480,7 @@ var _ = Describe("restart_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
 
@@ -520,7 +520,7 @@ var _ = Describe("restart_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		r := act.(*RestartReconciler)
 
@@ -556,7 +556,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, &vdb.Spec.Subclusters[0], fpr, []int32{0, 1}, PodNotReadOnly)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		expectedRequeueTime := int(float64(vdb.Spec.LivenessProbeOverride.PeriodSeconds*vdb.Spec.LivenessProbeOverride.FailureThreshold) *
 			PctOfLivenessProbeWait)
@@ -590,7 +590,7 @@ var _ = Describe("restart_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, &vdb.Spec.Subclusters[0], fpr, []int32{0, 1}, PodNotReadOnly)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		expectedRequeueTime := int(float64(vdb.Spec.LivenessProbeOverride.PeriodSeconds*vdb.Spec.LivenessProbeOverride.FailureThreshold) *
 			PctOfLivenessProbeWait)
@@ -613,7 +613,7 @@ var _ = Describe("restart_reconciler", func() {
 
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithSlowStartup(ctx, vdb, &vdb.Spec.Subclusters[0], fpr, []int32{2})
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
 		expectedRequeueTime := int(float64(vdb.Spec.LivenessProbeOverride.PeriodSeconds*vdb.Spec.LivenessProbeOverride.FailureThreshold) *
 			PctOfLivenessProbeWait)

--- a/pkg/controllers/vdb/revivedb_reconciler_test.go
+++ b/pkg/controllers/vdb/revivedb_reconciler_test.go
@@ -41,7 +41,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(len(fpr.Histories)).Should(Equal(0))
@@ -60,7 +60,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		reviveCalls := fpr.FindCommands("/opt/vertica/bin/admintools", "revive_db")
@@ -82,7 +82,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, ScSize)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		r.Planr = reviveplanner.MakeATPlannerFromVDB(vdb, logger)
@@ -96,7 +96,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
@@ -148,7 +148,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		vdb.Spec.IgnoreClusterLease = false
@@ -184,7 +184,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		pods, ok := r.getPodList()
@@ -213,7 +213,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		pods, ok := r.getPodList()
@@ -232,7 +232,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 
@@ -254,7 +254,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		r.Planr = reviveplanner.MakeATPlannerFromVDB(vdb, logger)
@@ -282,7 +282,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		r.Planr = reviveplanner.MakeATPlannerFromVDB(vdb, logger)
@@ -324,7 +324,7 @@ var _ = Describe("revivedb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		pfacts.Detail[pn].stsRevisionPending = true
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, pfacts, dispatcher)

--- a/pkg/controllers/vdb/stopdb_reconciler_test.go
+++ b/pkg/controllers/vdb/stopdb_reconciler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("stopdb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, int(vdb.Spec.Subclusters[0].Size))
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(len(fpr.Histories)).Should(Equal(0))
@@ -53,7 +53,7 @@ var _ = Describe("stopdb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, &pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		hist := fpr.FindCommands("stop_db")
@@ -74,7 +74,7 @@ var _ = Describe("stopdb_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		hist := fpr.FindCommands("stop_db")

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	vops "github.com/vertica/vcluster/vclusterops"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
@@ -282,7 +283,7 @@ func (r *VerticaDBReconciler) checkShardToNodeRatio(vdb *vapi.VerticaDB, sc *vap
 // makeDispatcher will create a Dispatcher object based on the feature flags set.
 func (r *VerticaDBReconciler) makeDispatcher(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner) vadmin.Dispatcher {
 	if vmeta.UseVClusterOps(vdb.Annotations) {
-		return vadmin.MakeVClusterOps(log, vdb)
+		return vadmin.MakeVClusterOps(log, vdb, r.Client, &vops.VClusterCommands{})
 	}
 	return vadmin.MakeAdmintools(log, vdb, prunner, r.EVRec, r.OpCfg.DevMode)
 }

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -115,7 +115,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// much as we can. Some reconcilers will purposely invalidate the facts if
 	// it is known they did something to make them stale.
 	pfacts := MakePodFacts(r, prunner)
-	dispatcher := r.makeDispatcher(log, vdb, prunner)
+	dispatcher := r.makeDispatcher(log, vdb, prunner, passwd)
 	var res ctrl.Result
 
 	// Iterate over each actor
@@ -281,9 +281,10 @@ func (r *VerticaDBReconciler) checkShardToNodeRatio(vdb *vapi.VerticaDB, sc *vap
 }
 
 // makeDispatcher will create a Dispatcher object based on the feature flags set.
-func (r *VerticaDBReconciler) makeDispatcher(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner) vadmin.Dispatcher {
+func (r *VerticaDBReconciler) makeDispatcher(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner,
+	passwd string) vadmin.Dispatcher {
 	if vmeta.UseVClusterOps(vdb.Annotations) {
-		return vadmin.MakeVClusterOps(log, vdb, r.Client, &vops.VClusterCommands{})
+		return vadmin.MakeVClusterOps(log, vdb, r.Client, &vops.VClusterCommands{}, passwd)
 	}
 	return vadmin.MakeAdmintools(log, vdb, prunner, r.EVRec, r.OpCfg.DevMode)
 }

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -23,7 +23,7 @@ import (
 )
 
 // AddNode will add a new vertica node to the cluster
-func (v VClusterOps) AddNode(ctx context.Context, opts ...addnode.Option) error {
+func (v *VClusterOps) AddNode(ctx context.Context, opts ...addnode.Option) error {
 	v.Log.Info("Starting vcluster AddNode")
 	s := addnode.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -23,7 +23,7 @@ import (
 )
 
 // AddSubcluster will create a subcluster in the vertica cluster.
-func (v VClusterOps) AddSubcluster(ctx context.Context, opts ...addsc.Option) error {
+func (v *VClusterOps) AddSubcluster(ctx context.Context, opts ...addsc.Option) error {
 	v.Log.Info("Starting vcluster AddSubcluster")
 	s := addsc.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -27,7 +27,7 @@ import (
 )
 
 // CreateDB will construct a new DB using the vcluster-ops library
-func (v VClusterOps) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl.Result, error) {
+func (v *VClusterOps) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl.Result, error) {
 	v.Log.Info("Starting vcluster CreateDB")
 
 	// get the certs
@@ -52,7 +52,7 @@ func (v VClusterOps) CreateDB(ctx context.Context, opts ...createdb.Option) (ctr
 	return ctrl.Result{}, nil
 }
 
-func (v VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) vops.VCreateDatabaseOptions {
+func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) vops.VCreateDatabaseOptions {
 	opts := vops.VCreateDatabaseOptionsFactory()
 
 	opts.RawHosts = s.Hosts
@@ -82,6 +82,9 @@ func (v VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) vo
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
 	*opts.UserName = vapi.SuperUser
+	if v.Password != "" {
+		opts.Password = &v.Password
+	}
 
 	return opts
 }

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -17,8 +17,8 @@ package vadmin
 
 import (
 	"context"
-	"fmt"
 
+	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -26,5 +26,84 @@ import (
 // CreateDB will construct a new DB using the vcluster-ops library
 func (v VClusterOps) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl.Result, error) {
 	v.Log.Info("Starting vcluster CreateDB")
-	return ctrl.Result{}, fmt.Errorf("not implemented")
+
+	// get the certs
+	certs, err := v.retrieveHTTPSCerts(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// get create_db options
+	s := createdb.Parms{}
+	s.Make(opts...)
+
+	// call vcluster-ops library to create db
+	vopts := v.genCreateDBOptions(&s, certs)
+	vdb, err := v.VCreateDatabase(&vopts)
+	if err != nil {
+		v.Log.Error(err, "failed to create a database")
+		return ctrl.Result{}, err
+	}
+
+	v.Log.Info("Successfully created a database", "dbName", vdb.Name)
+	return ctrl.Result{}, nil
+}
+
+func (v VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) vops.VCreateDatabaseOptions {
+	opts := vops.VCreateDatabaseOptionsFactory()
+
+	opts.RawHosts = s.Hosts
+	opts.CatalogPrefix = &s.CatalogPath
+	opts.Name = &s.DBName
+	opts.LicensePathOnNode = &s.LicensePath
+	*opts.ForceRemovalAtCreation = true
+	opts.SkipPackageInstall = &s.SkipPackageInstall
+	opts.DataPrefix = &s.DataPath
+
+	// If a communal path is set, include all of the EON parameters.
+	if s.CommunalPath != "" {
+		opts.DepotPrefix = &s.DepotPath
+		opts.CommunalStorageLocation = &s.CommunalPath
+		// TODO: uncommented this line after vcluster-ops library implemented CommunalStorageParamsPath
+		// TODO: might need to create a new NMA endpoint for this option
+		// TODO: might need to use paths.AuthParmsFile instead of s.CommunalStorageParams
+		// opts.CommunalStorageParamsPath = &s.CommunalStorageParams
+	}
+
+	if s.ShardCount > 0 {
+		opts.ShardCount = &s.ShardCount
+	}
+
+	// auth options
+	opts.Key = certs.Key
+	opts.Cert = certs.Cert
+	opts.CaCert = certs.CaCert
+	// the value of this one needs to be the same as vertica pod's username,
+	// otherwise we cannot access vertica HTTPS server
+	// TODO: check if we need to add UserName to CRD
+	*opts.UserName = "dbadmin"
+
+	// TODO: uncomment this line after vcluster-ops implemented PostDBCreateSQLFile
+	// opts.SQLFile = &s.PostDBCreateSQLFile
+
+	// TODO low priority: add this option in vcluster-ops library
+	// "`--skip-fs-checks`"
+
+	// TODO low priority: check if we need to add the new options of vcluster-ops create_db to CRD
+	// opts.GetAwsCredentialsFromEnv
+	// opts.Policy
+	// opts.Broadcast
+	// opts.P2p
+	// opts.LargeCluster
+	// opts.Ipv6
+	// opts.ClientPort
+	// opts.SkipStartupPolling
+	// opts.SpreadLogging
+	// opts.SpreadLoggingLevel
+	// opts.ForceCleanupOnFailure
+	// opts.TimeoutNodeStartupSeconds
+	// opts.Password
+	// opts.ConfigurationParameters
+
+	return opts
 }

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -56,7 +56,7 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 	opts := vops.VCreateDatabaseOptionsFactory()
 
 	opts.RawHosts = s.Hosts
-	v.Log.Info("Create database on the hosts: " + strings.Join(s.Hosts, ","))
+	v.Log.Info("Setup create db options", "hosts", strings.Join(s.Hosts, ","))
 	if len(opts.RawHosts) > 0 {
 		*opts.Ipv6 = net.IsIPv6(opts.RawHosts[0])
 	}

--- a/pkg/vadmin/create_db_vc_test.go
+++ b/pkg/vadmin/create_db_vc_test.go
@@ -1,0 +1,115 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var TestHosts = []string{"pod-1", "pod-2", "pod-3"}
+
+const (
+	TestDBName             = "test-db"
+	TestCommunalPath       = "/communal"
+	TestCatalogPath        = "/catalog"
+	TestDepotPath          = "/depot"
+	TestDataPath           = "/data"
+	TestLicensePath        = "/root/license.key"
+	TestShardCount         = 11
+	TestSkipPackageInstall = true
+	TestUserName           = "dbadmin"
+)
+
+// mock version of VCreateDatabase() that is invoked inside VClusterOps.CreateDB()
+func (m *MockVClusterOps) VCreateDatabase(options *vops.VCreateDatabaseOptions) (vops.VCoordinationDatabase, error) {
+	vdb := vops.VCoordinationDatabase{}
+
+	// verify basic options
+	if !reflect.DeepEqual(options.RawHosts, TestHosts) {
+		return vdb, fmt.Errorf("failed to retrieve hosts")
+	}
+	if *options.Name != TestDBName {
+		return vdb, fmt.Errorf("failed to retrieve database name")
+	}
+	if *options.CommunalStorageLocation != TestCommunalPath {
+		return vdb, fmt.Errorf("failed to retrieve communal path")
+	}
+	if *options.CatalogPrefix != TestCatalogPath {
+		return vdb, fmt.Errorf("failed to retrieve catalog path")
+	}
+	if *options.DepotPrefix != TestDepotPath {
+		return vdb, fmt.Errorf("failed to retrieve depot path")
+	}
+	if *options.DataPrefix != TestDataPath {
+		return vdb, fmt.Errorf("failed to retrieve data path")
+	}
+	if *options.LicensePathOnNode != TestLicensePath {
+		return vdb, fmt.Errorf("failed to retrieve license path")
+	}
+	if *options.ShardCount != TestShardCount {
+		return vdb, fmt.Errorf("failed to retrieve shard count")
+	}
+	if *options.SkipPackageInstall != TestSkipPackageInstall {
+		return vdb, fmt.Errorf("failed to retrieve SkipPackageInstall")
+	}
+
+	// verify auth options
+	if *options.UserName != TestUserName {
+		return vdb, fmt.Errorf("failed to retrieve Vertica username")
+	}
+	if options.Key != test.TestKeyValue {
+		return vdb, fmt.Errorf("failed to load key")
+	}
+	if options.Cert != test.TestCertValue {
+		return vdb, fmt.Errorf("failed to load cert")
+	}
+	if options.CaCert != test.TestCaCertValue {
+		return vdb, fmt.Errorf("failed to load ca cert")
+	}
+
+	// vdb.Name is used in VClusterOps.CreateDB() so we give it a value
+	vdb.Name = TestDBName
+	return vdb, nil
+}
+
+var _ = Describe("create_db_vc", func() {
+	ctx := context.Background()
+
+	It("should call vcluster-ops library with create_db task", func() {
+		dispatcher := mockVClusterOpsDispatcher()
+		test.CreateFakeTLSSecret(ctx, dispatcher.VDB, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)
+		defer test.DeleteSecret(ctx, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)
+		Ω(dispatcher.CreateDB(ctx,
+			createdb.WithHosts(TestHosts),
+			createdb.WithDBName(TestDBName),
+			createdb.WithCommunalPath(TestCommunalPath),
+			createdb.WithCatalogPath(TestCatalogPath),
+			createdb.WithDepotPath(TestDepotPath),
+			createdb.WithDataPath(TestDataPath),
+			createdb.WithLicensePath(TestLicensePath),
+			createdb.WithShardCount(TestShardCount),
+			createdb.WithSkipPackageInstall())).Should(Equal(ctrl.Result{}))
+	})
+})

--- a/pkg/vadmin/create_db_vc_test.go
+++ b/pkg/vadmin/create_db_vc_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vops "github.com/vertica/vcluster/vclusterops"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,7 +40,6 @@ const (
 	TestLicensePath        = "/root/license.key"
 	TestShardCount         = 11
 	TestSkipPackageInstall = true
-	TestUserName           = "dbadmin"
 )
 
 // mock version of VCreateDatabase() that is invoked inside VClusterOps.CreateDB()
@@ -76,7 +76,10 @@ func (m *MockVClusterOps) VCreateDatabase(options *vops.VCreateDatabaseOptions) 
 	}
 
 	// verify auth options
-	if *options.UserName != TestUserName {
+	if *options.UserName != vapi.SuperUser {
+		return vdb, fmt.Errorf("failed to retrieve Vertica username")
+	}
+	if *options.Password != TestPassword {
 		return vdb, fmt.Errorf("failed to retrieve Vertica username")
 	}
 	if options.Key != test.TestKeyValue {

--- a/pkg/vadmin/describe_db_vc.go
+++ b/pkg/vadmin/describe_db_vc.go
@@ -24,7 +24,7 @@ import (
 )
 
 // DescribeDB will get information about a database from communal storage.
-func (v VClusterOps) DescribeDB(ctx context.Context, opts ...describedb.Option) (string, ctrl.Result, error) {
+func (v *VClusterOps) DescribeDB(ctx context.Context, opts ...describedb.Option) (string, ctrl.Result, error) {
 	v.Log.Info("Starting vcluster DescribeDB")
 	return "", ctrl.Result{}, fmt.Errorf("not implemented")
 }

--- a/pkg/vadmin/fetch_node_state_vc.go
+++ b/pkg/vadmin/fetch_node_state_vc.go
@@ -25,7 +25,7 @@ import (
 
 // FetchNodeState will determine if the given set of nodes are considered UP
 // or DOWN in our consensous state. It returns a map of vnode to its node state.
-func (v VClusterOps) FetchNodeState(ctx context.Context, opts ...fetchnodestate.Option) (map[string]string, ctrl.Result, error) {
+func (v *VClusterOps) FetchNodeState(ctx context.Context, opts ...fetchnodestate.Option) (map[string]string, ctrl.Result, error) {
 	v.Log.Info("Starting vcluster FetchNodeState")
 	return nil, ctrl.Result{}, fmt.Errorf("not implemented")
 }

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -121,15 +121,17 @@ type VClusterOps struct {
 	VDB    *vapi.VerticaDB
 	Client client.Client
 	VClusterProvider
+	Password string
 }
 
 // MakeVClusterOps will create a dispatcher that uses the vclusterops library for admin commands.
-func MakeVClusterOps(log logr.Logger, vdb *vapi.VerticaDB, cli client.Client, vopsi VClusterProvider) Dispatcher {
-	return VClusterOps{
+func MakeVClusterOps(log logr.Logger, vdb *vapi.VerticaDB, cli client.Client, vopsi VClusterProvider, passwd string) Dispatcher {
+	return &VClusterOps{
 		Log:              log,
 		VDB:              vdb,
 		Client:           cli,
 		VClusterProvider: vopsi,
+		Password:         passwd,
 	}
 }
 

--- a/pkg/vadmin/opts/createdb/opts.go
+++ b/pkg/vadmin/opts/createdb/opts.go
@@ -26,6 +26,7 @@ type Parms struct {
 	PostDBCreateSQLFile   string
 	CatalogPath           string
 	DepotPath             string
+	DataPath              string
 	DBName                string
 	LicensePath           string
 	CommunalPath          string
@@ -70,6 +71,12 @@ func WithCatalogPath(path string) Option {
 func WithDepotPath(path string) Option {
 	return func(s *Parms) {
 		s.DepotPath = path
+	}
+}
+
+func WithDataPath(path string) Option {
+	return func(s *Parms) {
+		s.DataPath = path
 	}
 }
 

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -24,7 +24,7 @@ import (
 )
 
 // ReIP will update the catalog on disk with new IPs for all of the nodes given.
-func (v VClusterOps) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error) {
+func (v *VClusterOps) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error) {
 	v.Log.Info("Starting vcluster ReIP")
 	s := reip.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -23,7 +23,7 @@ import (
 )
 
 // RemoveNode will remove an existng vertica node from the cluster.
-func (v VClusterOps) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
+func (v *VClusterOps) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
 	v.Log.Info("Starting vcluster RemoveNode")
 	s := removenode.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -23,7 +23,7 @@ import (
 )
 
 // RemoveSubcluster will remove the given subcluster from the vertica cluster.
-func (v VClusterOps) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
+func (v *VClusterOps) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
 	v.Log.Info("Starting vcluster RemoveSubcluster")
 	s := removesc.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -26,7 +26,7 @@ import (
 // RestartNode will restart a subset of nodes. Use this when vertica has not
 // lost cluster quorum. The IP given for each vnode may not match the current IP
 // in the vertica catalogs.
-func (v VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error) {
+func (v *VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error) {
 	v.Log.Info("Starting vcluster RestartNode")
 	s := restartnode.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/revive_db_vc.go
+++ b/pkg/vadmin/revive_db_vc.go
@@ -25,7 +25,7 @@ import (
 
 // ReviveDB will initialized a database using an existing communal path. It does
 // this using the vclusterops library.
-func (v VClusterOps) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ctrl.Result, error) {
+func (v *VClusterOps) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ctrl.Result, error) {
 	v.Log.Info("Starting vcluster ReviveDB")
 	return ctrl.Result{}, fmt.Errorf("not implemented")
 }

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -26,7 +26,7 @@ import (
 // StartDB will start a subset of nodes. Use this when vertica has lost
 // cluster quorum. The IP given for each vnode *must* match the current IP
 // in the vertica catalog. If they aren't a call to ReIP is necessary.
-func (v VClusterOps) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
+func (v *VClusterOps) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
 	s := startdb.Parms{}
 	s.Make(opts...)
 	return ctrl.Result{}, fmt.Errorf("not implemented")

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -23,7 +23,7 @@ import (
 )
 
 // StopDB will stop all the vertica hosts of a running cluster
-func (v VClusterOps) StopDB(ctx context.Context, opts ...stopdb.Option) error {
+func (v *VClusterOps) StopDB(ctx context.Context, opts ...stopdb.Option) error {
 	v.Log.Info("Starting vcluster StopDB")
 	s := stopdb.Parms{}
 	s.Make(opts...)

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -85,10 +85,12 @@ func mockAdmintoolsDispatcher() (Admintools, *vapi.VerticaDB, *cmds.FakePodRunne
 type MockVClusterOps struct {
 }
 
+const TestPassword = "test-pw"
+
 // mockVClusterOpsDispatcher will create an vcluster-ops dispatcher for test purposes
-func mockVClusterOpsDispatcher() VClusterOps {
+func mockVClusterOpsDispatcher() *VClusterOps {
 	vdb := vapi.MakeVDBForHTTP("test-secret")
 	mockVops := MockVClusterOps{}
-	dispatcher := MakeVClusterOps(logger, vdb, k8sClient, &mockVops)
-	return dispatcher.(VClusterOps)
+	dispatcher := MakeVClusterOps(logger, vdb, k8sClient, &mockVops, TestPassword)
+	return dispatcher.(*VClusterOps)
 }

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -16,6 +16,7 @@
 package vadmin
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -24,13 +25,45 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/mgmterrors"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+var k8sClient client.Client
+var testEnv *envtest.Environment
 var logger logr.Logger
+var restCfg *rest.Config
 
 var _ = BeforeSuite(func() {
 	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(logger)
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, cfg).NotTo(BeNil())
+	restCfg = cfg
+
+	err = vapi.AddToScheme(scheme.Scheme)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 })
 
 func TestAPIs(t *testing.T) {
@@ -39,12 +72,23 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "vadmin Suite")
 }
 
-// mockAdmintoolsDispatcher will create an admintools dispatcher for test
-// purposes.
+// mockAdmintoolsDispatcher will create an admintools dispatcher for test purposes
 func mockAdmintoolsDispatcher() (Admintools, *vapi.VerticaDB, *cmds.FakePodRunner) {
 	vdb := vapi.MakeVDB()
 	fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 	evWriter := mgmterrors.TestEVWriter{}
 	dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter, false)
 	return dispatcher.(Admintools), vdb, fpr
+}
+
+// MockVClusterOps is used to invoke mock vcluster-ops functions
+type MockVClusterOps struct {
+}
+
+// mockVClusterOpsDispatcher will create an vcluster-ops dispatcher for test purposes
+func mockVClusterOpsDispatcher() VClusterOps {
+	vdb := vapi.MakeVDBForHTTP("test-secret")
+	mockVops := MockVClusterOps{}
+	dispatcher := MakeVClusterOps(logger, vdb, k8sClient, &mockVops)
+	return dispatcher.(VClusterOps)
 }

--- a/pkg/vadmin/vc.go
+++ b/pkg/vadmin/vc.go
@@ -24,7 +24,7 @@ import (
 )
 
 // retrieveHTTPSCerts will retrieve the certs from HTTPServerTLSSecret for calling NMA endpoints
-func (v VClusterOps) retrieveHTTPSCerts(ctx context.Context) (*HTTPSCerts, error) {
+func (v *VClusterOps) retrieveHTTPSCerts(ctx context.Context) (*HTTPSCerts, error) {
 	certs := HTTPSCerts{}
 
 	nm := types.NamespacedName{

--- a/pkg/vadmin/vc.go
+++ b/pkg/vadmin/vc.go
@@ -1,0 +1,57 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// retrieveHTTPSCerts will retrieve the certs from HTTPServerTLSSecret for calling NMA endpoints
+func (v VClusterOps) retrieveHTTPSCerts(ctx context.Context) (*HTTPSCerts, error) {
+	certs := HTTPSCerts{}
+
+	nm := types.NamespacedName{
+		Namespace: v.VDB.Namespace,
+		Name:      v.VDB.Spec.HTTPServerTLSSecret,
+	}
+	tlsCerts := &corev1.Secret{}
+	err := v.Client.Get(ctx, nm, tlsCerts)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsKey, ok := tlsCerts.Data[corev1.TLSPrivateKeyKey]
+	if !ok {
+		return nil, fmt.Errorf("key %s is missing in the secret %s", corev1.TLSPrivateKeyKey, tlsCerts.Name)
+	}
+	tlsCrt, ok := tlsCerts.Data[corev1.TLSCertKey]
+	if !ok {
+		return nil, fmt.Errorf("cert %s is missing in the secret %s", corev1.TLSCertKey, tlsCerts.Name)
+	}
+	tlsCaCrt, ok := tlsCerts.Data[corev1.ServiceAccountRootCAKey]
+	if !ok {
+		return nil, fmt.Errorf("ca cert %s is missing in the secret %s", corev1.ServiceAccountRootCAKey, tlsCerts.Name)
+	}
+	certs.Key = string(tlsKey)
+	certs.Cert = string(tlsCrt)
+	certs.CaCert = string(tlsCaCrt)
+
+	return &certs, nil
+}


### PR DESCRIPTION
This is the integration work that calls vclusterops library to create a database. When the vclusterops flag is true, we will create a vclusterops dispatcher instead of an admintool dispatcher. 

Since the test suite isn't ready, I didn't write an e2e test for vclusterops create_db. The e2e test will be in another PR.