### PR TITLE
Build images with docker buildx build

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -21,7 +21,7 @@ This guide explains how to set up an environment to develop and test the Vertica
 # Software Setup
 Prior to developing, the following software needs to be installed manually.  There is other software that needed, but it is downloaded through make targets in the repo's bin directory.
 
-- [docker](https://docs.docker.com/get-docker/) (version 19.03 or newer)
+- [docker](https://docs.docker.com/get-docker/) (version 23.0)
 - [go](https://golang.org/doc/install) (version 1.19.6)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (version 1.20.1)
 - [helm](https://helm.sh/docs/intro/install/) (version 3.5.0)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -21,7 +21,7 @@ This guide explains how to set up an environment to develop and test the Vertica
 # Software Setup
 Prior to developing, the following software needs to be installed manually.  There is other software that needed, but it is downloaded through make targets in the repo's bin directory.
 
-- [docker](https://docs.docker.com/get-docker/)
+- [docker](https://docs.docker.com/get-docker/) (version 19.03 or newer)
 - [go](https://golang.org/doc/install) (version 1.19.6)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (version 1.20.1)
 - [helm](https://helm.sh/docs/intro/install/) (version 3.5.0)

--- a/Makefile
+++ b/Makefile
@@ -317,8 +317,8 @@ docker-build-operator: manifests generate fmt vet ## Build operator docker image
 docker-build-vlogger:  ## Build vertica logger docker image
 	docker buildx build -t ${VLOGGER_IMG} --load -f docker-vlogger/Dockerfile .
 
-# If you wish built the manager image targeting other platforms you can use the --platform flag.
-# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# If you wish to build the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker buildx build --platform=linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-push-operator
 docker-push-operator: ## Push operator docker image with the manager.
@@ -387,7 +387,7 @@ endif
 
 .PHONY: docker-build-bundle
 docker-build-bundle: bundle ## Build the bundle image
-	docker build -f $(BUNDLE_DOCKERFILE) -t $(BUNDLE_IMG) .
+	docker buildx build --load -f $(BUNDLE_DOCKERFILE) -t $(BUNDLE_IMG) .
 
 .PHONY: docker-push-bundle
 docker-push-bundle: ## Push the bundle image

--- a/Makefile
+++ b/Makefile
@@ -311,11 +311,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build-operator
 docker-build-operator: manifests generate fmt vet ## Build operator docker image with the manager.
-	docker build -t ${OPERATOR_IMG} -f docker-operator/Dockerfile .
+	docker buildx build --tag ${OPERATOR_IMG} --load -f docker-operator/Dockerfile .
 
 .PHONY: docker-build-vlogger
 docker-build-vlogger:  ## Build vertica logger docker image
-	docker build -t ${VLOGGER_IMG} -f docker-vlogger/Dockerfile .
+	docker buildx build -t ${VLOGGER_IMG} --load -f docker-vlogger/Dockerfile .
 
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.

--- a/docker-vertica-v2/Makefile
+++ b/docker-vertica-v2/Makefile
@@ -11,7 +11,8 @@ all: docker-build-vertica
 .PHONY: docker-build-vertica
 docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 	docker pull ubuntu:$(BASE_OS_VERSION) ## make sure we use the latest ubuntu image
-	docker build \
+	docker buildx build \
+		--load \
 		-f Dockerfile \
 		--label minimal=${MINIMAL_VERTICA_IMG} \
 		--label os-version=${BASE_OS_VERSION} \

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -11,7 +11,8 @@ all: docker-build-vertica
 .PHONY: docker-build-vertica
 docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 	docker pull ubuntu:$(BASE_OS_VERSION) ## make sure we use the latest ubuntu image
-	docker build \
+	docker buildx build \
+		--load \
 		-f Dockerfile \
 		--label minimal=${MINIMAL_VERTICA_IMG} \
 		--label os-version=${BASE_OS_VERSION} \


### PR DESCRIPTION
As of Docker Engine 23.0, Buildx is the default build client. So we are now using it to build our images instead of `docker build`.
All `docker build` calls have been replaced by `docker buildx build`.