### PR TITLE
Fix flaky e2e test

### DIFF
--- a/tests/e2e-leg-4/restart-with-liveness-probe/35-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/35-assert.yaml
@@ -19,10 +19,6 @@ status:
   containerStatuses:
   - name: server
     ready: false
-    lastState:
-      terminated:
-        exitCode: 137
-        reason: Error
     started: false
     restartCount: 1
 ---

--- a/tests/e2e-leg-4/restart-with-liveness-probe/55-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/55-assert.yaml
@@ -44,10 +44,6 @@ status:
     restartCount: 2
     started: true
     ready: true
-    lastState:
-      terminated:
-        exitCode: 137
-        reason: Error
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
I have seen the restart-with-liveness-probe test fail on occasion. One part of the test will wait for the livenessProbe to kick in an restart the pod. The test assertion check the lastState field in the Pod's container status. I have seen this not be filled in as expected. I am removing it from the assertion in an attempt to make the test run more reliably.