### PR TITLE
implemented VClusterOps.StopDB()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230626111548-d9d8c0dd50db
+	github.com/vertica/vcluster v0.0.0-20230630151840-081eb662e260
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -77,5 +77,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/vertica/vcluster => github.com/cchen-vertica/vcluster v0.0.10-test

--- a/go.mod
+++ b/go.mod
@@ -77,3 +77,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/vertica/vcluster => github.com/cchen-vertica/vcluster v0.0.10-test

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead h1:UhYWAphNveMty305skySR5ST/hbYDexgsgkhcy0MDhM=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead/go.mod h1:RI5D4DqbDX0Kb0SvKTuAKMYlkSBND3zLQZI/wiS5Ij0=
+github.com/cchen-vertica/vcluster v0.0.10-test h1:tK33BfxYubyucO91ui9mJ0ow3Md2T3dwC4IsLsyB4H8=
+github.com/cchen-vertica/vcluster v0.0.10-test/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -276,8 +278,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/vertica/vcluster v0.0.0-20230626111548-d9d8c0dd50db h1:R9IVk9DTRg+CXrYOrSsWoCYj6Iv3Og/p0EbuTdHS8M4=
-github.com/vertica/vcluster v0.0.0-20230626111548-d9d8c0dd50db/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead h1:UhYWAphNveMty305skySR5ST/hbYDexgsgkhcy0MDhM=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead/go.mod h1:RI5D4DqbDX0Kb0SvKTuAKMYlkSBND3zLQZI/wiS5Ij0=
-github.com/cchen-vertica/vcluster v0.0.10-test h1:tK33BfxYubyucO91ui9mJ0ow3Md2T3dwC4IsLsyB4H8=
-github.com/cchen-vertica/vcluster v0.0.10-test/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -278,6 +276,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/vertica/vcluster v0.0.0-20230630151840-081eb662e260 h1:q2TQBIUvqgi96uNZ2YfNvEBTWTWhNbRRo1V8ThC4QM0=
+github.com/vertica/vcluster v0.0.0-20230630151840-081eb662e260/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
@@ -58,7 +59,11 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 	opts.RawHosts = s.Hosts
 	v.Log.Info("Setup create db options", "hosts", strings.Join(s.Hosts, ","))
 	if len(opts.RawHosts) > 0 {
-		*opts.Ipv6 = net.IsIPv6(opts.RawHosts[0])
+		if net.IsIPv6(opts.RawHosts[0]) {
+			opts.Ipv6 = vstruct.True
+		} else {
+			opts.Ipv6 = vstruct.False
+		}
 	}
 	opts.CatalogPrefix = &s.CatalogPath
 	opts.Name = &s.DBName

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -146,4 +146,5 @@ type HTTPSCerts struct {
 // 1. real implementation in vcluster-ops library 2. mock implementation for unit test
 type VClusterProvider interface {
 	VCreateDatabase(options *vops.VCreateDatabaseOptions) (vops.VCoordinationDatabase, error)
+	VStopDatabase(options *vops.VStopDatabaseOptions) (string, error)
 }

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
@@ -49,11 +50,15 @@ func (v *VClusterOps) genStopDBOptions(s *stopdb.Parms) vops.VStopDatabaseOption
 
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 	v.Log.Info("Setup stop db options", "hosts", opts.RawHosts[0])
-	*opts.Ipv6 = net.IsIPv6(s.InitiatorIP)
+	if net.IsIPv6(s.InitiatorIP) {
+		opts.Ipv6 = vstruct.True
+	} else {
+		opts.Ipv6 = vstruct.False
+	}
 
 	opts.Name = &v.VDB.Spec.DBName
 	if v.VDB.IsEON() {
-		opts.IsEon = vops.True
+		opts.IsEon = vstruct.True
 	}
 
 	// auth options

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -17,15 +17,49 @@ package vadmin
 
 import (
 	"context"
-	"fmt"
 
+	vops "github.com/vertica/vcluster/vclusterops"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 )
 
 // StopDB will stop all the vertica hosts of a running cluster
 func (v *VClusterOps) StopDB(ctx context.Context, opts ...stopdb.Option) error {
 	v.Log.Info("Starting vcluster StopDB")
+
+	// get stop_db options
 	s := stopdb.Parms{}
 	s.Make(opts...)
-	return fmt.Errorf("not implemented")
+
+	// call vcluster-ops library to stop db
+	vopts := v.genStopDBOptions(&s)
+	dbName, err := v.VStopDatabase(&vopts)
+	if err != nil {
+		v.Log.Error(err, "failed to stop a database")
+		return err
+	}
+
+	v.Log.Info("Successfully stopped a database", "dbName", dbName)
+	return nil
+}
+
+func (v *VClusterOps) genStopDBOptions(s *stopdb.Parms) vops.VStopDatabaseOptions {
+	opts := vops.VStopDatabaseOptionsFactory()
+
+	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
+	v.Log.Info("Setup stop db options", "hosts", opts.RawHosts[0])
+	*opts.Ipv6 = net.IsIPv6(s.InitiatorIP)
+
+	opts.Name = &v.VDB.Spec.DBName
+	if v.VDB.IsEON() {
+		opts.IsEon = vops.True
+	}
+
+	// auth options
+	*opts.UserName = vapi.SuperUser
+	opts.Password = &v.Password
+	*opts.HonorUserInput = true
+
+	return opts
 }

--- a/pkg/vadmin/stop_db_vc_test.go
+++ b/pkg/vadmin/stop_db_vc_test.go
@@ -1,0 +1,64 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
+)
+
+const (
+	TestInitiatorIP = "10.10.10.10"
+	TestIsEon       = true
+)
+
+// mock version of VStopDatabase() that is invoked inside VClusterOps.StopDB()
+func (m *MockVClusterOps) VStopDatabase(options *vops.VStopDatabaseOptions) (string, error) {
+	dbName := ""
+
+	// verify common options
+	err := m.VerifyCommonOptions(&options.DatabaseOptions)
+	if err != nil {
+		return dbName, err
+	}
+
+	// verify basic options
+	if len(options.RawHosts) == 0 || options.RawHosts[0] != TestInitiatorIP {
+		return dbName, fmt.Errorf("failed to retrieve hosts")
+	}
+	if options.IsEon.ToBool() != TestIsEon {
+		return dbName, fmt.Errorf("failed to retrieve eon mode")
+	}
+
+	// dbName is used in VClusterOps.StopDB() so we give it a value
+	dbName = TestDBName
+	return dbName, nil
+}
+
+var _ = Describe("stop_db_vc", func() {
+	ctx := context.Background()
+
+	It("should call vcluster-ops library with stop_db task", func() {
+		dispatcher := mockVClusterOpsDispatcher()
+		dispatcher.VDB.Spec.DBName = TestDBName
+		Ω(dispatcher.StopDB(ctx, stopdb.WithInitiator(dispatcher.VDB.ExtractNamespacedName(), TestInitiatorIP))).Should(Succeed())
+	})
+})

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -16,12 +16,14 @@
 package vadmin
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	vops "github.com/vertica/vcluster/vclusterops"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/aterrors"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
@@ -85,7 +87,33 @@ func mockAdmintoolsDispatcher() (Admintools, *vapi.VerticaDB, *cmds.FakePodRunne
 type MockVClusterOps struct {
 }
 
-const TestPassword = "test-pw"
+// const variables used for vcluster-ops unit test
+const (
+	TestDBName   = "test-db"
+	TestPassword = "test-pw"
+	TestIPv6     = false
+)
+
+// VerifyCommonOptions is used in vcluster-ops unit test for verifying the common options among all db ops
+func (m *MockVClusterOps) VerifyCommonOptions(options *vops.DatabaseOptions) error {
+	// verify basic options
+	if *options.Ipv6 != TestIPv6 {
+		return fmt.Errorf("failed to retrieve IPv6")
+	}
+	if *options.Name != TestDBName {
+		return fmt.Errorf("failed to retrieve database name")
+	}
+
+	// verify auth options
+	if *options.UserName != vapi.SuperUser {
+		return fmt.Errorf("failed to retrieve Vertica username")
+	}
+	if *options.Password != TestPassword {
+		return fmt.Errorf("failed to retrieve Vertica password")
+	}
+
+	return nil
+}
 
 // mockVClusterOpsDispatcher will create an vcluster-ops dispatcher for test purposes
 func mockVClusterOpsDispatcher() *VClusterOps {

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -97,7 +97,7 @@ const (
 // VerifyCommonOptions is used in vcluster-ops unit test for verifying the common options among all db ops
 func (m *MockVClusterOps) VerifyCommonOptions(options *vops.DatabaseOptions) error {
 	// verify basic options
-	if *options.Ipv6 != TestIPv6 {
+	if options.Ipv6.ToBool() != TestIPv6 {
 		return fmt.Errorf("failed to retrieve IPv6")
 	}
 	if *options.Name != TestDBName {

--- a/tests/e2e-vcluster/vcluster-ks-0/17-assert.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-0/17-assert.yaml
@@ -1,0 +1,58 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-vcluster-ks-0-sc1
+status:
+  replicas: 1
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-vcluster-ks-0
+status:
+  subclusters:
+    - addedToDBCount: 1
+---
+apiVersion: v1
+kind: Event
+reason: CreateDBSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-0
+---
+# We enable spread encryption, so the cluster will be stopped after create_db
+apiVersion: v1
+kind: Event
+reason: StopDBStart
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-0
+---
+apiVersion: v1
+kind: Event
+reason: StopDBSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-0

--- a/tests/e2e-vcluster/vcluster-ks-0/17-wait-for-stopdb.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-0/17-wait-for-stopdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-vcluster/vcluster-ks-0/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-0/setup-vdb/base/setup-vdb.yaml
@@ -36,3 +36,5 @@ spec:
   imagePullSecrets: []
   volumes: []
   volumeMounts: []
+  httpServerMode: Enabled
+  encryptSpreadComm: vertica

--- a/tests/e2e-vcluster/vcluster-ks-1/17-assert.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-1/17-assert.yaml
@@ -1,0 +1,58 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-vcluster-ks-1-main
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-vcluster-ks-1
+status:
+  subclusters:
+    - addedToDBCount: 3
+---
+apiVersion: v1
+kind: Event
+reason: CreateDBSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-1
+---
+# We enable spread encryption, so the cluster will be stopped after create_db
+apiVersion: v1
+kind: Event
+reason: StopDBStart
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-1
+---
+apiVersion: v1
+kind: Event
+reason: StopDBSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-1

--- a/tests/e2e-vcluster/vcluster-ks-1/17-wait-for-stopdb.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-1/17-wait-for-stopdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-vcluster/vcluster-ks-1/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-1/setup-vdb/base/setup-vdb.yaml
@@ -36,3 +36,4 @@ spec:
   imagePullSecrets: []
   volumes: []
   volumeMounts: []
+  httpServerMode: Enabled


### PR DESCRIPTION
This is the integration work that calls vclusterops library to stop a database.

The e2e test will cover create_db case as well. In my code, I am using a test version of vcluster library. I will change the go.mod and go.sum after my PR of vcluster library is approved and merged.