### PR TITLE
Add additional configuration parameters for VClusterOps create db

### DIFF
--- a/pkg/controllers/vdb/createdb_reconciler.go
+++ b/pkg/controllers/vdb/createdb_reconciler.go
@@ -92,8 +92,9 @@ func (c *CreateDBReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (
 
 // execCmd will do the actual execution of creating a database.
 // This handles logging of necessary events.
-func (c *CreateDBReconciler) execCmd(ctx context.Context, initiatorPod types.NamespacedName, hostList []string) (ctrl.Result, error) {
-	opts, err := c.genOptions(ctx, initiatorPod, hostList)
+func (c *CreateDBReconciler) execCmd(ctx context.Context, initiatorPod types.NamespacedName,
+	hostList []string, confParms map[string]string) (ctrl.Result, error) {
+	opts, err := c.genOptions(ctx, initiatorPod, hostList, confParms)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -231,7 +232,7 @@ func (c *CreateDBReconciler) getFirstPrimarySubcluster() *vapi.Subcluster {
 
 // genOptions will return the options to use for the create db command
 func (c *CreateDBReconciler) genOptions(ctx context.Context, initiatorPod types.NamespacedName,
-	hostList []string) ([]createdb.Option, error) {
+	hostList []string, confParms map[string]string) ([]createdb.Option, error) {
 	licPath, err := license.GetPath(ctx, c.VRec.Client, c.Vdb)
 	if err != nil {
 		return nil, err
@@ -253,6 +254,7 @@ func (c *CreateDBReconciler) genOptions(ctx context.Context, initiatorPod types.
 		opts = append(opts,
 			createdb.WithCommunalPath(c.Vdb.GetCommunalPath()),
 			createdb.WithCommunalStorageParams(paths.AuthParmsFile),
+			createdb.WithConfigurationParams(confParms),
 		)
 	}
 

--- a/pkg/controllers/vdb/createdb_reconciler.go
+++ b/pkg/controllers/vdb/createdb_reconciler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/license"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
+	vtypes "github.com/vertica/vertica-kubernetes/pkg/types"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
@@ -53,7 +54,7 @@ type CreateDBReconciler struct {
 	PRunner             cmds.PodRunner
 	PFacts              *PodFacts
 	Dispatcher          vadmin.Dispatcher
-	ConfigurationParams map[string]string
+	ConfigurationParams *vtypes.CiMap
 }
 
 // MakeCreateDBReconciler will build a CreateDBReconciler object
@@ -67,7 +68,7 @@ func MakeCreateDBReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 		PRunner:             prunner,
 		PFacts:              pfacts,
 		Dispatcher:          dispatcher,
-		ConfigurationParams: make(map[string]string),
+		ConfigurationParams: vtypes.MakeCiMap(),
 	}
 }
 
@@ -256,7 +257,7 @@ func (c *CreateDBReconciler) genOptions(ctx context.Context, initiatorPod types.
 		opts = append(opts,
 			createdb.WithCommunalPath(c.Vdb.GetCommunalPath()),
 			createdb.WithCommunalStorageParams(paths.AuthParmsFile),
-			createdb.WithConfigurationParams(c.ConfigurationParams),
+			createdb.WithConfigurationParams(c.ConfigurationParams.GetMap()),
 		)
 	}
 

--- a/pkg/controllers/vdb/createdb_reconciler_test.go
+++ b/pkg/controllers/vdb/createdb_reconciler_test.go
@@ -17,7 +17,6 @@ package vdb
 
 import (
 	"context"
-	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -139,51 +138,6 @@ var _ = Describe("createdb_reconciler", func() {
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchVdb)).Should(Succeed())
 		Expect(len(fetchVdb.Status.Conditions)).Should(BeNumerically(">=", vapi.VerticaRestartNeededIndex))
 		Expect(fetchVdb.Status.Conditions[vapi.VerticaRestartNeededIndex].Status).Should(Equal(corev1.ConditionTrue))
-	})
-
-	It("should generate a requeue error for various known createdb errors", func() {
-		vdb := vapi.MakeVDB()
-
-		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
-		r := act.(*CreateDBReconciler)
-		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
-
-		errStrings := []string{
-			"Unable to connect to endpoint",
-			"The specified bucket does not exist.",
-			"Communal location [s3://blah] is not empty",
-			"You are trying to access your S3 bucket using the wrong region. If you are using S3",
-			"The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-central-1'.",
-			"An error occurred during kerberos authentication",
-		}
-
-		for i := range errStrings {
-			fpr.Results = cmds.CmdResults{
-				atPod: []cmds.CmdResult{
-					{
-						Stdout: errStrings[i],
-						Err:    errors.New("at command failed"),
-					},
-				},
-			}
-			Expect(r.execCmd(ctx, atPod, []string{"create_db"}, map[string]string{})).
-				Should(Equal(ctrl.Result{Requeue: true}), "Failing with '%s'", errStrings[i])
-		}
-
-		fpr.Results = cmds.CmdResults{
-			atPod: []cmds.CmdResult{
-				{
-					Stdout: "*** Unknown error",
-					Err:    errors.New("at command failed"),
-				},
-			},
-		}
-		res, err := r.execCmd(ctx, atPod, []string{"create_db"}, map[string]string{})
-		Expect(err).ShouldNot(Succeed())
-		Expect(res).Should(Equal(ctrl.Result{}))
 	})
 
 	It("should always run AT commands from the first pod of the first primary subcluster", func() {

--- a/pkg/controllers/vdb/createdb_reconciler_test.go
+++ b/pkg/controllers/vdb/createdb_reconciler_test.go
@@ -169,7 +169,8 @@ var _ = Describe("createdb_reconciler", func() {
 					},
 				},
 			}
-			Expect(r.execCmd(ctx, atPod, []string{"create_db"})).Should(Equal(ctrl.Result{Requeue: true}), "Failing with '%s'", errStrings[i])
+			Expect(r.execCmd(ctx, atPod, []string{"create_db"}, map[string]string{})).
+				Should(Equal(ctrl.Result{Requeue: true}), "Failing with '%s'", errStrings[i])
 		}
 
 		fpr.Results = cmds.CmdResults{
@@ -180,7 +181,7 @@ var _ = Describe("createdb_reconciler", func() {
 				},
 			},
 		}
-		res, err := r.execCmd(ctx, atPod, []string{"create_db"})
+		res, err := r.execCmd(ctx, atPod, []string{"create_db"}, map[string]string{})
 		Expect(err).ShouldNot(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
 	})

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -22,13 +22,11 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/lithammer/dedent"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cloud"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
@@ -51,19 +49,19 @@ const (
 type DatabaseInitializer interface {
 	getPodList() ([]*PodFact, bool)
 	findPodToRunInit() (*PodFact, bool)
-	execCmd(ctx context.Context, initiatorPod types.NamespacedName,
-		hostList []string, confParms map[string]string) (ctrl.Result, error)
+	execCmd(ctx context.Context, initiatorPod types.NamespacedName, hostList []string) (ctrl.Result, error)
 	preCmdSetup(ctx context.Context, initiatorPod types.NamespacedName, podList []*PodFact) (ctrl.Result, error)
 	postCmdCleanup(ctx context.Context) (ctrl.Result, error)
 }
 
 type GenericDatabaseInitializer struct {
-	initializer DatabaseInitializer
-	VRec        *VerticaDBReconciler
-	Log         logr.Logger
-	Vdb         *vapi.VerticaDB
-	PRunner     cmds.PodRunner
-	PFacts      *PodFacts
+	initializer         DatabaseInitializer
+	VRec                *VerticaDBReconciler
+	Log                 logr.Logger
+	Vdb                 *vapi.VerticaDB
+	PRunner             cmds.PodRunner
+	PFacts              *PodFacts
+	ConfigurationParams map[string]string
 }
 
 // checkAndRunInit will check if the database needs to be initialized and run init if applicable
@@ -103,7 +101,7 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 	}
 	initiatorPod := initPodFact.name
 
-	content, res, err := g.ConstructAuthParms(ctx)
+	res, err := g.ConstructAuthParms(ctx)
 	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
@@ -116,20 +114,13 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{}, err
 	}
 
-	if res, err := g.initializer.execCmd(ctx, initiatorPod,
-		getHostList(podList), genCommunalParmsMap(content)); verrors.IsReconcileAborted(res, err) {
+	if res, err := g.initializer.execCmd(ctx, initiatorPod, getHostList(podList)); verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 
 	cond := vapi.VerticaDBCondition{Type: vapi.DBInitialized, Status: corev1.ConditionTrue}
 	if err := vdbstatus.UpdateCondition(ctx, g.VRec.Client, g.Vdb, cond); err != nil {
 		return ctrl.Result{}, err
-	}
-
-	if err := g.DestroyAuthParms(ctx, initiatorPod); err != nil {
-		// Destroying the auth parms is a best effort. If we fail to delete it,
-		// the reconcile will continue on.
-		g.Log.Info("failed to destroy auth parms, ignoring failure", "err", err)
 	}
 
 	// The DB has been initialized. We invalidate the cache now so that next
@@ -168,12 +159,12 @@ func (g *GenericDatabaseInitializer) prepLocalDataInPods(ctx context.Context, po
 }
 
 // ConstructAuthParms builds the authentication parms.
-func (g *GenericDatabaseInitializer) ConstructAuthParms(ctx context.Context) (string, ctrl.Result, error) {
-	var contentGen func(ctx context.Context) (string, ctrl.Result, error)
+func (g *GenericDatabaseInitializer) ConstructAuthParms(ctx context.Context) (ctrl.Result, error) {
+	var contentGen func(ctx context.Context) (ctrl.Result, error)
 
 	if g.Vdb.Spec.Communal.Path == "" {
 		g.Log.Info("Communal path is empty. Not setting up communal auth parms")
-		return "", ctrl.Result{}, nil
+		return ctrl.Result{}, nil
 	}
 
 	if g.Vdb.IsS3() {
@@ -188,23 +179,20 @@ func (g *GenericDatabaseInitializer) ConstructAuthParms(ctx context.Context) (st
 		g.Log.Info("No special auth setup for communal path", "path", g.Vdb.Spec.Communal.Path)
 	}
 
-	var content string
 	var res ctrl.Result
 	var err error
 	if contentGen != nil {
-		content, res, err = contentGen(ctx)
+		res, err = contentGen(ctx)
 		if verrors.IsReconcileAborted(res, err) {
-			return "", res, err
+			return res, err
 		}
 	}
 
 	if g.Vdb.HasKerberosConfig() {
 		if res = g.hasCompatibleVersionForKerberos(); verrors.IsReconcileAborted(res, nil) {
-			return "", res, nil
+			return res, nil
 		}
-		content = dedent.Dedent(fmt.Sprintf(`
-			%s
-			%s`, content, g.getKerberosAuthParmsContent()))
+		g.getKerberosAuthParmsContent()
 	}
 
 	// Add any additional config parameters that were included in the CR.
@@ -213,125 +201,99 @@ func (g *GenericDatabaseInitializer) ConstructAuthParms(ctx context.Context) (st
 	// key/value pair in this map is skipped.
 	// This must be the last thing added to the auth parms.
 	if !g.Vdb.IsAdditionalConfigMapEmpty() {
-		content = fmt.Sprintf("%s\n%s", content, g.getAdditionalConfigParmsContent(content))
+		g.getAdditionalConfigParmsContent()
 	}
 
-	return content, ctrl.Result{}, nil
-}
-
-// DestroyAuthParms will remove the auth parms file that was created in the pod
-func (g *GenericDatabaseInitializer) DestroyAuthParms(ctx context.Context, initiatorPod types.NamespacedName) error {
-	if vmeta.UseVClusterOps(g.Vdb.Annotations) {
-		return nil
-	}
-	_, _, err := g.PRunner.ExecInPod(ctx, initiatorPod, names.ServerContainer,
-		"rm", paths.AuthParmsFile,
-	)
-	return err
+	return ctrl.Result{}, nil
 }
 
 // getAuth will retrieve the auth parms if they exist.  If no credential secret
 // then an empty string is returned.
-func (g *GenericDatabaseInitializer) getAuth(ctx context.Context, parmName string) (string, ctrl.Result, error) {
+func (g *GenericDatabaseInitializer) getAuth(ctx context.Context, parmName string) (ctrl.Result, error) {
 	if g.Vdb.Spec.Communal.CredentialSecret == "" {
-		return "", ctrl.Result{}, nil
+		return ctrl.Result{}, nil
 	}
 
 	// Extract the auth from the credential secret.
 	auth, res, err := g.getCommunalAuth(ctx)
 	if verrors.IsReconcileAborted(res, err) {
-		return "", res, err
+		return res, err
 	}
 
-	content := fmt.Sprintf("%s = %s", parmName, auth)
-	return content, ctrl.Result{}, nil
+	g.ConfigurationParams[parmName] = auth
+	return ctrl.Result{}, nil
 }
 
-// getS3AuthParmsContent construct a string for the auth parms when using S3
+// getS3AuthParmsContent adds auth parms to the config parms map when using S3
 // communal storage.
-func (g *GenericDatabaseInitializer) getS3AuthParmsContent(ctx context.Context) (string, ctrl.Result, error) {
-	auth, res, err := g.getAuth(ctx, "awsauth")
+func (g *GenericDatabaseInitializer) getS3AuthParmsContent(ctx context.Context) (ctrl.Result, error) {
+	res, err := g.getAuth(ctx, "awsauth")
 	if verrors.IsReconcileAborted(res, err) {
-		return "", res, err
+		return res, err
 	}
 
-	configParms := ""
 	if g.Vdb.IsKnownSseType() {
 		if res = g.hasCompatibleVersionForServerSideEncryption(); verrors.IsReconcileAborted(res, nil) {
-			return "", res, nil
+			return res, nil
 		}
-		configParms, res, err = g.getServerSideEncryptionParmsContent(ctx)
+		res, err = g.getServerSideEncryptionParmsContent(ctx)
 		if verrors.IsReconcileAborted(res, err) {
-			return "", res, err
+			return res, err
 		}
 	}
 
-	content := fmt.Sprintf(`
-			%s
-			%s
-			awsendpoint = %s
-			awsenablehttps = %s
-			%s
-			%s
-		`, configParms, auth, g.getCommunalEndpoint(), g.getEnableHTTPS(), g.getRegion(AWSRegionParm), g.getCAFile(),
-	)
-	return dedent.Dedent(content), ctrl.Result{}, nil
+	g.ConfigurationParams["awsendpoint"] = g.getCommunalEndpoint()
+	g.ConfigurationParams["awsenablehttps"] = g.getEnableHTTPS()
+	g.getRegion(AWSRegionParm)
+	g.getCAFile()
+	return ctrl.Result{}, nil
 }
 
-// getHDFSAuthParmsContent construct a string for the auth parms when using
+// getHDFSAuthParmsContent adds auth parms to the config parms map when using
 // HDFS communal storage.
-func (g *GenericDatabaseInitializer) getHDFSAuthParmsContent(ctx context.Context) (string, ctrl.Result, error) {
-	content := fmt.Sprintf(`
-			%s
-			%s
-		`, g.getHadoopConfDir(), g.getCAFile(),
-	)
-	return strings.TrimSpace(dedent.Dedent(content)), ctrl.Result{}, nil
+func (g *GenericDatabaseInitializer) getHDFSAuthParmsContent(ctx context.Context) (ctrl.Result, error) {
+	g.getHadoopConfDir()
+	g.getCAFile()
+	return ctrl.Result{}, nil
 }
 
-// getKerberosAuthParmsContent constructs a string for Kerberos related auth
-// parms if that is setup.  Must have Kerberos config in the Vdb.
-func (g *GenericDatabaseInitializer) getKerberosAuthParmsContent() string {
+// getKerberosAuthParmsContent adds Kerberos related auth parms to the config parms map.
+// Must have Kerberos config in the Vdb.
+func (g *GenericDatabaseInitializer) getKerberosAuthParmsContent() {
 	// We disable KerberosEnableKeytabPermissionCheck, otherwise the engine will
 	// complain that the keytab file doesn't have read/write permissions from
 	// dbadmin only.
-	return dedent.Dedent(fmt.Sprintf(`
-			KerberosServiceName = %s
-			KerberosRealm = %s
-			KerberosKeytabFile = %s
-			KerberosEnableKeytabPermissionCheck = 0
-	`, g.Vdb.Spec.Communal.KerberosServiceName,
-		g.Vdb.Spec.Communal.KerberosRealm, paths.Krb5Keytab))
+	g.ConfigurationParams["KerberosServiceName"] = g.Vdb.Spec.Communal.KerberosServiceName
+	g.ConfigurationParams["KerberosRealm"] = g.Vdb.Spec.Communal.KerberosRealm
+	g.ConfigurationParams["KerberosKeytabFile"] = paths.Krb5Keytab
+	g.ConfigurationParams["KerberosEnableKeytabPermissionCheck"] = "0"
 }
 
-// getGCloudAuthParmsContent will get the content for the auth parms when we are
+// getGCloudAuthParmsContent adds auth parms to the config parms map when we are
 // connecting to google cloud storage.
-func (g *GenericDatabaseInitializer) getGCloudAuthParmsContent(ctx context.Context) (string, ctrl.Result, error) {
-	auth, res, err := g.getAuth(ctx, "GCSAuth")
+func (g *GenericDatabaseInitializer) getGCloudAuthParmsContent(ctx context.Context) (ctrl.Result, error) {
+	res, err := g.getAuth(ctx, "GCSAuth")
 	if verrors.IsReconcileAborted(res, err) {
-		return "", res, err
+		return res, err
 	}
 
-	content := fmt.Sprintf(`
-	    %s
-		GCSEndpoint = %s
-		GCSEnableHttps = %s
-		%s
-		%s
-	`, auth, g.getCommunalEndpoint(), g.getEnableHTTPS(), g.getRegion(GCloudRegionParm), g.getCAFile())
-	return dedent.Dedent(content), ctrl.Result{}, nil
+	g.ConfigurationParams["GCSEndpoint"] = g.getCommunalEndpoint()
+	g.ConfigurationParams["GCSEnableHttps"] = g.getEnableHTTPS()
+	g.getRegion(GCloudRegionParm)
+	g.getCAFile()
+	return ctrl.Result{}, nil
 }
 
-// getAzureAuthParmsContent will get the content for an EON database created in
+// getAzureAuthParmsContent adds auth parms to the config parms map for an EON database created in
 // Azure Blob Storage
-func (g *GenericDatabaseInitializer) getAzureAuthParmsContent(ctx context.Context) (string, ctrl.Result, error) {
+func (g *GenericDatabaseInitializer) getAzureAuthParmsContent(ctx context.Context) (ctrl.Result, error) {
 	if g.Vdb.Spec.Communal.CredentialSecret == "" {
-		return "", ctrl.Result{}, nil
+		return ctrl.Result{}, nil
 	}
 
 	azureCreds, azureConfig, res, err := g.getAzureAuth(ctx)
 	if verrors.IsReconcileAborted(res, err) {
-		return "", res, err
+		return res, err
 	}
 
 	var azureCredsJSON strings.Builder
@@ -370,18 +332,16 @@ func (g *GenericDatabaseInitializer) getAzureAuthParmsContent(ctx context.Contex
 	}
 	azureConfigJSON.WriteString("}]")
 
-	content := fmt.Sprintf(`
-	  AzureStorageCredentials = %s
-	  AzureStorageEndpointConfig = %s
-	  %s
-	`, azureCredsJSON.String(), azureConfigJSON.String(), g.getCAFile())
-	return dedent.Dedent(content), ctrl.Result{}, nil
+	g.ConfigurationParams["AzureStorageCredentials"] = azureCredsJSON.String()
+	g.ConfigurationParams["AzureStorageEndpointConfig"] = azureConfigJSON.String()
+	g.getCAFile()
+	return ctrl.Result{}, nil
 }
 
-// getAdditionalConfigParmsContent constructs a string containing additional server config parameters
-func (g *GenericDatabaseInitializer) getAdditionalConfigParmsContent(content string) string {
-	parmNames := genCommunalParmsMap(content)
-	parms := strings.Builder{}
+// getAdditionalConfigParmsContent adds additional server config parameters
+// to the config parms map
+func (g *GenericDatabaseInitializer) getAdditionalConfigParmsContent() {
+	parmNames := g.genLowerCaseKeysMap()
 	for k, v := range g.Vdb.Spec.Communal.AdditionalConfig {
 		// we lowercase parm names to catch duplications
 		// like AWSauth/awsauth. In case of duplicate names,
@@ -391,9 +351,8 @@ func (g *GenericDatabaseInitializer) getAdditionalConfigParmsContent(content str
 			g.Log.Info("additional config parameter ignored", "parameter", k)
 			continue
 		}
-		parms.WriteString(fmt.Sprintf("%s = %s\n", k, v))
+		g.ConfigurationParams[k] = v
 	}
-	return parms.String()
 }
 
 // getCommunalAuth will return the access key and secret key.
@@ -473,7 +432,7 @@ func (g *GenericDatabaseInitializer) getAzureAuth(ctx context.Context) (
 }
 
 // getCommunalCredsSecret returns the contents of the communal credentials
-// secret.  It handles if the secret is not found and will log an event.
+// secret. It handles if the secret is not found and will log an event.
 func (g *GenericDatabaseInitializer) getCommunalCredsSecret(ctx context.Context) (*corev1.Secret, ctrl.Result, error) {
 	return getSecret(ctx, g.VRec, g.Vdb, names.GenCommunalCredSecretName(g.Vdb))
 }
@@ -505,63 +464,59 @@ func (g *GenericDatabaseInitializer) getEnableHTTPS() string {
 }
 
 // getCAFile will return an entry for SystemCABundlePath if one needs to be included
-func (g *GenericDatabaseInitializer) getCAFile() string {
-	if g.Vdb.Spec.Communal.CaFile == "" {
-		return ""
+func (g *GenericDatabaseInitializer) getCAFile() {
+	if g.Vdb.Spec.Communal.CaFile != "" {
+		g.ConfigurationParams["SystemCABundlePath"] = g.Vdb.Spec.Communal.CaFile
 	}
-	return fmt.Sprintf("SystemCABundlePath = %s", g.Vdb.Spec.Communal.CaFile)
 }
 
-// getServerSideEncryptionParmsContent constructs a string for server-side encryption related auth
-// parms if that is setup.  Must have encryption type in the Vdb.
-func (g *GenericDatabaseInitializer) getServerSideEncryptionParmsContent(ctx context.Context) (string, reconcile.Result, error) {
+// getServerSideEncryptionParmsContent adds server-side encryption related auth
+// parms, if that is setup, to the config parms map. Must have encryption type in the Vdb.
+func (g *GenericDatabaseInitializer) getServerSideEncryptionParmsContent(ctx context.Context) (reconcile.Result, error) {
 	// Extract customer key from secret
-	clienKey, res, err := g.getS3SseCustomerKey(ctx)
+	res, err := g.getS3SseCustomerKey(ctx)
 	if verrors.IsReconcileAborted(res, err) {
-		return "", res, err
+		return res, err
 	}
 
-	content := fmt.Sprintf(`
-			%s
-			%s
-			%s
-		`, g.getServerSideEncryptionAlgorithm(), g.getS3SseKmsKeyID(), clienKey,
-	)
-	return content, ctrl.Result{}, nil
+	g.getServerSideEncryptionAlgorithm()
+	g.getS3SseKmsKeyID()
+	return ctrl.Result{}, nil
 }
 
-// getServerSideEncryptionAlgorithm returns an entry for S3ServerSideEncryption
-// if sse type is SSE-S3|SSE-KMS or for S3SseCustomerAlgorithm if SSE-C.
-func (g *GenericDatabaseInitializer) getServerSideEncryptionAlgorithm() string {
+// getServerSideEncryptionAlgorithm adds an entry for S3ServerSideEncryption
+// if sse type is SSE-S3|SSE-KMS or for S3SseCustomerAlgorithm if SSE-C
+// to the config parms map.
+func (g *GenericDatabaseInitializer) getServerSideEncryptionAlgorithm() {
 	if g.Vdb.IsSseC() {
-		return fmt.Sprintf("%s = %s", S3SseCustomerAlgorithm, SseAlgorithmAES256)
+		g.ConfigurationParams[S3SseCustomerAlgorithm] = SseAlgorithmAES256
 	}
 	if g.Vdb.IsSseS3() {
-		return fmt.Sprintf("%s = %s", S3ServerSideEncryption, SseAlgorithmAES256)
+		g.ConfigurationParams[S3ServerSideEncryption] = SseAlgorithmAES256
 	}
 	if g.Vdb.IsSseKMS() {
-		return fmt.Sprintf("%s = %s", S3ServerSideEncryption, SseAlgorithmAWSKMS)
+		g.ConfigurationParams[S3ServerSideEncryption] = SseAlgorithmAWSKMS
 	}
-	return ""
 }
 
-// getS3SseKmsKeyID returns an entry for S3SseKmsKeyId when SSE-KMS is enabled.
-func (g *GenericDatabaseInitializer) getS3SseKmsKeyID() string {
-	if !g.Vdb.IsSseKMS() {
-		return ""
+// getS3SseKmsKeyID adds an entry for S3SseKmsKeyId to the config parms map
+// when SSE-KMS is enabled.
+func (g *GenericDatabaseInitializer) getS3SseKmsKeyID() {
+	if g.Vdb.IsSseKMS() {
+		g.ConfigurationParams[vapi.S3SseKmsKeyID] = g.Vdb.Spec.Communal.AdditionalConfig[vapi.S3SseKmsKeyID]
 	}
-	return fmt.Sprintf("%s = %s", vapi.S3SseKmsKeyID, g.Vdb.Spec.Communal.AdditionalConfig[vapi.S3SseKmsKeyID])
 }
 
-// getS3SseCustomerKey returns an entry for S3SseCustomerKey, only when sse type is SSE-C
-func (g *GenericDatabaseInitializer) getS3SseCustomerKey(ctx context.Context) (string, ctrl.Result, error) {
+// getS3SseCustomerKey adds an entry for S3SseCustomerKey to the config parms map,
+// only when sse type is SSE-C
+func (g *GenericDatabaseInitializer) getS3SseCustomerKey(ctx context.Context) (ctrl.Result, error) {
 	if !g.Vdb.IsSseC() {
-		return "", ctrl.Result{}, nil
+		return ctrl.Result{}, nil
 	}
 
 	secret, res, err := g.getS3SseCustomerKeySecret(ctx)
 	if verrors.IsReconcileAborted(res, err) {
-		return "", res, err
+		return res, err
 	}
 
 	clientKey, ok := secret.Data[cloud.S3SseCustomerKeyName]
@@ -569,20 +524,20 @@ func (g *GenericDatabaseInitializer) getS3SseCustomerKey(ctx context.Context) (s
 		g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.S3SseCustomerWrongKey,
 			"The s3SseCustomerKey secret '%s' does not have a key named '%s'",
 			g.Vdb.Spec.Communal.S3SseCustomerKeySecret, cloud.S3SseCustomerKeyName)
-		return "", ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
-	content := fmt.Sprintf("%s = %s", S3SseCustomerKey, string(clientKey))
-	return content, ctrl.Result{}, nil
+	g.ConfigurationParams[S3SseCustomerKey] = string(clientKey)
+	return ctrl.Result{}, nil
 }
 
-// getRegion will return an entry for region, specific to the cloud provider
-func (g *GenericDatabaseInitializer) getRegion(parmName string) string {
+// getRegion adds an entry for region, to the config parms map, specific to the cloud provider
+func (g *GenericDatabaseInitializer) getRegion(parmName string) {
 	// We have a webhook to set the default value, but for legacy purposes we
 	// always check for the empty string.
 	if g.Vdb.Spec.Communal.Region == "" {
-		return fmt.Sprintf("%s = %s", parmName, vapi.DefaultS3Region)
+		g.ConfigurationParams[parmName] = vapi.DefaultS3Region
 	}
-	return fmt.Sprintf("%s = %s", parmName, g.Vdb.Spec.Communal.Region)
+	g.ConfigurationParams[parmName] = g.Vdb.Spec.Communal.Region
 }
 
 // getEndpointProtocol returns the protocol (HTTPS or HTTP) for the given endpoint
@@ -608,13 +563,12 @@ func getEndpointHostPort(blobEndpoint string) string {
 	return strings.TrimSuffix(m[0][2], "/")
 }
 
-// getHadoopConfDir gets the string to include in the auth parms for
+// getHadoopConfDir adds an entry to the config parms map for
 // HadoopConfDir.  If that isn't present, an empty string is returned.
-func (g *GenericDatabaseInitializer) getHadoopConfDir() string {
+func (g *GenericDatabaseInitializer) getHadoopConfDir() {
 	if g.Vdb.Spec.Communal.HadoopConfig != "" {
-		return fmt.Sprintf(`HadoopConfDir = %s`, paths.HadoopConfPath)
+		g.ConfigurationParams["HadoopConfDir"] = paths.HadoopConfPath
 	}
-	return ""
 }
 
 // hasCompatibleVersionForKerberos checks whether it has the required engine fix
@@ -646,17 +600,13 @@ func (g *GenericDatabaseInitializer) hasCompatibleVersion(supportedVersion, even
 	return ctrl.Result{Requeue: true}
 }
 
-// genCommunalParmsMap takes a multiline string containing the parms already
-// set(in "parm = value" format) and returns the corresponding map.
-func genCommunalParmsMap(content string) map[string]string {
+// genLowerCaseKeysMap will generate a lowercase keys copy of
+// ConfigurationParams map. This is useful to detect duplication
+// between user-defined and operator-generated params.
+func (g *GenericDatabaseInitializer) genLowerCaseKeysMap() map[string]string {
 	parmNames := map[string]string{}
-	for _, row := range strings.Split(content, "\n") {
-		if row != "" {
-			s := strings.Split(row, " = ")
-			// we lowercase the parm names because they are case insensitive(for the server)
-			// and we want to catch duplications like awsauth/AWSauth
-			parmNames[strings.ToLower(s[0])] = s[1]
-		}
+	for k, v := range g.ConfigurationParams {
+		parmNames[strings.ToLower(k)] = v
 	}
 	return parmNames
 }

--- a/pkg/controllers/vdb/init_db_test.go
+++ b/pkg/controllers/vdb/init_db_test.go
@@ -201,7 +201,7 @@ var _ = Describe("init_db", func() {
 		}
 
 		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
-		res, err := g.ConstructAuthParms(ctx, atPod)
+		_, res, err := g.ConstructAuthParms(ctx, atPod)
 		ExpectWithOffset(1, err).Should(Succeed())
 		ExpectWithOffset(1, res).Should(Equal(ctrl.Result{Requeue: true}))
 	})
@@ -307,7 +307,7 @@ var _ = Describe("init_db", func() {
 		}
 
 		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
-		res, err := g.ConstructAuthParms(ctx, atPod)
+		_, res, err := g.ConstructAuthParms(ctx, atPod)
 		ExpectWithOffset(1, err).Should(Succeed())
 		ExpectWithOffset(1, res).Should(Equal(ctrl.Result{Requeue: true}))
 	})
@@ -372,7 +372,7 @@ func contructAuthParmsHelper(ctx context.Context, vdb *vapi.VerticaDB, mustHaveC
 	}
 
 	atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
-	res, err := g.ConstructAuthParms(ctx, atPod)
+	_, res, err := g.ConstructAuthParms(ctx, atPod)
 	ExpectWithOffset(1, err).Should(Succeed())
 	ExpectWithOffset(1, res).Should(Equal(ctrl.Result{}))
 	if mustHaveCmd == "" {

--- a/pkg/controllers/vdb/revivedb_reconciler.go
+++ b/pkg/controllers/vdb/revivedb_reconciler.go
@@ -87,8 +87,9 @@ func (r *ReviveDBReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (
 
 // execCmd will do the actual execution of revive DB.
 // This handles logging of necessary events.
-func (r *ReviveDBReconciler) execCmd(ctx context.Context, initiatorPod types.NamespacedName, hostList []string) (ctrl.Result, error) {
-	opts := r.genReviveOpts(initiatorPod, hostList)
+func (r *ReviveDBReconciler) execCmd(ctx context.Context, initiatorPod types.NamespacedName,
+	hostList []string, confParms map[string]string) (ctrl.Result, error) {
+	opts := r.genReviveOpts(initiatorPod, hostList, confParms)
 	r.VRec.Event(r.Vdb, corev1.EventTypeNormal, events.ReviveDBStart, "Starting revive database")
 	start := time.Now()
 	if res, err := r.Dispatcher.ReviveDB(ctx, opts...); verrors.IsReconcileAborted(res, err) {
@@ -204,7 +205,8 @@ func (r *ReviveDBReconciler) findPodToRunInit() (*PodFact, bool) {
 }
 
 // genReviveOpts will return the options to use with the revive command
-func (r *ReviveDBReconciler) genReviveOpts(initiatorPod types.NamespacedName, hostList []string) []revivedb.Option {
+func (r *ReviveDBReconciler) genReviveOpts(initiatorPod types.NamespacedName,
+	hostList []string, confParms map[string]string) []revivedb.Option {
 	opts := []revivedb.Option{
 		revivedb.WithInitiator(initiatorPod),
 		revivedb.WithHosts(hostList),
@@ -214,6 +216,7 @@ func (r *ReviveDBReconciler) genReviveOpts(initiatorPod types.NamespacedName, ho
 		opts = append(opts,
 			revivedb.WithCommunalPath(r.Vdb.GetCommunalPath()),
 			revivedb.WithCommunalStorageParams(paths.AuthParmsFile),
+			revivedb.WithConfigurationParams(confParms),
 		)
 	}
 	if r.Vdb.Spec.IgnoreClusterLease {

--- a/pkg/controllers/vdb/revivedb_reconciler.go
+++ b/pkg/controllers/vdb/revivedb_reconciler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/reviveplanner"
+	vtypes "github.com/vertica/vertica-kubernetes/pkg/types"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/describedb"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
@@ -48,7 +49,7 @@ type ReviveDBReconciler struct {
 	PFacts              *PodFacts
 	Planr               reviveplanner.Planner
 	Dispatcher          vadmin.Dispatcher
-	ConfigurationParams map[string]string
+	ConfigurationParams *vtypes.CiMap
 }
 
 // MakeReviveDBReconciler will build a ReviveDBReconciler object
@@ -63,7 +64,7 @@ func MakeReviveDBReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 		PFacts:              pfacts,
 		Planr:               reviveplanner.MakeATPlanner(log),
 		Dispatcher:          dispatcher,
-		ConfigurationParams: make(map[string]string),
+		ConfigurationParams: vtypes.MakeCiMap(),
 	}
 }
 
@@ -217,7 +218,7 @@ func (r *ReviveDBReconciler) genReviveOpts(initiatorPod types.NamespacedName, ho
 		opts = append(opts,
 			revivedb.WithCommunalPath(r.Vdb.GetCommunalPath()),
 			revivedb.WithCommunalStorageParams(paths.AuthParmsFile),
-			revivedb.WithConfigurationParams(r.ConfigurationParams),
+			revivedb.WithConfigurationParams(r.ConfigurationParams.GetMap()),
 		)
 	}
 	if r.Vdb.Spec.IgnoreClusterLease {
@@ -233,7 +234,7 @@ func (r *ReviveDBReconciler) genDescribeOpts(initiatorPod types.NamespacedName) 
 		describedb.WithDBName(r.Vdb.Spec.DBName),
 		describedb.WithCommunalPath(r.Vdb.GetCommunalPath()),
 		describedb.WithCommunalStorageParams(paths.AuthParmsFile),
-		describedb.WithConfigurationParams(r.ConfigurationParams),
+		describedb.WithConfigurationParams(r.ConfigurationParams.GetMap()),
 	}
 }
 

--- a/pkg/controllers/vdb/revivedb_reconciler_test.go
+++ b/pkg/controllers/vdb/revivedb_reconciler_test.go
@@ -17,7 +17,6 @@ package vdb
 
 import (
 	"context"
-	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,59 +88,6 @@ var _ = Describe("revivedb_reconcile", func() {
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		reviveCalls := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "revive_db")
 		Expect(len(reviveCalls)).Should(Equal(2)) // 1 for display-only and 1 for the real thing
-	})
-
-	It("should generate a requeue error for various known s3 errors", func() {
-		vdb := vapi.MakeVDB()
-
-		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
-		r := act.(*ReviveDBReconciler)
-		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
-
-		errStrings := []string{
-			"Error: The database vertdb cannot continue because the communal storage location\n\ts3://nimbusdb/db\n" +
-				"might still be in use.\n\nthe cluster lease will expire:\n\t2021-05-13 14:35:00.280925",
-			"Could not copy file [s3://nimbusdb/db/empty/metadata/newdb/cluster_config.json] to [/tmp/desc.json]: " +
-				"No such file or directory [s3://nimbusdb/db/empty/metadata/newdb/cluster_config.json]",
-			"Could not copy file [gs://vertica-fleeting/mspilchen/revivedb-failures/metadata/vertdb/cluster_conf] to [/tmp/desc.json]: " +
-				"File not found",
-			"Could not copy file [webhdfs://vertdb/cluster_config.json] to [/tmp/desc.json]: Seen WebHDFS exception: " +
-				"\nURL: [http://vertdb/cluster_config.json]\nHTTP response code: 404\nException type: FileNotFoundException",
-			"Could not copy file [azb://cluster_config.json] to [/tmp/desc.json]: : The specified blob does not exist",
-			"\n10.244.1.34 Permission Denied \n\n",
-			"Database could not be revived.\nError: Node count mismatch",
-			"Error: Primary node count mismatch:",
-			"Could not copy file [s3://nimbusdb/db/spilly/metadata/vertdb/cluster_config.json] to [/tmp/desc.json]: Unable to connect to endpoint\n",
-			"[/tmp/desc.json]: The specified bucket does not exist\nExit",
-		}
-
-		for i := range errStrings {
-			fpr.Results = cmds.CmdResults{
-				atPod: []cmds.CmdResult{
-					{
-						Stdout: errStrings[i],
-						Err:    errors.New("at command failed"),
-					},
-				},
-			}
-			Expect(r.execCmd(ctx, atPod, []string{"revive_db"}, map[string]string{})).
-				Should(Equal(ctrl.Result{Requeue: true}), "Failing with '%s'", errStrings[i])
-		}
-
-		fpr.Results = cmds.CmdResults{
-			atPod: []cmds.CmdResult{
-				{
-					Stdout: "*** Unknown error",
-					Err:    errors.New("at command failed"),
-				},
-			},
-		}
-		res, err := r.execCmd(ctx, atPod, []string{"create_db"}, map[string]string{})
-		Expect(err).ShouldNot(Succeed())
-		Expect(res).Should(Equal(ctrl.Result{}))
 	})
 
 	It("should include --ignore-cluster-lease in revive_db command", func() {

--- a/pkg/controllers/vdb/revivedb_reconciler_test.go
+++ b/pkg/controllers/vdb/revivedb_reconciler_test.go
@@ -17,6 +17,7 @@ package vdb
 
 import (
 	"context"
+	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -90,6 +91,58 @@ var _ = Describe("revivedb_reconcile", func() {
 		Expect(len(reviveCalls)).Should(Equal(2)) // 1 for display-only and 1 for the real thing
 	})
 
+	It("should generate a requeue error for various known s3 errors", func() {
+		vdb := vapi.MakeVDB()
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := MakePodFacts(vdbRec, fpr)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
+		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
+		r := act.(*ReviveDBReconciler)
+		atPod := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+
+		errStrings := []string{
+			"Error: The database vertdb cannot continue because the communal storage location\n\ts3://nimbusdb/db\n" +
+				"might still be in use.\n\nthe cluster lease will expire:\n\t2021-05-13 14:35:00.280925",
+			"Could not copy file [s3://nimbusdb/db/empty/metadata/newdb/cluster_config.json] to [/tmp/desc.json]: " +
+				"No such file or directory [s3://nimbusdb/db/empty/metadata/newdb/cluster_config.json]",
+			"Could not copy file [gs://vertica-fleeting/mspilchen/revivedb-failures/metadata/vertdb/cluster_conf] to [/tmp/desc.json]: " +
+				"File not found",
+			"Could not copy file [webhdfs://vertdb/cluster_config.json] to [/tmp/desc.json]: Seen WebHDFS exception: " +
+				"\nURL: [http://vertdb/cluster_config.json]\nHTTP response code: 404\nException type: FileNotFoundException",
+			"Could not copy file [azb://cluster_config.json] to [/tmp/desc.json]: : The specified blob does not exist",
+			"\n10.244.1.34 Permission Denied \n\n",
+			"Database could not be revived.\nError: Node count mismatch",
+			"Error: Primary node count mismatch:",
+			"Could not copy file [s3://nimbusdb/db/spilly/metadata/vertdb/cluster_config.json] to [/tmp/desc.json]: Unable to connect to endpoint\n",
+			"[/tmp/desc.json]: The specified bucket does not exist\nExit",
+		}
+
+		for i := range errStrings {
+			fpr.Results = cmds.CmdResults{
+				atPod: []cmds.CmdResult{
+					{
+						Stdout: errStrings[i],
+						Err:    errors.New("at command failed"),
+					},
+				},
+			}
+			Expect(r.execCmd(ctx, atPod, []string{"revive_db"})).Should(Equal(ctrl.Result{Requeue: true}), "Failing with '%s'", errStrings[i])
+		}
+
+		fpr.Results = cmds.CmdResults{
+			atPod: []cmds.CmdResult{
+				{
+					Stdout: "*** Unknown error",
+					Err:    errors.New("at command failed"),
+				},
+			},
+		}
+		res, err := r.execCmd(ctx, atPod, []string{"create_db"})
+		Expect(err).ShouldNot(Succeed())
+		Expect(res).Should(Equal(ctrl.Result{}))
+	})
+
 	It("should include --ignore-cluster-lease in revive_db command", func() {
 		vdb := vapi.MakeVDB()
 
@@ -99,12 +152,12 @@ var _ = Describe("revivedb_reconcile", func() {
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		vdb.Spec.IgnoreClusterLease = false
-		opts := r.genReviveOpts(types.NamespacedName{}, []string{"hostA"}, map[string]string{})
+		opts := r.genReviveOpts(types.NamespacedName{}, []string{"hostA"})
 		parms := revivedb.Parms{}
 		parms.Make(opts...)
 		Expect(parms.IgnoreClusterLease).Should(BeFalse())
 		vdb.Spec.IgnoreClusterLease = true
-		opts = r.genReviveOpts(types.NamespacedName{}, []string{"hostA"}, map[string]string{})
+		opts = r.genReviveOpts(types.NamespacedName{}, []string{"hostA"})
 		parms = revivedb.Parms{}
 		parms.Make(opts...)
 		Expect(parms.IgnoreClusterLease).Should(BeTrue())

--- a/pkg/controllers/vdb/revivedb_reconciler_test.go
+++ b/pkg/controllers/vdb/revivedb_reconciler_test.go
@@ -127,7 +127,8 @@ var _ = Describe("revivedb_reconcile", func() {
 					},
 				},
 			}
-			Expect(r.execCmd(ctx, atPod, []string{"revive_db"})).Should(Equal(ctrl.Result{Requeue: true}), "Failing with '%s'", errStrings[i])
+			Expect(r.execCmd(ctx, atPod, []string{"revive_db"}, map[string]string{})).
+				Should(Equal(ctrl.Result{Requeue: true}), "Failing with '%s'", errStrings[i])
 		}
 
 		fpr.Results = cmds.CmdResults{
@@ -138,7 +139,7 @@ var _ = Describe("revivedb_reconcile", func() {
 				},
 			},
 		}
-		res, err := r.execCmd(ctx, atPod, []string{"create_db"})
+		res, err := r.execCmd(ctx, atPod, []string{"create_db"}, map[string]string{})
 		Expect(err).ShouldNot(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
 	})
@@ -152,12 +153,12 @@ var _ = Describe("revivedb_reconcile", func() {
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
 		vdb.Spec.IgnoreClusterLease = false
-		opts := r.genReviveOpts(types.NamespacedName{}, []string{"hostA"})
+		opts := r.genReviveOpts(types.NamespacedName{}, []string{"hostA"}, map[string]string{})
 		parms := revivedb.Parms{}
 		parms.Make(opts...)
 		Expect(parms.IgnoreClusterLease).Should(BeFalse())
 		vdb.Spec.IgnoreClusterLease = true
-		opts = r.genReviveOpts(types.NamespacedName{}, []string{"hostA"})
+		opts = r.genReviveOpts(types.NamespacedName{}, []string{"hostA"}, map[string]string{})
 		parms = revivedb.Parms{}
 		parms.Make(opts...)
 		Expect(parms.IgnoreClusterLease).Should(BeTrue())

--- a/pkg/types/case_insensitive_map.go
+++ b/pkg/types/case_insensitive_map.go
@@ -1,0 +1,72 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package types
+
+import (
+	"strings"
+)
+
+// CiMap is a thin wrapper around a map to allow
+// case insensitive keys.
+type CiMap struct {
+	m map[string]string
+}
+
+// MakeCiMap is a helper that constructs a CiMap struct.
+func MakeCiMap() *CiMap {
+	return &CiMap{m: make(map[string]string)}
+}
+
+// Set inserts a key and its value into the map.
+func (c *CiMap) Set(k, v string) {
+	c.m[strings.ToLower(k)] = v
+}
+
+// Get returns two values: the actual value for the
+// key and a boolean that indicates if the key exists.
+func (c *CiMap) Get(k string) (string, bool) {
+	v, ok := c.m[strings.ToLower(k)]
+	return v, ok
+}
+
+// GetMap extracts the inner map from the wrapper.
+func (c *CiMap) GetMap() map[string]string {
+	return c.m
+}
+
+// ContainKeyValuePair returns true if the specified key
+// exists and has as value the specified value.
+func (c *CiMap) ContainKeyValuePair(key, val string) bool {
+	v, ok := c.Get(key)
+	if !ok {
+		return false
+	}
+	return v == val
+}
+
+// GetValue returns the value for the given key.
+func (c *CiMap) GetValue(k string) string {
+	v, ok := c.Get(k)
+	if !ok {
+		return ""
+	}
+	return v
+}
+
+// Size returns the number of elements in the map.
+func (c *CiMap) Size() int {
+	return len(c.m)
+}

--- a/pkg/types/case_insensitive_map_test.go
+++ b/pkg/types/case_insensitive_map_test.go
@@ -1,0 +1,48 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNames(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "case_insensitive_map Suite")
+}
+
+var _ = Describe("case_insensitive_map", func() {
+	It("should set a case insensitive map", func() {
+		c := MakeCiMap()
+		c.Set("key1", "val1")
+		c.Set("kEY1", "val2")
+		Expect(c.Size()).Should(Equal(1))
+		Expect(c.ContainKeyValuePair("KEY1", "val2")).Should(Equal(true))
+	})
+
+	It("should create a map from a cimap", func() {
+		c := MakeCiMap()
+		c.Set("kEY2", "v2")
+		c.Set("kEY3", "v3")
+		m := c.GetMap()
+		Expect(len(m)).Should(Equal(2))
+		Expect(m["key2"]).Should(Equal("v2"))
+	})
+})

--- a/pkg/vadmin/add_node_at.go
+++ b/pkg/vadmin/add_node_at.go
@@ -26,7 +26,7 @@ import (
 
 // AddNode will add a new vertica node to the cluster. If add node fails due to
 // a license limit, the error will be of type addnode.LicenseLimitError.
-func (a Admintools) AddNode(ctx context.Context, opts ...addnode.Option) error {
+func (a *Admintools) AddNode(ctx context.Context, opts ...addnode.Option) error {
 	s := addnode.Parms{}
 	s.Make(opts...)
 	cmd := a.genAddNodeCommand(&s)
@@ -57,7 +57,7 @@ func isLicenseLimitError(stdout string) bool {
 }
 
 // genAddNodeCommand returns the command to run to add nodes to the cluster.
-func (a Admintools) genAddNodeCommand(s *addnode.Parms) []string {
+func (a *Admintools) genAddNodeCommand(s *addnode.Parms) []string {
 	return []string{
 		"-t", "db_add_node",
 		"--hosts", strings.Join(s.Hosts, ","),

--- a/pkg/vadmin/add_sc_at.go
+++ b/pkg/vadmin/add_sc_at.go
@@ -22,7 +22,7 @@ import (
 )
 
 // AddSubcluster will create a subcluster in the vertica cluster.
-func (a Admintools) AddSubcluster(ctx context.Context, opts ...addsc.Option) error {
+func (a *Admintools) AddSubcluster(ctx context.Context, opts ...addsc.Option) error {
 	s := addsc.Parms{}
 	s.Make(opts...)
 	cmd := []string{

--- a/pkg/vadmin/at.go
+++ b/pkg/vadmin/at.go
@@ -69,8 +69,20 @@ func (a *Admintools) copyAuthFile(ctx context.Context, initiatorPod types.Namesp
 	return err
 }
 
+// DestroyAuthParms will remove the auth parms file that was created in the pod
+func (a *Admintools) DestroyAuthParms(ctx context.Context, initiatorPod types.NamespacedName) {
+	_, _, err := a.PRunner.ExecInPod(ctx, initiatorPod, names.ServerContainer,
+		"rm", paths.AuthParmsFile,
+	)
+	if err != nil {
+		// Destroying the auth parms is a best effort. If we fail to delete it,
+		// the reconcile will continue on.
+		a.Log.Info("failed to destroy auth parms, ignoring failure", "err", err)
+	}
+}
+
 // genAuthParmsFileContent will generate the content to write into auth_parms.conf
-func genAuthParmsFileContent(parms map[string]string) string {
+func (a *Admintools) genAuthParmsFileContent(parms map[string]string) string {
 	fileContent := strings.Builder{}
 	for k, v := range parms {
 		fileContent.WriteString(fmt.Sprintf("%s = %s\n", k, v))

--- a/pkg/vadmin/create_db_at.go
+++ b/pkg/vadmin/create_db_at.go
@@ -27,9 +27,12 @@ import (
 )
 
 // CreateDB will create a brand new database using the admintools API (-t create_db).
-func (a Admintools) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl.Result, error) {
+func (a *Admintools) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl.Result, error) {
 	s := createdb.Parms{}
 	s.Make(opts...)
+	if err := a.copyAuthFile(ctx, s.Initiator, genAuthParmsFileContent(s.ConfigurationParams)); err != nil {
+		return ctrl.Result{}, err
+	}
 	cmd := a.genCreateDBCmd(&s)
 	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
 	if err != nil {
@@ -39,7 +42,7 @@ func (a Admintools) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl
 }
 
 // genCreateDBCmd will generate the command line options for calling admintools -t create_db
-func (a Admintools) genCreateDBCmd(s *createdb.Parms) []string {
+func (a *Admintools) genCreateDBCmd(s *createdb.Parms) []string {
 	cmd := []string{
 		"-t", "create_db",
 		"--skip-fs-checks",

--- a/pkg/vadmin/create_db_at.go
+++ b/pkg/vadmin/create_db_at.go
@@ -30,11 +30,12 @@ import (
 func (a *Admintools) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl.Result, error) {
 	s := createdb.Parms{}
 	s.Make(opts...)
-	if err := a.copyAuthFile(ctx, s.Initiator, genAuthParmsFileContent(s.ConfigurationParams)); err != nil {
+	if err := a.copyAuthFile(ctx, s.Initiator, a.genAuthParmsFileContent(s.ConfigurationParams)); err != nil {
 		return ctrl.Result{}, err
 	}
 	cmd := a.genCreateDBCmd(&s)
 	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
+	a.DestroyAuthParms(ctx, s.Initiator)
 	if err != nil {
 		return a.logFailure("create_db", events.CreateDBFailed, stdout, err)
 	}

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -71,6 +71,7 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 	if s.CommunalPath != "" {
 		opts.DepotPrefix = &s.DepotPath
 		opts.CommunalStorageLocation = &s.CommunalPath
+		opts.ConfigurationParameters = s.ConfigurationParams
 	}
 
 	if s.ShardCount > 0 {

--- a/pkg/vadmin/describe_db_at.go
+++ b/pkg/vadmin/describe_db_at.go
@@ -28,10 +28,10 @@ import (
 // DescribeDB will get information about a database from communal storage. For
 // the admintools implementation, this is running the revive with the
 // --display-only option.
-func (a Admintools) DescribeDB(ctx context.Context, opts ...describedb.Option) (string, ctrl.Result, error) {
+func (a *Admintools) DescribeDB(ctx context.Context, opts ...describedb.Option) (string, ctrl.Result, error) {
 	s := describedb.Parms{}
 	s.Make(opts...)
-	cmd := a.genDescribeCmd(&s)
+	cmd := genDescribeCmd(&s)
 	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
 	if err != nil {
 		res, err2 := a.logFailure("revive_db", events.ReviveDBFailed, stdout, err)
@@ -42,7 +42,7 @@ func (a Admintools) DescribeDB(ctx context.Context, opts ...describedb.Option) (
 
 // genDescribeCmd will generate the command line options for calling
 // admintools -t revive_db --display-only.
-func (a Admintools) genDescribeCmd(s *describedb.Parms) []string {
+func genDescribeCmd(s *describedb.Parms) []string {
 	return []string{
 		"-t", "revive_db",
 		"--display-only",

--- a/pkg/vadmin/describe_db_at.go
+++ b/pkg/vadmin/describe_db_at.go
@@ -31,7 +31,10 @@ import (
 func (a *Admintools) DescribeDB(ctx context.Context, opts ...describedb.Option) (string, ctrl.Result, error) {
 	s := describedb.Parms{}
 	s.Make(opts...)
-	cmd := genDescribeCmd(&s)
+	if err := a.copyAuthFile(ctx, s.Initiator, a.genAuthParmsFileContent(s.ConfigurationParams)); err != nil {
+		return "", ctrl.Result{}, err
+	}
+	cmd := a.genDescribeCmd(&s)
 	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
 	if err != nil {
 		res, err2 := a.logFailure("revive_db", events.ReviveDBFailed, stdout, err)
@@ -42,7 +45,7 @@ func (a *Admintools) DescribeDB(ctx context.Context, opts ...describedb.Option) 
 
 // genDescribeCmd will generate the command line options for calling
 // admintools -t revive_db --display-only.
-func genDescribeCmd(s *describedb.Parms) []string {
+func (a *Admintools) genDescribeCmd(s *describedb.Parms) []string {
 	return []string{
 		"-t", "revive_db",
 		"--display-only",

--- a/pkg/vadmin/fetch_node_state_at.go
+++ b/pkg/vadmin/fetch_node_state_at.go
@@ -39,11 +39,11 @@ func (a *Admintools) FetchNodeState(ctx context.Context, opts ...fetchnodestate.
 		res, err2 := a.logFailure("list_allnodes", events.MgmtFailed, stdout, err)
 		return nil, res, err2
 	}
-	return parseClusterNodeStatus(stdout, s.HostsNeeded), ctrl.Result{}, nil
+	return a.parseClusterNodeStatus(stdout, s.HostsNeeded), ctrl.Result{}, nil
 }
 
 // parseClusterNodeStatus will parse the output from a AT -t list_allnodes call
-func parseClusterNodeStatus(stdout string, hostsNeeded map[string]bool) map[string]string {
+func (a *Admintools) parseClusterNodeStatus(stdout string, hostsNeeded map[string]bool) map[string]string {
 	stateMap := map[string]string{}
 	lines := strings.Split(stdout, "\n")
 	const HeaderRowCount = 2

--- a/pkg/vadmin/fetch_node_state_at.go
+++ b/pkg/vadmin/fetch_node_state_at.go
@@ -26,7 +26,7 @@ import (
 
 // FetchNodeState will determine if the given set of nodes are considered UP
 // or DOWN in our consensus state. It returns a map of vnode and its node state.
-func (a Admintools) FetchNodeState(ctx context.Context, opts ...fetchnodestate.Option) (map[string]string, ctrl.Result, error) {
+func (a *Admintools) FetchNodeState(ctx context.Context, opts ...fetchnodestate.Option) (map[string]string, ctrl.Result, error) {
 	s := fetchnodestate.Parms{}
 	if err := s.Make(opts...); err != nil {
 		return nil, ctrl.Result{}, err
@@ -39,11 +39,11 @@ func (a Admintools) FetchNodeState(ctx context.Context, opts ...fetchnodestate.O
 		res, err2 := a.logFailure("list_allnodes", events.MgmtFailed, stdout, err)
 		return nil, res, err2
 	}
-	return a.parseClusterNodeStatus(stdout, s.HostsNeeded), ctrl.Result{}, nil
+	return parseClusterNodeStatus(stdout, s.HostsNeeded), ctrl.Result{}, nil
 }
 
 // parseClusterNodeStatus will parse the output from a AT -t list_allnodes call
-func (a Admintools) parseClusterNodeStatus(stdout string, hostsNeeded map[string]bool) map[string]string {
+func parseClusterNodeStatus(stdout string, hostsNeeded map[string]bool) map[string]string {
 	stateMap := map[string]string{}
 	lines := strings.Split(stdout, "\n")
 	const HeaderRowCount = 2

--- a/pkg/vadmin/fetch_node_state_at_test.go
+++ b/pkg/vadmin/fetch_node_state_at_test.go
@@ -56,8 +56,7 @@ var _ = Describe("fetch_node_state_at", func() {
 	})
 
 	It("should parse the list_allnodes output", func() {
-		at, _, _ := mockAdmintoolsDispatcher()
-		stateMap := at.parseClusterNodeStatus(
+		stateMap := parseClusterNodeStatus(
 			" Node          | Host       | State | Version                 | DB \n"+
 				"---------------+------------+-------+-------------------------+----\n"+
 				" v_d_node0001 | 10.244.1.6 | UP    | vertica-11.0.0.20210309 | db \n"+

--- a/pkg/vadmin/fetch_node_state_at_test.go
+++ b/pkg/vadmin/fetch_node_state_at_test.go
@@ -56,7 +56,8 @@ var _ = Describe("fetch_node_state_at", func() {
 	})
 
 	It("should parse the list_allnodes output", func() {
-		stateMap := parseClusterNodeStatus(
+		at, _, _ := mockAdmintoolsDispatcher()
+		stateMap := at.parseClusterNodeStatus(
 			" Node          | Host       | State | Version                 | DB \n"+
 				"---------------+------------+-------+-------------------------+----\n"+
 				" v_d_node0001 | 10.244.1.6 | UP    | vertica-11.0.0.20210309 | db \n"+

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -104,7 +104,7 @@ type Admintools struct {
 // MakeAdmintools will create a dispatcher that uses admintools to call the
 // admin commands.
 func MakeAdmintools(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner, evWriter events.EVWriter, devMode bool) Dispatcher {
-	return Admintools{
+	return &Admintools{
 		PRunner:  prunner,
 		VDB:      vdb,
 		Log:      log,

--- a/pkg/vadmin/opts/createdb/opts.go
+++ b/pkg/vadmin/opts/createdb/opts.go
@@ -31,6 +31,7 @@ type Parms struct {
 	LicensePath           string
 	CommunalPath          string
 	CommunalStorageParams string
+	ConfigurationParams   map[string]string
 	ShardCount            int
 	SkipPackageInstall    bool
 }
@@ -101,6 +102,12 @@ func WithCommunalPath(path string) Option {
 func WithCommunalStorageParams(path string) Option {
 	return func(s *Parms) {
 		s.CommunalStorageParams = path
+	}
+}
+
+func WithConfigurationParams(parms map[string]string) Option {
+	return func(s *Parms) {
+		s.ConfigurationParams = parms
 	}
 }
 

--- a/pkg/vadmin/opts/describedb/opts.go
+++ b/pkg/vadmin/opts/describedb/opts.go
@@ -26,6 +26,7 @@ type Parms struct {
 	DBName                string
 	CommunalPath          string
 	CommunalStorageParams string
+	ConfigurationParams   map[string]string
 }
 
 type Option func(*Parms)
@@ -58,5 +59,11 @@ func WithCommunalPath(path string) Option {
 func WithCommunalStorageParams(path string) Option {
 	return func(s *Parms) {
 		s.CommunalStorageParams = path
+	}
+}
+
+func WithConfigurationParams(parms map[string]string) Option {
+	return func(s *Parms) {
+		s.ConfigurationParams = parms
 	}
 }

--- a/pkg/vadmin/opts/revivedb/opts.go
+++ b/pkg/vadmin/opts/revivedb/opts.go
@@ -26,6 +26,7 @@ type Parms struct {
 	DBName                string
 	CommunalPath          string
 	CommunalStorageParams string
+	ConfigurationParams   map[string]string
 	IgnoreClusterLease    bool
 }
 
@@ -65,6 +66,12 @@ func WithCommunalPath(path string) Option {
 func WithCommunalStorageParams(path string) Option {
 	return func(s *Parms) {
 		s.CommunalStorageParams = path
+	}
+}
+
+func WithConfigurationParams(parms map[string]string) Option {
+	return func(s *Parms) {
+		s.ConfigurationParams = parms
 	}
 }
 

--- a/pkg/vadmin/re_ip_at.go
+++ b/pkg/vadmin/re_ip_at.go
@@ -57,13 +57,13 @@ func (a *Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result
 		return ctrl.Result{}, err
 	}
 
-	mapFileContents, ipChanging := genMapFile(oldIPs, &s)
+	mapFileContents, ipChanging := a.genMapFile(oldIPs, &s)
 	if !ipChanging {
 		// no re-ip is necessary, the IP are not changing
 		return ctrl.Result{}, nil
 	}
 
-	cmd := genMapFileUploadCmd(mapFileContents)
+	cmd := a.genMapFileUploadCmd(mapFileContents)
 	if _, _, err := a.PRunner.ExecInPod(ctx, s.Initiator, names.ServerContainer, cmd...); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -83,7 +83,7 @@ func (a *Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result
 // The list of old IPs are passed in. We combine that with the new IPs in the
 // podfacts to generate the map file. The map file is returned as a list of
 // strings. Its format is what is expected by admintools -t re_ip.
-func genMapFile(oldIPs verticaIPLookup, s *reip.Parms) (mapContents []string, ipChanging bool) {
+func (a *Admintools) genMapFile(oldIPs verticaIPLookup, s *reip.Parms) (mapContents []string, ipChanging bool) {
 	mapContents = []string{}
 	ipChanging = false
 
@@ -124,7 +124,7 @@ func (a *Admintools) genReIPCommand() []string {
 }
 
 // genMapFileUploadCmd returns the command to run to upload the map file
-func genMapFileUploadCmd(mapFileContents []string) []string {
+func (a *Admintools) genMapFileUploadCmd(mapFileContents []string) []string {
 	return []string{
 		"bash", "-c", "cat > " + AdminToolsMapFile + "<<< '" + strings.Join(mapFileContents, "\n") + "'",
 	}

--- a/pkg/vadmin/re_ip_at.go
+++ b/pkg/vadmin/re_ip_at.go
@@ -40,7 +40,7 @@ const (
 type verticaIPLookup map[string]string
 
 // ReIP will update the catalog on disk with new IPs for all of the nodes given.
-func (a Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error) {
+func (a *Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error) {
 	s := reip.Parms{}
 	s.Make(opts...)
 
@@ -57,13 +57,13 @@ func (a Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result,
 		return ctrl.Result{}, err
 	}
 
-	mapFileContents, ipChanging := a.genMapFile(oldIPs, &s)
+	mapFileContents, ipChanging := genMapFile(oldIPs, &s)
 	if !ipChanging {
 		// no re-ip is necessary, the IP are not changing
 		return ctrl.Result{}, nil
 	}
 
-	cmd := a.genMapFileUploadCmd(mapFileContents)
+	cmd := genMapFileUploadCmd(mapFileContents)
 	if _, _, err := a.PRunner.ExecInPod(ctx, s.Initiator, names.ServerContainer, cmd...); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -83,7 +83,7 @@ func (a Admintools) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result,
 // The list of old IPs are passed in. We combine that with the new IPs in the
 // podfacts to generate the map file. The map file is returned as a list of
 // strings. Its format is what is expected by admintools -t re_ip.
-func (a Admintools) genMapFile(oldIPs verticaIPLookup, s *reip.Parms) (mapContents []string, ipChanging bool) {
+func genMapFile(oldIPs verticaIPLookup, s *reip.Parms) (mapContents []string, ipChanging bool) {
 	mapContents = []string{}
 	ipChanging = false
 
@@ -105,7 +105,7 @@ func (a Admintools) genMapFile(oldIPs verticaIPLookup, s *reip.Parms) (mapConten
 }
 
 // genReIPCommand will return the command to run for the re_ip command
-func (a Admintools) genReIPCommand() []string {
+func (a *Admintools) genReIPCommand() []string {
 	cmd := []string{
 		"-t", "re_ip",
 		"--file=" + AdminToolsMapFile,
@@ -124,7 +124,7 @@ func (a Admintools) genReIPCommand() []string {
 }
 
 // genMapFileUploadCmd returns the command to run to upload the map file
-func (a Admintools) genMapFileUploadCmd(mapFileContents []string) []string {
+func genMapFileUploadCmd(mapFileContents []string) []string {
 	return []string{
 		"bash", "-c", "cat > " + AdminToolsMapFile + "<<< '" + strings.Join(mapFileContents, "\n") + "'",
 	}
@@ -134,8 +134,8 @@ func (a Admintools) genMapFileUploadCmd(mapFileContents []string) []string {
 // The IPs from an admintools.conf represent the *old* IPs. We store them in a
 // map, where the lookup is by the node name. This function only handles
 // compat21 node names.
-func (a Admintools) fetchOldIPsFromNode(ctx context.Context, atPod types.NamespacedName) (verticaIPLookup, error) {
-	cmd := a.genGrepNodeCmd()
+func (a *Admintools) fetchOldIPsFromNode(ctx context.Context, atPod types.NamespacedName) (verticaIPLookup, error) {
+	cmd := genGrepNodeCmd()
 	stdout, _, err := a.PRunner.ExecInPod(ctx, atPod, names.ServerContainer, cmd...)
 	if err != nil {
 		return verticaIPLookup{}, err
@@ -145,7 +145,7 @@ func (a Admintools) fetchOldIPsFromNode(ctx context.Context, atPod types.Namespa
 
 // genGrepNodeCmd returns the command to run to get the nodes from admintools.conf
 // This function only handles grepping compat21 nodes.
-func (a Admintools) genGrepNodeCmd() []string {
+func genGrepNodeCmd() []string {
 	return []string{
 		"bash", "-c", fmt.Sprintf("grep --regexp='^node[0-9]' %s", paths.AdminToolsConf),
 	}

--- a/pkg/vadmin/remove_node_at.go
+++ b/pkg/vadmin/remove_node_at.go
@@ -23,7 +23,7 @@ import (
 )
 
 // RemoveNode will remove an existng vrtica node from the cluster.
-func (a Admintools) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
+func (a *Admintools) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
 	s := removenode.Parms{}
 	s.Make(opts...)
 	cmd := []string{

--- a/pkg/vadmin/remove_sc_at.go
+++ b/pkg/vadmin/remove_sc_at.go
@@ -23,7 +23,7 @@ import (
 )
 
 // RemoveSubcluster will remove the given subcluster from the vertica cluster.
-func (a Admintools) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
+func (a *Admintools) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
 	s := removesc.Parms{}
 	s.Make(opts...)
 	cmd := []string{

--- a/pkg/vadmin/restart_node_at.go
+++ b/pkg/vadmin/restart_node_at.go
@@ -28,7 +28,7 @@ import (
 // RestartNode will restart a subset of nodes. Use this when vertica has not
 // lost cluster quorum. The IP given for each vnode may not match the current IP
 // in the vertica catalogs.
-func (a Admintools) RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error) {
+func (a *Admintools) RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error) {
 	s := restartnode.Parms{}
 	s.Make(opts...)
 	cmd := a.genRestartNodeCmd(&s)
@@ -40,7 +40,7 @@ func (a Admintools) RestartNode(ctx context.Context, opts ...restartnode.Option)
 }
 
 // genRestartNodeCmd returns the command to run to restart a pod
-func (a Admintools) genRestartNodeCmd(s *restartnode.Parms) []string {
+func (a *Admintools) genRestartNodeCmd(s *restartnode.Parms) []string {
 	cmd := []string{
 		"-t", "restart_node",
 		"--database=" + a.VDB.Spec.DBName,

--- a/pkg/vadmin/revive_db_at.go
+++ b/pkg/vadmin/revive_db_at.go
@@ -31,11 +31,9 @@ import (
 func (a *Admintools) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ctrl.Result, error) {
 	s := revivedb.Parms{}
 	s.Make(opts...)
-	if err := a.copyAuthFile(ctx, s.Initiator, genAuthParmsFileContent(s.ConfigurationParams)); err != nil {
-		return ctrl.Result{}, err
-	}
-	cmd := genReviveCmd(&s)
+	cmd := a.genReviveCmd(&s)
 	stdout, err := a.execAdmintools(ctx, s.Initiator, cmd...)
+	a.DestroyAuthParms(ctx, s.Initiator)
 	if err != nil {
 		return a.logFailure("revive_db", events.ReviveDBFailed, stdout, err)
 	}
@@ -43,7 +41,7 @@ func (a *Admintools) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ctr
 }
 
 // genReviveCmd will generate the command line options for calling admintools -t revive_db
-func genReviveCmd(s *revivedb.Parms) []string {
+func (a *Admintools) genReviveCmd(s *revivedb.Parms) []string {
 	cmd := []string{
 		"-t", "revive_db",
 		"--hosts=" + strings.Join(s.Hosts, ","),

--- a/pkg/vadmin/revive_db_at_test.go
+++ b/pkg/vadmin/revive_db_at_test.go
@@ -17,9 +17,11 @@ package vadmin
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/revivedb"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -37,5 +39,21 @@ var _ = Describe("revive_db_at", func() {
 		Ω(len(hist)).Should(Equal(1))
 		Ω(hist[0].Command).Should(ContainElement("--communal-storage-location=/communal-1"))
 		Ω(hist[0].Command).Should(ContainElement("testdb"))
+	})
+
+	It("should delete auth file at the end", func() {
+		confParms := map[string]string{
+			TestParm: TestValue,
+		}
+		dispatcher, _, fpr := mockAdmintoolsDispatcher()
+		res, err := dispatcher.ReviveDB(ctx,
+			revivedb.WithCommunalPath("/communal"),
+			revivedb.WithConfigurationParams(confParms),
+		)
+		Ω(err).Should(Succeed())
+		Ω(res).Should(Equal(ctrl.Result{}))
+		cmd := fmt.Sprintf("rm %s", paths.AuthParmsFile)
+		hist := fpr.FindCommands(cmd)
+		Ω(len(hist)).Should(Equal(1))
 	})
 })

--- a/pkg/vadmin/start_db_at.go
+++ b/pkg/vadmin/start_db_at.go
@@ -29,7 +29,7 @@ import (
 // StartDB will start a subset of nodes. Use this when vertica has lost
 // cluster quorum. The IP given for each vnode *must* match the current IP
 // in the vertica catalog. If they aren't a call to ReIP is necessary.
-func (a Admintools) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
+func (a *Admintools) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
 	s := startdb.Parms{}
 	s.Make(opts...)
 	cmd := a.genStartDBCommand(&s)
@@ -41,7 +41,7 @@ func (a Admintools) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.R
 }
 
 // genStartDBCommand will return the command for start_db
-func (a Admintools) genStartDBCommand(s *startdb.Parms) []string {
+func (a *Admintools) genStartDBCommand(s *startdb.Parms) []string {
 	cmd := []string{
 		"-t", "start_db",
 		"--database=" + a.VDB.Spec.DBName,

--- a/pkg/vadmin/stop_db_at.go
+++ b/pkg/vadmin/stop_db_at.go
@@ -22,7 +22,7 @@ import (
 )
 
 // StopDB will stop all the vertica hosts of a running cluster
-func (a Admintools) StopDB(ctx context.Context, opts ...stopdb.Option) error {
+func (a *Admintools) StopDB(ctx context.Context, opts ...stopdb.Option) error {
 	s := stopdb.Parms{}
 	s.Make(opts...)
 	cmd := []string{

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -73,12 +73,12 @@ func TestAPIs(t *testing.T) {
 }
 
 // mockAdmintoolsDispatcher will create an admintools dispatcher for test purposes
-func mockAdmintoolsDispatcher() (Admintools, *vapi.VerticaDB, *cmds.FakePodRunner) {
+func mockAdmintoolsDispatcher() (*Admintools, *vapi.VerticaDB, *cmds.FakePodRunner) {
 	vdb := vapi.MakeVDB()
 	fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 	evWriter := aterrors.TestEVWriter{}
 	dispatcher := MakeAdmintools(logger, vdb, fpr, &evWriter, false)
-	return dispatcher.(Admintools), vdb, fpr
+	return dispatcher.(*Admintools), vdb, fpr
 }
 
 // MockVClusterOps is used to invoke mock vcluster-ops functions

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -86,6 +86,8 @@ type MockVClusterOps struct {
 }
 
 const TestPassword = "test-pw"
+const TestParm = "Parm1"
+const TestValue = "val1"
 
 // mockVClusterOpsDispatcher will create an vcluster-ops dispatcher for test purposes
 func mockVClusterOpsDispatcher() *VClusterOps {

--- a/tests/e2e-vcluster/vcluster-ks-0/00-create-creds.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-0/00-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-vcluster/vcluster-ks-0/17-assert.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-0/17-assert.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: CreateDBSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-0
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-vcluster-ks-0
+status:
+  addedToDBCount: 1
+  upNodeCount: 1

--- a/tests/e2e-vcluster/vcluster-ks-0/17-wait-for-createdb.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-0/17-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl


### PR DESCRIPTION
When calling create_db for admintools we would create a file that has a bunch of config options in it. n the vclusterOps, these are all implemented using a parameter called ConfigurationParameters. So we collect all the parameters and pass them as a map to createdb.