### PR TITLE
Include curl in v2 image

### DIFF
--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -129,6 +129,7 @@ RUN set -x \
   && apt-get install -y --no-install-recommends \
   ca-certificates \
   cron \
+  curl \
   dialog \
   gdb \
   iproute2 \


### PR DESCRIPTION
Including curl in the v2 image. This will make it easier to debug connection issues with the NMA and HTTPS service.