### PR TITLE
Always run e2e-vcluster with latest master changes

### DIFF
--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -29,7 +29,6 @@ runs:
         docker load --input nokeys-vertica-image/nokeys-vertica-image.tar
         docker load --input minimal-vertica-image/minimal-vertica-image.tar
         docker load --input operator-image/operator-image.tar
-        docker load --input v2-vertica-image/v2-vertica-image.tar
         docker load --input vlogger-image/vlogger-image.tar
         docker image ls -a
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -285,10 +285,9 @@ jobs:
       uses: spilchen/switch-case-action@v2
       id: v2_vertica_image
       with:
-        default: ghcr.io/${{ env.OWNER_LC }}/vertica-k8s:${{ github.sha }}-v2
+        default: docker.io/verticadocker/vertica-k8s-private:latest-master
         conditionals-with-values: |
           ${{ inputs.v2_vertica_image != '' }} => ${{ inputs.v2_vertica_image }}
-          ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind-v2
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
@@ -312,26 +311,16 @@ jobs:
       uses: ./.github/actions/download-rpm
       if: ${{ inputs.v2_vertica_image == '' }}
 
-    - name: Build and optionally push v2 server image
+    - name: Build the v2 image
       if: ${{ inputs.v2_vertica_image == '' }}
       run: |
-        export VERTICA_IMG=${{ steps.v2_vertica_image.outputs.value }}
+        # We never push the image we build here because the RPM we use is too
+        # old. The RPM needs to be from at least a 23.3.0 server. So, we build
+        # here only to test the creation of the image. We don't verify this
+        # image in the remaining CI. Pick a dummy image name so as not to
+        # overwrite the output build image that the e2e tests will use.
+        export VERTICA_IMG=vertica-k8s:kind-v2
         make docker-build-vertica-v2
-        if [ $GITHUB_EVENT_NAME != 'pull_request' ]
-        then
-          make docker-push-vertica
-        fi
-
-    - name: Save the image for consumption by dependent jobs (PRs only)
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        docker save ${{ steps.v2_vertica_image.outputs.value }} > v2-vertica-image.tar
-
-    - uses: actions/upload-artifact@v3
-      if: ${{ github.event_name == 'pull_request' }}
-      with:
-        name: v2-vertica-image
-        path: v2-vertica-image.tar
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.v2_vertica_image != '' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,7 +148,8 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   e2e-vcluster:
-    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '' }}
+  steps:
+    if: ${{ github.repository == 'vertica/vertica-kubernetes' && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
     needs: [build] 
     uses: ./.github/workflows/e2e-vcluster.yml
     with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,7 +148,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   e2e-vcluster:
-    if: ${{ github.repository == 'vertica/vertica-kubernetes' && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
+    if: ${{ github.repository == 'https://github.com/vertica/vertica-kubernetes' && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
     needs: [build] 
     uses: ./.github/workflows/e2e-vcluster.yml
     with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,7 +148,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   e2e-vcluster:
-    if: ${{ github.repository == 'https://github.com/vertica/vertica-kubernetes.git' && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
+    if: ${{  github.event.pull_request.head.repo.full_name == github.repository && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
     needs: [build] 
     uses: ./.github/workflows/e2e-vcluster.yml
     with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,7 +148,6 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   e2e-vcluster:
-  steps:
     if: ${{ github.repository == 'vertica/vertica-kubernetes' && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
     needs: [build] 
     uses: ./.github/workflows/e2e-vcluster.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,7 +148,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   e2e-vcluster:
-    if: ${{ github.repository == 'https://github.com/vertica/vertica-kubernetes' && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
+    if: ${{ github.repository == 'https://github.com/vertica/vertica-kubernetes.git' && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster' || inputs.e2e_test_suites == '')}}
     needs: [build] 
     uses: ./.github/workflows/e2e-vcluster.yml
     with:


### PR DESCRIPTION
The e2e-vcluster test suite needs to run with the latest version of the server. For this reason, when we run that test suite we will use a private image from the dockerhub repo with the lag lastest-master. We also skip this test suite on forks because it requires secrets that are only accessible through the vertica-kubernetes repo.

We still build the v2 image to make sure nothing is broken. But since it uses an RPM from version 12.0.3 of the server, it doesn't have all of the functionality that the e2e-vcluster test suite needs. So, no e2e tests will run with it.