### PR TITLE
Fix prometheus-service-monitor e2e testcase

### DIFF
--- a/tests/e2e-leg-3/prometheus-service-monitor/05-install-prometheus-crd.yaml
+++ b/tests/e2e-leg-3/prometheus-service-monitor/05-install-prometheus-crd.yaml
@@ -18,4 +18,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl apply -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
+  - command: kubectl apply -f https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml


### PR DESCRIPTION
There was a change in a dependent github repo causing a failure in our test. Updating the path to the file in the dependent repo.