### PR TITLE
Fix the db existence check in the operator

### DIFF
--- a/changes/unreleased/Fixed-20230719-140852.yaml
+++ b/changes/unreleased/Fixed-20230719-140852.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Fix the db existence check in the operator
+time: 2023-07-19T14:08:52.881914538-03:00
+custom:
+  Issue: "460"

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -399,7 +399,8 @@ func (p *PodFacts) genGatherScript(vdb *vapi.VerticaDB, pf *PodFact) string {
 		echo -n '  %s: '
 		test -f %s && echo true || echo false
 		echo -n 'dbExists: '
-		ls --almost-all --hide-control-chars -1 %s/%s/v_%s_node????_catalog 2> /dev/null | grep --quiet . && echo true || echo false
+		ls --almost-all --hide-control-chars -1 %s/%s/v_%s_node????_catalog/Catalog/*config*.cat 2> /dev/null \
+			| grep --quiet . && echo true || echo false
 		echo -n 'compat21NodeName: '
 		test -f %s && echo -n '"' && echo -n $(cat %s) && echo '"' || echo '""'
 		echo -n 'vnodeName: '

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -399,7 +399,7 @@ func (p *PodFacts) genGatherScript(vdb *vapi.VerticaDB, pf *PodFact) string {
 		echo -n '  %s: '
 		test -f %s && echo true || echo false
 		echo -n 'dbExists: '
-		ls --almost-all --hide-control-chars -1 %s/%s/v_%s_node????_catalog/Catalog/*config*.cat 2> /dev/null \
+		ls --almost-all --hide-control-chars -1 %s/%s/v_%s_node????_catalog/%s 2> /dev/null \
 			| grep --quiet . && echo true || echo false
 		echo -n 'compat21NodeName: '
 		test -f %s && echo -n '"' && echo -n $(cat %s) && echo '"' || echo '""'
@@ -434,7 +434,7 @@ func (p *PodFacts) genGatherScript(vdb *vapi.VerticaDB, pf *PodFact) string {
 		paths.AgentCertFile, paths.AgentCertFile,
 		paths.AgentKeyFile, paths.AgentKeyFile,
 		paths.VerticaAPIKeysFile, paths.VerticaAPIKeysFile,
-		pf.catalogPath, vdb.Spec.DBName, strings.ToLower(vdb.Spec.DBName),
+		pf.catalogPath, vdb.Spec.DBName, strings.ToLower(vdb.Spec.DBName), getPathToVerifyCatalogExists(pf),
 		vdb.GenInstallerIndicatorFileName(),
 		vdb.GenInstallerIndicatorFileName(),
 		pf.catalogPath, vdb.Spec.DBName, strings.ToLower(vdb.Spec.DBName),
@@ -444,6 +444,29 @@ func (p *PodFacts) genGatherScript(vdb *vapi.VerticaDB, pf *PodFact) string {
 		paths.DBadminAgentPath,
 		fmt.Sprintf("%d", builder.VerticaHTTPPort),
 	))
+}
+
+// getPathToVerifyCatalogExists will return a suffix of a path that we can check
+// to see if the catalog is setup at the pod. This is used for a db existence
+// check. The path will be used in a bash script, so it can contain wildcards
+// like * or ?.
+func getPathToVerifyCatalogExists(pf *PodFact) string {
+	// When checking if the catalog exists at a pod, we have two types of checks
+	// depending on the subcluster type.
+	//
+	// For primary subclusters, the Catalog directory will be up to date. So it
+	// should have a version of the config.cat file -- it could be in a slightly
+	// different form depending if it's in the middle of a commit.
+	if pf.isPrimary {
+		return "Catalog/*config*.cat"
+	}
+	// For secondary subclusters, we just look to see if the standard
+	// Catalog directory exists. The secondary will not always have the full
+	// catalog, which is why we can't use the same check as the primary. For
+	// instance, a secondary after a revive won't have any catalog contents,
+	// just the required directories. It isn't until the database is started
+	// after the revive will the secondary have a populated catalog.
+	return "Catalog"
 }
 
 // checkIsInstalled will check a single pod to see if the installation has happened.
@@ -772,6 +795,13 @@ func setShardSubscription(op string, pf *PodFact) error {
 // exist anywhere.
 func (p *PodFacts) doesDBExist() bool {
 	for _, v := range p.Detail {
+		// dbExists check is based off the existence of the catalog. So, we only
+		// check pods from primary subclusters, as the check is only accurate
+		// for them. Pods for secondary may not have pulled down the catalog yet
+		// (e.g. revive before a restart).
+		if !v.isPrimary {
+			continue
+		}
 		if v.dbExists {
 			return true
 		}

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -92,12 +92,15 @@ var _ = Describe("podfacts", func() {
 
 	It("should verify all doesDBExist return codes", func() {
 		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
-		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{dbExists: false, isPodRunning: true}
+		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{dbExists: false, isPodRunning: true, isPrimary: true}
 		Expect(pf.doesDBExist()).Should(BeFalse())
-		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{dbExists: false, isPodRunning: false}
+		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{dbExists: false, isPodRunning: false, isPrimary: true}
 		Expect(pf.doesDBExist()).Should(BeFalse())
-		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{dbExists: true, isPodRunning: true}
+		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{dbExists: true, isPodRunning: true, isPrimary: true}
 		Expect(pf.doesDBExist()).Should(BeTrue())
+		// Change pf to be a secondary
+		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{dbExists: true, isPodRunning: true, isPrimary: false}
+		Expect(pf.doesDBExist()).Should(BeFalse())
 	})
 
 	It("should verify return of countNotReadOnlyWithOldImage", func() {


### PR DESCRIPTION
This change fixes a bug in the operator's database existence check in version 1.10.1. The operator used to check for the existence of the catalog directory, but this could lead to errors if the create or revive DB commands failed, as the catalog directory would remain even though the database was not created or revived. This change fixes the bug by looking for a specific file in the catalog directory that is only present for fully initialized databases.