### PR TITLE
Add event logging for errors from vclusterops library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230711152101-80cb2a961bd3
+	github.com/vertica/vcluster v0.0.0-20230724115215-b51df4374b30
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -77,3 +77,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/vertica/vcluster => github.com/spilchen/vcluster v0.0.0-20230724135938-2c1151afe15c

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230724115215-b51df4374b30
+	github.com/vertica/vcluster v0.0.0-20230724183939-9aa7b19e151f
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -77,5 +77,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/vertica/vcluster => github.com/spilchen/vcluster v0.0.0-20230724135938-2c1151afe15c

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/vertica/vcluster v0.0.0-20230711152101-80cb2a961bd3 h1:iuNNfWnaImdZq+hqXf5bl4wyorsKtP1ACk0x0/e3qKA=
 github.com/vertica/vcluster v0.0.0-20230711152101-80cb2a961bd3/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
+github.com/vertica/vcluster v0.0.0-20230724183939-9aa7b19e151f h1:ZTgYmKnaEEVFKvC50Ciu4WVNDjmHRUtzj548z9+8SvA=
+github.com/vertica/vcluster v0.0.0-20230724183939-9aa7b19e151f/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -105,6 +107,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -165,6 +168,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -266,6 +270,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spilchen/vcluster v0.0.0-20230724135938-2c1151afe15c h1:nh9jNW4ThlW6hl5xaP+JtFP4kLOwgTViT1qBwWenjPI=
+github.com/spilchen/vcluster v0.0.0-20230724135938-2c1151afe15c/go.mod h1:zAO9nH73iAc40oZI+jd3sEZ3FRkrMLHWCvB0TIA4EHo=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/aterrors/aterrors.go
+++ b/pkg/aterrors/aterrors.go
@@ -66,8 +66,8 @@ func (a *ATErrors) LogFailure(cmd, op string, err error) (ctrl.Result, error) {
 		return ctrl.Result{Requeue: false, RequeueAfter: time.Second * RestartNodesNotDownRequeueWaitTimeInSeconds}, nil
 
 	case cloud.IsEndpointBadError(op):
-		a.Writer.Eventf(a.VDB, corev1.EventTypeWarning, events.S3EndpointIssue,
-			"Unable to write to the bucket in the S3 endpoint '%s'", a.VDB.Spec.Communal.Endpoint)
+		a.Writer.Eventf(a.VDB, corev1.EventTypeWarning, events.CommunalEndpointIssue,
+			"Unable to write to the communal endpoint '%s'", a.VDB.Spec.Communal.Endpoint)
 		return ctrl.Result{Requeue: true}, nil
 
 	case cloud.IsBucketNotExistError(op):

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -284,7 +284,7 @@ func (r *VerticaDBReconciler) checkShardToNodeRatio(vdb *vapi.VerticaDB, sc *vap
 func (r *VerticaDBReconciler) makeDispatcher(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner,
 	passwd string) vadmin.Dispatcher {
 	if vmeta.UseVClusterOps(vdb.Annotations) {
-		return vadmin.MakeVClusterOps(log, vdb, r.Client, &vops.VClusterCommands{}, passwd)
+		return vadmin.MakeVClusterOps(log, vdb, r.Client, &vops.VClusterCommands{}, passwd, r.EVRec)
 	}
 	return vadmin.MakeAdmintools(log, vdb, prunner, r.EVRec, r.OpCfg.DevMode)
 }

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -34,7 +34,7 @@ const (
 	ReviveOrderBad                  = "ReviveOrderBad"
 	ObjectNotFound                  = "ObjectNotFound"
 	CommunalCredsWrongKey           = "CommunalCredsWrongKey" //nolint:gosec
-	CommunalEndpointIssue           = "S3EndpointIssue"
+	CommunalEndpointIssue           = "CommunalEndpointIssue"
 	S3BucketDoesNotExist            = "S3BucketDoesNotExist"
 	S3WrongRegion                   = "S3WrongRegion"
 	S3SseCustomerWrongKey           = "S3SseCustomerWrongKey"

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -34,7 +34,7 @@ const (
 	ReviveOrderBad                  = "ReviveOrderBad"
 	ObjectNotFound                  = "ObjectNotFound"
 	CommunalCredsWrongKey           = "CommunalCredsWrongKey" //nolint:gosec
-	S3EndpointIssue                 = "S3EndpointIssue"
+	CommunalEndpointIssue           = "S3EndpointIssue"
 	S3BucketDoesNotExist            = "S3BucketDoesNotExist"
 	S3WrongRegion                   = "S3WrongRegion"
 	S3SseCustomerWrongKey           = "S3SseCustomerWrongKey"

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -22,6 +22,7 @@ import (
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,8 +46,7 @@ func (v *VClusterOps) CreateDB(ctx context.Context, opts ...createdb.Option) (ct
 	vopts := v.genCreateDBOptions(&s, certs)
 	vdb, err := v.VCreateDatabase(&vopts)
 	if err != nil {
-		v.Log.Error(err, "failed to create a database")
-		return ctrl.Result{}, err
+		return v.logFailure("VCreateDatabase", events.CreateDBFailed, err)
 	}
 
 	v.Log.Info("Successfully created a database", "dbName", vdb.Name)

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -122,16 +122,18 @@ type VClusterOps struct {
 	Client client.Client
 	VClusterProvider
 	Password string
+	EVWriter events.EVWriter
 }
 
 // MakeVClusterOps will create a dispatcher that uses the vclusterops library for admin commands.
-func MakeVClusterOps(log logr.Logger, vdb *vapi.VerticaDB, cli client.Client, vopsi VClusterProvider, passwd string) Dispatcher {
+func MakeVClusterOps(log logr.Logger, vdb *vapi.VerticaDB, cli client.Client, vopsi VClusterProvider, passwd string, evWriter events.EVWriter) Dispatcher {
 	return &VClusterOps{
 		Log:              log,
 		VDB:              vdb,
 		Client:           cli,
 		VClusterProvider: vopsi,
 		Password:         passwd,
+		EVWriter:         evWriter,
 	}
 }
 

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -126,7 +126,8 @@ type VClusterOps struct {
 }
 
 // MakeVClusterOps will create a dispatcher that uses the vclusterops library for admin commands.
-func MakeVClusterOps(log logr.Logger, vdb *vapi.VerticaDB, cli client.Client, vopsi VClusterProvider, passwd string, evWriter events.EVWriter) Dispatcher {
+func MakeVClusterOps(log logr.Logger, vdb *vapi.VerticaDB, cli client.Client, vopsi VClusterProvider,
+	passwd string, evWriter events.EVWriter) Dispatcher {
 	return &VClusterOps{
 		Log:              log,
 		VDB:              vdb,

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -141,7 +141,8 @@ func (m *MockVClusterOps) VerifyInitiatorIPAndEonMode(options *vops.DatabaseOpti
 func mockVClusterOpsDispatcher() *VClusterOps {
 	vdb := vapi.MakeVDBForHTTP("test-secret")
 	mockVops := MockVClusterOps{}
-	dispatcher := MakeVClusterOps(logger, vdb, k8sClient, &mockVops, TestPassword)
+	evWriter := aterrors.TestEVWriter{}
+	dispatcher := MakeVClusterOps(logger, vdb, k8sClient, &mockVops, TestPassword, &evWriter)
 	return dispatcher.(*VClusterOps)
 }
 

--- a/pkg/vadmin/vc.go
+++ b/pkg/vadmin/vc.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // retrieveHTTPSCerts will retrieve the certs from HTTPServerTLSSecret for calling NMA endpoints
@@ -54,4 +55,15 @@ func (v *VClusterOps) retrieveHTTPSCerts(ctx context.Context) (*HTTPSCerts, erro
 	certs.CaCert = string(tlsCaCrt)
 
 	return &certs, nil
+}
+
+// logFailure will log and record an event for a vclusterOps API failure
+func (v *VClusterOps) logFailure(cmd, genericFailureReason string, err error) (ctrl.Result, error) {
+	evLogr := vcErrors{
+		VDB:                  v.VDB,
+		Log:                  v.Log,
+		GenericFailureReason: genericFailureReason,
+		EVWriter:             v.EVWriter,
+	}
+	return evLogr.LogFailure(cmd, err)
 }

--- a/pkg/vadmin/vc_errors.go
+++ b/pkg/vadmin/vc_errors.go
@@ -1,0 +1,69 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/vertica/vcluster/rfc7807"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/events"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type vcErrors struct {
+	VDB                  *vapi.VerticaDB
+	Log                  logr.Logger
+	GenericFailureReason string
+	EVWriter             events.EVWriter
+}
+
+// rfc7807TypeToEventMap is a mapping from known rfc7807 errors to the event
+// reason type. Some errors are intentionally omitted. These will use the
+// generic failure reason that is setup for the command.
+var rfc7807TypeToEventMap = map[string]string{
+	// rfc7807.GenericBootstrapCatalogFailure.Type left out
+	rfc7807.CommunalStorageNotEmpty.Type: events.CommunalPathIsNotEmpty,
+	// rfc7807.CommunalStoragePathInvalid.Type left out
+	rfc7807.CommunalRWAccessError.Type: events.CommunalEndpointIssue,
+	rfc7807.CommunalAccessError.Type:   events.CommunalEndpointIssue,
+}
+
+func (v *vcErrors) LogFailure(cmd string, err error) (ctrl.Result, error) {
+	vproblem := &rfc7807.VProblem{}
+	if ok := errors.As(err, &vproblem); !ok {
+		// Unable to know exactly what the error is. Just return as-is and don't
+		// do any k8s event logging
+		v.Log.Error(err, "vclusterOps command failed", "cmd", cmd)
+		return ctrl.Result{}, err
+	}
+	v.Log.Error(err, "vclusterOps command failed", "cmd", cmd,
+		"type", vproblem.Type, "title", vproblem.Title, "detail", vproblem.Detail,
+		"host", vproblem.Host, "status", vproblem.Status)
+	reason, ok := rfc7807TypeToEventMap[vproblem.Type]
+	if !ok {
+		reason = v.GenericFailureReason
+	}
+	v.EVWriter.Eventf(v.VDB, corev1.EventTypeWarning, reason, vproblem.Title)
+	if !ok {
+		return ctrl.Result{}, fmt.Errorf("failed command %s: %w", cmd, err)
+	}
+	// All known errors we return with requeue set to true.
+	return ctrl.Result{Requeue: true}, nil
+}

--- a/pkg/vadmin/vc_errors_test.go
+++ b/pkg/vadmin/vc_errors_test.go
@@ -1,0 +1,68 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vertica/vcluster/rfc7807"
+	"github.com/vertica/vertica-kubernetes/pkg/aterrors"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("verrors suite", func() {
+	It("should handle case where non-rfc7807 is passed in", func() {
+		vce := vcErrors{
+			Log: logger,
+		}
+		origErr := errors.New("generic error")
+		res, err := vce.LogFailure("test non-rfc7807", origErr)
+		Ω(res).Should(Equal(ctrl.Result{}))
+		Ω(err).Should(Equal(origErr))
+	})
+
+	It("should handle known rfc7807 error", func() {
+		vce := vcErrors{
+			Log:      logger,
+			EVWriter: &aterrors.TestEVWriter{},
+		}
+		origErr := rfc7807.New(rfc7807.CommunalStorageNotEmpty).
+			WithDetail("existing db already at /host").
+			WithStatus(500).
+			WithHost("pod-4")
+		wrappedErr := errors.Join(origErr, errors.New("we hit an error"))
+		res, err := vce.LogFailure("test rfc7807", wrappedErr)
+		Ω(res).Should(Equal(ctrl.Result{Requeue: true}))
+		Ω(err).Should(BeNil())
+	})
+
+	It("should handle unknown rfc7807 errors", func() {
+		vce := vcErrors{
+			Log:      logger,
+			EVWriter: &aterrors.TestEVWriter{},
+		}
+		origErr := rfc7807.New(rfc7807.GenericBootstrapCatalogFailure).
+			WithDetail("internal error occurred").
+			WithStatus(500).
+			WithHost("pod-5")
+		res, err := vce.LogFailure("test unknown rfc7807", origErr)
+		Ω(res).Should(Equal(ctrl.Result{}))
+		Ω(err).Should(Equal(err))
+	})
+
+})


### PR DESCRIPTION
This is a continuation of the vclusterOps integration. The vclusterops library can now flow errors that follow the [RFC 7807 spec](https://datatracker.ietf.org/doc/html/rfc7807). This allows the operator to know about specific error without having to resort to regex based searching. 

We only handle some of the more popular create db failures for now. But this work here will allow us to easily add support for additional types that flow from the vclusterops library.

For instance, if you create a VerticaDB with vclusterops enabled, and the communal storage path given is not empty, we will now see a message like this:
```
Events:
  Type     Reason                  Age                   From                Message
  ----     ------                  ----                  ----                -------
  Normal   CreateDBStart           4m19s (x40 over 14m)  verticadb-operator  Starting create database
  Warning  CommunalPathIsNotEmpty  9m14s (x20 over 14m)  verticadb-operator  Communal storage is not empty
```