### PR TITLE
CSV updates to improve VerticaDB web ui creation

### DIFF
--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -44,7 +44,7 @@ type VerticaDBSpec struct {
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// ImagePullSecrets is an optional list of references to secrets in the same
 	// namespace to use for pulling the image. If specified, these secrets will
 	// be passed to individual puller implementations for them to use. For
@@ -201,7 +201,7 @@ type VerticaDBSpec struct {
 	Subclusters []Subcluster `json:"subclusters"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	// When doing an online upgrade, we designate a subcluster to
 	// accept traffic while the other subclusters restart.  The designated
 	// subcluster is specified here.  The name of the subcluster can refer to an
@@ -267,7 +267,7 @@ type VerticaDBSpec struct {
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	// Secrets that will be mounted in the vertica container.  The purpose of
 	// this is to allow custom certs to be available.  The full path is:
 	//   /certs/<secretName>/<key_i>
@@ -556,7 +556,7 @@ type CommunalStorage struct {
 	Region string `json:"region,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:io.kubernetes:ConfigMap"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:ConfigMap","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	// A config map that contains the contents of the /etc/hadoop directory.
 	// This gets mounted in the container and is used to configure connections
 	// to an HDFS communal path
@@ -736,13 +736,13 @@ type Subcluster struct {
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 	Affinity Affinity `json:"affinity,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	// The priority class name given to pods in this subcluster. This affects
 	// where the pod gets scheduled.
 	// More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	// Any tolerations and taints to use to aid in where to schedule a pod.
 	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
@@ -778,7 +778,7 @@ type Subcluster struct {
 	ServiceName string `json:"serviceName,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	// When setting serviceType to NodePort, this parameter allows you to define the
 	// port that is opened at each node for Vertica client connections. If using
 	// NodePort and this is omitted, Kubernetes will choose the port
@@ -795,14 +795,14 @@ type Subcluster struct {
 	VerticaHTTPNodePort int32 `json:"verticaHTTPNodePort,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	// Allows the service object to be attached to a list of external IPs that you
 	// specify. If not set, the external IP list is left empty in the service object.
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
 	ExternalIPs []string `json:"externalIPs,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	// Specify IP address of LoadBalancer service for this subcluster.
 	// This field is ignored when serviceType != "LoadBalancer".
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer

--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -198,6 +198,8 @@ spec:
           the service object. More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips'
         displayName: External IPs
         path: template.externalIPs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: This allows a different image to be used for the subcluster than
           the one in VerticaDB.  This is intended to be used internally by the online
           image change process.
@@ -222,6 +224,8 @@ spec:
           This field is ignored when serviceType != "LoadBalancer". More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer'
         displayName: Load Balancer IP
         path: template.loadBalancerIP
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The name of the subcluster. This is a required parameter. This
           cannot change after CRD creation.
         displayName: Name
@@ -235,6 +239,7 @@ spec:
         path: template.nodePort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'A map of label keys and values to restrict Vertica node scheduling
           to workers with matching labels. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector'
         displayName: Node Selector
@@ -243,6 +248,8 @@ spec:
           affects where the pod gets scheduled. More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass'
         displayName: Priority Class Name
         path: template.priorityClassName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'This defines the resource requests and limits for pods in the
           subcluster. It is advisable that the request and limits match as this ensures
           the pods are assigned to the guaranteed QoS class. This will reduces the
@@ -292,6 +299,8 @@ spec:
           a pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
         displayName: Tolerations
         path: template.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'Like the nodePort parameter, except this controls the node port
           to use for the http endpoint in the Vertica server.  The same rules apply:
           it must be defined within the range allocated by the control plane, if omitted
@@ -367,6 +376,8 @@ spec:
           in the secret and <key_i> is one of the keys in the secret.'
         displayName: Cert Secrets
         path: certSecrets
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         displayName: Name
         path: certSecrets[0].name
@@ -422,6 +433,7 @@ spec:
         path: communal.hadoopConfig
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:ConfigMap
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: If true, the operator will include the VerticaDB's UID in the
           path.  This option exists if you reuse the communal path in the same endpoint
           as it forces each database path to be unique.
@@ -544,8 +556,6 @@ spec:
           are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
         displayName: Image Pull Secrets
         path: imagePullSecrets
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
         displayName: Name
         path: imagePullSecrets[0].name
@@ -779,6 +789,8 @@ spec:
           the service object. More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips'
         displayName: External IPs
         path: subclusters[0].externalIPs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: This allows a different image to be used for the subcluster than
           the one in VerticaDB.  This is intended to be used internally by the online
           image change process.
@@ -803,6 +815,8 @@ spec:
           This field is ignored when serviceType != "LoadBalancer". More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer'
         displayName: Load Balancer IP
         path: subclusters[0].loadBalancerIP
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The name of the subcluster. This is a required parameter. This
           cannot change after CRD creation.
         displayName: Name
@@ -816,6 +830,7 @@ spec:
         path: subclusters[0].nodePort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'A map of label keys and values to restrict Vertica node scheduling
           to workers with matching labels. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector'
         displayName: Node Selector
@@ -824,6 +839,8 @@ spec:
           affects where the pod gets scheduled. More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass'
         displayName: Priority Class Name
         path: subclusters[0].priorityClassName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'This defines the resource requests and limits for pods in the
           subcluster. It is advisable that the request and limits match as this ensures
           the pods are assigned to the guaranteed QoS class. This will reduces the
@@ -873,6 +890,8 @@ spec:
           a pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
         displayName: Tolerations
         path: subclusters[0].tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'Like the nodePort parameter, except this controls the node port
           to use for the http endpoint in the Vertica server.  The same rules apply:
           it must be defined within the range allocated by the control plane, if omitted
@@ -898,6 +917,8 @@ spec:
           operator will default to picking existing subclusters.
         displayName: Temporary Subcluster Routing
         path: temporarySubclusterRouting
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Names of existing subclusters to use for temporary routing of
           client connections.  The operator will use the first subcluster that is
           online.
@@ -936,6 +957,8 @@ spec:
           the service object. More info: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips'
         displayName: External IPs
         path: temporarySubclusterRouting.template.externalIPs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: This allows a different image to be used for the subcluster than
           the one in VerticaDB.  This is intended to be used internally by the online
           image change process.
@@ -960,6 +983,8 @@ spec:
           This field is ignored when serviceType != "LoadBalancer". More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer'
         displayName: Load Balancer IP
         path: temporarySubclusterRouting.template.loadBalancerIP
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: The name of the subcluster. This is a required parameter. This
           cannot change after CRD creation.
         displayName: Name
@@ -973,6 +998,7 @@ spec:
         path: temporarySubclusterRouting.template.nodePort
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'A map of label keys and values to restrict Vertica node scheduling
           to workers with matching labels. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector'
         displayName: Node Selector
@@ -981,6 +1007,8 @@ spec:
           affects where the pod gets scheduled. More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass'
         displayName: Priority Class Name
         path: temporarySubclusterRouting.template.priorityClassName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'This defines the resource requests and limits for pods in the
           subcluster. It is advisable that the request and limits match as this ensures
           the pods are assigned to the guaranteed QoS class. This will reduces the
@@ -1030,6 +1058,8 @@ spec:
           a pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
         displayName: Tolerations
         path: temporarySubclusterRouting.template.tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: 'Like the nodePort parameter, except this controls the node port
           to use for the http endpoint in the Vertica server.  The same rules apply:
           it must be defined within the range allocated by the control plane, if omitted

--- a/config/samples/v1beta1_verticadb.yaml
+++ b/config/samples/v1beta1_verticadb.yaml
@@ -16,19 +16,10 @@ kind: VerticaDB
 metadata:
   name: verticadb-sample
 spec:
-  image: "vertica/vertica-k8s:latest"
+  image: "vertica/vertica-k8s:23.3.0-0-minimal"
   communal:
-    path: "s3://nimbusdb/db"
-    endpoint: "http://minio"
-    credentialSecret: s3-auth
-    includeUIDInPath: true
+    # path: "s3://<your-bucket>/"
+    endpoint: https://s3.amazonaws.com
   subclusters:
-    - name: defaultsubcluster
+    - name: default_subcluster
       size: 3
-      # The CPU resource setting is here is a sample.  We set it so that this
-      # will work with the sample VerticaAutoscaler resource.  The actual amount
-      # should be sized according to:
-      # https://www.vertica.com/kb/Recommendations-for-Sizing-Vertica-Nodes-and-Clusters/Content/Hardware/Recommendations-for-Sizing-Vertica-Nodes-and-Clusters.htm
-      resources:
-        requests:
-          cpu: 500m

--- a/config/samples/verticadb_sample.yaml
+++ b/config/samples/verticadb_sample.yaml
@@ -1,0 +1,34 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: verticadb-sample
+spec:
+  image: "vertica/vertica-k8s:latest"
+  communal:
+    path: "s3://nimbusdb/db"
+    endpoint: "http://minio"
+    credentialSecret: s3-auth
+    includeUIDInPath: true
+  subclusters:
+    - name: defaultsubcluster
+      size: 3
+      # The CPU resource setting is here is a sample.  We set it so that this
+      # will work with the sample VerticaAutoscaler resource.  The actual amount
+      # should be sized according to:
+      # https://www.vertica.com/kb/Recommendations-for-Sizing-Vertica-Nodes-and-Clusters/Content/Hardware/Recommendations-for-Sizing-Vertica-Nodes-and-Clusters.htm
+      resources:
+        requests:
+          cpu: 500m

--- a/scripts/setup-olm.sh
+++ b/scripts/setup-olm.sh
@@ -95,8 +95,9 @@ else
     kubectl apply -f $CUSTOM_SCC_DIR/custom-scc.yaml
 fi
 
+kubectl delete catalogsource $CATALOG_SOURCE_NAME -n $OLM_NS || true
 # Create a catalog source using the catalog we build with 'docker-build-olm-catalog'
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl create -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:


### PR DESCRIPTION
In OpenShift, you can create an instance of a VerticaDB using the web UI. It builds the input based on annotations supplied for the various fields in the CR. This updates those annotations to improve the UI for an upcoming demo. Changes to v1beta1_verticadb.yaml were done because the OpenShift web UI uses that to see default values.