### PR TITLE
Log successful add nodes in the event log

### DIFF
--- a/pkg/controllers/vdb/dbaddnode_reconciler.go
+++ b/pkg/controllers/vdb/dbaddnode_reconciler.go
@@ -191,8 +191,9 @@ func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pods []*PodF
 	}
 	err := d.Dispatcher.AddNode(ctx, opts...)
 	if err != nil {
-		d.VRec.Eventf(d.Vdb, corev1.EventTypeNormal, events.AddNodeSucceeded,
-			"Successfully added database nodes and it took %s", time.Since(start))
+		return err
 	}
-	return err
+	d.VRec.Eventf(d.Vdb, corev1.EventTypeNormal, events.AddNodeSucceeded,
+		"Successfully added database nodes and it took %s", time.Since(start))
+	return nil
 }

--- a/pkg/controllers/vdb/install_reconciler.go
+++ b/pkg/controllers/vdb/install_reconciler.go
@@ -92,8 +92,6 @@ func (d *InstallReconciler) installForVClusterOps(ctx context.Context) (ctrl.Res
 		d.Log.Info("Requeue reconcile cycle because not all nodes have done the install for vclusterOps")
 		return ctrl.Result{Requeue: true}, nil
 	}
-	// Invalidate the pod facts cache since its out of date due to the install
-	d.PFacts.Invalidate()
 	return ctrl.Result{}, nil
 }
 
@@ -224,6 +222,8 @@ func (d *InstallReconciler) generateHTTPCerts(ctx context.Context) (bool, error)
 			if err != nil {
 				return false, errors.Wrap(err, fmt.Sprintf("failed to copy %s to the pod %s", fname, p.name))
 			}
+			// Invalidate the pod facts cache since its out of date due the https generation
+			d.PFacts.Invalidate()
 		}
 		installedPodCount++
 	}


### PR DESCRIPTION
This fixes a small regression in this release. We were not logging an event message when add nodes was successful.

Also, moving the pod facts invalidation for vclusterOps. Where it was before meant that we would always invalidate the pod facts cache, even for the case where the install reconciler does nothing.