### PR TITLE
Obfuscate access credentials in operator log

### DIFF
--- a/pkg/cmds/exec.go
+++ b/pkg/cmds/exec.go
@@ -84,8 +84,8 @@ func generateLogOutput(cmd ...string) string {
 func obfuscateForLog(s string) string {
 	pats := map[string]string{
 		"awsauth = .*":                 "awsauth = ****",
-		"GCSAuth = .*":                 "GCSAuth = ****",
-		"AzureStorageCredentials = .*": "AzureStorageCredentials = ****",
+		"gcsauth = .*":                 "gcsauth = ****",
+		"azurestoragecredentials = .*": "azurestoragecredentials = ****",
 	}
 	for expr, replacement := range pats {
 		r := regexp.MustCompile(expr)

--- a/pkg/cmds/exec_test.go
+++ b/pkg/cmds/exec_test.go
@@ -35,14 +35,14 @@ awsendpoint = minio`)
 
 	It("should obfuscate gcs credentials", func() {
 		s := generateLogOutput(`cat > auth_parms.conf<<< '
-GCSAuth = user:pass
+gcsauth = user:pass
 GCSEndpoint = google`)
-		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\nGCSAuth = ****\nGCSEndpoint = google "))
+		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\ngcsauth = ****\nGCSEndpoint = google "))
 	})
 
 	It("should obfuscate azure credentials", func() {
 		s := generateLogOutput(`cat > auth_parms.conf<<< '
-AzureStorageCredentials = {"elem1": "a", "elem2": "b"}`)
-		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\nAzureStorageCredentials = **** "))
+azurestoragecredentials = {"elem1": "a", "elem2": "b"}`)
+		Expect(s).Should(Equal("cat > auth_parms.conf<<< '\nazurestoragecredentials = **** "))
 	})
 })


### PR DESCRIPTION
We have code that obfuscates access credentials before logging them in the operator pod. This is looking for key/value pairs that we setup for create or revive. The keys that we were searching for was recently changed to be all lowercase. This caused the obfuscation code to not find/replace the access key. Updating this to account for that key change.

The prior release of the operator (1.11.1) did proper obfuscation. This is a fix only for a regression in the current release.