### PR TITLE
Improve status retention in the status reconciler

### DIFF
--- a/pkg/controllers/vdb/status_reconciler.go
+++ b/pkg/controllers/vdb/status_reconciler.go
@@ -68,10 +68,13 @@ func (s *StatusReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ct
 			if i == len(vdbChg.Status.Subclusters) {
 				vdbChg.Status.Subclusters = append(vdbChg.Status.Subclusters, vapi.SubclusterStatus{})
 			}
-			// Preserve the oid in case all of the subclusters pods are down
 			if i < len(s.Vdb.Status.Subclusters) {
-				vdbChg.Status.Subclusters[i].Oid = s.Vdb.Status.Subclusters[i].Oid
+				// Preserve as much state as we can from the prior version. This
+				// is necessary so we don't lose state in case all of the
+				// subcluster pods are down
+				vdbChg.Status.Subclusters[i] = s.Vdb.Status.Subclusters[i]
 			}
+
 			if err := s.calculateSubclusterStatus(ctx, subclusters[i], &vdbChg.Status.Subclusters[i]); err != nil {
 				return fmt.Errorf("failed to calculate subcluster status %s %w", subclusters[i].Name, err)
 			}


### PR DESCRIPTION
This improves the status reconciler so that it doesn't lose state in the VerticaDB's status fields. I saw a case where we were losing the vnode information -- happened while working on the vclusterops integration and was due to another integration bug. But I thought it would be good to improve the resiliency of this reconciler to handle those edge cases.