### PR TITLE
Update base image for vlogger

### DIFF
--- a/changes/unreleased/Changed-20230728-090741.yaml
+++ b/changes/unreleased/Changed-20230728-090741.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Update base image for vlogger
+time: 2023-07-28T09:07:41.750787603-03:00
+custom:
+  Issue: "470"

--- a/docker-vlogger/Dockerfile
+++ b/docker-vlogger/Dockerfile
@@ -14,7 +14,7 @@
 # A docker container that will tail the vertica.log.  This allows vertica to
 # follow the idiomatic way in Kubernetes of logging to stdout.
 
-FROM alpine:3.15
+FROM alpine:3.18
 
 # Tini - A tiny but valid init for containers
 RUN apk add --no-cache tini


### PR DESCRIPTION
This upgrades the base image of the vertica logger image to address security vulnerabilities. We are moving from alpine 3.15 to 3.18.