### PR TITLE
Run reip/startdb with consistent node order

### DIFF
--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler.go
@@ -75,7 +75,7 @@ func (d *DBAddSubclusterReconciler) Reconcile(ctx context.Context, req *ctrl.Req
 
 // addMissingSubclusters will compare subclusters passed in and create any missing ones
 func (d *DBAddSubclusterReconciler) addMissingSubclusters(ctx context.Context, scs []vapi.Subcluster) (ctrl.Result, error) {
-	atPod, ok := d.PFacts.findPodToRunAdmintoolsAny()
+	atPod, ok := d.PFacts.findPodToRunAdminCmdAny()
 	if !ok || !atPod.upNode {
 		d.Log.Info("No pod found to run admintools from. Requeue reconciliation.")
 		return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/vdb/dbremovenode_reconciler.go
+++ b/pkg/controllers/vdb/dbremovenode_reconciler.go
@@ -114,7 +114,7 @@ func (d *DBRemoveNodeReconciler) removeNodesInSubcluster(ctx context.Context, sc
 	startPodIndex, endPodIndex int32) (ctrl.Result, error) {
 	podsToRemove, requeueNeeded := d.findPodsSuitableForScaleDown(sc, startPodIndex, endPodIndex)
 	if len(podsToRemove) > 0 {
-		initiatorPod, ok := d.PFacts.findPodToRunAdmintoolsAny()
+		initiatorPod, ok := d.PFacts.findPodToRunAdminCmdAny()
 		if !ok {
 			// Requeue since we couldn't find a running pod
 			d.Log.Info("Requeue since we could not find a pod to run admintools")

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
@@ -84,7 +84,7 @@ func (d *DBRemoveSubclusterReconciler) removeExtraSubclusters(ctx context.Contex
 	}
 
 	if len(subclusters) > 0 {
-		atPod, ok := d.PFacts.findPodToRunAdmintoolsAny()
+		atPod, ok := d.PFacts.findPodToRunAdminCmdAny()
 		if !ok || !atPod.upNode {
 			d.Log.Info("No pod found to run admintools from. Requeue reconciliation.")
 			return ctrl.Result{Requeue: true}, nil

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -845,10 +845,10 @@ func (p *PodFacts) findPodToRunVsql(allowReadOnly bool, scName string) (*PodFact
 	return &PodFact{}, false
 }
 
-// findPodToRunAdmintoolsAny returns the name of the pod we will exec into into
+// findPodToRunAdminCmdAny returns the name of the pod we will exec into into
 // order to run admintools.
 // Will return false for second parameter if no pod could be found.
-func (p *PodFacts) findPodToRunAdmintoolsAny() (*PodFact, bool) {
+func (p *PodFacts) findPodToRunAdminCmdAny() (*PodFact, bool) {
 	// Our preference for the pod is as follows:
 	// - up, not read-only and not pending delete
 	// - up and not read-only
@@ -874,9 +874,9 @@ func (p *PodFacts) findPodToRunAdmintoolsAny() (*PodFact, bool) {
 	})
 }
 
-// findPodToRunAdmintoolsOffline will return a pod to run an offline admintools
+// findPodToRunAdminCmdOffline will return a pod to run an offline admintools
 // command.  If nothing is found, the second parameter returned will be false.
-func (p *PodFacts) findPodToRunAdmintoolsOffline() (*PodFact, bool) {
+func (p *PodFacts) findPodToRunAdminCmdOffline() (*PodFact, bool) {
 	for _, v := range p.Detail {
 		if v.isInstalled && v.isPodRunning && !v.upNode {
 			return v, true
@@ -952,6 +952,11 @@ func (p *PodFacts) filterPods(filterFunc func(p *PodFact) bool) []*PodFact {
 			pods = append(pods, v)
 		}
 	}
+	// Return a slice sorted by the vnode name. This will allow for easier
+	// debugging because the pod list will be deterministic.
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].vnodeName < pods[j].vnodeName
+	})
 	return pods
 }
 

--- a/pkg/controllers/vdb/revivedb_reconciler.go
+++ b/pkg/controllers/vdb/revivedb_reconciler.go
@@ -204,7 +204,7 @@ func (r *ReviveDBReconciler) getPodList() ([]*PodFact, bool) {
 // findPodToRunInit will return a PodFact of the pod that should run the init
 // command from
 func (r *ReviveDBReconciler) findPodToRunInit() (*PodFact, bool) {
-	return r.PFacts.findPodToRunAdmintoolsOffline()
+	return r.PFacts.findPodToRunAdminCmdOffline()
 }
 
 // genReviveOpts will return the options to use with the revive command

--- a/pkg/controllers/vdb/stopdb_reconciler.go
+++ b/pkg/controllers/vdb/stopdb_reconciler.go
@@ -90,7 +90,7 @@ func (s *StopDBReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ct
 
 // stopVertica will stop vertica on all of the running pods
 func (s *StopDBReconciler) stopVertica(ctx context.Context) error {
-	pf, ok := s.PFacts.findPodToRunAdmintoolsAny()
+	pf, ok := s.PFacts.findPodToRunAdminCmdAny()
 	if !ok {
 		// If no running pod found, then there is nothing to stop and we can just continue on
 		return nil


### PR DESCRIPTION
The node list that we pass to reip and start will now be in vnode sorted order. Having a deterministic order for the pods will improve debugging. Also, its temporarily needed for vclusterops integration as that library has a strict requriement on the nodes being in vnode order. This will be dropped later, but I think this improvement can stand on its own just for the improvement to debugging.

This also includes some refactor to cleanup references to admintools in the main vdb package since now the backend could be admintools or vclusterops.