### PR TITLE
Fix e2e server upgrade test

### DIFF
--- a/tests/e2e-server-upgrade/online-upgrade-block-downgrade/20-initiate-upgrade.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-block-downgrade/20-initiate-upgrade.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade vertica/vertica-k8s:11.0.1-0-minimal # This must be an older image than what all the other tests are using
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade vertica/vertica-k8s:11.1.1-0-minimal # This must be an older image than what all the other tests are using


### PR DESCRIPTION
We have to pick a slightly newer image for the online-upgrade-block-downgrade test. Going back to an image that is too old will fail to start due to permission problems required in the docker entry point. This is only a problem with the nightly test that run with the latest server code.