### PR TITLE
Allow use of GSM for superuser password secret

### DIFF
--- a/changes/unreleased/Added-20230731-202319.yaml
+++ b/changes/unreleased/Added-20230731-202319.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Allow use of GSM for superuser password secret
+time: 2023-07-31T20:23:19.559653595-03:00
+custom:
+  Issue: "474"

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/meta"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	v1 "k8s.io/api/core/v1"
@@ -226,10 +225,10 @@ var _ = Describe("builder", func() {
 
 	It("should not use canary query probe if using GSM", func() {
 		vdb := vapi.MakeVDB()
-		vdb.Spec.SuperuserPasswordSecret = "some-secret"
+		vdb.Spec.SuperuserPasswordSecret = "project/team/dbadmin/secret/1"
 		vdb.Spec.Communal.Path = "gs://vertica-fleeting/mydb"
 		vdb.Annotations = map[string]string{
-			meta.GcpGsmAnnotation: "true",
+			vmeta.GcpGsmAnnotation: "true",
 		}
 		c := buildPodSpec(vdb, &vdb.Spec.Subclusters[0], &DeploymentNames{})
 		Expect(isPasswdIncludedInPodInfo(vdb, &c)).Should(BeFalse())

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -1,0 +1,56 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+
+	gsm "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+)
+
+// ReadFromGSM will fetch a secret from Google Secret Manager (GSM)
+func ReadFromGSM(ctx context.Context, secName string) (map[string]string, error) {
+	clnt, err := gsm.NewClient(ctx)
+	if err != nil {
+		return make(map[string]string), fmt.Errorf("failed to create secretmanager client")
+	}
+	defer clnt.Close()
+
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: secName,
+	}
+
+	result, err := clnt.AccessSecretVersion(ctx, req)
+	if err != nil {
+		return make(map[string]string), fmt.Errorf("could not fetch secret: %w", err)
+	}
+
+	crc32c := crc32.MakeTable(crc32.Castagnoli)
+	checksum := int64(crc32.Checksum(result.Payload.Data, crc32c))
+	if checksum != *result.Payload.DataCrc32C {
+		return make(map[string]string), fmt.Errorf("data corruption detected")
+	}
+	contents := make(map[string]string)
+	err = json.Unmarshal(result.Payload.Data, &contents)
+	if err != nil {
+		return make(map[string]string), err
+	}
+	return contents, nil
+}

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -271,43 +271,45 @@ func (g *GenericDatabaseInitializer) setKerberosAuthParms() {
 }
 
 // setAuthFromGCSSecret sets the config parms map when we are the secrets are configured in GSM
-func (g *GenericDatabaseInitializer) setAuthFromGCSSecret(ctx context.Context) (string, ctrl.Result, error) {
-	GcpCred, err := g.VRec.GetDetailsFromGSM(ctx, g.Vdb.Spec.Communal.CredentialSecret, g.Log)
-	var auth string
-	if len(GcpCred) == 0 || err != nil {
-		return "", ctrl.Result{}, err
-	} else {
-		// Pull the keys from the secret. Note, this code is largely duplicated from
-		// getCommunalAuth but had to be duplicated because we couldn't make the
-		// secret here the same datatype.
-		accessKey, ok := GcpCred[cloud.CommunalAccessKeyName]
-		if !ok {
-			g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
-				"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalAccessKeyName)
-			return "", ctrl.Result{Requeue: true}, nil
-		}
-
-		secretKey, ok := GcpCred[cloud.CommunalSecretKeyName]
-		if !ok {
-			g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
-				"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalSecretKeyName)
-			return "", ctrl.Result{Requeue: true}, nil
-		}
-
-		auth = fmt.Sprintf("%s:%s", strings.TrimSuffix(accessKey, "\n"), strings.TrimSuffix(secretKey, "\n"))
+func (g *GenericDatabaseInitializer) setAuthFromGCSSecret(ctx context.Context) (ctrl.Result, error) {
+	if g.Vdb.Spec.Communal.CredentialSecret == "" {
+		return ctrl.Result{}, nil
 	}
-	return auth, ctrl.Result{}, nil
+
+	gcpCred, err := cloud.ReadFromGSM(ctx, g.Vdb.Spec.Communal.CredentialSecret)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// Pull the keys from the secret. Note, this code is largely duplicated from
+	// getCommunalAuth but had to be duplicated because we couldn't make the
+	// secret here the same datatype.
+	accessKey, ok := gcpCred[cloud.CommunalAccessKeyName]
+	if !ok {
+		g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
+			"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalAccessKeyName)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	secretKey, ok := gcpCred[cloud.CommunalSecretKeyName]
+	if !ok {
+		g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
+			"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalSecretKeyName)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	auth := fmt.Sprintf("%s:%s", strings.TrimSuffix(accessKey, "\n"), strings.TrimSuffix(secretKey, "\n"))
+	g.ConfigurationParams.Set("GCSAuth", auth)
+	return ctrl.Result{}, nil
 }
 
 // setGCloudAuthParms adds the auth parms to the config parms map when we are
 // connecting to google cloud storage.
 func (g *GenericDatabaseInitializer) setGCloudAuthParms(ctx context.Context) (ctrl.Result, error) {
 	if meta.UseGCPSecretManager(g.Vdb.Annotations) {
-		auth, res, err := g.setAuthFromGCSSecret(ctx)
+		res, err := g.setAuthFromGCSSecret(ctx)
 		if verrors.IsReconcileAborted(res, err) {
 			return res, err
 		}
-		g.ConfigurationParams.Set("GCSAuth", auth)
 	} else {
 		res, err := g.setAuth(ctx, "GCSAuth")
 		if verrors.IsReconcileAborted(res, err) {

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -17,14 +17,10 @@ package vdb
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"hash/crc32"
 	"regexp"
 	"strings"
 
-	gsm "cloud.google.com/go/secretmanager/apiv1"
-	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cloud"
@@ -276,52 +272,30 @@ func (g *GenericDatabaseInitializer) setKerberosAuthParms() {
 
 // setAuthFromGCSSecret sets the config parms map when we are the secrets are configured in GSM
 func (g *GenericDatabaseInitializer) setAuthFromGCSSecret(ctx context.Context) (string, ctrl.Result, error) {
-	client, err := gsm.NewClient(ctx)
-	if err != nil {
+	GcpCred, err := g.VRec.GetDetailsFromGSM(ctx, g.Vdb.Spec.Communal.CredentialSecret, g.Log)
+	var auth string
+	if len(GcpCred) == 0 || err != nil {
 		return "", ctrl.Result{}, err
-	}
-	defer client.Close()
+	} else {
+		// Pull the keys from the secret. Note, this code is largely duplicated from
+		// getCommunalAuth but had to be duplicated because we couldn't make the
+		// secret here the same datatype.
+		accessKey, ok := GcpCred[cloud.CommunalAccessKeyName]
+		if !ok {
+			g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
+				"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalAccessKeyName)
+			return "", ctrl.Result{Requeue: true}, nil
+		}
 
-	req := &secretmanagerpb.AccessSecretVersionRequest{
-		Name: g.Vdb.Spec.Communal.CredentialSecret,
-	}
+		secretKey, ok := GcpCred[cloud.CommunalSecretKeyName]
+		if !ok {
+			g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
+				"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalSecretKeyName)
+			return "", ctrl.Result{Requeue: true}, nil
+		}
 
-	result, err := client.AccessSecretVersion(ctx, req)
-	if err != nil {
-		g.Log.Error(err, "could not fetch secrets, credential error")
-		return "", ctrl.Result{}, err
+		auth = fmt.Sprintf("%s:%s", strings.TrimSuffix(accessKey, "\n"), strings.TrimSuffix(secretKey, "\n"))
 	}
-
-	crc32c := crc32.MakeTable(crc32.Castagnoli)
-	checksum := int64(crc32.Checksum(result.Payload.Data, crc32c))
-	if checksum != *result.Payload.DataCrc32C {
-		return "", ctrl.Result{}, fmt.Errorf("data corruption detected, expected %d but got %d", *result.Payload.DataCrc32C, checksum)
-	}
-
-	GcpCred := map[string]string{}
-	err = json.Unmarshal(result.Payload.Data, &GcpCred)
-	if err != nil {
-		return "", ctrl.Result{}, err
-	}
-
-	// Pull the keys from the secret. Note, this code is largely duplicated from
-	// getCommunalAuth but had to be duplicated because we couldn't make the
-	// secret here the same datatype.
-	accessKey, ok := GcpCred[cloud.CommunalAccessKeyName]
-	if !ok {
-		g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
-			"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalAccessKeyName)
-		return "", ctrl.Result{Requeue: true}, nil
-	}
-
-	secretKey, ok := GcpCred[cloud.CommunalSecretKeyName]
-	if !ok {
-		g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
-			"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalSecretKeyName)
-		return "", ctrl.Result{Requeue: true}, nil
-	}
-
-	auth := fmt.Sprintf("%s:%s", strings.TrimSuffix(accessKey, "\n"), strings.TrimSuffix(secretKey, "\n"))
 	return auth, ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -17,9 +17,13 @@ package vdb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"time"
 
+	gsm "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -237,27 +241,72 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 	}
 }
 
+// GetDetailsFromGSM returns the secret or password configured in Google Secret Manager
+func (r *VerticaDBReconciler) GetDetailsFromGSM(ctx context.Context, secName string, log logr.Logger) (map[string]string, error) {
+	clnt, err := gsm.NewClient(ctx)
+	if err != nil {
+		return make(map[string]string), fmt.Errorf("failed to create secretmanager client")
+	}
+	defer clnt.Close()
+
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: secName,
+	}
+
+	result, err := clnt.AccessSecretVersion(ctx, req)
+	if err != nil {
+		log.Error(err, "could not fetch secrets, credential error")
+		return make(map[string]string), err
+	}
+
+	crc32c := crc32.MakeTable(crc32.Castagnoli)
+	checksum := int64(crc32.Checksum(result.Payload.Data, crc32c))
+	if checksum != *result.Payload.DataCrc32C {
+		return make(map[string]string), fmt.Errorf("data corruption detected")
+	}
+	SecPasswd := make(map[string]string)
+	err = json.Unmarshal(result.Payload.Data, &SecPasswd)
+	if err != nil {
+		return make(map[string]string), err
+	}
+	return SecPasswd, nil
+}
+
 // GetSuperuserPassword returns the superuser password if it has been provided
 func (r *VerticaDBReconciler) GetSuperuserPassword(ctx context.Context, vdb *vapi.VerticaDB, log logr.Logger) (string, error) {
-	secret := &corev1.Secret{}
 	passwd := ""
-	secretName := names.GenSUPasswdSecretName(vdb)
-	if secretName.Name == "" {
-		return passwd, nil
-	}
-	err := r.Get(ctx, secretName, secret)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			r.EVRec.Eventf(vdb, corev1.EventTypeWarning, events.SuperuserPasswordSecretNotFound,
-				"Secret for superuser password '%s' was not found", secretName.Name)
+	if vmeta.UseGCPSecretManager(vdb.Annotations) {
+		SuperPw, err := r.GetDetailsFromGSM(ctx, vdb.Spec.SuperuserPasswordSecret, log)
+		if len(SuperPw) == 0 || err != nil {
+			return passwd, err
+		} else {
+			pwd, ok := SuperPw[builder.SuperuserPasswordKey]
+			if ok {
+				passwd = pwd
+			} else {
+				log.Error(err, fmt.Sprintf("password not found, secret must have a key with name '%s'", builder.SuperuserPasswordKey))
+			}
 		}
-		return passwd, err
-	}
-	pwd, ok := secret.Data[builder.SuperuserPasswordKey]
-	if ok {
-		passwd = string(pwd)
 	} else {
-		log.Error(err, fmt.Sprintf("password not found, secret must have a key with name '%s'", builder.SuperuserPasswordKey))
+		secret := &corev1.Secret{}
+		secretName := names.GenSUPasswdSecretName(vdb)
+		if secretName.Name == "" {
+			return passwd, nil
+		}
+		err := r.Get(ctx, secretName, secret)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				r.EVRec.Eventf(vdb, corev1.EventTypeWarning, events.SuperuserPasswordSecretNotFound,
+					"Secret for superuser password '%s' was not found", secretName.Name)
+			}
+			return passwd, err
+		}
+		pwd, ok := secret.Data[builder.SuperuserPasswordKey]
+		if ok {
+			passwd = string(pwd)
+		} else {
+			log.Error(err, fmt.Sprintf("password not found, secret must have a key with name '%s'", builder.SuperuserPasswordKey))
+		}
 	}
 	return passwd, nil
 }


### PR DESCRIPTION
This is similar to #458 except we read from GSM for the superuser password secret. We use the same feature flag as before. Here is a sample CR to enable it.

```
kind: VerticaDB
metadata:
  name: v
  annotations:
    vertica.com/use-gcp-secret-manager: "true" 
spec:
  superuserPasswordSecret: <full name of the secret in GSM>
...
```

The name of the GSM secret is taken from the existing `spec.superuserPasswordSecret` field.

Note, we no longer use the canary query for health probes as that depends on the superuser password being a k8s secret. Instead, we check if vertica is running by seeing if anyone is listening on the vertica client port.


