### PR TITLE
Improve error message when GSM secret is malformed

### DIFF
--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -50,7 +50,7 @@ func ReadFromGSM(ctx context.Context, secName string) (map[string]string, error)
 	contents := make(map[string]string)
 	err = json.Unmarshal(result.Payload.Data, &contents)
 	if err != nil {
-		return make(map[string]string), err
+		return nil, fmt.Errorf("failed to unmarshal the contents of the GSM secret '%s': %w", secName, err)
 	}
 	return contents, nil
 }

--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -306,7 +306,7 @@ func (g *GenericDatabaseInitializer) setAuthFromGCSSecret(ctx context.Context) (
 
 	gcpCred, err := cloud.ReadFromGSM(ctx, g.Vdb.Spec.Communal.CredentialSecret)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to read GCS credentials from GSM: %w", err)
 	}
 	// Pull the keys from the secret. Note, this code is largely duplicated from
 	// getCommunalAuth but had to be duplicated because we couldn't make the

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -247,7 +247,7 @@ func (r *VerticaDBReconciler) GetSuperuserPassword(ctx context.Context, vdb *vap
 	if vmeta.UseGCPSecretManager(vdb.Annotations) {
 		secretCnts, err := cloud.ReadFromGSM(ctx, vdb.Spec.SuperuserPasswordSecret)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to read superuser password from GSM: %w", err)
 		}
 		pwd, ok := secretCnts[builder.SuperuserPasswordKey]
 		if !ok {


### PR DESCRIPTION
If you are using GSM to store secrets, but have not put valid JSON in for the secret contents, you get a very cryptic error. This improves the error output. Here is a sample of what the output will look like now:
```
2023-08-02T17:55:04.019Z        ERROR   Reconciler error        {"controller": "verticadb", "controllerGroup": "vertica.com",
"controllerKind": "VerticaDB", "VerticaDB": {"name":"vertica-gs","namespace":"vertica"}, "namespace": "vertica", 
"name": "vertica-gs", "reconcileID": "5abd8c8e-49c3-4d1c-bb1c-9416747a69e1", 
"error": "failed to read superuser password from GSM: failed to unmarshal the contents of the GSM secret 'projects/1680942424/secrets/kguan-gsm-1/versions/13': invalid character '\\'' looking for beginning of value"}
```