### PR TITLE
Implement VClusterOps.RestartNodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,8 +254,11 @@ ifeq ($(STERN_PLUGIN_INSTALLED), 0)
 	kubectl krew install stern
 endif
 
+.PHONY: init-e2e-env
+init-e2e-env: install-kuttl-plugin install-stern-plugin kustomize ## Download necessary tools to run the integration tests
+
 .PHONY: run-int-tests
-run-int-tests: install-kuttl-plugin install-stern-plugin kustomize vdb-gen setup-e2e-communal ## Run the integration tests
+run-int-tests: init-e2e-env vdb-gen setup-e2e-communal ## Run the integration tests
 ifeq ($(DEPLOY_WITH), $(filter $(DEPLOY_WITH), olm random))
 	$(MAKE) setup-olm
 endif

--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/vertica/vcluster => github.com/spilchen/vcluster v0.0.0-20230817115315-f80e42b78a4c

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230816112817-2474665dae3f
+	github.com/vertica/vcluster v0.0.0-20230817171046-fc38e5c46354
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -90,5 +90,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/vertica/vcluster => github.com/spilchen/vcluster v0.0.0-20230817115315-f80e42b78a4c

--- a/go.sum
+++ b/go.sum
@@ -294,12 +294,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spilchen/vcluster v0.0.0-20230816181949-4ca288e96945 h1:6dHN+aDW2Q6liOwa9sjq+zKVtsTC4+yL2r9NBWSVMtw=
-github.com/spilchen/vcluster v0.0.0-20230816181949-4ca288e96945/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
-github.com/spilchen/vcluster v0.0.0-20230816191709-5a6540c63963 h1:V3DTy6Ljrf45IIV6DQMBEx7MtrEzqoFR9uuqueAH9zo=
-github.com/spilchen/vcluster v0.0.0-20230816191709-5a6540c63963/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
-github.com/spilchen/vcluster v0.0.0-20230817115315-f80e42b78a4c h1:It3wWDoIrh1Ik4ub/Rea2FJz/aIV8LpGU/GrrfGPY1w=
-github.com/spilchen/vcluster v0.0.0-20230817115315-f80e42b78a4c/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -316,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230816112817-2474665dae3f h1:VS3/CHDR3YPDLDmtcEVz+5p8AgUi+rU+iR/9GdzHRQw=
-github.com/vertica/vcluster v0.0.0-20230816112817-2474665dae3f/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230817171046-fc38e5c46354 h1:h5FEcnL4Li3H95LsUZ9FwhH8sal38C2NpzCSv2k8nQs=
+github.com/vertica/vcluster v0.0.0-20230817171046-fc38e5c46354/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,12 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spilchen/vcluster v0.0.0-20230816181949-4ca288e96945 h1:6dHN+aDW2Q6liOwa9sjq+zKVtsTC4+yL2r9NBWSVMtw=
+github.com/spilchen/vcluster v0.0.0-20230816181949-4ca288e96945/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/spilchen/vcluster v0.0.0-20230816191709-5a6540c63963 h1:V3DTy6Ljrf45IIV6DQMBEx7MtrEzqoFR9uuqueAH9zo=
+github.com/spilchen/vcluster v0.0.0-20230816191709-5a6540c63963/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/spilchen/vcluster v0.0.0-20230817115315-f80e42b78a4c h1:It3wWDoIrh1Ik4ub/Rea2FJz/aIV8LpGU/GrrfGPY1w=
+github.com/spilchen/vcluster v0.0.0-20230817115315-f80e42b78a4c/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -378,13 +378,13 @@ var _ = Describe("podfacts", func() {
 	It("should correctly return re-ip pods", func() {
 		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
-			dnsName: "p1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true,
+			dnsName: "p1", vnodeName: "node1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true,
 		}
 		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
-			dnsName: "p2", dbExists: false, exists: true, isPodRunning: true, isInstalled: true,
+			dnsName: "p2", vnodeName: "node2", dbExists: false, exists: true, isPodRunning: true, isInstalled: true,
 		}
 		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
-			dnsName: "p3", dbExists: false, exists: true, isPodRunning: true, isInstalled: false,
+			dnsName: "p3", vnodeName: "node3", dbExists: false, exists: true, isPodRunning: true, isInstalled: false,
 		}
 		By("finding any installed pod")
 		pods := pf.findReIPPods(dBCheckAny)

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -374,4 +374,32 @@ var _ = Describe("podfacts", func() {
 		Expect(ok).Should(BeTrue())
 		Expect(p.dnsName).Should(Equal("p2"))
 	})
+
+	It("should correctly return re-ip pods", func() {
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
+			dnsName: "p1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true,
+		}
+		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
+			dnsName: "p2", dbExists: false, exists: true, isPodRunning: true, isInstalled: true,
+		}
+		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
+			dnsName: "p3", dbExists: false, exists: true, isPodRunning: true, isInstalled: false,
+		}
+		By("finding any installed pod")
+		pods := pf.findReIPPods(dBCheckAny)
+		Ω(pods).Should(HaveLen(2))
+		Ω(pods[0].dnsName).Should(Equal("p1"))
+		Ω(pods[1].dnsName).Should(Equal("p2"))
+
+		By("finding pods with a db")
+		pods = pf.findReIPPods(dBCheckOnlyWithDBs)
+		Ω(pods).Should(HaveLen(1))
+		Ω(pods[0].dnsName).Should(Equal("p1"))
+
+		By("finding pods without a db")
+		pods = pf.findReIPPods(dBCheckOnlyWithoutDBs)
+		Ω(pods).Should(HaveLen(1))
+		Ω(pods[0].dnsName).Should(Equal("p2"))
+	})
 })

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -128,13 +128,9 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{Requeue: true}, nil
 	}
 	// Check if cluster start needs to include all of the pods.
-	if (r.Vdb.Spec.KSafety == vapi.KSafety0 || meta.UseVClusterOps(r.Vdb.Annotations)) &&
-		r.PFacts.countInstalledAndNotRestartable() > 0 {
+	if r.Vdb.Spec.KSafety == vapi.KSafety0 && r.PFacts.countInstalledAndNotRestartable() > 0 {
 		// For k-safety 0, we need all of the pods because the absence of one
 		// will cause us not to have enough pods for cluster quorum.
-		//
-		// For vclusterOps, we need all pods as a temporary measure until the
-		// library is able to read catalog information (see VER-88084).
 		r.Log.Info("Waiting for all installed pods to be running before attempt a cluster restart")
 		return ctrl.Result{Requeue: true}, nil
 	}

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -139,7 +139,7 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Find an initiator pod. You must pick a that has no vertica process running.
+	// Find an initiator pod. You must pick one that has no vertica process running.
 	// This is needed to be able to start the primaries when secondary read-only
 	// nodes could be running.
 	if ok := r.setInitiatorPod(r.PFacts.findPodToRunAdminCmdOffline); !ok {
@@ -184,10 +184,9 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 		return ctrl.Result{}, err
 	}
 
-	// re_ip/start_db require all pods to be running that have run the
-	// installation.  This check is done when we generate the map file
-	// (genMapFile).
-	if res, err := r.reipNodes(ctx, r.PFacts.findReIPPods(false)); verrors.IsReconcileAborted(res, err) {
+	// re_ip nodes. This is done ahead of the db check in case we need to update
+	// the IP of nodes that have been installed but not yet added to the db.
+	if res, err := r.reipNodes(ctx, r.getReIPPods(false)); verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 
@@ -222,12 +221,11 @@ func (r *RestartReconciler) reconcileNodes(ctx context.Context) (ctrl.Result, er
 	if err := r.acceptEulaIfMissing(ctx); err != nil {
 		return ctrl.Result{}, err
 	}
+	if ok := r.setInitiatorPod(r.PFacts.findPodToRunAdminCmdAny); !ok {
+		r.Log.Info("No initiator pod found for admin command. Requeue reconciliation.")
+		return ctrl.Result{Requeue: true}, nil
+	}
 	if len(downPods) > 0 {
-		if ok := r.setInitiatorPod(r.PFacts.findPodToRunAdminCmdAny); !ok {
-			r.Log.Info("No initiator pod found for admin command. Requeue reconciliation.")
-			return ctrl.Result{Requeue: true}, nil
-		}
-
 		if res, err := r.restartPods(ctx, downPods); verrors.IsReconcileAborted(res, err) {
 			return res, err
 		}
@@ -241,17 +239,9 @@ func (r *RestartReconciler) reconcileNodes(ctx context.Context) (ctrl.Result, er
 		return ctrl.Result{Requeue: r.shouldRequeueIfPodsNotRunning()}, nil
 	}
 
-	// Find any pods that need to have their IP updated.  These are nodes that
-	// have been installed but not yet added to a database.
-	reIPPods := r.PFacts.findReIPPods(true)
-	if len(reIPPods) > 0 {
-		if ok := r.setInitiatorPod(r.PFacts.findPodToRunAdminCmdAny); !ok {
-			r.Log.Info("No initiator pod found to run admin command. Requeue reconciliation.")
-			return ctrl.Result{Requeue: true}, nil
-		}
-		if res, err := r.reipNodes(ctx, reIPPods); verrors.IsReconcileAborted(res, err) {
-			return res, err
-		}
+	// Find any pods that need to have their IP updated.
+	if res, err := r.reipNodes(ctx, r.getReIPPods(true)); verrors.IsReconcileAborted(res, err) {
+		return res, err
 	}
 
 	return ctrl.Result{Requeue: r.shouldRequeueIfPodsNotRunning()}, nil
@@ -379,8 +369,8 @@ func (r *RestartReconciler) execRestartPods(ctx context.Context, downPods []*Pod
 // If it detects that no IPs are changing, then no re_ip is done.
 func (r *RestartReconciler) reipNodes(ctx context.Context, pods []*PodFact) (ctrl.Result, error) {
 	if len(pods) == 0 {
-		r.Log.Info("No pods qualify for possible re-ip. Need to requeue restart reconciler.")
-		return ctrl.Result{Requeue: true}, nil
+		r.Log.Info("No pods qualify for possible re-ip.")
+		return ctrl.Result{}, nil
 	}
 	opts := []reip.Option{
 		reip.WithInitiator(r.InitiatorPod, r.InitiatorPodIP),
@@ -589,4 +579,26 @@ func (r *RestartReconciler) shouldRequeueIfPodsNotRunning() bool {
 // accepts the end user license agreement.
 func (r *RestartReconciler) acceptEulaIfMissing(ctx context.Context) error {
 	return acceptEulaIfMissing(ctx, r.PFacts, r.PRunner)
+}
+
+// getReIPPods will return the list of pods that may need a re-ip. Factors that
+// can affect the list is the restart type (cluster vs node) and usage of
+// vclusterOps.
+func (r *RestartReconciler) getReIPPods(isRestartNode bool) []*PodFact {
+	// For restart node, we only re-ip nodes that won't be restarted. This is
+	// necessary to keep installed-only nodes up to date in admintools.conf. For
+	// this reason, we can skip if using vclusterOps.
+	if isRestartNode {
+		if meta.UseVClusterOps(r.Vdb.Annotations) {
+			return nil
+		}
+		return r.PFacts.findReIPPods(dBCheckOnlyWithoutDBs)
+	}
+	// For cluster restart, we re-ip all nodes that have been added to the DB.
+	// And if using admintools, we also need to re-ip installed pods that
+	// haven't been added to the db to keep admintools.conf in-sync.
+	if meta.UseVClusterOps(r.Vdb.Annotations) {
+		return r.PFacts.findReIPPods(dBCheckOnlyWithDBs)
+	}
+	return r.PFacts.findReIPPods(dBCheckAny)
 }

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -157,4 +157,5 @@ type VClusterProvider interface {
 	VAddNode(options *vops.VAddNodeOptions) (vops.VCoordinationDatabase, error)
 	VRemoveNode(options *vops.VRemoveNodeOptions) (vops.VCoordinationDatabase, error)
 	VReIP(options *vops.VReIPOptions) error
+	VRestartNodes(options *vops.VRestartNodesOptions) error
 }

--- a/pkg/vadmin/opts/restartnode/opts.go
+++ b/pkg/vadmin/opts/restartnode/opts.go
@@ -23,8 +23,7 @@ import (
 type Parms struct {
 	InitiatorName types.NamespacedName
 	InitiatorIP   string
-	HostVNodes    []string
-	HostIPs       []string
+	RestartHosts  map[string]string // All of the hosts we want to restart. This is a map of vnodes to their IP.
 }
 
 type Option func(*Parms)
@@ -45,13 +44,9 @@ func WithInitiator(nm types.NamespacedName, ip string) Option {
 
 func WithHost(vnode, ip string) Option {
 	return func(s *Parms) {
-		if s.HostVNodes == nil {
-			s.HostVNodes = make([]string, 0)
+		if s.RestartHosts == nil {
+			s.RestartHosts = make(map[string]string)
 		}
-		if s.HostIPs == nil {
-			s.HostIPs = make([]string, 0)
-		}
-		s.HostVNodes = append(s.HostVNodes, vnode)
-		s.HostIPs = append(s.HostIPs, ip)
+		s.RestartHosts[vnode] = ip
 	}
 }

--- a/pkg/vadmin/restart_node_at.go
+++ b/pkg/vadmin/restart_node_at.go
@@ -41,11 +41,17 @@ func (a *Admintools) RestartNode(ctx context.Context, opts ...restartnode.Option
 
 // genRestartNodeCmd returns the command to run to restart a pod
 func (a *Admintools) genRestartNodeCmd(s *restartnode.Parms) []string {
+	hostVNodes := make([]string, 0, len(s.RestartHosts))
+	hostIPs := make([]string, 0, len(s.RestartHosts))
+	for vnode, ip := range s.RestartHosts {
+		hostVNodes = append(hostVNodes, vnode)
+		hostIPs = append(hostIPs, ip)
+	}
 	cmd := []string{
 		"-t", "restart_node",
 		"--database=" + a.VDB.Spec.DBName,
-		"--hosts=" + strings.Join(s.HostVNodes, ","),
-		"--new-host-ips=" + strings.Join(s.HostIPs, ","),
+		"--hosts=" + strings.Join(hostVNodes, ","),
+		"--new-host-ips=" + strings.Join(hostIPs, ","),
 		"--noprompt",
 	}
 	if a.VDB.Spec.RestartTimeout != 0 {

--- a/pkg/vadmin/restart_node_at.go
+++ b/pkg/vadmin/restart_node_at.go
@@ -18,6 +18,7 @@ package vadmin
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/vertica/vertica-kubernetes/pkg/events"
@@ -42,10 +43,16 @@ func (a *Admintools) RestartNode(ctx context.Context, opts ...restartnode.Option
 // genRestartNodeCmd returns the command to run to restart a pod
 func (a *Admintools) genRestartNodeCmd(s *restartnode.Parms) []string {
 	hostVNodes := make([]string, 0, len(s.RestartHosts))
-	hostIPs := make([]string, 0, len(s.RestartHosts))
-	for vnode, ip := range s.RestartHosts {
+	for vnode := range s.RestartHosts {
 		hostVNodes = append(hostVNodes, vnode)
-		hostIPs = append(hostIPs, ip)
+	}
+	// Sort by vnode so the order of nodes we restart is consistent.
+	sort.Slice(hostVNodes, func(i, j int) bool {
+		return hostVNodes[i] < hostVNodes[j]
+	})
+	hostIPs := make([]string, 0, len(s.RestartHosts))
+	for _, vnode := range hostVNodes {
+		hostIPs = append(hostIPs, s.RestartHosts[vnode])
 	}
 	cmd := []string{
 		"-t", "restart_node",

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 
 	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -55,6 +57,7 @@ func (v *VClusterOps) genRestartNodeOptions(s *restartnode.Parms, certs *HTTPSCe
 		DatabaseOptions: vops.DatabaseOptions{
 			Name:           &v.VDB.Spec.DBName,
 			RawHosts:       []string{s.InitiatorIP},
+			Ipv6:           vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP)),
 			Key:            certs.Key,
 			Cert:           certs.Cert,
 			CaCert:         certs.CaCert,

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -20,9 +20,7 @@ import (
 	"fmt"
 
 	vops "github.com/vertica/vcluster/vclusterops"
-	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -51,16 +49,12 @@ func (v *VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Optio
 }
 
 func (v *VClusterOps) genRestartNodeOptions(s *restartnode.Parms, certs *HTTPSCerts) *vops.VRestartNodesOptions {
-	catPath := v.VDB.Spec.Local.GetCatalogPath()
 	su := vapi.SuperUser
 	honorUserInput := true
 	opts := vops.VRestartNodesOptions{
 		DatabaseOptions: vops.DatabaseOptions{
 			Name:           &v.VDB.Spec.DBName,
 			RawHosts:       []string{s.InitiatorIP},
-			Ipv6:           vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP)),
-			IsEon:          vstruct.MakeNullableBool(v.VDB.IsEON()),
-			CatalogPrefix:  &catPath,
 			Key:            certs.Key,
 			Cert:           certs.Cert,
 			CaCert:         certs.CaCert,

--- a/pkg/vadmin/restart_node_vc_test.go
+++ b/pkg/vadmin/restart_node_vc_test.go
@@ -1,0 +1,70 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vadmin
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// mock version of VStartDatabase() that is invoked inside VClusterOps.StartDB()
+func (m *MockVClusterOps) VRestartNodes(options *vops.VRestartNodesOptions) error {
+	// verify basic options
+	err := m.VerifyCommonOptions(&options.DatabaseOptions)
+	if err != nil {
+		return err
+	}
+
+	// verify eon options
+	err = m.VerifyInitiatorIPAndEonMode(&options.DatabaseOptions)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ = Describe("restart_node_vc", func() {
+	ctx := context.Background()
+
+	var nodeIPs []string
+	for i := 0; i < 3; i++ {
+		nodeIP := fmt.Sprintf("10.10.10.1%d", i)
+		nodeIPs = append(nodeIPs, nodeIP)
+	}
+
+	It("should call vcluster-ops library with restart_node task", func() {
+		dispatcher := mockVClusterOpsDispatcher()
+		dispatcher.VDB.Spec.DBName = TestDBName
+		dispatcher.VDB.Spec.HTTPServerTLSSecret = "restart-node-test-secret"
+		test.CreateFakeTLSSecret(ctx, dispatcher.VDB, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)
+		defer test.DeleteSecret(ctx, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)
+
+		ctrlRes, err := dispatcher.RestartNode(ctx,
+			restartnode.WithInitiator(dispatcher.VDB.ExtractNamespacedName(), nodeIPs[0]),
+			restartnode.WithHost("vnode1", nodeIPs[1]),
+		)
+		Ω(err).Should(Succeed())
+		Ω(ctrlRes).Should(Equal(ctrl.Result{}))
+	})
+})

--- a/pkg/vadmin/restart_node_vc_test.go
+++ b/pkg/vadmin/restart_node_vc_test.go
@@ -35,10 +35,8 @@ func (m *MockVClusterOps) VRestartNodes(options *vops.VRestartNodesOptions) erro
 		return err
 	}
 
-	// verify eon options
-	err = m.VerifyInitiatorIPAndEonMode(&options.DatabaseOptions)
-	if err != nil {
-		return err
+	if len(options.RawHosts) == 0 || options.RawHosts[0] != TestInitiatorIP {
+		return fmt.Errorf("failed to retrieve hosts")
 	}
 
 	return nil

--- a/tests/e2e-vcluster/vcluster-ks-1/30-assert.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-1/30-assert.yaml
@@ -19,4 +19,14 @@ status:
   subclusters:
     - addedToDBCount: 3
       installCount: 3
-      upNodeCount: 2
+      upNodeCount: 3
+---
+apiVersion: v1
+kind: Event
+reason: NodeRestartSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaDB
+  name: v-vcluster-ks-1

--- a/tests/e2e-vcluster/vcluster-ks-1/30-wait-for-restart.yaml
+++ b/tests/e2e-vcluster/vcluster-ks-1/30-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl


### PR DESCRIPTION
This integration incorporates the vclusterops restart nodes functionality into the operator.

To get restart to work, I had to change the re-ip process. There were cases where, when using admintools, we had to re-ip hosts that had been installed but not yet added to the database. This was necessary to keep the hosts' IP addresses up to date in admintools.conf. This step is not necessary for vclusterops because there is no state file that needs to be synchronized.