### PR TITLE
Update VClusterOps.AddNode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230816112817-2474665dae3f
+	github.com/vertica/vcluster v0.0.0-20230825142712-91bc5a9af516
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230816112817-2474665dae3f h1:VS3/CHDR3YPDLDmtcEVz+5p8AgUi+rU+iR/9GdzHRQw=
-github.com/vertica/vcluster v0.0.0-20230816112817-2474665dae3f/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230825142712-91bc5a9af516 h1:FGetau7wYqMCFHnfHuW5oM0swH9gQ1aJ1C/4J7V4vso=
+github.com/vertica/vcluster v0.0.0-20230825142712-91bc5a9af516/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/controllers/vdb/dbaddnode_reconciler.go
+++ b/pkg/controllers/vdb/dbaddnode_reconciler.go
@@ -113,18 +113,6 @@ func (d *DBAddNodeReconciler) findAddNodePods(scName string) ([]*PodFact, ctrl.R
 	return podList, ctrl.Result{}
 }
 
-// genVNodeMap returns a map of (vnode - ip) for nodes
-// that are alreay part of the vertica cluster
-func (d *DBAddNodeReconciler) genVNodeMap() map[string]string {
-	vNodes := map[string]string{}
-	for _, v := range d.PFacts.Detail {
-		if v.dbExists {
-			vNodes[v.vnodeName] = v.podIP
-		}
-	}
-	return vNodes
-}
-
 // reconcileSubcluster will reconcile a single subcluster.  Add node will be
 // triggered if we determine that it hasn't been run.
 func (d *DBAddNodeReconciler) reconcileSubcluster(ctx context.Context, sc *vapi.Subcluster) (ctrl.Result, error) {
@@ -184,7 +172,6 @@ func (d *DBAddNodeReconciler) runAddNodeForPod(ctx context.Context, pods []*PodF
 	opts := []addnode.Option{
 		addnode.WithInitiator(initiatorPod.name, initiatorPod.podIP),
 		addnode.WithSubcluster(pods[0].subclusterName),
-		addnode.WithVNodeToHostMap(d.genVNodeMap()),
 	}
 	for i := range pods {
 		opts = append(opts, addnode.WithHost(pods[i].dnsName))

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -59,14 +59,12 @@ func (v *VClusterOps) genAddNodeOptions(s *addnode.Parms, certs *HTTPSCerts) vop
 	opts.NewHosts = s.Hosts
 	opts.Name = &v.VDB.Spec.DBName
 
-	opts.Nodes = s.VNodeToHostMap
-	opts.InputHost = s.InitiatorIP
-	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(opts.NewHosts[0]))
+	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
+	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))
 	opts.SCName = &s.Subcluster
-	catalogPath := v.VDB.Spec.Local.GetCatalogPath()
-	opts.CatalogPrefix = &catalogPath
 	opts.DataPrefix = &v.VDB.Spec.Local.DataPath
-	opts.IsEon = vstruct.MakeNullableBool(v.VDB.IsEON())
+	*opts.HonorUserInput = true
+	*opts.SkipRebalanceShards = true
 
 	if v.VDB.Spec.Communal.Path != "" {
 		opts.DepotPrefix = &v.VDB.Spec.Local.DepotPath
@@ -78,6 +76,6 @@ func (v *VClusterOps) genAddNodeOptions(s *addnode.Parms, certs *HTTPSCerts) vop
 	opts.CaCert = certs.CaCert
 	*opts.UserName = vapi.SuperUser
 	opts.Password = &v.Password
-	*opts.HonorUserInput = true
+
 	return opts
 }

--- a/pkg/vadmin/opts/addnode/opts.go
+++ b/pkg/vadmin/opts/addnode/opts.go
@@ -25,8 +25,6 @@ type Parms struct {
 	InitiatorIP   string
 	Hosts         []string
 	Subcluster    string
-	// will be removed after VER-88096
-	VNodeToHostMap map[string]string
 }
 
 type Option func(*Parms)
@@ -57,11 +55,5 @@ func WithHost(fqdn string) Option {
 func WithSubcluster(subcluster string) Option {
 	return func(s *Parms) {
 		s.Subcluster = subcluster
-	}
-}
-
-func WithVNodeToHostMap(vNodeToHostMap map[string]string) Option {
-	return func(s *Parms) {
-		s.VNodeToHostMap = vNodeToHostMap
 	}
 }

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -52,9 +52,9 @@ func (v *VClusterOps) genRemoveNodeOptions(s *removenode.Parms, certs *HTTPSCert
 	opts.Name = &v.VDB.Spec.DBName
 
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
-	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(opts.HostsToRemove[0]))
+	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))
 	opts.DataPrefix = &v.VDB.Spec.Local.DataPath
-	opts.IsEon = vstruct.MakeNullableBool(v.VDB.IsEON())
+	*opts.HonorUserInput = true
 
 	if v.VDB.Spec.Communal.Path != "" {
 		opts.DepotPrefix = &v.VDB.Spec.Local.DepotPath
@@ -66,6 +66,6 @@ func (v *VClusterOps) genRemoveNodeOptions(s *removenode.Parms, certs *HTTPSCert
 	opts.CaCert = certs.CaCert
 	*opts.UserName = vapi.SuperUser
 	opts.Password = &v.Password
-	*opts.HonorUserInput = true
+
 	return opts
 }


### PR DESCRIPTION
Now that we have a better way of getting node info from vclusterops, some refactoring was needed is order to get rid of some options that are not used anymore.