### PR TITLE
Remove NO_KEYS from v2 image

### DIFF
--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -66,7 +66,7 @@ RUN set -x \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
   && chown -R dbadmin:verticadba /home/dbadmin/ \
-  && rm -rf /opt/vertica/config/share/agent*;
+  && rm -rf /opt/vertica/config/share/agent*
 
 ##############################################################################################
 FROM ubuntu:${BASE_OS_VERSION} as initial

--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -6,13 +6,11 @@
 ARG BASE_OS_VERSION="lunar"
 ARG BUILDER_OS_VERSION="stream8"
 ARG MINIMAL=""
-ARG NO_KEYS=""
 ARG S6_OVERLAY_VERSION=3.1.2.1
 FROM quay.io/centos/centos:${BUILDER_OS_VERSION} as builder
 
 ARG VERTICA_RPM="vertica-x86_64.RHEL6.latest.rpm"
 ARG MINIMAL
-ARG NO_KEYS
 ARG DBADMIN_GID=5000
 ARG DBADMIN_UID=5000
 
@@ -59,11 +57,6 @@ RUN set -x \
   && mkdir -p /home/dbadmin/logrotate \
   && cp -r /opt/vertica/config/logrotate /home/dbadmin/logrotate/  \
   && cp /opt/vertica/config/logrotate_base.conf /home/dbadmin/logrotate/ \
-  && if [[ ${NO_KEYS^^} != "YES" ]] ; then \
-    mkdir -p /home/dbadmin/agent; \
-    cp -r /opt/vertica/config/share/agent* /home/dbadmin/agent/; \
-    cp /opt/vertica/config/apikeys.dat /home/dbadmin/agent/; \
-  fi \
   && chown -R dbadmin:verticadba /opt/vertica \
   # reduce the size of the final image
   && rm -rf /opt/vertica/lib64  \
@@ -73,9 +66,7 @@ RUN set -x \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
   && chown -R dbadmin:verticadba /home/dbadmin/ \
-  && if [[ ${NO_KEYS^^} == "YES" ]] ; then \
-    rm -rf /opt/vertica/config/share/agent*; \
-  fi
+  && rm -rf /opt/vertica/config/share/agent*;
 
 ##############################################################################################
 FROM ubuntu:${BASE_OS_VERSION} as initial
@@ -100,7 +91,6 @@ ARG DBADMIN_UID=5000
 # "apt-cache search jre | grep jre"
 ARG JRE_PKG=openjdk-8-jre-headless
 ARG MINIMAL
-ARG NO_KEYS
 ARG S6_OVERLAY_VERSION
 
 COPY --from=builder /opt/vertica /opt/vertica
@@ -144,13 +134,10 @@ RUN set -x \
   procps \
   sysstat \
   sudo \
+  vim-tiny \
   # Install jre if not minimal
   && if [[ ${MINIMAL^^} != "YES" ]] ; then \
     apt-get install -y --no-install-recommends $JRE_PKG; \
-  fi \
-  # install vim except in the -nokeys image \
-  && if [[ ${NO_KEYS^^} != "YES" ]] ; then \
-    apt-get install -y --no-install-recommends vim-tiny; \
   fi \
   && apt-get clean \
   && apt-get autoremove \

--- a/docker-vertica-v2/Makefile
+++ b/docker-vertica-v2/Makefile
@@ -3,8 +3,8 @@ BUILDER_OS_VERSION?=stream8
 BASE_OS_VERSION?=lunar
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
-NO_KEYS?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
+VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS?=
 
 all: docker-build-vertica
 
@@ -19,7 +19,7 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--label vertica-version=${VERTICA_VERSION} \
 		--build-arg MINIMAL=${MINIMAL_VERTICA_IMG} \
 		--build-arg VERTICA_RPM=${VERTICA_RPM} \
-		--build-arg NO_KEYS=${NO_KEYS} \
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
+		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \
 		-t ${VERTICA_IMG} .

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -5,6 +5,7 @@ VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 NO_KEYS?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
+VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS?=
 
 all: docker-build-vertica
 
@@ -22,4 +23,5 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--build-arg NO_KEYS=${NO_KEYS} \
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
+		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \
 		-t ${VERTICA_IMG} .


### PR DESCRIPTION
The v2 image will always be treated as the NO_KEYS version. Removing the option for checking the environment variable in that image. Treating all spots as if NO_KEYS=YES.

Also, you can now add additional arguments to the docker build for the vertica-k8s image by setting the VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS environment variable.

For example:
```
export VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS="--platform linux/amd64"
make docker-build-vertica
```