### PR TITLE
Add timeout option for VCluster APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230901172157-786ef089e17f
+	github.com/vertica/vcluster v0.0.0-20230906150007-b466b390976a
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230906150007-b466b390976a
+	github.com/vertica/vcluster v0.0.0-20230907154925-a7b1e1f7d472
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230901172157-786ef089e17f h1:Y9iiDDHf2RaoE7eVqKIxpPJevY0q2Qj68vTA0JU41kc=
-github.com/vertica/vcluster v0.0.0-20230901172157-786ef089e17f/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230906150007-b466b390976a h1:z/iaX8VDAGMEGpjmJACIBXYdsrKi9As+8L8w74IlCaA=
+github.com/vertica/vcluster v0.0.0-20230906150007-b466b390976a/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230906150007-b466b390976a h1:z/iaX8VDAGMEGpjmJACIBXYdsrKi9As+8L8w74IlCaA=
-github.com/vertica/vcluster v0.0.0-20230906150007-b466b390976a/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230907154925-a7b1e1f7d472 h1:B3YKW7A+wQTTdBrhXGl4Iwcx7AD+qkw7pwnfATV6bcE=
+github.com/vertica/vcluster v0.0.0-20230907154925-a7b1e1f7d472/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -152,7 +152,7 @@ type VClusterProvider interface {
 	VCreateDatabase(options *vops.VCreateDatabaseOptions) (vops.VCoordinationDatabase, error)
 	VStopDatabase(options *vops.VStopDatabaseOptions) error
 	VStartDatabase(options *vops.VStartDatabaseOptions) error
-	VReviveDatabase(options *vops.VReviveDatabaseOptions) error
+	VReviveDatabase(options *vops.VReviveDatabaseOptions) (string, error)
 	VFetchNodeState(options *vops.VFetchNodeStateOptions) ([]vops.NodeInfo, error)
 	VAddSubcluster(options *vops.VAddSubclusterOptions) error
 	VRemoveSubcluster(options *vops.VRemoveScOptions) (vops.VCoordinationDatabase, error)

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -68,8 +68,6 @@ func (v *VClusterOps) genRestartNodeOptions(s *restartnode.Parms, certs *HTTPSCe
 		Nodes: s.RestartHosts,
 	}
 	// timeout option
-	if v.VDB.Spec.RestartTimeout != 0 {
-		opts.StatePollingTimeout = v.VDB.Spec.RestartTimeout
-	}
+	opts.StatePollingTimeout = v.VDB.Spec.RestartTimeout
 	return &opts
 }

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -67,5 +67,9 @@ func (v *VClusterOps) genRestartNodeOptions(s *restartnode.Parms, certs *HTTPSCe
 		},
 		Nodes: s.RestartHosts,
 	}
+	// timeout option
+	if v.VDB.Spec.RestartTimeout != 0 {
+		opts.StatePollingTimeout = v.VDB.Spec.RestartTimeout
+	}
 	return &opts
 }

--- a/pkg/vadmin/restart_node_vc_test.go
+++ b/pkg/vadmin/restart_node_vc_test.go
@@ -39,6 +39,11 @@ func (m *MockVClusterOps) VRestartNodes(options *vops.VRestartNodesOptions) erro
 		return fmt.Errorf("failed to retrieve hosts")
 	}
 
+	// verify timeout
+	if options.StatePollingTimeout != TestTimeout {
+		return fmt.Errorf("failed to retrieve timeout")
+	}
+
 	return nil
 }
 
@@ -54,6 +59,7 @@ var _ = Describe("restart_node_vc", func() {
 	It("should call vcluster-ops library with restart_node task", func() {
 		dispatcher := mockVClusterOpsDispatcher()
 		dispatcher.VDB.Spec.DBName = TestDBName
+		dispatcher.VDB.Spec.RestartTimeout = 10
 		dispatcher.VDB.Spec.HTTPServerTLSSecret = "restart-node-test-secret"
 		test.CreateFakeTLSSecret(ctx, dispatcher.VDB, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)
 		defer test.DeleteSecret(ctx, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)

--- a/pkg/vadmin/revive_db_vc.go
+++ b/pkg/vadmin/revive_db_vc.go
@@ -40,7 +40,7 @@ func (v *VClusterOps) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ct
 	s.Make(opts...)
 
 	vcOpts := v.genReviveDBOptions(&s, certs)
-	err = v.VReviveDatabase(vcOpts)
+	_, err = v.VReviveDatabase(vcOpts)
 	if err != nil {
 		return v.logFailure("VReviveDatabase", events.ReviveDBFailed, err)
 	}
@@ -57,6 +57,7 @@ func (v *VClusterOps) genReviveDBOptions(s *revivedb.Parms, certs *HTTPSCerts) *
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(opts.RawHosts[0]))
 	opts.CommunalStorageLocation = &s.CommunalPath
 	opts.CommunalStorageParameters = s.ConfigurationParams
+	*opts.IgnoreClusterLease = s.IgnoreClusterLease
 
 	// auth options
 	opts.Key = certs.Key

--- a/pkg/vadmin/revive_db_vc_test.go
+++ b/pkg/vadmin/revive_db_vc_test.go
@@ -27,25 +27,25 @@ import (
 )
 
 // mock version of VReviveDatabase() that is invoked inside VClusterOps
-func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) error {
+func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) (string, error) {
 	// verify basic options
 	err := m.VerifyDBNameAndIPv6(&options.DatabaseOptions)
 	if err != nil {
-		return err
+		return "", err
 	}
 	err = m.VerifyHosts(&options.DatabaseOptions)
 	if err != nil {
-		return err
+		return "", err
 	}
 	err = m.VerifyCerts(&options.DatabaseOptions)
 	if err != nil {
-		return err
+		return "", err
 	}
 	err = m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.CommunalStorageParameters)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return "", nil
 }
 
 var _ = Describe("revive_db_vc", func() {

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -78,5 +78,10 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	*opts.UserName = vapi.SuperUser
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
+
+	// timeout option
+	if v.VDB.Spec.RestartTimeout != 0 {
+		opts.StatePollingTimeout = v.VDB.Spec.RestartTimeout
+	}
 	return opts, nil
 }

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -80,8 +80,6 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	*opts.HonorUserInput = true
 
 	// timeout option
-	if v.VDB.Spec.RestartTimeout != 0 {
-		opts.StatePollingTimeout = v.VDB.Spec.RestartTimeout
-	}
+	opts.StatePollingTimeout = v.VDB.Spec.RestartTimeout
 	return opts, nil
 }

--- a/pkg/vadmin/start_db_vc_test.go
+++ b/pkg/vadmin/start_db_vc_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 const TestCatalogPrefix = "/data"
+const TestTimeout = 10
 
 // mock version of VStartDatabase() that is invoked inside VClusterOps.StartDB()
 func (m *MockVClusterOps) VStartDatabase(options *vops.VStartDatabaseOptions) error {
@@ -48,6 +49,11 @@ func (m *MockVClusterOps) VStartDatabase(options *vops.VStartDatabaseOptions) er
 		return fmt.Errorf("failed to retrieve catalog prefix")
 	}
 
+	// verify timeout
+	if options.StatePollingTimeout != TestTimeout {
+		return fmt.Errorf("failed to retrieve timeout")
+	}
+
 	return nil
 }
 
@@ -63,6 +69,7 @@ var _ = Describe("start_db_vc", func() {
 	It("should call vcluster-ops library with start_db task", func() {
 		dispatcher := mockVClusterOpsDispatcher()
 		dispatcher.VDB.Spec.DBName = TestDBName
+		dispatcher.VDB.Spec.RestartTimeout = 10
 		dispatcher.VDB.Spec.HTTPServerTLSSecret = "start-db-test-secret"
 		test.CreateFakeTLSSecret(ctx, dispatcher.VDB, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)
 		defer test.DeleteSecret(ctx, dispatcher.Client, dispatcher.VDB.Spec.HTTPServerTLSSecret)


### PR DESCRIPTION
This makes changes to the vcluster API calls to add the timeout option, taken from spec.restartTimeout, for start_db and restart_node. There are also some revive_db changes to be able to integrate with the latest vcluster repo.