### PR TITLE
Add env var to run e2e tests with vclusterops

### DIFF
--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -118,6 +118,7 @@ echo -n "Using private registry: "
 if [ -n "$PRIVATE_REG_SERVER" ]; then echo "YES"; else echo "NO"; fi
 echo -n "Add server mounts: "
 if [ -n "$USE_SERVER_MOUNT_PATCH" ]; then echo "YES"; else echo "NO"; fi
+echo "Deployment method: $VERTICA_DEPLOYMENT_METHOD"
 
 function create_vdb_kustomization {
     BASE_DIR=$1
@@ -172,6 +173,15 @@ EOF
         else
           echo "*** Unknown protocol (create_vdb_kustomization): $PATH_PROTOCOL"
           exit 1
+        fi
+
+        if [ "$VERTICA_DEPLOYMENT_METHOD" == "vclusterops" ]
+        then
+            cat <<EOF >> kustomization.yaml
+    - op: add
+      path: /metadata/annotations/vertica.com~1vcluster-ops
+      value: "true"
+EOF
         fi
     fi
 

--- a/tests/kustomize-defaults.cfg
+++ b/tests/kustomize-defaults.cfg
@@ -110,3 +110,7 @@ USE_SERVER_MOUNT_PATCH=
 # such as AWS or GCP, then the default storage class does allow volume
 # expansion.  Set this value to 1 for those environments.
 ALLOW_VOLUME_EXPANSION=
+
+# The type of deployment to use when running vertica admin commands. Valid
+# values are: admintools or vclusterops
+VERTICA_DEPLOYMENT_METHOD=admintools


### PR DESCRIPTION
This adds a new environment variable that will control whether e2e tests are run with vclusterops enabled or not. This is controlled through kustomize. We can use this in the future to run a testcase in either deployment methods.

The default is to run with vclusterops disabled. To run with it enabled, run the following:
```
export VERTICA_DEPLOYMENT_METHOD=vclusterops
scripts/setup-kustomize.sh
<run your test>
```

Note, this works if an annotation is already present in the VerticaDB. I had to use some weird kustomize syntax to avoid clobbering other annotations.

fyi @roypaulin @cchen-vertica 