### PR TITLE
Include reconciler and vdb in log messages

### DIFF
--- a/pkg/controllers/vdb/agent_reconciler_test.go
+++ b/pkg/controllers/vdb/agent_reconciler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("agent_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr, true)
 		pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)].dbExists = false
-		r := MakeAgentReconciler(vdbRec, vdb, fpr, pfacts)
+		r := MakeAgentReconciler(vdbRec, logger, vdb, fpr, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		cmds := fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
 		Expect(len(cmds)).Should(Equal(0))
@@ -82,7 +82,7 @@ var _ = Describe("agent_reconcile", func() {
 func reconcileAndFindVerticaAgentStart(ctx context.Context, vdb *vapi.VerticaDB, hasAgentKeys bool) []cmds.CmdHistory {
 	fpr := &cmds.FakePodRunner{}
 	pfacts := createPodFactsWithAgentNotRunning(ctx, vdb, fpr, hasAgentKeys)
-	r := MakeAgentReconciler(vdbRec, vdb, fpr, pfacts)
+	r := MakeAgentReconciler(vdbRec, logger, vdb, fpr, pfacts)
 	Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	return fpr.FindCommands("/opt/vertica/sbin/vertica_agent", "start")
 }

--- a/pkg/controllers/vdb/annotateandlabelpod_reconciler.go
+++ b/pkg/controllers/vdb/annotateandlabelpod_reconciler.go
@@ -18,6 +18,7 @@ package vdb
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
@@ -32,14 +33,20 @@ import (
 // AnnotateAndLabelPodReconciler will maintain annotations and labels in pods about the running system
 type AnnotateAndLabelPodReconciler struct {
 	VRec   *VerticaDBReconciler
+	Log    logr.Logger
 	Vdb    *vapi.VerticaDB
 	PFacts *PodFacts
 }
 
 // MakeAnnotateAndLabelPodReconciler will build a AnnotateAndLabelPodReconciler object
-func MakeAnnotateAndLabelPodReconciler(vdbrecon *VerticaDBReconciler,
+func MakeAnnotateAndLabelPodReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, pfacts *PodFacts) controllers.ReconcileActor {
-	return &AnnotateAndLabelPodReconciler{VRec: vdbrecon, Vdb: vdb, PFacts: pfacts}
+	return &AnnotateAndLabelPodReconciler{
+		VRec:   vdbrecon,
+		Log:    log.WithName("AnnotateAndLabelPodReconciler"),
+		Vdb:    vdb,
+		PFacts: pfacts,
+	}
 }
 
 // Reconcile will add annotations to each of the pods so that we flow down
@@ -88,7 +95,7 @@ func (s *AnnotateAndLabelPodReconciler) generateAnnotations() (map[string]string
 	if err != nil {
 		return nil, err
 	}
-	s.VRec.Log.Info("Kubernetes server version", "version", ver.GitVersion, "gitCommit", ver.GitCommit, "buildDate", ver.BuildDate)
+	s.Log.Info("Kubernetes server version", "version", ver.GitVersion, "gitCommit", ver.GitCommit, "buildDate", ver.BuildDate)
 
 	return map[string]string{
 		vmeta.KubernetesVersionAnnotation:   ver.GitVersion,

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
@@ -50,7 +50,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		pfn2 := names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0)
 		pfacts.Detail[pfn2].shardSubscriptions = 3
 		pfacts.Detail[pfn2].upNode = true
-		r := MakeClientRoutingLabelReconciler(vdbRec, vdb, &pfacts, PodRescheduleApplyMethod, "")
+		r := MakeClientRoutingLabelReconciler(vdbRec, logger, vdb, &pfacts, PodRescheduleApplyMethod, "")
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		pod := &corev1.Pod{}
@@ -81,7 +81,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		pfn2 := names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0)
 		pfacts.Detail[pfn2].shardSubscriptions = 3
 		pfacts.Detail[pfn2].upNode = true
-		r := MakeClientRoutingLabelReconciler(vdbRec, vdb, &pfacts, PodRescheduleApplyMethod, vdb.Spec.Subclusters[0].Name)
+		r := MakeClientRoutingLabelReconciler(vdbRec, logger, vdb, &pfacts, PodRescheduleApplyMethod, vdb.Spec.Subclusters[0].Name)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		pod := &corev1.Pod{}
@@ -111,7 +111,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 			pfacts.Detail[pn].upNode = true
 			pfacts.Detail[pn].shardSubscriptions = int(i) // Ensures that only one pod will not have subscriptions
 		}
-		r := MakeClientRoutingLabelReconciler(vdbRec, vdb, &pfacts, AddNodeApplyMethod, "")
+		r := MakeClientRoutingLabelReconciler(vdbRec, logger, vdb, &pfacts, AddNodeApplyMethod, "")
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 
 		pod := &corev1.Pod{}
@@ -142,7 +142,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		pfacts.Detail[pn].upNode = true
 		pfacts.Detail[pn].shardSubscriptions = 10
-		act := MakeClientRoutingLabelReconciler(vdbRec, vdb, &pfacts, AddNodeApplyMethod, "")
+		act := MakeClientRoutingLabelReconciler(vdbRec, logger, vdb, &pfacts, AddNodeApplyMethod, "")
 		r := act.(*ClientRoutingLabelReconciler)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 

--- a/pkg/controllers/vdb/createdb_reconciler.go
+++ b/pkg/controllers/vdb/createdb_reconciler.go
@@ -64,7 +64,7 @@ func MakeCreateDBReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
 	return &CreateDBReconciler{
 		VRec:                vdbrecon,
-		Log:                 log,
+		Log:                 log.WithName("CreateDBReconciler"),
 		Vdb:                 vdb,
 		PRunner:             prunner,
 		PFacts:              pfacts,

--- a/pkg/controllers/vdb/dbaddnode_reconciler.go
+++ b/pkg/controllers/vdb/dbaddnode_reconciler.go
@@ -48,7 +48,7 @@ func MakeDBAddNodeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 ) controllers.ReconcileActor {
 	return &DBAddNodeReconciler{
 		VRec:       vdbrecon,
-		Log:        log,
+		Log:        log.WithName("DBAddNodeReconciler"),
 		Vdb:        vdb,
 		PRunner:    prunner,
 		PFacts:     pfacts,

--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler.go
@@ -50,7 +50,7 @@ func MakeDBAddSubclusterReconciler(vdbrecon *VerticaDBReconciler, log logr.Logge
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts, dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
 	return &DBAddSubclusterReconciler{
 		VRec:       vdbrecon,
-		Log:        log,
+		Log:        log.WithName("DBAddSubclusterReconciler"),
 		Vdb:        vdb,
 		PRunner:    prunner,
 		PFacts:     pfacts,

--- a/pkg/controllers/vdb/dbremovenode_reconciler.go
+++ b/pkg/controllers/vdb/dbremovenode_reconciler.go
@@ -50,7 +50,7 @@ func MakeDBRemoveNodeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts, dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
 	return &DBRemoveNodeReconciler{
 		VRec:       vdbrecon,
-		Log:        log,
+		Log:        log.WithName("DBRemoveNodeReconciler"),
 		Vdb:        vdb,
 		PRunner:    prunner,
 		PFacts:     pfacts,

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
@@ -51,7 +51,7 @@ func MakeDBRemoveSubclusterReconciler(vdbrecon *VerticaDBReconciler, log logr.Lo
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts, dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
 	return &DBRemoveSubclusterReconciler{
 		VRec:       vdbrecon,
-		Log:        log,
+		Log:        log.WithName("DBRemoveSubclusterReconciler"),
 		Vdb:        vdb,
 		PRunner:    prunner,
 		PFacts:     pfacts,

--- a/pkg/controllers/vdb/httpserverctrl_reconciler_test.go
+++ b/pkg/controllers/vdb/httpserverctrl_reconciler_test.go
@@ -81,7 +81,7 @@ var _ = Describe("httpserverctrl_reconcile", func() {
 func reconcileAndFindHTTPServerStart(ctx context.Context, vdb *vapi.VerticaDB) []cmds.CmdHistory {
 	fpr := &cmds.FakePodRunner{}
 	pfacts := createPodFactsWithHTTPServerNotRunning(ctx, vdb, fpr)
-	h := MakeHTTPServerCtrlReconciler(vdbRec, vdb, fpr, pfacts)
+	h := MakeHTTPServerCtrlReconciler(vdbRec, logger, vdb, fpr, pfacts)
 	Expect(h.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	return fpr.FindCommands("vsql", "-tAc", genHTTPServerCtrlQuery("start"))
 }

--- a/pkg/controllers/vdb/install_reconciler.go
+++ b/pkg/controllers/vdb/install_reconciler.go
@@ -50,7 +50,7 @@ func MakeInstallReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) controllers.ReconcileActor {
 	return &InstallReconciler{
 		VRec:     vdbrecon,
-		Log:      log,
+		Log:      log.WithName("InstallReconciler"),
 		Vdb:      vdb,
 		PRunner:  prunner,
 		PFacts:   pfacts,

--- a/pkg/controllers/vdb/metrics_reconciler_test.go
+++ b/pkg/controllers/vdb/metrics_reconciler_test.go
@@ -39,7 +39,7 @@ var _ = Describe("prometheus_reconcile", func() {
 
 		prunner := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(prunner)
-		actor := MakeMetricReconciler(vdbRec, vdb, prunner, pfacts)
+		actor := MakeMetricReconciler(vdbRec, logger, vdb, prunner, pfacts)
 		r := actor.(*MetricReconciler)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -70,7 +70,7 @@ func MakeObjReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger, vdb *vapi
 	mode ObjReconcileModeType) controllers.ReconcileActor {
 	return &ObjReconciler{
 		VRec:   vdbrecon,
-		Log:    log,
+		Log:    log.WithName("ObjReconciler"),
 		Vdb:    vdb,
 		PFacts: pfacts,
 		Mode:   mode,

--- a/pkg/controllers/vdb/offlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconciler.go
@@ -63,7 +63,12 @@ var OfflineUpgradeStatusMsgs = []string{
 // MakeOfflineUpgradeReconciler will build an OfflineUpgradeReconciler object
 func MakeOfflineUpgradeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts, dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
-	return &OfflineUpgradeReconciler{VRec: vdbrecon, Log: log, Vdb: vdb, PRunner: prunner, PFacts: pfacts,
+	return &OfflineUpgradeReconciler{
+		VRec:       vdbrecon,
+		Log:        log.WithName("OfflineUpgradeReconciler"),
+		Vdb:        vdb,
+		PRunner:    prunner,
+		PFacts:     pfacts,
 		Finder:     iter.MakeSubclusterFinder(vdbrecon.Client, vdb),
 		Manager:    *MakeUpgradeManager(vdbrecon, log, vdb, vapi.OfflineUpgradeInProgress, offlineUpgradeAllowed),
 		Dispatcher: dispatcher,
@@ -257,7 +262,7 @@ func (o *OfflineUpgradeReconciler) postRestartingClusterMsg(ctx context.Context)
 // addPodAnnotations will call the PodAnnotationReconciler so that we have the
 // necessary annotations on the pod prior to restart.
 func (o *OfflineUpgradeReconciler) addPodAnnotations(ctx context.Context) (ctrl.Result, error) {
-	r := MakeAnnotateAndLabelPodReconciler(o.VRec, o.Vdb, o.PFacts)
+	r := MakeAnnotateAndLabelPodReconciler(o.VRec, o.Log, o.Vdb, o.PFacts)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 
@@ -284,7 +289,7 @@ func (o *OfflineUpgradeReconciler) restartCluster(ctx context.Context) (ctrl.Res
 // objects will route to the pods.  This is done after the pods have been
 // reschedulde and vertica restarted.
 func (o *OfflineUpgradeReconciler) addClientRoutingLabel(ctx context.Context) (ctrl.Result, error) {
-	r := MakeClientRoutingLabelReconciler(o.VRec, o.Vdb, o.PFacts,
+	r := MakeClientRoutingLabelReconciler(o.VRec, o.Log, o.Vdb, o.PFacts,
 		PodRescheduleApplyMethod, "" /* all subclusters */)
 	return r.Reconcile(ctx, &ctrl.Request{})
 }

--- a/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
+++ b/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
@@ -39,7 +39,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		act := MakeAnnotateAndLabelPodReconciler(vdbRec, vdb, &pfacts)
+		act := MakeAnnotateAndLabelPodReconciler(vdbRec, logger, vdb, &pfacts)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		pod := &corev1.Pod{}
@@ -67,7 +67,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
-		act := MakeAnnotateAndLabelPodReconciler(vdbRec, vdb, &pfacts)
+		act := MakeAnnotateAndLabelPodReconciler(vdbRec, logger, vdb, &pfacts)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
 		Expect(k8sClient.Get(ctx, pn, pod)).Should(Succeed())

--- a/pkg/controllers/vdb/rebalanceshards_reconciler.go
+++ b/pkg/controllers/vdb/rebalanceshards_reconciler.go
@@ -44,7 +44,7 @@ func MakeRebalanceShardsReconciler(vdbrecon *VerticaDBReconciler, log logr.Logge
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts, scName string) controllers.ReconcileActor {
 	return &RebalanceShardsReconciler{
 		VRec:    vdbrecon,
-		Log:     log,
+		Log:     log.WithName("RebalanceShardsReconciler"),
 		Vdb:     vdb,
 		PRunner: prunner,
 		PFacts:  pfacts,

--- a/pkg/controllers/vdb/resizepv_reconciler_test.go
+++ b/pkg/controllers/vdb/resizepv_reconciler_test.go
@@ -100,7 +100,7 @@ func runResizePVReconciler(ctx context.Context, vdb *vapi.VerticaDB, expectedReq
 	for i := range pfacts.Detail {
 		pfacts.Detail[i].depotDiskPercentSize = "60%"
 	}
-	r := MakeResizePVReconciler(vdbRec, vdb, fpr, pfacts)
+	r := MakeResizePVReconciler(vdbRec, logger, vdb, fpr, pfacts)
 	res, err := r.Reconcile(ctx, &ctrl.Request{})
 	ExpectWithOffset(1, err).Should(Succeed())
 	ExpectWithOffset(1, res).Should(Equal(ctrl.Result{Requeue: expectedRequeue}))

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -71,7 +71,7 @@ func MakeRestartReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
 	return &RestartReconciler{
 		VRec:            vdbrecon,
-		Log:             log,
+		Log:             log.WithName("RestartReconciler"),
 		Vdb:             vdb,
 		PRunner:         prunner,
 		PFacts:          pfacts,

--- a/pkg/controllers/vdb/revivedb_reconciler.go
+++ b/pkg/controllers/vdb/revivedb_reconciler.go
@@ -59,7 +59,7 @@ func MakeReviveDBReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
 	return &ReviveDBReconciler{
 		VRec:                vdbrecon,
-		Log:                 log,
+		Log:                 log.WithName("ReviveDBReconciler"),
 		Vdb:                 vdb,
 		PRunner:             prunner,
 		PFacts:              pfacts,

--- a/pkg/controllers/vdb/status_reconciler.go
+++ b/pkg/controllers/vdb/status_reconciler.go
@@ -44,7 +44,13 @@ type StatusReconciler struct {
 // MakeStatusReconciler will build a StatusReconciler object
 func MakeStatusReconciler(cli client.Client, scheme *runtime.Scheme, log logr.Logger,
 	vdb *vapi.VerticaDB, pfacts *PodFacts) controllers.ReconcileActor {
-	return &StatusReconciler{Client: cli, Scheme: scheme, Log: log, Vdb: vdb, PFacts: pfacts}
+	return &StatusReconciler{
+		Client: cli,
+		Scheme: scheme,
+		Log:    log.WithName("StatusReconciler"),
+		Vdb:    vdb,
+		PFacts: pfacts,
+	}
 }
 
 // Reconcile will update the status of the Vdb based on the pod facts

--- a/pkg/controllers/vdb/uninstall_reconciler.go
+++ b/pkg/controllers/vdb/uninstall_reconciler.go
@@ -50,7 +50,7 @@ func MakeUninstallReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB, prunner cmds.PodRunner, pfacts *PodFacts) controllers.ReconcileActor {
 	return &UninstallReconciler{
 		VRec:     vdbrecon,
-		Log:      log,
+		Log:      log.WithName("UninstallReconciler"),
 		Vdb:      vdb,
 		PRunner:  prunner,
 		PFacts:   pfacts,

--- a/pkg/controllers/vdb/upgradeoperator120_reconciler.go
+++ b/pkg/controllers/vdb/upgradeoperator120_reconciler.go
@@ -40,7 +40,7 @@ type UpgradeOperator120Reconciler struct {
 // MakeUpgradeOperator120Reconciler will build a UpgradeOperatorFrom120Reconciler object
 func MakeUpgradeOperator120Reconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	vdb *vapi.VerticaDB) controllers.ReconcileActor {
-	return &UpgradeOperator120Reconciler{VRec: vdbrecon, Log: log, Vdb: vdb}
+	return &UpgradeOperator120Reconciler{VRec: vdbrecon, Log: log.WithName("UpgradeOperator120Reconciler"), Vdb: vdb}
 }
 
 // Reconcile will handle any upgrade actions for k8s objects created in 1.2.0 or prior.

--- a/pkg/controllers/vdb/version_reconciler.go
+++ b/pkg/controllers/vdb/version_reconciler.go
@@ -48,7 +48,7 @@ func MakeVersionReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
 	enforceUpgradePath bool) controllers.ReconcileActor {
 	return &VersionReconciler{
 		VRec:               vdbrecon,
-		Log:                log,
+		Log:                log.WithName("VersionReconciler"),
 		Vdb:                vdb,
 		PRunner:            prunner,
 		PFacts:             pfacts,

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -154,7 +154,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 	return []controllers.ReconcileActor{
 		// Always start with a status reconcile in case the prior reconcile failed.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
-		MakeMetricReconciler(r, vdb, prunner, pfacts),
+		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
 		// Report any pods that have low disk space
 		MakeLocalDataCheckReconciler(r, vdb, pfacts),
 		// Handle upgrade actions for any k8s objects created in prior versions
@@ -172,7 +172,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeObjReconciler(r, log, vdb, pfacts,
 			ObjReconcileModePreserveScaling|ObjReconcileModePreserveUpdateStrategy),
 		// Add annotations/labels to each pod about the host running them
-		MakeAnnotateAndLabelPodReconciler(r, vdb, pfacts),
+		MakeAnnotateAndLabelPodReconciler(r, log, vdb, pfacts),
 		// Handles vertica server upgrade (i.e., when spec.image changes)
 		MakeOfflineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeOnlineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
@@ -180,13 +180,13 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeStopDBReconciler(r, vdb, prunner, pfacts, dispatcher),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true, dispatcher),
-		MakeMetricReconciler(r, vdb, prunner, pfacts),
+		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Ensure we add labels to any pod rescheduled so that Service objects route traffic to it.
-		MakeClientRoutingLabelReconciler(r, vdb, pfacts, PodRescheduleApplyMethod, ""),
+		MakeClientRoutingLabelReconciler(r, log, vdb, pfacts, PodRescheduleApplyMethod, ""),
 		// Remove Service label for any pods that are pending delete.  This will
 		// cause the Service object to stop routing traffic to them.
-		MakeClientRoutingLabelReconciler(r, vdb, pfacts, DelNodeApplyMethod, ""),
+		MakeClientRoutingLabelReconciler(r, log, vdb, pfacts, DelNodeApplyMethod, ""),
 		// Wait for any nodes that are pending delete with active connections to leave.
 		MakeDrainNodeReconciler(r, vdb, prunner, pfacts),
 		// Handles calls to remove subcluster from vertica catalog
@@ -194,7 +194,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handles calls to remove a database node from the cluster
 		MakeDBRemoveNodeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
-		MakeMetricReconciler(r, vdb, prunner, pfacts),
+		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to remove hosts from admintools.conf
 		MakeUninstallReconciler(r, log, vdb, prunner, pfacts),
@@ -211,19 +211,19 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeCreateDBReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		// Handle calls to revive a database
 		MakeReviveDBReconciler(r, log, vdb, prunner, pfacts, dispatcher),
-		MakeMetricReconciler(r, vdb, prunner, pfacts),
+		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
 		// Create and revive are mutually exclusive exclusive, so this handles
 		// status updates after both of them.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Update the labels in pods so that Services route to nodes to them.
-		MakeClientRoutingLabelReconciler(r, vdb, pfacts, PodRescheduleApplyMethod, ""),
+		MakeClientRoutingLabelReconciler(r, log, vdb, pfacts, PodRescheduleApplyMethod, ""),
 		// Ensure the vertica agent is running on each pod
-		MakeAgentReconciler(r, vdb, prunner, pfacts),
+		MakeAgentReconciler(r, log, vdb, prunner, pfacts),
 		// Ensure http server is running on each pod
-		MakeHTTPServerCtrlReconciler(r, vdb, prunner, pfacts),
+		MakeHTTPServerCtrlReconciler(r, log, vdb, prunner, pfacts),
 		// Handle calls to add new subcluster to the catalog
 		MakeDBAddSubclusterReconciler(r, log, vdb, prunner, pfacts, dispatcher),
-		MakeMetricReconciler(r, vdb, prunner, pfacts),
+		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Handle calls to add a new database node to the cluster
 		MakeDBAddNodeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
@@ -232,9 +232,9 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeRebalanceShardsReconciler(r, log, vdb, prunner, pfacts, "" /* all subclusters */),
 		// Update the label in pods so that Service routing uses them if they
 		// have finished being rebalanced.
-		MakeClientRoutingLabelReconciler(r, vdb, pfacts, AddNodeApplyMethod, ""),
+		MakeClientRoutingLabelReconciler(r, log, vdb, pfacts, AddNodeApplyMethod, ""),
 		// Resize any PVs if the local data size changed in the vdb
-		MakeResizePVReconciler(r, vdb, prunner, pfacts),
+		MakeResizePVReconciler(r, log, vdb, prunner, pfacts),
 	}
 }
 


### PR DESCRIPTION
Our logging library that we use (logr.Logger) has the ability to create custom loggers with a name appended to it. This name is then displayed for all logging calls done with it. This change makes use of that so we can more easily trace where log messages are coming from.

We already include the VerticaDB name in each log messages. But we weren't consistent with the logger we used, so some messages omitted it.

Here is a sample log message from before this change:
```
2023-09-07T16:30:19.188Z        INFO    controllers.VerticaDB   Reconcile client routing label     {"applyMethod": "Add"}
```

After this change, 3rd column now identifies the reconciler that logged the message and we include the vdb.
```
2023-09-07T16:38:41.227Z        INFO controllers.VerticaDB.ClientRoutingLabelReconciler   Reconcile client routing label   {"verticadb": "spilly/vc", "applyMethod": "Add"}
```