### PR TITLE
Refresh with latest vcluster changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230907154925-a7b1e1f7d472
+	github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230907154925-a7b1e1f7d472 h1:B3YKW7A+wQTTdBrhXGl4Iwcx7AD+qkw7pwnfATV6bcE=
-github.com/vertica/vcluster v0.0.0-20230907154925-a7b1e1f7d472/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf h1:rpXxLs3equzjb0j+S8iGMGrG3jEgXsrQUGceYG5Ex98=
+github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vcluster/vclusterops/vlog"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cloud"
@@ -296,7 +297,10 @@ func (r *VerticaDBReconciler) makeDispatcher(log logr.Logger, vdb *vapi.VerticaD
 	passwd string) vadmin.Dispatcher {
 	if vmeta.UseVClusterOps(vdb.Annotations) {
 		vcc := vops.VClusterCommands{
-			Log: log.WithName("vcluster"),
+			Log: vlog.Printer{
+				Log:           log.WithName("vcluster"),
+				LogToFileOnly: false,
+			},
 		}
 		return vadmin.MakeVClusterOps(log, vdb, r.Client, &vcc, passwd, r.EVRec)
 	}


### PR DESCRIPTION
New vcluster changes use a different structure for the logger called vlog.Printer. It essentially wraps a logr.Logger with extra state to know if we are printing to a file only. This is used to control the logging for Print* messages; we avoid printing if we are already logging to stdout.