### PR TITLE
Log event message for revive cluster lease error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf
+	github.com/vertica/vcluster v0.0.0-20230908175858-97ca903b61af
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf h1:rpXxLs3equzjb0j+S8iGMGrG3jEgXsrQUGceYG5Ex98=
-github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230908175858-97ca903b61af h1:KmWrytGL2k1bnpoaQoP0DH5PR0FgQRU8kT5PqPLhSPw=
+github.com/vertica/vcluster v0.0.0-20230908175858-97ca903b61af/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/vc_errors.go
+++ b/pkg/vadmin/vc_errors.go
@@ -53,7 +53,7 @@ func (v *vcErrors) LogFailure(cmd string, err error) (ctrl.Result, error) {
 	}
 	clusterLeaseNotExpiredError := &vclusterops.ClusterLeaseNotExpiredError{}
 	if ok := errors.As(err, &clusterLeaseNotExpiredError); ok {
-		return v.logClusterLeaseNotExpiredError(cmd, clusterLeaseNotExpiredError)
+		return v.logClusterLeaseNotExpiredError(clusterLeaseNotExpiredError)
 	}
 	return v.logGenericFailure(cmd, err)
 }
@@ -84,8 +84,8 @@ func (v *vcErrors) logRfc7807Failure(cmd string, vproblem *rfc7807.VProblem) (ct
 	return ctrl.Result{Requeue: true}, nil
 }
 
-func (v *vcErrors) logClusterLeaseNotExpiredError(cmd string, clusterLeaseNotExpiredError *vclusterops.ClusterLeaseNotExpiredError) (ctrl.Result, error) {
-	v.Log.Info("vclusterOps command failed because the cluster lease was not expired", "msg", clusterLeaseNotExpiredError.Error())
+func (v *vcErrors) logClusterLeaseNotExpiredError(err *vclusterops.ClusterLeaseNotExpiredError) (ctrl.Result, error) {
+	v.Log.Info("vclusterOps command failed because the cluster lease was not expired", "msg", err.Error())
 	v.EVWriter.Eventf(v.VDB, corev1.EventTypeWarning, events.ReviveDBClusterInUse,
 		"revive_db failed because the cluster lease has not expired for '%s'",
 		v.VDB.GetCommunalPath())

--- a/pkg/vadmin/vc_errors_test.go
+++ b/pkg/vadmin/vc_errors_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vertica/vcluster/rfc7807"
+	"github.com/vertica/vcluster/vclusterops"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/aterrors"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -64,6 +66,18 @@ var _ = Describe("verrors suite", func() {
 		res, err := vce.LogFailure("test unknown rfc7807", origErr)
 		Ω(res).Should(Equal(ctrl.Result{}))
 		Ω(err).Should(Equal(err))
+	})
+
+	It("should handle cluster lease expired errors", func() {
+		vce := vcErrors{
+			Log:      logger,
+			EVWriter: &aterrors.TestEVWriter{},
+			VDB:      vapi.MakeVDB(),
+		}
+		origErr := &vclusterops.ClusterLeaseNotExpiredError{Expiration: "10 minutes"}
+		res, err := vce.LogFailure("test cluster lease error", origErr)
+		Ω(res).Should(Equal(ctrl.Result{Requeue: true}))
+		Ω(err).Should(BeNil())
 	})
 
 })


### PR DESCRIPTION
This applies to the vclusterops implementation of revive. We will now log an event message if we hit an cluster lease error. We use the new ClusterLeaseNotExpired concrete type to know if we hit this error. This gets us closer in sync with the admintools handling of specific errors (see aterrors.go)