### PR TITLE
Use permissive mTLS in istio e2e testcase

### DIFF
--- a/tests/e2e-leg-3/istio/10-deploy-operator.yaml
+++ b/tests/e2e-leg-3/istio/10-deploy-operator.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: sh -c "cd ../../.. && make deploy-operator DEPLOY_WITH=helm WATCH_NAMESPACE=$NAMESPACE HELM_OVERRIDES='--set webhook.enable=false'"
+  - command: sh -c "cd ../../.. && make deploy-operator DEPLOY_WITH=helm WATCH_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-3/istio/15-enable-permissive-mTLS.yaml
+++ b/tests/e2e-leg-3/istio/15-enable-permissive-mTLS.yaml
@@ -17,4 +17,4 @@ metadata:
   name: default
 spec:
   mtls:
-    mode: STRICT
+    mode: PERMISSIVE


### PR DESCRIPTION
Using strict mTLS for istio doesn't work at the moment in our vclusterOps integration. I am changing the testcase to use a more permissive mode. We don't officially support istio in Vertica. But we do use it internally for one of our projects, and that use case doesn't use strict mode. So, it should be okay to change the test for now. Also, deploying the operator with the webhook enabled. I recall at one point the webhook didn't work with istio, but it did when I tried it again, so enabling that part.