### PR TITLE
VCluster API refresh: option Name changed to DBName

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf
+	github.com/vertica/vcluster v0.0.0-20230911145730-ee52961dfba3
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf h1:rpXxLs3equzjb0j+S8iGMGrG3jEgXsrQUGceYG5Ex98=
-github.com/vertica/vcluster v0.0.0-20230908112525-aa319249b4bf/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230911145730-ee52961dfba3 h1:UsvrnURq4fzxGoHmLz/+h91pHjm9Ytj5hTNUebZSe88=
+github.com/vertica/vcluster v0.0.0-20230911145730-ee52961dfba3/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -57,7 +57,7 @@ func (v *VClusterOps) genAddNodeOptions(s *addnode.Parms, certs *HTTPSCerts) vop
 
 	// required options
 	opts.NewHosts = s.Hosts
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -41,7 +41,7 @@ func (v *VClusterOps) AddSubcluster(ctx context.Context, opts ...addsc.Option) e
 		return err
 	}
 
-	v.Log.Info("Successfully added a subcluster to the database", "scName", *vopts.SCName, "dbName", *vopts.Name)
+	v.Log.Info("Successfully added a subcluster to the database", "scName", *vopts.SCName, "dbName", *vopts.DBName)
 	return nil
 }
 
@@ -53,7 +53,7 @@ func (v *VClusterOps) genAddSubclusterOptions(s *addsc.Parms) vops.VAddSubcluste
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))
 
 	opts.SCName = &s.Subcluster
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 	opts.IsEon = vstruct.MakeNullableBool(v.VDB.IsEON())
 	opts.IsPrimary = &s.IsPrimary
 

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -62,7 +62,7 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 		opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(opts.RawHosts[0]))
 	}
 	opts.CatalogPrefix = &s.CatalogPath
-	opts.Name = &s.DBName
+	opts.DBName = &s.DBName
 	opts.LicensePathOnNode = &s.LicensePath
 	*opts.ForceRemovalAtCreation = true
 	opts.SkipPackageInstall = &s.SkipPackageInstall

--- a/pkg/vadmin/fetch_node_state_vc.go
+++ b/pkg/vadmin/fetch_node_state_vc.go
@@ -60,7 +60,7 @@ func (v *VClusterOps) FetchNodeState(ctx context.Context, opts ...fetchnodestate
 func (v *VClusterOps) genFetchNodeStateOptions(s *fetchnodestate.Parms) vops.VFetchNodeStateOptions {
 	opts := vops.VFetchNodeStateOptionsFactory()
 
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -71,7 +71,7 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	*opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
 
 	// database name
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 
 	// re-ip list
 	for _, h := range s.Hosts {

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -49,7 +49,7 @@ func (v *VClusterOps) genRemoveNodeOptions(s *removenode.Parms, certs *HTTPSCert
 
 	// required options
 	opts.HostsToRemove = s.Hosts
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 
 	opts.RawHosts = []string{s.InitiatorIP}
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -61,7 +61,7 @@ func (v *VClusterOps) genRemoveSubclusterOptions(s *removesc.Parms, certs *HTTPS
 	opts := vops.VRemoveScOptionsFactory()
 
 	// required options
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 	opts.SubclusterToRemove = &s.Subcluster
 
 	*opts.HonorUserInput = true

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -55,7 +55,7 @@ func (v *VClusterOps) genRestartNodeOptions(s *restartnode.Parms, certs *HTTPSCe
 	honorUserInput := true
 	opts := vops.VRestartNodesOptions{
 		DatabaseOptions: vops.DatabaseOptions{
-			Name:           &v.VDB.Spec.DBName,
+			DBName:         &v.VDB.Spec.DBName,
 			RawHosts:       []string{s.InitiatorIP},
 			Ipv6:           vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP)),
 			Key:            certs.Key,

--- a/pkg/vadmin/revive_db_vc.go
+++ b/pkg/vadmin/revive_db_vc.go
@@ -51,7 +51,7 @@ func (v *VClusterOps) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ct
 func (v *VClusterOps) genReviveDBOptions(s *revivedb.Parms, certs *HTTPSCerts) *vops.VReviveDatabaseOptions {
 	opts := vops.VReviveDBOptionsFactory()
 
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 	opts.RawHosts = s.Hosts
 	v.Log.Info("Setup revive database options", "hosts", opts.RawHosts)
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(opts.RawHosts[0]))

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -55,7 +55,7 @@ func (v *VClusterOps) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	v.Log.Info("Successfully start a database", "dbName", *vopts.Name)
+	v.Log.Info("Successfully start a database", "dbName", *vopts.DBName)
 	return ctrl.Result{}, nil
 }
 
@@ -68,7 +68,7 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	}
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(opts.RawHosts[0]))
 	*opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 	opts.IsEon = vstruct.MakeNullableBool(v.VDB.IsEON())
 
 	// auth options

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -41,7 +41,7 @@ func (v *VClusterOps) StopDB(ctx context.Context, opts ...stopdb.Option) error {
 		return err
 	}
 
-	v.Log.Info("Successfully stopped a database", "dbName", *vopts.Name)
+	v.Log.Info("Successfully stopped a database", "dbName", *vopts.DBName)
 	return nil
 }
 
@@ -52,7 +52,7 @@ func (v *VClusterOps) genStopDBOptions(s *stopdb.Parms) vops.VStopDatabaseOption
 	v.Log.Info("Setup stop db options", "hosts", opts.RawHosts[0])
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))
 
-	opts.Name = &v.VDB.Spec.DBName
+	opts.DBName = &v.VDB.Spec.DBName
 	opts.IsEon = vstruct.MakeNullableBool(v.VDB.IsEON())
 
 	// auth options

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -110,7 +110,7 @@ func (m *MockVClusterOps) VerifyDBNameAndIPv6(options *vops.DatabaseOptions) err
 	if options.Ipv6.ToBool() != TestIPv6 {
 		return fmt.Errorf("failed to retrieve IPv6")
 	}
-	if *options.Name != TestDBName {
+	if *options.DBName != TestDBName {
 		return fmt.Errorf("failed to retrieve database name")
 	}
 


### PR DESCRIPTION
This PR just changes the Name option to DBName for all operations in the VCluster APIs