### PR TITLE
log event message for revive_db node count mismatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20230911145730-ee52961dfba3
+	github.com/vertica/vcluster v0.0.0-20230913110733-871e603dcaf7
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20230911145730-ee52961dfba3 h1:UsvrnURq4fzxGoHmLz/+h91pHjm9Ytj5hTNUebZSe88=
-github.com/vertica/vcluster v0.0.0-20230911145730-ee52961dfba3/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20230913110733-871e603dcaf7 h1:KrGXj/jUe6bL9E4vuRIkjTnwzNzWQbM6QykF45ZErME=
+github.com/vertica/vcluster v0.0.0-20230913110733-871e603dcaf7/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/vc_errors_test.go
+++ b/pkg/vadmin/vc_errors_test.go
@@ -80,4 +80,21 @@ var _ = Describe("verrors suite", func() {
 		Ω(err).Should(BeNil())
 	})
 
+	It("should handle revive_db node count mismatch error", func() {
+		vce := vcErrors{
+			Log:      logger,
+			EVWriter: &aterrors.TestEVWriter{},
+			VDB:      vapi.MakeVDB(),
+		}
+		origErr := &vclusterops.ReviveDBNodeCountMismatchError{
+			ReviveDBStep:  "NMADownloadFileOp",
+			FailureHost:   "127.0.0.1",
+			NumOfNewNodes: 3,
+			NumOfOldNodes: 4,
+		}
+		res, err := vce.LogFailure("test revive_db node count mismatch error", origErr)
+		Ω(res).Should(Equal(ctrl.Result{Requeue: true}))
+		Ω(err).Should(BeNil())
+	})
+
 })


### PR DESCRIPTION
This checked revive_db node count mismatch error from vclusterops. When we get this kind of error, we will log the event "ReviveDBNodeCountMismatch".