### PR TITLE
Fix e2e-server-upgrade in nightly tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,12 +354,22 @@ docker-build-vertica-v2: docker-vertica-v2/Dockerfile ## Build next generation v
 	cd docker-vertica-v2 \
 	&& make VERTICA_IMG=${VERTICA_IMG} MINIMAL_VERTICA_IMG=${MINIMAL_VERTICA_IMG} NO_KEYS=${NO_KEYS}
 
-.PHONY: docker-push
+.PHONY: docker-push-vertica
 docker-push-vertica:  ## Push vertica server image -- either v1 or v2.
 ifeq ($(shell $(KIND_CHECK)), 0)
 	docker push ${VERTICA_IMG}
 else
 	scripts/push-to-kind.sh -i ${VERTICA_IMG}
+endif
+
+# Normally the base image is a pre-built image that we don't build. For this
+# reason, pushing this image will just put it in kind and never to docker.
+.PHONY: docker-push-base-vertica
+docker-push-base-vertica:  ## Push base vertica server image to kind
+ifneq ($(BASE_VERTICA_IMG), <not-set>)
+ifeq ($(shell $(KIND_CHECK)), 1)
+	scripts/push-to-kind.sh -i ${BASE_VERTICA_IMG}
+endif
 endif
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
@@ -420,7 +430,7 @@ docker-push-olm-catalog:
 docker-build: docker-build-vertica docker-build-operator docker-build-vlogger ## Build all docker images except OLM catalog
 
 .PHONY: docker-push
-docker-push: docker-push-vertica docker-push-operator docker-push-vlogger ## Push all docker images except OLM catalog
+docker-push: docker-push-vertica docker-push-base-vertica docker-push-operator docker-push-vlogger ## Push all docker images except OLM catalog
 
 .PHONY: echo-images
 echo-images:  ## Print the names of all of the images used


### PR DESCRIPTION
It is currently failing because it cannot find the base vertica image the tests start with. For nightly builds it is in a private repository. We need to push that image into kind as part of test setup. Adding a new make target for this. It will be called from within run-k8s-int-tests.sh -- as part of `make docker-push`.