### PR TITLE
Update linux capabilities required by the operator

### DIFF
--- a/changes/unreleased/Changed-20231003-094045.yaml
+++ b/changes/unreleased/Changed-20231003-094045.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: Removed linux capabilities for vclusterOps deployments to make it easier to
+  deploy in OpenShift
+time: 2023-10-03T09:40:45.847298082-03:00
+custom:
+  Issue: "524"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -748,6 +748,13 @@ func makeServerSecurityContext(vdb *vapi.VerticaDB) *corev1.SecurityContext {
 	if vdb.Spec.SecurityContext != nil {
 		sc = vdb.Spec.SecurityContext
 	}
+
+	// In vclusterops mode, we don't need neither SYS_CHROOT
+	// nor AUDIT_WRITE
+	if vmeta.UseVClusterOps(vdb.Annotations) {
+		return sc
+	}
+
 	if sc.Capabilities == nil {
 		sc.Capabilities = &corev1.Capabilities{}
 	}
@@ -756,8 +763,6 @@ func makeServerSecurityContext(vdb *vapi.VerticaDB) *corev1.SecurityContext {
 		"SYS_CHROOT",
 		// Needed to run sshd on OpenShift
 		"AUDIT_WRITE",
-		// Needed to be able to collect stacks via vstack
-		"SYS_PTRACE",
 	}
 	for i := range capabilitiesNeeded {
 		foundCap := false

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -749,8 +749,8 @@ func makeServerSecurityContext(vdb *vapi.VerticaDB) *corev1.SecurityContext {
 		sc = vdb.Spec.SecurityContext
 	}
 
-	// In vclusterops mode, we don't need neither SYS_CHROOT
-	// nor AUDIT_WRITE
+	// In vclusterops mode, we don't need SYS_CHROOT
+	// and AUDIT_WRITE to run on OpenShift
 	if vmeta.UseVClusterOps(vdb.Annotations) {
 		return sc
 	}

--- a/tests/e2e-leg-1-failed/client-access/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-1-failed/client-access/setup-vdb/base/setup-vdb.yaml
@@ -30,6 +30,9 @@ spec:
     - name: sc1
       size: 2
   kSafety: "0"
+  securityContext:
+    capabilities:
+      add: ["SYS_PTRACE"]
   certSecrets: []
   imagePullSecrets: []
   volumes: []


### PR DESCRIPTION
Before this change, when the operator set up the statefulset for the subcluster, it set the following capabilities:
```
// Needed to run sshd on OpenShift
"SYS_CHROOT",
// Needed to run sshd on OpenShift
"AUDIT_WRITE",
// Needed to be able to collect stacks via vstack
"SYS_PTRACE", 
``` 
SYS_CHROOT and AUDIT_WRITE are not needed in vclusterops mode so they are not added if vclusterops feature flag is set.
SYS_PTRACE is no longer set by default. If you need to collect stacks, you first have to set the SYS_PTRACE capability in the CR:
```
spec:
    securityContext:
        capabilities:
          add: ["SYS_PTRACE"]
```

