### PR TITLE
Ensure http service starts for vcluster create db

### DIFF
--- a/pkg/controllers/vdb/init_db.go
+++ b/pkg/controllers/vdb/init_db.go
@@ -126,9 +126,13 @@ func (g *GenericDatabaseInitializer) runInit(ctx context.Context) (ctrl.Result, 
 // checkPodList ensures all of the pods that we will use for the init call are running
 func (g *GenericDatabaseInitializer) checkPodList(podList []*PodFact) bool {
 	for _, pod := range podList {
-		// Bail if find one of the pods isn't running or doesn't have the
-		// annotations that we use in the k8s Vertica DC table.
-		if !pod.isPodRunning || !pod.hasDCTableAnnotations {
+		// Bail if:
+		// - find one of the pods isn't running
+		// - installer hasn't run yet for the pod.
+		// - doesn't have the annotations that we use in the k8s Vertica DC
+		//   table. This has to be present before we start vertica to populate
+		//   the DC table correctly.
+		if !pod.isPodRunning || !pod.isInstalled || !pod.hasDCTableAnnotations {
 			return false
 		}
 	}

--- a/pkg/vadmin/vc.go
+++ b/pkg/vadmin/vc.go
@@ -35,7 +35,7 @@ func (v *VClusterOps) retrieveHTTPSCerts(ctx context.Context) (*HTTPSCerts, erro
 	tlsCerts := &corev1.Secret{}
 	err := v.Client.Get(ctx, nm, tlsCerts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve httpServerTLSSecret named %s: %w", nm.Name, err)
 	}
 
 	tlsKey, ok := tlsCerts.Data[corev1.TLSPrivateKeyKey]


### PR DESCRIPTION
This fixes a timing issue that could cause the vclusters create db operation to fail. This can happen if the install is not run before the create db. The installer sets up a configuration file that starts the HTTP service. If this is skipped, the HTTP service will not start and create db will not succeed because it needs that endpoint to communicate with.