### PR TITLE
Rename v1 API fields: requeueTime

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -428,3 +428,8 @@ func (v *VerticaDB) GetKSafety() string {
 	}
 	return "1"
 }
+
+// GetRequeueTime returns the time in seconds to wait for the next reconiliation iteration.
+func (v *VerticaDB) GetRequeueTime() int {
+	return vmeta.GetRequeueTime(v.Annotations)
+}

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -184,17 +184,6 @@ type VerticaDBSpec struct {
 	// left empty the operator will default to picking existing subclusters.
 	TemporarySubclusterRouting *SubclusterSelection `json:"temporarySubclusterRouting,omitempty"`
 
-	// +kubebuilder:default:=0
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:advanced"}
-	// If a reconciliation iteration needs to be requeued this controls the
-	// amount of time in seconds to wait.  If this is set to 0, then the requeue
-	// time will increase using an exponential backoff algorithm.  Caution, when
-	// setting this to some positive value the exponential backoff is disabled.
-	// This should be reserved for test environments as an error scenario could
-	// easily consume the logs.
-	RequeueTime int `json:"requeueTime,omitempty"`
-
 	// +kubebuilder:default:=30
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:advanced"}

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -814,10 +814,10 @@ func (v *VerticaDB) transientSubclusterMustMatchTemplate(allErrs field.ErrorList
 // validateRequeueTimes is a check for the various requeue times in the CR.
 func (v *VerticaDB) validateRequeueTimes(allErrs field.ErrorList) field.ErrorList {
 	prefix := field.NewPath("spec")
-	if v.Spec.RequeueTime < 0 {
-		err := field.Invalid(prefix.Child("requeueTime"),
-			v.Spec.RequeueTime,
-			"requeueTime cannot be negative")
+	if v.GetRequeueTime() < 0 {
+		err := field.Invalid(field.NewPath("metadata").Child("annotations").Key(vmeta.RequeueTimeAnnotation),
+			v.Annotations[vmeta.RequeueTimeAnnotation],
+			"requeue time cannot be negative")
 		allErrs = append(allErrs, err)
 	}
 	if v.Spec.UpgradeRequeueTime < 0 {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -602,9 +602,9 @@ var _ = Describe("verticadb_webhook", func() {
 
 	It("should prevent negative values for requeueTime", func() {
 		vdb := MakeVDB()
-		vdb.Spec.RequeueTime = -30
+		vdb.Annotations[vmeta.RequeueTimeAnnotation] = "-30"
 		validateSpecValuesHaveErr(vdb, true)
-		vdb.Spec.RequeueTime = 0
+		vdb.Annotations[vmeta.RequeueTimeAnnotation] = "0"
 		vdb.Spec.UpgradeRequeueTime = -1
 		validateSpecValuesHaveErr(vdb, true)
 		vdb.Spec.UpgradeRequeueTime = 0

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -74,6 +74,9 @@ func convertToAnnotations(src *VerticaDB) (newAnnotations map[string]string) {
 	if src.Spec.KSafety != KSafetyType(vmeta.KSafetyDefaultValue) {
 		newAnnotations[vmeta.KSafetyAnnotation] = string(src.Spec.KSafety)
 	}
+	if src.Spec.RequeueTime != 0 {
+		newAnnotations[vmeta.RequeueTimeAnnotation] = strconv.FormatInt(int64(src.Spec.RequeueTime), 10)
+	}
 	return
 }
 
@@ -88,6 +91,7 @@ func convertFromAnnotations(src *v1.VerticaDB) (newAnnotations map[string]string
 		vmeta.IgnoreUpgradePathAnnotation:  true,
 		vmeta.RestartTimeoutAnnotation:     true,
 		vmeta.KSafetyAnnotation:            true,
+		vmeta.RequeueTimeAnnotation:        true,
 	}
 	for key, val := range src.Annotations {
 		if _, ok := omitKeys[key]; ok {
@@ -118,7 +122,6 @@ func convertToSpec(src *VerticaDBSpec) v1.VerticaDBSpec {
 		HadoopConfig:             src.Communal.HadoopConfig,
 		Local:                    convertToLocal(&src.Local),
 		Subclusters:              make([]v1.Subcluster, len(src.Subclusters)),
-		RequeueTime:              src.RequeueTime,
 		UpgradeRequeueTime:       src.UpgradeRequeueTime,
 		Sidecars:                 src.Sidecars,
 		Volumes:                  src.Volumes,
@@ -175,7 +178,7 @@ func convertFromSpec(src *v1.VerticaDB) VerticaDBSpec {
 		Local:                    convertFromLocal(&srcSpec.Local),
 		Subclusters:              make([]Subcluster, len(srcSpec.Subclusters)),
 		KSafety:                  KSafetyType(src.GetKSafety()),
-		RequeueTime:              srcSpec.RequeueTime,
+		RequeueTime:              src.GetRequeueTime(),
 		UpgradeRequeueTime:       srcSpec.UpgradeRequeueTime,
 		Sidecars:                 srcSpec.Sidecars,
 		Volumes:                  srcSpec.Volumes,

--- a/api/v1beta1/verticadb_conversion_test.go
+++ b/api/v1beta1/verticadb_conversion_test.go
@@ -112,4 +112,22 @@ var _ = Describe("verticadb_conversion", func() {
 		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
 		Ω(v1beta1VDB.Spec.KSafety).Should(Equal(KSafety1))
 	})
+
+	It("should convert requeueTime", func() {
+		v1beta1VDB := MakeVDB()
+		v1VDB := v1.VerticaDB{}
+
+		// v1beta1 -> v1
+		v1beta1VDB.Spec.RequeueTime = 33
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Annotations[vmeta.RequeueTimeAnnotation]).Should(Equal("33"))
+		v1beta1VDB.Spec.RequeueTime = 0
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Annotations[vmeta.RequeueTimeAnnotation]).Should(BeEmpty())
+
+		// v1 -> v1beta1
+		v1VDB.Annotations[vmeta.RequeueTimeAnnotation] = "13"
+		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
+		Ω(v1beta1VDB.Spec.RequeueTime).Should(Equal(13))
+	})
 })

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -144,9 +144,9 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// If any function needs a requeue and we have a RequeueTime set,
 			// then overwrite RequeueAfter.
 			// Functions such as Upgrade may already set RequeueAfter and Requeue to false
-			if (res.Requeue || res.RequeueAfter > 0) && vdb.Spec.RequeueTime > 0 {
+			if (res.Requeue || res.RequeueAfter > 0) && vdb.GetRequeueTime() > 0 {
 				res.Requeue = false
-				res.RequeueAfter = time.Second * time.Duration(vdb.Spec.RequeueTime)
+				res.RequeueAfter = time.Second * time.Duration(vdb.GetRequeueTime())
 			}
 			log.Info("aborting reconcile of VerticaDB", "result", res, "err", err)
 			return res, err

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -15,7 +15,9 @@
 
 package meta
 
-import "strconv"
+import (
+	"strconv"
+)
 
 const (
 	// Annotations that we set in each of the pod.  These are set by the
@@ -70,6 +72,14 @@ const (
 	KSafetyAnnotation   = "vertica.com/k-safety"
 	KSafetyDefaultValue = "1"
 
+	// If a reconciliation iteration needs to be requeued this controls the
+	// amount of time in seconds to wait.  If this is set to 0, or not set, then
+	// the requeue time will increase using an exponential backoff algorithm.
+	// Caution, when setting this to some positive value the exponential backoff
+	// is disabled.  This should be reserved for test environments as an error
+	// scenario could easily consume the logs.
+	RequeueTimeAnnotation = "vertica.com/requeue-time"
+
 	// Annotations that we add by parsing vertica --version output
 	VersionAnnotation   = "vertica.com/version"
 	BuildDateAnnotation = "vertica.com/buildDate"
@@ -116,6 +126,12 @@ func GetRestartTimeout(annotations map[string]string) int {
 // IsKSafety0 returns true if k-safety is set to 0. False implies 1.
 func IsKSafety0(annotations map[string]string) bool {
 	return lookupStringAnnotation(annotations, KSafetyAnnotation, KSafetyDefaultValue) == "0"
+}
+
+// GetRequeueTime returns the amount of seconds to wait between reconciliation
+// that are requeued. 0 means use the exponential backoff algorithm.
+func GetRequeueTime(annotations map[string]string) int {
+	return lookupIntAnnotation(annotations, RequeueTimeAnnotation)
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/tests/e2e-leg-1/autoscale-by-pod/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-1/autoscale-by-pod/setup-vdb/base/setup-vdb.yaml
@@ -15,6 +15,8 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-autoscale-by-pod
+  annotations:
+    vertica.com/requeue-time: "5"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
@@ -30,7 +32,6 @@ spec:
       size: 2
     - name: sc2
       size: 1
-  requeueTime: 5
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-leg-1/autoscale-by-subcluster/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-1/autoscale-by-subcluster/setup-vdb/base/setup-vdb.yaml
@@ -15,6 +15,8 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-autoscale-by-subcluster
+  annotations:
+    vertica.com/requeue-time: "5"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
@@ -28,7 +30,6 @@ spec:
   subclusters:
     - name: pri
       size: 3
-  requeueTime: 5
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-leg-2/restart-sanity/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-2/restart-sanity/setup-vdb/base/setup-vdb.yaml
@@ -17,6 +17,7 @@ metadata:
   name: v-restart
   annotations:
     vertica.com/restart-timeout: "1500"
+    vertica.com/requeue-time: "4"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
@@ -28,7 +29,6 @@ spec:
     requestSize: 100Mi
   dbName: spilchendb2
   shardCount: 20
-  requeueTime: 4
   subclusters:
     - name: defsc
       size: 3

--- a/tests/e2e-leg-4/createdb-failures/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/createdb-failures/setup-vdb/base/setup-vdb.yaml
@@ -17,6 +17,9 @@ metadata:
   name: v-createdb-failures
   annotations:
     vertica.com/k-safety: "0"
+    # Set requeueTime since we are intentionally failing.  This prevents the
+    # exponential backoff kicking in, which can cause the test to timeout.
+    vertica.com/requeue-time: "4"
 spec:
   image: kustomize-vertica-image
   communal:
@@ -29,9 +32,6 @@ spec:
     - name: sc
       size: 1
   initPolicy: CreateSkipPackageInstall
-  # Set requeueTime since we are intentionally failing.  This prevents the
-  # exponential backoff kicking in, which can cause the test to timeout.
-  requeueTime: 4
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-leg-4/pvc-expansion/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/pvc-expansion/setup-vdb/base/setup-vdb.yaml
@@ -17,6 +17,7 @@ metadata:
   name: v-pvc-expansion
   annotations:
     vertica.com/k-safety: "0"
+    vertica.com/requeue-time: "5"
 spec:
   image: kustomize-vertica-image
   sidecars:
@@ -32,7 +33,6 @@ spec:
     - name: main
       size: 1
   certSecrets: []
-  requeueTime: 5
   imagePullSecrets: []
   volumes: []
   volumeMounts: []

--- a/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/setup-vdb.yaml
@@ -15,6 +15,8 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-restart-with-liveness-probe
+  annotations:
+    vertica.com/requeue-time: "5"
 spec:
   image: kustomize-vertica-image
   communal:
@@ -23,7 +25,6 @@ spec:
     requestSize: 100Mi
   dbName: db
   initPolicy: CreateSkipPackageInstall
-  requeueTime: 5
   subclusters:
     - name: pri1
       size: 2

--- a/tests/e2e-leg-4/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/vdb-to-create/base/setup-vdb.yaml
@@ -15,6 +15,8 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-create-3-node
+  annotations:
+    vertica.com/requeue-time: "5"
 spec:
   image: kustomize-vertica-image
   communal:
@@ -25,7 +27,6 @@ spec:
     depotPath: /my-data
     requestSize: 100Mi
   dbName: vertdb
-  requeueTime: 5
   subclusters:
     - name: main
       size: 3

--- a/tests/e2e-leg-4/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
@@ -17,6 +17,7 @@ metadata:
   name: v-revive-3-node
   annotations:
     vertica.com/ignore-cluster-lease: true
+    vertica.com/requeue-time: "5"
 spec:
   image: kustomize-vertica-image
   communal:
@@ -28,7 +29,6 @@ spec:
     depotVolume: EmptyDir
     requestSize: 100Mi
   dbName: vertdb
-  requeueTime: 5
   subclusters:
     - name: main
       size: 3

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
@@ -15,6 +15,8 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-base-upgrade
+  annotations:
+    vertica.com/requeue-time: "4"
 spec:
   image: kustomize-vertica-image
   communal:
@@ -29,7 +31,6 @@ spec:
       size: 3
       isPrimary: true
   certSecrets: []
-  requeueTime: 4
   imagePullSecrets: []
   volumes: []
   volumeMounts: []

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/setup-vdb/base/setup-vdb.yaml
@@ -15,6 +15,10 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-base-upgrade
+  annotations:
+    # Set requeueTime to prevent the exponential backoff kicking in, which can
+    # cause the test to timeout.
+    vertica.com/requeue-time: "5"
 spec:
   image: kustomize-vertica-image
   imagePullPolicy: IfNotPresent
@@ -26,9 +30,6 @@ spec:
   subclusters:
     - name: sc1
       size: 3
-  # Set requeueTime to prevent the exponential backoff kicking in, which can
-  # cause the test to timeout.
-  requeueTime: 5
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/setup-vdb/base/setup-vdb.yaml
@@ -17,6 +17,7 @@ metadata:
   name: v-base-upgrade
   annotations:
     vertica.com/k-safety: "0"
+    vertica.com/requeue-time: "5"
 spec:
   image: kustomize-vertica-image
   communal:
@@ -28,7 +29,6 @@ spec:
     - name: pri
       size: 1
       isPrimary: true
-  requeueTime: 5
   temporarySubclusterRouting:
     template:
       name: transient


### PR DESCRIPTION
Same rationale as in #531 . This moves the `spec.requeueTime` field to an annotation. The v1beta1 API is not impacted by this.