### PR TITLE
Set a custom logger for each vcluster API

### DIFF
--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -31,8 +31,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	vops "github.com/vertica/vcluster/vclusterops"
-	"github.com/vertica/vcluster/vclusterops/vlog"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cloud"
@@ -307,13 +305,7 @@ func (r *VerticaDBReconciler) checkShardToNodeRatio(vdb *vapi.VerticaDB, sc *vap
 func (r *VerticaDBReconciler) makeDispatcher(log logr.Logger, vdb *vapi.VerticaDB, prunner cmds.PodRunner,
 	passwd string) vadmin.Dispatcher {
 	if vmeta.UseVClusterOps(vdb.Annotations) {
-		vcc := vops.VClusterCommands{
-			Log: vlog.Printer{
-				Log:           log.WithName("vcluster"),
-				LogToFileOnly: false,
-			},
-		}
-		return vadmin.MakeVClusterOps(log, vdb, r.Client, &vcc, passwd, r.EVRec)
+		return vadmin.MakeVClusterOps(log, vdb, r.Client, passwd, r.EVRec, vadmin.SetupVClusterOps)
 	}
 	return vadmin.MakeAdmintools(log, vdb, prunner, r.EVRec, r.OpCfg.DevMode)
 }

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -30,6 +30,8 @@ import (
 
 // AddNode will add a new vertica node to the cluster
 func (v *VClusterOps) AddNode(ctx context.Context, opts ...addnode.Option) error {
+	v.setupForAPICall("AddNode")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster AddNode")
 
 	// get the certs

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -27,6 +27,8 @@ import (
 
 // AddSubcluster will create a subcluster in the vertica cluster.
 func (v *VClusterOps) AddSubcluster(_ context.Context, opts ...addsc.Option) error {
+	v.setupForAPICall("AddSubcluster")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster AddSubcluster")
 
 	// get add_subcluster k8s configs

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -30,6 +30,8 @@ import (
 
 // CreateDB will construct a new DB using the vcluster-ops library
 func (v *VClusterOps) CreateDB(ctx context.Context, opts ...createdb.Option) (ctrl.Result, error) {
+	v.setupForAPICall("CreateDB")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster CreateDB")
 
 	// get the certs

--- a/pkg/vadmin/describe_db_vc.go
+++ b/pkg/vadmin/describe_db_vc.go
@@ -26,6 +26,8 @@ import (
 
 // DescribeDB will get information about a database from communal storage.
 func (v *VClusterOps) DescribeDB(ctx context.Context, opts ...describedb.Option) (string, ctrl.Result, error) {
+	v.setupForAPICall("DescribeDB")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster DescribeDB")
 
 	certs, err := v.retrieveHTTPSCerts(ctx)

--- a/pkg/vadmin/fetch_node_state_vc.go
+++ b/pkg/vadmin/fetch_node_state_vc.go
@@ -29,6 +29,8 @@ import (
 // FetchNodeState will determine if the given set of nodes are considered UP
 // or DOWN in our consensous state. It returns a map of vnode to its node state.
 func (v *VClusterOps) FetchNodeState(_ context.Context, opts ...fetchnodestate.Option) (map[string]string, ctrl.Result, error) {
+	v.setupForAPICall("FetchNodeState")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster FetchNodeState")
 
 	// get fetch node state options

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -30,6 +30,8 @@ import (
 
 // ReIP will update the catalog on disk with new IPs for all of the nodes given.
 func (v *VClusterOps) ReIP(ctx context.Context, opts ...reip.Option) (ctrl.Result, error) {
+	v.setupForAPICall("ReIP")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster ReIP")
 
 	// get the certs

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -27,6 +27,8 @@ import (
 
 // RemoveNode will remove an existng vertica node from the cluster.
 func (v *VClusterOps) RemoveNode(ctx context.Context, opts ...removenode.Option) error {
+	v.setupForAPICall("RemoveNode")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster RemoveNode")
 
 	// get the certs

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -29,6 +29,8 @@ import (
 
 // RemoveSubcluster will remove the given subcluster from the vertica cluster.
 func (v *VClusterOps) RemoveSubcluster(ctx context.Context, opts ...removesc.Option) error {
+	v.setupForAPICall("RemoveSubcluster")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster RemoveSubcluster")
 
 	// get the certs

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -31,6 +31,8 @@ import (
 // lost cluster quorum. The IP given for each vnode may not match the current IP
 // in the vertica catalogs.
 func (v *VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Option) (ctrl.Result, error) {
+	v.setupForAPICall("RestartNode")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster RestartNode")
 
 	certs, err := v.retrieveHTTPSCerts(ctx)

--- a/pkg/vadmin/revive_db_vc.go
+++ b/pkg/vadmin/revive_db_vc.go
@@ -29,6 +29,8 @@ import (
 // ReviveDB will initialized a database using an existing communal path. It does
 // this using the vclusterops library.
 func (v *VClusterOps) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ctrl.Result, error) {
+	v.setupForAPICall("ReviveDB")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting VCluster ReviveDB")
 
 	certs, err := v.retrieveHTTPSCerts(ctx)

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -30,6 +30,8 @@ import (
 
 // StartDB will start a subset of nodes of the database
 func (v *VClusterOps) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl.Result, error) {
+	v.setupForAPICall("StartDB")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster StartDB")
 
 	// get the certs

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -27,6 +27,8 @@ import (
 
 // StopDB will stop all the vertica hosts of a running cluster
 func (v *VClusterOps) StopDB(_ context.Context, opts ...stopdb.Option) error {
+	v.setupForAPICall("StopDB")
+	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster StopDB")
 
 	// get stop_db options

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -193,9 +193,14 @@ func (m *MockVClusterOps) VerifyCerts(options *vops.DatabaseOptions) error {
 func mockVClusterOpsDispatcher() *VClusterOps {
 	vdb := vapi.MakeVDB()
 	vdb.Spec.HTTPServerTLSSecret = "test-secret"
-	mockVops := MockVClusterOps{}
 	evWriter := aterrors.TestEVWriter{}
-	dispatcher := MakeVClusterOps(logger, vdb, k8sClient, &mockVops, TestPassword, &evWriter)
+	// We use a function to construct the VClusterProvider. This is called
+	// ahead of each API rather than once so that we can setup a custom
+	// logger for each API call.
+	setupAPIFunc := func(log logr.Logger, apiName string) (VClusterProvider, logr.Logger) {
+		return &MockVClusterOps{}, logr.Logger{}
+	}
+	dispatcher := MakeVClusterOps(logger, vdb, k8sClient, TestPassword, &evWriter, setupAPIFunc)
 	return dispatcher.(*VClusterOps)
 }
 


### PR DESCRIPTION
This creates a custom logger for each vcluster API call. The purpose is so that we can construct a logr.Logger object using the WithName() function. This will give us a better idea of where the various log entries are coming from. For instance, with this change, you can see the 3 log messages below all originate from the CreateDB API call (3rd column in each log statement).

2023-10-14T21:14:35.123Z    INFO    controllers.VerticaDB.CreateDB Starting vcluster CreateDB  {"verticadb": "kuttl-test-able-insect/v-client-access"}
2023-10-14T21:14:35.123Z    INFO    controllers.VerticaDB.CreateDB Setup create db options {"verticadb": "kuttl-test-able-insect/v-client-access", "hosts": "10.244.0.28"}
2023-10-14T21:14:35.123Z    INFO    controllers.VerticaDB.CreateDB starting VCreateDatabase    {"verticadb": "kuttl-test-able-insect/v-client-access"}