### PR TITLE
Rename v1 API fields: upgradeRequeueTime and SSHSecret

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -272,14 +272,6 @@ func (v *VerticaDB) isConditionIndexSet(inx int) bool {
 	return inx < len(v.Status.Conditions) && v.Status.Conditions[inx].Status == corev1.ConditionTrue
 }
 
-// GetUpgradeRequeueTime returns default upgrade requeue time if not set in the CRD
-func (v *VerticaDB) GetUpgradeRequeueTime() time.Duration {
-	if v.Spec.UpgradeRequeueTime == 0 {
-		return time.Second * time.Duration(URTime)
-	}
-	return time.Second * time.Duration(v.Spec.UpgradeRequeueTime)
-}
-
 // buildTransientSubcluster creates a temporary read-only sc based on an existing subcluster
 func (v *VerticaDB) BuildTransientSubcluster(imageOverride string) *Subcluster {
 	return &Subcluster{
@@ -432,4 +424,19 @@ func (v *VerticaDB) GetKSafety() string {
 // GetRequeueTime returns the time in seconds to wait for the next reconiliation iteration.
 func (v *VerticaDB) GetRequeueTime() int {
 	return vmeta.GetRequeueTime(v.Annotations)
+}
+
+// GetUpgradeRequeueTime returns the time in seconds to wait between
+// reconciliations during an upgrade. This is the raw value as set in the CR.
+func (v *VerticaDB) GetUpgradeRequeueTime() int {
+	return vmeta.GetUpgradeRequeueTime(v.Annotations)
+}
+
+// GetUpgradeRequeueTimeDuration returns default upgrade requeue time if not set
+// in the CRD. The value returned is of type Duration.
+func (v *VerticaDB) GetUpgradeRequeueTimeDuration() time.Duration {
+	if v.GetUpgradeRequeueTime() == 0 {
+		return time.Second * time.Duration(URTime)
+	}
+	return time.Second * time.Duration(v.GetUpgradeRequeueTime())
 }

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -440,3 +440,9 @@ func (v *VerticaDB) GetUpgradeRequeueTimeDuration() time.Duration {
 	}
 	return time.Second * time.Duration(v.GetUpgradeRequeueTime())
 }
+
+// GetSSHSecretName returns the name of the secret that contains SSH keys to use
+// for admintools style of deployments.
+func (v *VerticaDB) GetSSHSecretName() string {
+	return vmeta.GetSSHSecretName(v.Annotations)
+}

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -230,15 +230,6 @@ type VerticaDBSpec struct {
 	KerberosSecret string `json:"kerberosSecret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:io.kubernetes:Secret","urn:alm:descriptor:com.tectonic.ui:advanced"}
-	// An optional secret that has the files for /home/dbadmin/.ssh.  If this is
-	// omitted, the ssh files from the image are used.  You can this option if
-	// you have a cluster that talks to Vertica notes outside of Kubernetes, as
-	// it has the public keys to be able to ssh to those nodes.  It must have
-	// the following keys present: id_rsa, id_rsa.pub and authorized_keys.
-	SSHSecret string `json:"sshSecret,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	// Controls if the spread communication between pods is encrypted.  Valid
 	// values are 'vertica' or an empty string if not enabled.  When set to

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -184,14 +184,6 @@ type VerticaDBSpec struct {
 	// left empty the operator will default to picking existing subclusters.
 	TemporarySubclusterRouting *SubclusterSelection `json:"temporarySubclusterRouting,omitempty"`
 
-	// +kubebuilder:default:=30
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number","urn:alm:descriptor:com.tectonic.ui:advanced"}
-	// If a reconciliation iteration during an operation such as Upgrade needs to be requeued, this controls the
-	// amount of time in seconds to delay adding the key to the reconcile queue.  If RequeueTime is set, it overrides this value.
-	//  If RequeueTime is not set either, then we set the default value only for upgrades. For other reconciles we use the exponential backoff algorithm.
-	UpgradeRequeueTime int `json:"upgradeRequeueTime,omitempty"`
-
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
 	// Optional sidecar containers that run along side the vertica server.  The

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -813,17 +813,17 @@ func (v *VerticaDB) transientSubclusterMustMatchTemplate(allErrs field.ErrorList
 
 // validateRequeueTimes is a check for the various requeue times in the CR.
 func (v *VerticaDB) validateRequeueTimes(allErrs field.ErrorList) field.ErrorList {
-	prefix := field.NewPath("spec")
+	prefix := field.NewPath("metadata").Child("annotations")
 	if v.GetRequeueTime() < 0 {
-		err := field.Invalid(field.NewPath("metadata").Child("annotations").Key(vmeta.RequeueTimeAnnotation),
+		err := field.Invalid(prefix.Key(vmeta.RequeueTimeAnnotation),
 			v.Annotations[vmeta.RequeueTimeAnnotation],
 			"requeue time cannot be negative")
 		allErrs = append(allErrs, err)
 	}
-	if v.Spec.UpgradeRequeueTime < 0 {
-		err := field.Invalid(prefix.Child("upgradeRequeueTime"),
-			v.Spec.UpgradeRequeueTime,
-			"upgradeRequeueTime cannot be negative")
+	if v.GetUpgradeRequeueTime() < 0 {
+		err := field.Invalid(prefix.Key(vmeta.UpgradeRequeueTimeAnnotation),
+			v.Annotations[vmeta.UpgradeRequeueTimeAnnotation],
+			"upgrade requeue time cannot be negative")
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -605,9 +605,9 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Annotations[vmeta.RequeueTimeAnnotation] = "-30"
 		validateSpecValuesHaveErr(vdb, true)
 		vdb.Annotations[vmeta.RequeueTimeAnnotation] = "0"
-		vdb.Spec.UpgradeRequeueTime = -1
+		vdb.Annotations[vmeta.UpgradeRequeueTimeAnnotation] = "-1"
 		validateSpecValuesHaveErr(vdb, true)
-		vdb.Spec.UpgradeRequeueTime = 0
+		vdb.Annotations[vmeta.UpgradeRequeueTimeAnnotation] = "0"
 		validateSpecValuesHaveErr(vdb, false)
 	})
 

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -80,6 +80,9 @@ func convertToAnnotations(src *VerticaDB) (newAnnotations map[string]string) {
 	if src.Spec.UpgradeRequeueTime != 0 {
 		newAnnotations[vmeta.UpgradeRequeueTimeAnnotation] = strconv.FormatInt(int64(src.Spec.UpgradeRequeueTime), 10)
 	}
+	if src.Spec.SSHSecret != "" {
+		newAnnotations[vmeta.SSHSecAnnotation] = src.Spec.SSHSecret
+	}
 	return
 }
 
@@ -96,6 +99,7 @@ func convertFromAnnotations(src *v1.VerticaDB) (newAnnotations map[string]string
 		vmeta.KSafetyAnnotation:            true,
 		vmeta.RequeueTimeAnnotation:        true,
 		vmeta.UpgradeRequeueTimeAnnotation: true,
+		vmeta.SSHSecAnnotation:             true,
 	}
 	for key, val := range src.Annotations {
 		if _, ok := omitKeys[key]; ok {
@@ -131,7 +135,6 @@ func convertToSpec(src *VerticaDBSpec) v1.VerticaDBSpec {
 		VolumeMounts:             src.VolumeMounts,
 		CertSecrets:              convertToLocalReferenceSlice(src.CertSecrets),
 		KerberosSecret:           src.KerberosSecret,
-		SSHSecret:                src.SSHSecret,
 		EncryptSpreadComm:        src.EncryptSpreadComm,
 		SecurityContext:          src.SecurityContext,
 		PodSecurityContext:       src.PodSecurityContext,
@@ -188,7 +191,7 @@ func convertFromSpec(src *v1.VerticaDB) VerticaDBSpec {
 		VolumeMounts:             srcSpec.VolumeMounts,
 		CertSecrets:              convertFromLocalReferenceSlice(srcSpec.CertSecrets),
 		KerberosSecret:           srcSpec.KerberosSecret,
-		SSHSecret:                srcSpec.SSHSecret,
+		SSHSecret:                src.GetSSHSecretName(),
 		EncryptSpreadComm:        srcSpec.EncryptSpreadComm,
 		SecurityContext:          srcSpec.SecurityContext,
 		PodSecurityContext:       srcSpec.PodSecurityContext,

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -77,6 +77,9 @@ func convertToAnnotations(src *VerticaDB) (newAnnotations map[string]string) {
 	if src.Spec.RequeueTime != 0 {
 		newAnnotations[vmeta.RequeueTimeAnnotation] = strconv.FormatInt(int64(src.Spec.RequeueTime), 10)
 	}
+	if src.Spec.UpgradeRequeueTime != 0 {
+		newAnnotations[vmeta.UpgradeRequeueTimeAnnotation] = strconv.FormatInt(int64(src.Spec.UpgradeRequeueTime), 10)
+	}
 	return
 }
 
@@ -92,6 +95,7 @@ func convertFromAnnotations(src *v1.VerticaDB) (newAnnotations map[string]string
 		vmeta.RestartTimeoutAnnotation:     true,
 		vmeta.KSafetyAnnotation:            true,
 		vmeta.RequeueTimeAnnotation:        true,
+		vmeta.UpgradeRequeueTimeAnnotation: true,
 	}
 	for key, val := range src.Annotations {
 		if _, ok := omitKeys[key]; ok {
@@ -122,7 +126,6 @@ func convertToSpec(src *VerticaDBSpec) v1.VerticaDBSpec {
 		HadoopConfig:             src.Communal.HadoopConfig,
 		Local:                    convertToLocal(&src.Local),
 		Subclusters:              make([]v1.Subcluster, len(src.Subclusters)),
-		UpgradeRequeueTime:       src.UpgradeRequeueTime,
 		Sidecars:                 src.Sidecars,
 		Volumes:                  src.Volumes,
 		VolumeMounts:             src.VolumeMounts,
@@ -179,7 +182,7 @@ func convertFromSpec(src *v1.VerticaDB) VerticaDBSpec {
 		Subclusters:              make([]Subcluster, len(srcSpec.Subclusters)),
 		KSafety:                  KSafetyType(src.GetKSafety()),
 		RequeueTime:              src.GetRequeueTime(),
-		UpgradeRequeueTime:       srcSpec.UpgradeRequeueTime,
+		UpgradeRequeueTime:       src.GetUpgradeRequeueTime(),
 		Sidecars:                 srcSpec.Sidecars,
 		Volumes:                  srcSpec.Volumes,
 		VolumeMounts:             srcSpec.VolumeMounts,

--- a/api/v1beta1/verticadb_conversion_test.go
+++ b/api/v1beta1/verticadb_conversion_test.go
@@ -130,4 +130,22 @@ var _ = Describe("verticadb_conversion", func() {
 		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
 		Ω(v1beta1VDB.Spec.RequeueTime).Should(Equal(13))
 	})
+
+	It("should convert upgradeRequeueTime", func() {
+		v1beta1VDB := MakeVDB()
+		v1VDB := v1.VerticaDB{}
+
+		// v1beta1 -> v1
+		v1beta1VDB.Spec.UpgradeRequeueTime = 60
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Annotations[vmeta.UpgradeRequeueTimeAnnotation]).Should(Equal("60"))
+		v1beta1VDB.Spec.UpgradeRequeueTime = 0
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Annotations[vmeta.UpgradeRequeueTimeAnnotation]).Should(BeEmpty())
+
+		// v1 -> v1beta1
+		v1VDB.Annotations[vmeta.UpgradeRequeueTimeAnnotation] = "75"
+		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
+		Ω(v1beta1VDB.Spec.UpgradeRequeueTime).Should(Equal(75))
+	})
 })

--- a/api/v1beta1/verticadb_conversion_test.go
+++ b/api/v1beta1/verticadb_conversion_test.go
@@ -148,4 +148,22 @@ var _ = Describe("verticadb_conversion", func() {
 		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
 		Ω(v1beta1VDB.Spec.UpgradeRequeueTime).Should(Equal(75))
 	})
+
+	It("should convert sshSecret", func() {
+		v1beta1VDB := MakeVDB()
+		v1VDB := v1.VerticaDB{}
+
+		// v1beta1 -> v1
+		v1beta1VDB.Spec.SSHSecret = "s1"
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Annotations[vmeta.SSHSecAnnotation]).Should(Equal("s1"))
+		v1beta1VDB.Spec.SSHSecret = ""
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Annotations[vmeta.SSHSecAnnotation]).Should(BeEmpty())
+
+		// v1 -> v1beta1
+		v1VDB.Annotations[vmeta.SSHSecAnnotation] = "s2"
+		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
+		Ω(v1beta1VDB.Spec.SSHSecret).Should(Equal("s2"))
+	})
 })

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -189,7 +189,7 @@ func buildVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 		volMnts = append(volMnts, buildKerberosVolumeMounts()...)
 	}
 
-	if vdb.Spec.SSHSecret != "" {
+	if vdb.GetSSHSecretName() != "" {
 		volMnts = append(volMnts, buildSSHVolumeMounts()...)
 	}
 
@@ -281,7 +281,7 @@ func buildVolumes(vdb *vapi.VerticaDB) []corev1.Volume {
 	if vdb.Spec.KerberosSecret != "" {
 		vols = append(vols, buildKerberosVolume(vdb))
 	}
-	if vdb.Spec.SSHSecret != "" {
+	if vdb.GetSSHSecretName() != "" {
 		vols = append(vols, buildSSHVolume(vdb))
 	}
 	if vdb.Spec.HTTPServerTLSSecret != "" {
@@ -504,7 +504,7 @@ func buildSSHVolume(vdb *vapi.VerticaDB) corev1.Volume {
 		Name: vapi.SSHMountName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: vdb.Spec.SSHSecret,
+				SecretName: vdb.GetSSHSecretName(),
 			},
 		},
 	}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -263,7 +263,7 @@ var _ = Describe("builder", func() {
 
 	It("should mount ssh secret for dbadmin and root", func() {
 		vdb := vapi.MakeVDB()
-		vdb.Spec.SSHSecret = "my-secret"
+		vdb.Annotations[vmeta.SSHSecAnnotation] = "my-secret"
 		c := buildPodSpec(vdb, &vdb.Spec.Subclusters[0])
 		cnt := &c.Containers[0]
 		i, ok := getFirstSSHSecretVolumeMountIndex(cnt)

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -157,8 +157,8 @@ func (o *ObjReconciler) checkMountedObjs(ctx context.Context) (ctrl.Result, erro
 		}
 	}
 
-	if o.Vdb.Spec.SSHSecret != "" {
-		if res, err := o.checkSecretHasKeys(ctx, "SSH", o.Vdb.Spec.SSHSecret, paths.SSHKeyPaths); verrors.IsReconcileAborted(res, err) {
+	if o.Vdb.GetSSHSecretName() != "" {
+		if res, err := o.checkSecretHasKeys(ctx, "SSH", o.Vdb.GetSSHSecretName(), paths.SSHKeyPaths); verrors.IsReconcileAborted(res, err) {
 			return res, err
 		}
 	}

--- a/pkg/controllers/vdb/obj_reconciler_test.go
+++ b/pkg/controllers/vdb/obj_reconciler_test.go
@@ -548,12 +548,12 @@ var _ = Describe("obj_reconcile", func() {
 
 		It("should requeue if the ssh secret has a missing keys", func() {
 			vdb := vapi.MakeVDB()
-			vdb.Spec.SSHSecret = "my-secret-v3"
-			nm := names.GenNamespacedName(vdb, vdb.Spec.SSHSecret)
+			vdb.Annotations[vmeta.SSHSecAnnotation] = "my-secret-v3"
+			nm := names.GenNamespacedName(vdb, vdb.GetSSHSecretName())
 			secret := builder.BuildSecretBase(nm)
 			secret.Data[paths.SSHKeyPaths[0]] = []byte("conf") // Only 1 of the keys
 			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
-			defer deleteSecret(ctx, vdb, vdb.Spec.SSHSecret)
+			defer deleteSecret(ctx, vdb, vdb.GetSSHSecretName())
 			createCrd(vdb, false)
 			defer deleteCrd(vdb)
 

--- a/pkg/controllers/vdb/offlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconciler.go
@@ -118,7 +118,7 @@ func (o *OfflineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Reques
 			// If Reconcile was aborted with a requeue, set the RequeueAfter interval to prevent exponential backoff
 			if err == nil {
 				res.Requeue = false
-				res.RequeueAfter = o.Vdb.GetUpgradeRequeueTime()
+				res.RequeueAfter = o.Vdb.GetUpgradeRequeueTimeDuration()
 			}
 			return res, err
 		}

--- a/pkg/controllers/vdb/offlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconciler_test.go
@@ -49,7 +49,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, NewImage)
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[0]), sts)).Should(Succeed())
 		Expect(sts.Spec.Template.Spec.Containers[names.ServerContainerIndex].Image).Should(Equal(NewImage))
@@ -66,7 +66,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, "container1:newimage")
 
 		r, fpr, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 		h := fpr.FindCommands("admintools -t stop_db")
 		Expect(len(h)).Should(Equal(1))
 	})
@@ -81,13 +81,13 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, "container2:newimage")
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 		// Delete the sts in preparation of recrating everything with the new
 		// image.  Pods will come up not running to force a requeue by the
 		// restart reconciler.
 		test.DeletePods(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 	})
 
 	It("should delete pods during an upgrade", func() {
@@ -100,7 +100,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		updateVdbToCauseUpgrade(ctx, vdb, "container2:newimage")
 
 		r, _, _ := createOfflineUpgradeReconciler(vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 
 		finder := iter.MakeSubclusterFinder(k8sClient, vdb)
 		pods, err := finder.FindPods(ctx, iter.FindExisting)
@@ -120,7 +120,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		r, fpr, pfacts := createOfflineUpgradeReconciler(vdb)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)].upNode = false
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 		h := fpr.FindCommands("admintools -t stop_db")
 		Expect(len(h)).Should(Equal(0))
 	})
@@ -149,7 +149,7 @@ var _ = Describe("offlineupgrade_reconcile", func() {
 		// Read the latest vdb to get status conditions, etc.
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), vdb)).Should(Succeed())
 
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 		Expect(r.Manager.ContinuingUpgrade).Should(Equal(true))
 	})
 })

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -115,7 +115,7 @@ func (o *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 			// If Reconcile was aborted with a requeue, set the RequeueAfter interval to prevent exponential backoff
 			if err == nil {
 				res.Requeue = false
-				res.RequeueAfter = o.Vdb.GetUpgradeRequeueTime()
+				res.RequeueAfter = o.Vdb.GetUpgradeRequeueTimeDuration()
 			}
 			return res, err
 		}

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -328,7 +328,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		// may need a restart.  It would have gotten far enough to update the
 		// sts for the primaries.
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(
-			ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+			ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 
 		sts := &appsv1.StatefulSet{}
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[0]), sts)).Should(Succeed())
@@ -359,7 +359,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		r := createOnlineUpgradeReconciler(ctx, vdb)
-		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTime()}))
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: vdb.GetUpgradeRequeueTimeDuration()}))
 		Expect(vdb.Status.UpgradeStatus).Should(Equal("Checking if new version is compatible"))
 	})
 
@@ -405,7 +405,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		vdb.Spec.TemporarySubclusterRouting = &vapi.SubclusterSelection{
 			Names: []string{vdb.Spec.Subclusters[0].Name},
 		}
-		vdb.Spec.UpgradeRequeueTime = 100 // Set a non-default UpgradeRequeueTime for the test
+		vdb.Annotations[vmeta.UpgradeRequeueTimeAnnotation] = "100" // Set a non-default UpgradeRequeueTime for the test
 		vdb.ObjectMeta.Annotations[vmeta.VersionAnnotation] = vapi.OnlineUpgradeVersion
 
 		test.CreateVDB(ctx, k8sClient, vdb)

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -88,6 +88,15 @@ const (
 	// reconciles we use the exponential backoff algorithm.
 	UpgradeRequeueTimeAnnotation = "vertica.com/upgrade-requeue-time"
 
+	// A secret that has the files for /home/dbadmin/.ssh.  If this is
+	// omitted, the ssh files from the image are used (if applicable). SSH is
+	// only required when deploying via admintools and is present only in images
+	// tailored for that deployment type.  You can use this option if you have a
+	// cluster that talks to Vertica notes outside of Kubernetes, as it has the
+	// public keys to be able to ssh to those nodes.  It must have the following
+	// keys present: id_rsa, id_rsa.pub and authorized_keys.
+	SSHSecAnnotation = "vertica.com/ssh-secret"
+
 	// Annotations that we add by parsing vertica --version output
 	VersionAnnotation   = "vertica.com/version"
 	BuildDateAnnotation = "vertica.com/buildDate"
@@ -146,6 +155,12 @@ func GetRequeueTime(annotations map[string]string) int {
 // reconciliations during an upgrade.
 func GetUpgradeRequeueTime(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, UpgradeRequeueTimeAnnotation)
+}
+
+// GetSSHSecretName returns the name of the secret that contains SSH keys to use
+// for admintools style of deployments.
+func GetSSHSecretName(annotations map[string]string) string {
+	return lookupStringAnnotation(annotations, SSHSecAnnotation, "")
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -80,6 +80,14 @@ const (
 	// scenario could easily consume the logs.
 	RequeueTimeAnnotation = "vertica.com/requeue-time"
 
+	// If a reconciliation iteration during an operation such as Upgrade needs
+	// to be requeued, this controls the amount of time in seconds to delay
+	// adding the key to the reconcile queue.  If the RequeueTimeAnnotation is
+	// set, it overrides this value.  If RequeueTimeAnnotation is not set
+	// either, then we set the default value only for upgrades. For other
+	// reconciles we use the exponential backoff algorithm.
+	UpgradeRequeueTimeAnnotation = "vertica.com/upgrade-requeue-time"
+
 	// Annotations that we add by parsing vertica --version output
 	VersionAnnotation   = "vertica.com/version"
 	BuildDateAnnotation = "vertica.com/buildDate"
@@ -132,6 +140,12 @@ func IsKSafety0(annotations map[string]string) bool {
 // that are requeued. 0 means use the exponential backoff algorithm.
 func GetRequeueTime(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, RequeueTimeAnnotation)
+}
+
+// GetUpgradeRequeueTime returns the amount of seconds to wait between
+// reconciliations during an upgrade.
+func GetUpgradeRequeueTime(annotations map[string]string) int {
+	return lookupIntAnnotation(annotations, UpgradeRequeueTimeAnnotation)
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/tests/e2e-leg-1/autoscale-by-pod/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-1/autoscale-by-pod/setup-vdb/base/setup-vdb.yaml
@@ -17,10 +17,10 @@ metadata:
   name: v-autoscale-by-pod
   annotations:
     vertica.com/requeue-time: "5"
+    vertica.com/ssh-secret: "ssh-keys"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
-  sshSecret: ssh-keys
   communal:
     includeUIDInPath: true
   local:

--- a/tests/e2e-leg-1/autoscale-by-subcluster/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-1/autoscale-by-subcluster/setup-vdb/base/setup-vdb.yaml
@@ -17,10 +17,10 @@ metadata:
   name: v-autoscale-by-subcluster
   annotations:
     vertica.com/requeue-time: "5"
+    vertica.com/ssh-secret: "ssh-keys"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
-  sshSecret: ssh-keys
   communal:
     includeUIDInPath: true
   local:

--- a/tests/e2e-leg-5/custom-cert-webhook-cabundle-in-secret/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-5/custom-cert-webhook-cabundle-in-secret/setup-vdb/base/setup-vdb.yaml
@@ -17,10 +17,10 @@ metadata:
   name: v-custom-cert-webhook-cabundle-in-secret
   annotations:
     vertica.com/k-safety: "0"
+    vertica.com/ssh-secret: "ssh-keys"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
-  sshSecret: ssh-keys
   communal:
     includeUIDInPath: false
   local:


### PR DESCRIPTION
Another change to move CR parms to annotations in the v1 API. This moves both upgradeRequeueTime and SSHSecret over. See #531 to understand why we are making this change. No change is done to the v1beta1 API.