### PR TITLE
Rename v1 API fields: kerberosRealm and kerberosServiceName

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -474,18 +474,6 @@ type CommunalStorage struct {
 	// Vertica retries several times before giving up.
 	Region string `json:"region,omitempty"`
 
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
-	// The service name portion of the Vertica Kerberos principal. This is set
-	// in the database config parameter KerberosServiceName during bootstrapping.
-	KerberosServiceName string `json:"kerberosServiceName,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
-	// Name of the Kerberos realm.  This is set in the database config parameter
-	// KerberosRealm during bootstrapping.
-	KerberosRealm string `json:"kerberosRealm,omitempty"`
-
 	// +kubebuilder:default:=""
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:SSE-S3","urn:alm:descriptor:com.tectonic.ui:select:SSE-KMS","urn:alm:descriptor:com.tectonic.ui:select:SSE-C"}

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -404,8 +404,8 @@ var _ = Describe("verticadb_webhook", func() {
 		for _, vals := range kerberosSetup {
 			vdb := createVDBHelper()
 			vdb.Spec.KerberosSecret = vals[0]
-			vdb.Spec.Communal.KerberosRealm = vals[1]
-			vdb.Spec.Communal.KerberosServiceName = vals[2]
+			vdb.Spec.Communal.AdditionalConfig[vmeta.KerberosRealmConfig] = vals[1]
+			vdb.Spec.Communal.AdditionalConfig[vmeta.KerberosServiceNameConfig] = vals[2]
 			validateSpecValuesHaveErr(vdb, true)
 		}
 	})

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -307,18 +307,23 @@ func convertFromSubcluster(src *v1.Subcluster) Subcluster {
 
 // convertToCommunal will convert to a v1 VerticaDBCondition from a v1beta1 version
 func convertToCommunal(src *CommunalStorage) v1.CommunalStorage {
-	return v1.CommunalStorage{
+	cs := v1.CommunalStorage{
 		Path:                   src.Path,
 		Endpoint:               src.Endpoint,
 		CredentialSecret:       src.CredentialSecret,
 		CaFile:                 src.CaFile,
 		Region:                 src.Region,
-		KerberosServiceName:    src.KerberosServiceName,
-		KerberosRealm:          src.KerberosRealm,
 		S3ServerSideEncryption: v1.ServerSideEncryptionType(src.S3ServerSideEncryption),
 		S3SseCustomerKeySecret: src.S3SseCustomerKeySecret,
 		AdditionalConfig:       src.AdditionalConfig,
 	}
+	if src.KerberosServiceName != "" {
+		cs.AdditionalConfig[vmeta.KerberosServiceNameConfig] = src.KerberosServiceName
+	}
+	if src.KerberosRealm != "" {
+		cs.AdditionalConfig[vmeta.KerberosRealmConfig] = src.KerberosRealm
+	}
+	return cs
 }
 
 // convertFromCommunal will convert from a v1 CommunalStorage to a v1beta1 version
@@ -332,8 +337,8 @@ func convertFromCommunal(src *v1.VerticaDB) CommunalStorage {
 		HadoopConfig:           src.Spec.HadoopConfig,
 		CaFile:                 comSpec.CaFile,
 		Region:                 comSpec.Region,
-		KerberosServiceName:    comSpec.KerberosServiceName,
-		KerberosRealm:          comSpec.KerberosRealm,
+		KerberosServiceName:    comSpec.AdditionalConfig[vmeta.KerberosServiceNameConfig],
+		KerberosRealm:          comSpec.AdditionalConfig[vmeta.KerberosRealmConfig],
 		S3ServerSideEncryption: ServerSideEncryptionType(comSpec.S3ServerSideEncryption),
 		S3SseCustomerKeySecret: comSpec.S3SseCustomerKeySecret,
 		AdditionalConfig:       comSpec.AdditionalConfig,

--- a/api/v1beta1/verticadb_conversion_test.go
+++ b/api/v1beta1/verticadb_conversion_test.go
@@ -184,4 +184,24 @@ var _ = Describe("verticadb_conversion", func() {
 		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
 		Ω(v1beta1VDB.Spec.Communal.IncludeUIDInPath).Should(BeTrue())
 	})
+
+	It("should convert kerberos fields", func() {
+		v1beta1VDB := MakeVDB()
+		v1VDB := v1.VerticaDB{}
+
+		// v1beta1 -> v1
+		v1beta1VDB.Spec.Communal.KerberosRealm = "krealm"
+		v1beta1VDB.Spec.Communal.KerberosServiceName = "kservice"
+		v1beta1VDB.Spec.Communal.AdditionalConfig = make(map[string]string)
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Spec.Communal.AdditionalConfig[vmeta.KerberosRealmConfig]).Should(Equal("krealm"))
+		Ω(v1VDB.Spec.Communal.AdditionalConfig[vmeta.KerberosServiceNameConfig]).Should(Equal("kservice"))
+
+		// v1 -> v1beta1
+		v1VDB.Spec.Communal.AdditionalConfig[vmeta.KerberosRealmConfig] = "new-krealm"
+		v1VDB.Spec.Communal.AdditionalConfig[vmeta.KerberosServiceNameConfig] = "new-kservice"
+		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
+		Ω(v1beta1VDB.Spec.Communal.KerberosRealm).Should(Equal("new-krealm"))
+		Ω(v1beta1VDB.Spec.Communal.KerberosServiceName).Should(Equal("new-kservice"))
+	})
 })

--- a/pkg/controllers/vdb/init_db_test.go
+++ b/pkg/controllers/vdb/init_db_test.go
@@ -191,20 +191,10 @@ var _ = Describe("init_db", func() {
 		contructAuthParmsHelper(ctx, vdb, "", "")
 	})
 
-	It("should include Kerberos parms if there are kerberos settings", func() {
-		vdb := vapi.MakeVDB()
-		vdb.Spec.Communal.KerberosRealm = "EXAMPLE.COM"
-		vdb.Spec.Communal.KerberosServiceName = "vertica"
-		createS3CredSecret(ctx, vdb)
-		defer deleteCommunalCredSecret(ctx, vdb)
-
-		contructAuthParmsHelper(ctx, vdb, "KerberosRealm", "")
-	})
-
 	It("should requeue if trying to use Kerberos but have an older engine version", func() {
 		vdb := vapi.MakeVDB()
-		vdb.Spec.Communal.KerberosRealm = "VERTICACORP.COM"
-		vdb.Spec.Communal.KerberosServiceName = "vert"
+		vdb.Spec.Communal.AdditionalConfig[vmeta.KerberosRealmConfig] = "VERTICACORP.COM"
+		vdb.Spec.Communal.AdditionalConfig[vmeta.KerberosServiceNameConfig] = "vert"
 		// Setting this annotation will set the version in the vdb.  The version
 		// was picked because it isn't compatible with Kerberos.
 		vdb.Annotations[vmeta.VersionAnnotation] = "v11.0.1"

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -1,0 +1,22 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package meta
+
+const (
+	// Two vertica config parameters that are used with kerberos based deployments
+	KerberosRealmConfig       = "KerberosRealm"
+	KerberosServiceNameConfig = "KerberosServiceName"
+)

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -148,6 +148,7 @@ func (d *DBGenerator) setParmsFromOptions() {
 	d.Objs.Vdb.TypeMeta.Kind = vapi.VerticaDBKind
 	d.Objs.Vdb.Spec.InitPolicy = vapi.CommunalInitPolicyRevive
 	d.Objs.Vdb.Annotations = make(map[string]string)
+	d.Objs.Vdb.Spec.Communal.AdditionalConfig = make(map[string]string)
 	d.Objs.Vdb.Spec.DBName = d.Opts.DBName
 	d.Objs.Vdb.Spec.AutoRestartVertica = true
 	d.Objs.Vdb.ObjectMeta.Name = d.Opts.VdbName
@@ -928,10 +929,8 @@ func (d *DBGenerator) readKrb5KeytabFile(_ context.Context) error {
 }
 
 func (d *DBGenerator) setKrb5Secret(_ context.Context) error {
-	const KerberosServiceNameKey = "KerberosServiceName"
-	const KerberosRealmKey = "KerberosRealm"
-	realm, okRealm := d.DBCfg[KerberosRealmKey]
-	svcName, okSvc := d.DBCfg[KerberosServiceNameKey]
+	realm, okRealm := d.DBCfg[vmeta.KerberosRealmConfig]
+	svcName, okSvc := d.DBCfg[vmeta.KerberosServiceNameConfig]
 
 	if !okRealm || !okSvc {
 		// Not an error, this just means there is no Kerberos setup
@@ -946,8 +945,8 @@ func (d *DBGenerator) setKrb5Secret(_ context.Context) error {
 	}
 
 	d.Objs.HasKerberosSecret = true
-	d.Objs.Vdb.Spec.Communal.KerberosRealm = realm
-	d.Objs.Vdb.Spec.Communal.KerberosServiceName = svcName
+	d.Objs.Vdb.Spec.Communal.AdditionalConfig[vmeta.KerberosRealmConfig] = realm
+	d.Objs.Vdb.Spec.Communal.AdditionalConfig[vmeta.KerberosServiceNameConfig] = svcName
 	d.Objs.KerberosSecret.TypeMeta.APIVersion = SecretAPIVersion
 	d.Objs.KerberosSecret.TypeMeta.Kind = SecretKindName
 	d.Objs.KerberosSecret.ObjectMeta.Name = fmt.Sprintf("%s-krb5", d.Opts.VdbName)

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -516,6 +516,7 @@ var _ = Describe("vdb", func() {
 
 		dbGen := DBGenerator{Conn: db, Opts: &Options{},
 			Krb5ConfData: []byte("data1"), Krb5KeytabData: []byte("data2")}
+		dbGen.setParmsFromOptions()
 
 		mock.ExpectQuery(Queries[DBCfgKey]).
 			WillReturnRows(sqlmock.NewRows([]string{"key", "value"}).


### PR DESCRIPTION
Another change to move CR parms to annotations in the v1 API. This removes both kerberosServiceName and kerberosRealm. Both of them can be specified through the `spec.communal.additionalConfig`, so it didn't make sense to have separate fields. See #531 to understand why we are changing the v1 API. No change is done to the v1beta1 API.