### PR TITLE
Rename v1 API fields: add subcluster type

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -602,20 +602,16 @@ type Subcluster struct {
 	// db.licenseSecret parameter.
 	Size int32 `json:"size"`
 
-	// +kubebuilder:default:=true
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
-	// Indicates whether the subcluster is a primary or secondary. You must have
-	// at least one primary subcluster in the database.
-	IsPrimary bool `json:"isPrimary"`
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
-	// Internal state that indicates whether this is a transient read-only
-	// subcluster used for online upgrade.  A subcluster that exists
-	// temporarily to serve traffic for subclusters that are restarting with the
-	// new image.
-	IsTransient bool `json:"isTransient,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:primary","urn:alm:descriptor:com.tectonic.ui:select:secondary"}
+	// Indicates the type of subcluster it is. Valid values are: primary,
+	// secondary or transient. You must have at least one primary subcluster in
+	// the database. If omitted, the webhook will choose a suitable default;
+	// primary if none exists, otherwise it will default to a secondary.
+	// Transient should only be set internally by the operator during online
+	// upgrade. It is used to indicate a subcluster that exists temporarily to
+	// serve traffic for subclusters that are restarting with a new image.
+	Type string `json:"type"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
@@ -835,6 +831,14 @@ type VerticaDBCondition struct {
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 }
+
+const (
+	// The different type names for the subcluster type. A webhook exists to
+	// allow the types to be set as any type.
+	PrimarySubcluster   = "primary"
+	SecondarySubcluster = "secondary"
+	TransientSubcluster = "transient"
+)
 
 // SubclusterStatus defines the per-subcluster status that we track
 type SubclusterStatus struct {

--- a/api/v1/verticadb_types_test.go
+++ b/api/v1/verticadb_types_test.go
@@ -52,9 +52,9 @@ var _ = Describe("verticadb_types", func() {
 		Expect(vdb.RequiresTransientSubcluster()).Should(BeFalse())
 		vdb.Spec.TemporarySubclusterRouting = &SubclusterSelection{
 			Template: Subcluster{
-				Name:      "the-transient-sc-name",
-				Size:      1,
-				IsPrimary: false,
+				Name: "the-transient-sc-name",
+				Size: 1,
+				Type: TransientSubcluster,
 			},
 		}
 		Expect(vdb.RequiresTransientSubcluster()).Should(BeTrue())
@@ -63,10 +63,10 @@ var _ = Describe("verticadb_types", func() {
 	It("should return the first primary subcluster", func() {
 		vdb := MakeVDB()
 		vdb.Spec.Subclusters = []Subcluster{
-			{Name: "sec1", IsPrimary: false, Size: 1},
-			{Name: "sec2", IsPrimary: false, Size: 1},
-			{Name: "pri1", IsPrimary: true, Size: 1},
-			{Name: "pri2", IsPrimary: true, Size: 1},
+			{Name: "sec1", Type: SecondarySubcluster, Size: 1},
+			{Name: "sec2", Type: SecondarySubcluster, Size: 1},
+			{Name: "pri1", Type: PrimarySubcluster, Size: 1},
+			{Name: "pri2", Type: PrimarySubcluster, Size: 1},
 		}
 		sc := vdb.GetFirstPrimarySubcluster()
 		Ω(sc).ShouldNot(BeNil())

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -264,8 +264,7 @@ func convertToSubcluster(src *Subcluster) v1.Subcluster {
 	return v1.Subcluster{
 		Name:                src.Name,
 		Size:                src.Size,
-		IsPrimary:           src.IsPrimary,
-		IsTransient:         src.IsTransient,
+		Type:                convertToSubclusterType(src),
 		ImageOverride:       src.ImageOverride,
 		NodeSelector:        src.NodeSelector,
 		Affinity:            v1.Affinity(src.Affinity),
@@ -287,8 +286,8 @@ func convertFromSubcluster(src *v1.Subcluster) Subcluster {
 	return Subcluster{
 		Name:                src.Name,
 		Size:                src.Size,
-		IsPrimary:           src.IsPrimary,
-		IsTransient:         src.IsTransient,
+		IsPrimary:           src.IsPrimary(),
+		IsTransient:         src.IsTransient(),
 		ImageOverride:       src.ImageOverride,
 		NodeSelector:        src.NodeSelector,
 		Affinity:            Affinity(src.Affinity),
@@ -461,4 +460,16 @@ func convertFromStatusCondition(src v1.VerticaDBCondition) VerticaDBCondition {
 		Status:             src.Status,
 		LastTransitionTime: src.LastTransitionTime,
 	}
+}
+
+// convertToSubclusterType returns the v1 Subcluster type for a given v1beta1
+// Subcluster
+func convertToSubclusterType(src *Subcluster) string {
+	if src.IsPrimary {
+		return v1.PrimarySubcluster
+	}
+	if src.IsTransient {
+		return v1.TransientSubcluster
+	}
+	return v1.SecondarySubcluster
 }

--- a/api/v1beta1/verticadb_webhook.go
+++ b/api/v1beta1/verticadb_webhook.go
@@ -128,7 +128,7 @@ var _ webhook.Defaulter = &VerticaDB{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (v *VerticaDB) Default() {
-	verticadblog.Info("default", "name", v.Name)
+	verticadblog.Info("default", "name", v.Name, "GroupVersion", GroupVersion)
 
 	// imagePullPolicy: if not set should default to Always if the tag in the image is latest,
 	// otherwise it should be IfNotPresent (set in verticadb_types.go)

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,9 +13,29 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-vertica-com-v1-verticadb
+  failurePolicy: Fail
+  name: mverticadb.v1.kb.io
+  rules:
+  - apiGroups:
+    - vertica.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - verticadbs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-vertica-com-v1beta1-verticadb
   failurePolicy: Fail
-  name: mverticadb.kb.io
+  name: mverticadb.v1beta1.kb.io
   rules:
   - apiGroups:
     - vertica.com
@@ -100,9 +120,29 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-vertica-com-v1-verticadb
+  failurePolicy: Fail
+  name: vverticadb.v1.kb.io
+  rules:
+  - apiGroups:
+    - vertica.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - verticadbs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-vertica-com-v1beta1-verticadb
   failurePolicy: Fail
-  name: vverticadb.kb.io
+  name: vverticadb.v1beta1.kb.io
   rules:
   - apiGroups:
     - vertica.com

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -28,11 +28,11 @@ func MakeSubclusterLabels(sc *vapi.Subcluster) map[string]string {
 	m := map[string]string{
 		vmeta.SubclusterNameLabel:      sc.Name,
 		vmeta.SubclusterTypeLabel:      sc.GetType(),
-		vmeta.SubclusterTransientLabel: strconv.FormatBool(sc.IsTransient),
+		vmeta.SubclusterTransientLabel: strconv.FormatBool(sc.IsTransient()),
 	}
 	// Transient subclusters never have the service name label set.  At various
 	// parts of the upgrade, it will accept traffic from all of the subclusters.
-	if !sc.IsTransient {
+	if !sc.IsTransient() {
 		m[vmeta.SubclusterSvcNameLabel] = sc.GetServiceName()
 	}
 	return m

--- a/pkg/controllers/vdb/createdb_reconciler_test.go
+++ b/pkg/controllers/vdb/createdb_reconciler_test.go
@@ -128,8 +128,8 @@ var _ = Describe("createdb_reconciler", func() {
 	It("should always run AT commands from the first pod of the first primary subcluster", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters = []vapi.Subcluster{
-			{Name: "sec", IsPrimary: false, Size: 1},
-			{Name: "pri", IsPrimary: true, Size: 2},
+			{Name: "sec", Type: vapi.SecondarySubcluster, Size: 1},
+			{Name: "pri", Type: vapi.PrimarySubcluster, Size: 2},
 		}
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)

--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler.go
@@ -137,7 +137,7 @@ func (d *DBAddSubclusterReconciler) createSubcluster(ctx context.Context, sc *va
 	err := d.Dispatcher.AddSubcluster(ctx,
 		addsc.WithInitiator(d.ATPod.name, d.ATPod.podIP),
 		addsc.WithSubcluster(sc.Name),
-		addsc.WithIsPrimary(sc.IsPrimary),
+		addsc.WithIsPrimary(sc.IsPrimary()),
 	)
 	if err != nil {
 		return err

--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
@@ -100,14 +100,14 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		r.ATPod = pfacts.Detail[names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)]
 
-		vdb.Spec.Subclusters[0].IsPrimary = false
+		vdb.Spec.Subclusters[0].Type = vapi.SecondarySubcluster
 		Expect(r.createSubcluster(ctx, &vdb.Spec.Subclusters[0])).Should(Succeed())
 		hists := fpr.FindCommands("db_add_subcluster")
 		Expect(len(hists)).Should(Equal(1))
 		Expect(hists[0].Command).Should(ContainElement("--is-secondary"))
 
 		fpr.Histories = []cmds.CmdHistory{}
-		vdb.Spec.Subclusters[0].IsPrimary = true
+		vdb.Spec.Subclusters[0].Type = vapi.PrimarySubcluster
 		Expect(r.createSubcluster(ctx, &vdb.Spec.Subclusters[0])).Should(Succeed())
 		hists = fpr.FindCommands("db_add_subcluster")
 		Expect(len(hists)).Should(Equal(1))

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -197,7 +197,7 @@ func (o *ObjReconciler) checkForCreatedSubclusters(ctx context.Context) (ctrl.Re
 		sc := &o.Vdb.Spec.Subclusters[i]
 		// Transient subclusters never have their own service objects.  They always
 		// reuse ones we have for other primary/secondary subclusters.
-		if !sc.IsTransient {
+		if !sc.IsTransient() {
 			// Multiple subclusters may share the same service name. Only
 			// reconcile for the first subcluster.
 			svcName := names.GenExtSvcName(o.Vdb, sc)

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -163,7 +163,7 @@ func (o *OnlineUpgradeReconciler) precomputeStatusMsgs(ctx context.Context) (ctr
 		)
 		return ctrl.Result{}, nil
 	}
-	if res, err := o.iterateSubclusterType(ctx, vapi.SecondarySubclusterType, procFunc); verrors.IsReconcileAborted(res, err) {
+	if res, err := o.iterateSubclusterType(ctx, vapi.SecondarySubcluster, procFunc); verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 	o.StatusMsgs = append(o.StatusMsgs, "Destroying transient secondary subcluster")
@@ -360,7 +360,7 @@ func (o *OnlineUpgradeReconciler) restartPrimaries(ctx context.Context) (ctrl.Re
 		if res, err := o.postNextStatusMsg(ctx); verrors.IsReconcileAborted(res, err) {
 			return res, err
 		}
-		if res, err := o.iterateSubclusterType(ctx, vapi.PrimarySubclusterType, fn); verrors.IsReconcileAborted(res, err) {
+		if res, err := o.iterateSubclusterType(ctx, vapi.PrimarySubcluster, fn); verrors.IsReconcileAborted(res, err) {
 			o.Log.Info("Error iterating subclusters over function", "i", i)
 			return res, err
 		}
@@ -372,7 +372,7 @@ func (o *OnlineUpgradeReconciler) restartPrimaries(ctx context.Context) (ctrl.Re
 // rerouting traffic to the transient while it does the restart.
 func (o *OnlineUpgradeReconciler) restartSecondaries(ctx context.Context) (ctrl.Result, error) {
 	o.Log.Info("Starting the handling of secondaries")
-	res, err := o.iterateSubclusterType(ctx, vapi.SecondarySubclusterType, o.processSecondary)
+	res, err := o.iterateSubclusterType(ctx, vapi.SecondarySubcluster, o.processSecondary)
 	return res, err
 }
 
@@ -548,7 +548,7 @@ func (o *OnlineUpgradeReconciler) removeTransientFromVdb(ctx context.Context) (c
 		// Remove the transient.
 		removedTransient := false
 		for i := len(o.Vdb.Spec.Subclusters) - 1; i >= 0; i-- {
-			if o.Vdb.Spec.Subclusters[i].IsTransient {
+			if o.Vdb.Spec.Subclusters[i].IsTransient() {
 				o.Vdb.Spec.Subclusters = append(o.Vdb.Spec.Subclusters[:i], o.Vdb.Spec.Subclusters[i+1:]...)
 				removedTransient = true
 			}
@@ -615,7 +615,7 @@ func (o *OnlineUpgradeReconciler) cachePrimaryImages(ctx context.Context) error 
 	}
 	for i := range stss.Items {
 		sts := &stss.Items[i]
-		if sts.Labels[vmeta.SubclusterTypeLabel] == vapi.PrimarySubclusterType {
+		if sts.Labels[vmeta.SubclusterTypeLabel] == vapi.PrimarySubcluster {
 			img := sts.Spec.Template.Spec.Containers[ServerContainerIndex].Image
 			imageFound := false
 			for j := range o.PrimaryImages {
@@ -770,10 +770,10 @@ func (o *OnlineUpgradeReconciler) pickDefaultSubclusterForTemporaryRouting(offli
 	// the first secondary we can find.  If there are no secondaries, then
 	// selecting the first subcluster will do.  The upgrade won't be online in
 	// this case, but there isn't anything we can do.
-	if offlineSc.IsPrimary {
+	if offlineSc.IsPrimary() {
 		for i := range o.Vdb.Spec.Subclusters {
 			sc := &o.Vdb.Spec.Subclusters[i]
-			if !sc.IsPrimary {
+			if !sc.IsPrimary() {
 				return sc
 			}
 		}

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -263,7 +263,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 	pf := PodFact{
 		name:           names.GenPodName(vdb, sc, podIndex),
 		subclusterName: sc.Name,
-		isPrimary:      sc.IsPrimary,
+		isPrimary:      sc.IsPrimary(),
 		podIndex:       podIndex,
 	}
 	// It is possible for a pod to be managed by a parent sts but not yet exist.

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -435,9 +435,9 @@ var _ = Describe("restart_reconciler", func() {
 		vdb.Spec.Subclusters[0].Size = 1
 		vdb.Spec.TemporarySubclusterRouting = &vapi.SubclusterSelection{
 			Template: vapi.Subcluster{
-				Name:      "the-transient-sc",
-				Size:      1,
-				IsPrimary: false,
+				Name: "the-transient-sc",
+				Size: 1,
+				Type: vapi.SecondarySubcluster,
 			},
 		}
 		createS3CredSecret(ctx, vdb)

--- a/pkg/controllers/vdb/upgrade_test.go
+++ b/pkg/controllers/vdb/upgrade_test.go
@@ -38,9 +38,9 @@ var _ = Describe("upgrade", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.TemporarySubclusterRouting = &vapi.SubclusterSelection{
 			Template: vapi.Subcluster{
-				Name:      "t",
-				Size:      1,
-				IsPrimary: false,
+				Name: "t",
+				Size: 1,
+				Type: vapi.SecondarySubcluster,
 			},
 		}
 
@@ -95,8 +95,8 @@ var _ = Describe("upgrade", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Image = OldImage
 		vdb.Spec.Subclusters = []vapi.Subcluster{
-			{Name: "sc1", Size: 2, IsPrimary: true},
-			{Name: "sc2", Size: 3, IsPrimary: false},
+			{Name: "sc1", Size: 2, Type: vapi.PrimarySubcluster},
+			{Name: "sc2", Size: 3, Type: vapi.SecondarySubcluster},
 		}
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
@@ -121,8 +121,8 @@ var _ = Describe("upgrade", func() {
 	It("should delete pods of all subclusters", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters = []vapi.Subcluster{
-			{Name: "sc1", Size: 1, IsPrimary: true},
-			{Name: "sc2", Size: 1, IsPrimary: false},
+			{Name: "sc1", Size: 1, Type: vapi.PrimarySubcluster},
+			{Name: "sc2", Size: 1, Type: vapi.SecondarySubcluster},
 		}
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
@@ -142,8 +142,8 @@ var _ = Describe("upgrade", func() {
 	It("should delete pods of specific subcluster", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Subclusters = []vapi.Subcluster{
-			{Name: "sc1", Size: 1, IsPrimary: false},
-			{Name: "sc2", Size: 1, IsPrimary: false},
+			{Name: "sc1", Size: 1, Type: vapi.SecondarySubcluster},
+			{Name: "sc2", Size: 1, Type: vapi.SecondarySubcluster},
 		}
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)

--- a/pkg/iter/sc_finder_test.go
+++ b/pkg/iter/sc_finder_test.go
@@ -104,8 +104,8 @@ var _ = Describe("sc_finder", func() {
 		scNames := []string{"first", "second"}
 		scSizes := []int32{2, 3}
 		vdb.Spec.Subclusters = []vapi.Subcluster{
-			{Name: scNames[0], Size: scSizes[0], IsPrimary: true},
-			{Name: scNames[1], Size: scSizes[1], IsPrimary: false},
+			{Name: scNames[0], Size: scSizes[0], Type: vapi.PrimarySubcluster},
+			{Name: scNames[1], Size: scSizes[1], Type: vapi.SecondarySubcluster},
 		}
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		vdbCopy := *vdb // Make a copy for cleanup since we will mutate vdb

--- a/pkg/reviveplanner/atparser/at_parser.go
+++ b/pkg/reviveplanner/atparser/at_parser.go
@@ -141,7 +141,7 @@ func MakeATParserFromVDB(vdb *vapi.VerticaDB, logger logr.Logger) Parser {
 			db.Nodes = append(db.Nodes, Node{
 				Name:        fmt.Sprintf("v_%s_node%04d", db.Name, nc),
 				CatalogPath: fmt.Sprintf("%s/v_%s_node%04d_catalog", vdb.GetDBCatalogPath(), db.Name, nc),
-				IsPrimary:   vdb.Spec.Subclusters[i].IsPrimary,
+				IsPrimary:   vdb.Spec.Subclusters[i].IsPrimary(),
 				VStorageLocations: []StorageLocation{
 					{
 						Path:  fmt.Sprintf("%s/%s/v_%s_node%04d_data", vdb.Spec.Local.DataPath, db.Name, db.Name, nc),

--- a/pkg/security/webhook.go
+++ b/pkg/security/webhook.go
@@ -240,7 +240,6 @@ func patchConversionWebhookConfig(ctx context.Context, log *logr.Logger, cfg *re
 				CABundle: caCert,
 			},
 			ConversionReviewVersions: []string{
-				v1vapi.Version,
 				v1beta1vapi.Version,
 			},
 		}

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -601,11 +601,17 @@ func (d *DBGenerator) setSubclusterDetail(ctx context.Context) error {
 		}
 
 		inx, ok := subclusterInxMap[name]
+		var scType string
+		if isPrimary {
+			scType = vapi.PrimarySubcluster
+		} else {
+			scType = vapi.SecondarySubcluster
+		}
 		if !ok {
 			inx = len(d.Objs.Vdb.Spec.Subclusters)
 			// Add an empty subcluster.  We increment the count a few lines down.
 			d.Objs.Vdb.Spec.Subclusters = append(d.Objs.Vdb.Spec.Subclusters,
-				vapi.Subcluster{Name: name, Size: 0, IsPrimary: isPrimary})
+				vapi.Subcluster{Name: name, Size: 0, Type: scType})
 			subclusterInxMap[name] = inx
 		}
 		d.Objs.Vdb.Spec.Subclusters[inx].Size++

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -407,9 +407,9 @@ var _ = Describe("vdb", func() {
 				AddRow(Sc3Name, true))
 
 		expScDetail := []vapi.Subcluster{
-			{Name: Sc1Name, Size: 4, IsPrimary: true},
-			{Name: Sc2Name, Size: 1, IsPrimary: false},
-			{Name: Sc3Name, Size: 2, IsPrimary: true},
+			{Name: Sc1Name, Size: 4, Type: vapi.PrimarySubcluster},
+			{Name: Sc2Name, Size: 1, Type: vapi.SecondarySubcluster},
+			{Name: Sc3Name, Size: 2, Type: vapi.PrimarySubcluster},
 		}
 		expReviveOrder := []vapi.SubclusterPodCount{
 			{SubclusterIndex: 0, PodCount: 3},

--- a/tests/e2e-leg-1/autoscale-by-subcluster/40-manually-add-new-subcluster.yaml
+++ b/tests/e2e-leg-1/autoscale-by-subcluster/40-manually-add-new-subcluster.yaml
@@ -19,19 +19,19 @@ spec:
   subclusters:
     - name: pri
       size: 3
-      isPrimary: true
+      type: primary
     - name: as-0
       size: 2
-      isPrimary: false
+      type: secondary
       serviceName: as
     - name: as-1
       size: 2
-      isPrimary: false
+      type: secondary
       serviceName: as
     - name: manual
       size: 1
-      isPrimary: false
+      type: secondary
     - name: as-2
       size: 2
-      isPrimary: false
+      type: secondary
       serviceName: as

--- a/tests/e2e-leg-2/webhook/115-add-sc.yaml
+++ b/tests/e2e-leg-2/webhook/115-add-sc.yaml
@@ -19,8 +19,9 @@ spec:
   subclusters:
     - name: sc1
       size: 1
-      isPrimary: true
+      type: primary
       serviceType: ClusterIP
       clientNodePort: 0
     - name: sc2
       size: 1
+      type: primary

--- a/tests/e2e-leg-2/webhook/75-assert.yaml
+++ b/tests/e2e-leg-2/webhook/75-assert.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
 apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
@@ -19,4 +18,4 @@ metadata:
 spec:
   subclusters:
     - name: sc1
-      isPrimary: true
+      type: primary

--- a/tests/e2e-leg-2/webhook/75-invalid-sc-primary.yaml
+++ b/tests/e2e-leg-2/webhook/75-invalid-sc-primary.yaml
@@ -14,6 +14,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: kubectl -n verticadb-operator get verticadb v-webhook -o json | jq '.spec.subclusters[0].isPrimary="false"' | kubectl -n verticadb-operator replace -f -
+  - script: kubectl -n $NAMESPACE get verticadb v-webhook -o json | jq '.spec.subclusters[0].type="Secondary"' | kubectl -n $NAMESPACE replace -f -
     ignoreFailure: true
   - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator $NAMESPACE"

--- a/tests/e2e-leg-3/readiness-probe-override/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/setup-vdb/base/setup-vdb.yaml
@@ -27,10 +27,10 @@ spec:
   subclusters:
     - name: queries
       size: 1
-      isPrimary: false
+      type: secondary
     - name: admin
       size: 1
-      isPrimary: true
+      type: primary
   readinessProbeOverride:
     timeoutSeconds: 5
     periodSeconds: 20

--- a/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/setup-vdb/base/setup-vdb.yaml
@@ -28,10 +28,10 @@ spec:
   subclusters:
     - name: pri1
       size: 2
-      isPrimary: true
+      type: primary
     - name: pri2
       size: 1
-      isPrimary: true
+      type: primary
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-leg-5-failed/istio/setup-vdb-tproxy/base/setup-vdb.yaml
+++ b/tests/e2e-leg-5-failed/istio/setup-vdb-tproxy/base/setup-vdb.yaml
@@ -28,7 +28,7 @@ spec:
   subclusters:
     - name: main
       size: 3
-      isPrimary: true
+      type: primary
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-leg-5/operator-metrics/35-remove-subcluster.yaml
+++ b/tests/e2e-leg-5/operator-metrics/35-remove-subcluster.yaml
@@ -19,4 +19,4 @@ spec:
   subclusters:
     - name: pri-sc
       size: 1
-      isPrimary: true
+      type: primary

--- a/tests/e2e-leg-5/operator-metrics/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-5/operator-metrics/setup-vdb/base/setup-vdb.yaml
@@ -28,10 +28,10 @@ spec:
   subclusters:
     - name: sec-sc
       size: 1
-      isPrimary: false
+      type: secondary
     - name: pri-sc
       size: 1
-      isPrimary: true
+      type: primary
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/setup-vdb/base/setup-vdb.yaml
@@ -29,7 +29,7 @@ spec:
   subclusters:
     - name: pri
       size: 3
-      isPrimary: true
+      type: primary
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/20-initiate-upgrade-and-scale-up.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/20-initiate-upgrade-and-scale-up.yaml
@@ -24,7 +24,7 @@ spec:
   subclusters:
     - name: pri
       size: 1
-      isPrimary: true
+      type: primary
     - name: sec
       size: 1
-      isPrimary: false
+      type: secondary

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/setup-vdb/base/setup-vdb.yaml
@@ -27,11 +27,12 @@ spec:
   subclusters:
     - name: pri
       size: 1
-      isPrimary: true
+      type: primary
   temporarySubclusterRouting:
     template:
       name: transient
       size: 1
+      type: secondary
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-server-upgrade/online-upgrade-drain/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/setup-vdb/base/setup-vdb.yaml
@@ -28,13 +28,13 @@ spec:
   subclusters:
     - name: pri1
       size: 1
-      isPrimary: true
+      type: primary
     - name: pri2
       size: 1
-      isPrimary: true
+      type: primary
     - name: sec1
       size: 1
-      isPrimary: false
+      type: secondary
   temporarySubclusterRouting:
     names:
       - sec1

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/setup-vdb/base/setup-vdb.yaml
@@ -27,7 +27,7 @@ spec:
   subclusters:
     - name: pri
       size: 3
-      isPrimary: true
+      type: primary
   # Intentionally leaving out temporarySubclusterRouting to test the
   # default.  Leaving the default in as comments.
   # temporarySubclusterRouting:

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/35-modify-actual-transient.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/35-modify-actual-transient.yaml
@@ -20,10 +20,9 @@ metadata:
 spec:
   subclusters:
     - name: pri
-      isPrimary: true
+      type: Primary
       size: 1
     - name: transient
-      isTransient: true
-      isPrimary: false
+      type: Transient
       resources: {}
       size: 1

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/setup-vdb/base/setup-vdb.yaml
@@ -28,7 +28,6 @@ spec:
   subclusters:
     - name: pri
       size: 1
-      isPrimary: true
   temporarySubclusterRouting:
     template:
       name: transient


### PR DESCRIPTION
This adds a string field called Type to subclusters. This is more expressive as it replaces the isPrimary and isTransient boolean. It also allows for future expansion if we introduce different subcluster types in the future. See #531 to understand why we are making this change. No change is done to the v1beta1 API.