### PR TITLE
Rename v1 API fields: status field updates

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -502,3 +502,21 @@ func (s *Subcluster) GetType() string {
 	}
 	return s.Type
 }
+
+func (v *VerticaDBStatus) InstallCount() int32 {
+	var c int32
+	for i := range v.Subclusters {
+		c += v.Subclusters[i].InstallCount()
+	}
+	return c
+}
+
+func (s *SubclusterStatus) InstallCount() int32 {
+	var c int32
+	for i := range s.Detail {
+		if s.Detail[i].Installed {
+			c++
+		}
+	}
+	return c
+}

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -734,10 +734,6 @@ type Affinity struct {
 // VerticaDBStatus defines the observed state of VerticaDB
 type VerticaDBStatus struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status
-	// A count of the number of pods that have been installed into the vertica cluster.
-	InstallCount int32 `json:"installCount"`
-
-	// +operator-sdk:csv:customresourcedefinitions:type=status
 	// A count of the number of pods that have been added to the database.
 	AddedToDBCount int32 `json:"addedToDBCount"`
 
@@ -772,10 +768,10 @@ const (
 	AutoRestartVertica VerticaDBConditionType = "AutoRestartVertica"
 	// DBInitialized indicates the database has been created or revived
 	DBInitialized VerticaDBConditionType = "DBInitialized"
-	// ImageChangeInProgress indicates if the vertica server is in the process
-	// of having its image change (aka upgrade).  We have two additional conditions to
+	// UpgradeInProgress indicates if the vertica server is in the process
+	// of having its image change.  We have two additional conditions to
 	// distinguish between online and offline upgrade.
-	ImageChangeInProgress    VerticaDBConditionType = "ImageChangeInProgress"
+	UpgradeInProgress        VerticaDBConditionType = "UpgradeInProgress"
 	OfflineUpgradeInProgress VerticaDBConditionType = "OfflineUpgradeInProgress"
 	OnlineUpgradeInProgress  VerticaDBConditionType = "OnlineUpgradeInProgress"
 	// VerticaRestartNeeded is a condition that when set to true will force the
@@ -787,7 +783,7 @@ const (
 const (
 	AutoRestartVerticaIndex = iota
 	DBInitializedIndex
-	ImageChangeInProgressIndex
+	UpgradeInProgressIndex
 	OfflineUpgradeInProgressIndex
 	OnlineUpgradeInProgressIndex
 	VerticaRestartNeededIndex
@@ -798,7 +794,7 @@ const (
 var VerticaDBConditionIndexMap = map[VerticaDBConditionType]int{
 	AutoRestartVertica:       AutoRestartVerticaIndex,
 	DBInitialized:            DBInitializedIndex,
-	ImageChangeInProgress:    ImageChangeInProgressIndex,
+	UpgradeInProgress:        UpgradeInProgressIndex,
 	OfflineUpgradeInProgress: OfflineUpgradeInProgressIndex,
 	OnlineUpgradeInProgress:  OnlineUpgradeInProgressIndex,
 	VerticaRestartNeeded:     VerticaRestartNeededIndex,
@@ -809,7 +805,7 @@ var VerticaDBConditionIndexMap = map[VerticaDBConditionType]int{
 var VerticaDBConditionNameMap = map[int]VerticaDBConditionType{
 	AutoRestartVerticaIndex:       AutoRestartVertica,
 	DBInitializedIndex:            DBInitialized,
-	ImageChangeInProgressIndex:    ImageChangeInProgress,
+	UpgradeInProgressIndex:        UpgradeInProgress,
 	OfflineUpgradeInProgressIndex: OfflineUpgradeInProgress,
 	OnlineUpgradeInProgressIndex:  OnlineUpgradeInProgress,
 	VerticaRestartNeededIndex:     VerticaRestartNeeded,
@@ -851,21 +847,12 @@ type SubclusterStatus struct {
 	Oid string `json:"oid"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
-	// A count of the number of pods that have been installed into the subcluster.
-	InstallCount int32 `json:"installCount"`
-
-	// +operator-sdk:csv:customresourcedefinitions:type=status
 	// A count of the number of pods that have been added to the database for this subcluster.
 	AddedToDBCount int32 `json:"addedToDBCount"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	// A count of the number of pods that have a running vertica process in this subcluster.
 	UpNodeCount int32 `json:"upNodeCount"`
-
-	// +operator-sdk:csv:customresourcedefinitions:type=status
-	// +kubebuilder:validation:Optional
-	// A count of the number of pods that are in read-only state in this subcluster.
-	ReadOnlyCount int32 `json:"readOnlyCount"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Detail []VerticaDBPodStatus `json:"detail"`
@@ -886,10 +873,6 @@ type VerticaDBPodStatus struct {
 	// True means the vertica process is running on this pod and it can accept
 	// connections on port 5433.
 	UpNode bool `json:"upNode"`
-	// +operator-sdk:csv:customresourcedefinitions:type=status
-	// +kubebuilder:validation:Optional
-	// True means the vertica process on this pod is in read-only state
-	ReadOnly bool `json:"readOnly"`
 }
 
 //+kubebuilder:object:root=true
@@ -898,9 +881,6 @@ type VerticaDBPodStatus struct {
 //+kubebuilder:resource:categories=all;vertica,shortName=vdb
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="Subclusters",type="integer",JSONPath=".status.subclusterCount"
-//+kubebuilder:printcolumn:name="Installed",type="integer",JSONPath=".status.installCount"
-//+kubebuilder:printcolumn:name="DBAdded",type="integer",JSONPath=".status.addedToDBCount"
-//+kubebuilder:printcolumn:name="Up",type="integer",JSONPath=".status.upNodeCount"
 // +operator-sdk:csv:customresourcedefinitions:resources={{Statefulset,apps/v1,""},{Pod,v1,""},{Service,v1,""}}
 
 // VerticaDB is the CR that defines a Vertica Eon mode cluster that is managed by the verticadb-operator.

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -883,8 +883,8 @@ func (v *VerticaDB) hasValidProbeOverride(allErrs field.ErrorList, fieldPath *fi
 	return allErrs
 }
 
-func (v *VerticaDB) isImageChangeInProgress() bool {
-	return v.isConditionIndexSet(ImageChangeInProgressIndex)
+func (v *VerticaDB) isUpgradeInProgress() bool {
+	return v.isConditionIndexSet(UpgradeInProgressIndex)
 }
 
 func (v *VerticaDB) isDBInitialized() bool {
@@ -896,7 +896,7 @@ func (v *VerticaDB) isDBInitialized() bool {
 // when it isn't allowed.
 func (v *VerticaDB) checkImmutableUpgradePolicy(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
 	if v.Spec.UpgradePolicy == oldObj.Spec.UpgradePolicy ||
-		!oldObj.isImageChangeInProgress() {
+		!oldObj.isUpgradeInProgress() {
 		return allErrs
 	}
 	err := field.Invalid(field.NewPath("spec").Child("upgradePolicy"),
@@ -911,7 +911,7 @@ func (v *VerticaDB) checkImmutableUpgradePolicy(oldObj *VerticaDB, allErrs field
 func (v *VerticaDB) checkImmutableTemporarySubclusterRouting(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
 	// TemporarySubclusterRouting is allowed to change as long as an image
 	// change isn't in progress
-	if !oldObj.isImageChangeInProgress() {
+	if !oldObj.isUpgradeInProgress() {
 		return allErrs
 	}
 	if v.Spec.TemporarySubclusterRouting == nil && oldObj.Spec.TemporarySubclusterRouting == nil {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -419,7 +419,7 @@ var _ = Describe("verticadb_webhook", func() {
 		allErrs := vdbOrig.validateImmutableFields(vdbUpdate)
 		Expect(allErrs).Should(BeNil())
 
-		resetStatusConditionsForImageChangeInProgress(vdbUpdate)
+		resetStatusConditionsForUpgradeInProgress(vdbUpdate)
 		allErrs = vdbOrig.validateImmutableFields(vdbUpdate)
 		Expect(allErrs).ShouldNot(BeNil())
 	})
@@ -467,8 +467,8 @@ var _ = Describe("verticadb_webhook", func() {
 		}
 		vdbUpdate := MakeVDB()
 		vdbUpdate.Spec.TemporarySubclusterRouting = nil
-		resetStatusConditionsForImageChangeInProgress(vdbUpdate)
-		resetStatusConditionsForImageChangeInProgress(vdbOrig)
+		resetStatusConditionsForUpgradeInProgress(vdbUpdate)
+		resetStatusConditionsForUpgradeInProgress(vdbOrig)
 		allErrs := vdbOrig.validateImmutableFields(vdbUpdate)
 		Ω(allErrs).ShouldNot(BeNil())
 
@@ -500,7 +500,7 @@ var _ = Describe("verticadb_webhook", func() {
 		vdbUpdate := createVDBHelper()
 		vdbOrig := createVDBHelper()
 
-		resetStatusConditionsForImageChangeInProgress(vdbUpdate)
+		resetStatusConditionsForUpgradeInProgress(vdbUpdate)
 
 		vdbUpdate.Spec.TemporarySubclusterRouting = &SubclusterSelection{
 			Names: []string{"sc1", "sc2"},
@@ -817,8 +817,8 @@ func checkErrorsForImmutableFields(vdbOrig, vdbUpdate *VerticaDB, expectError bo
 	}
 }
 
-func resetStatusConditionsForImageChangeInProgress(v *VerticaDB) {
-	resetStatusConditionsForCondition(v, ImageChangeInProgressIndex)
+func resetStatusConditionsForUpgradeInProgress(v *VerticaDB) {
+	resetStatusConditionsForCondition(v, UpgradeInProgressIndex)
 }
 
 func resetStatusConditionsForDBInitialized(v *VerticaDB) {

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -222,7 +222,6 @@ func convertFromSpec(src *v1.VerticaDB) VerticaDBSpec {
 // convertToStatus will convert to a v1 VerticaDBStatus from a v1beta1 version
 func convertToStatus(src *VerticaDBStatus) v1.VerticaDBStatus {
 	dst := v1.VerticaDBStatus{
-		InstallCount:    src.InstallCount,
 		AddedToDBCount:  src.AddedToDBCount,
 		UpNodeCount:     src.UpNodeCount,
 		SubclusterCount: src.SubclusterCount,
@@ -242,7 +241,7 @@ func convertToStatus(src *VerticaDBStatus) v1.VerticaDBStatus {
 // convertFromStatus will convert from a v1 VerticaDBStatus to a v1beta1 version
 func convertFromStatus(src *v1.VerticaDBStatus) VerticaDBStatus {
 	dst := VerticaDBStatus{
-		InstallCount:    src.InstallCount,
+		InstallCount:    src.InstallCount(),
 		AddedToDBCount:  src.AddedToDBCount,
 		UpNodeCount:     src.UpNodeCount,
 		SubclusterCount: src.SubclusterCount,
@@ -393,10 +392,8 @@ func convertToSubclusterStatus(src SubclusterStatus) v1.SubclusterStatus {
 	return v1.SubclusterStatus{
 		Name:           src.Name,
 		Oid:            src.Oid,
-		InstallCount:   src.InstallCount,
 		AddedToDBCount: src.AddedToDBCount,
 		UpNodeCount:    src.UpNodeCount,
-		ReadOnlyCount:  src.ReadOnlyCount,
 		Detail:         convertToPodStatus(src.Detail),
 	}
 }
@@ -406,10 +403,9 @@ func convertFromSubclusterStatus(src v1.SubclusterStatus) SubclusterStatus {
 	return SubclusterStatus{
 		Name:           src.Name,
 		Oid:            src.Oid,
-		InstallCount:   src.InstallCount,
+		InstallCount:   src.InstallCount(),
 		AddedToDBCount: src.AddedToDBCount,
 		UpNodeCount:    src.UpNodeCount,
-		ReadOnlyCount:  src.ReadOnlyCount,
 		Detail:         convertFromPodStatus(src.Detail),
 	}
 }
@@ -423,7 +419,6 @@ func convertToPodStatus(src []VerticaDBPodStatus) []v1.VerticaDBPodStatus {
 			AddedToDB: src[i].AddedToDB,
 			VNodeName: src[i].VNodeName,
 			UpNode:    src[i].UpNode,
-			ReadOnly:  src[i].ReadOnly,
 		}
 	}
 	return pods
@@ -438,7 +433,6 @@ func convertFromPodStatus(src []v1.VerticaDBPodStatus) []VerticaDBPodStatus {
 			AddedToDB: src[i].AddedToDB,
 			VNodeName: src[i].VNodeName,
 			UpNode:    src[i].UpNode,
-			ReadOnly:  src[i].ReadOnly,
 		}
 	}
 	return pods
@@ -447,7 +441,7 @@ func convertFromPodStatus(src []v1.VerticaDBPodStatus) []VerticaDBPodStatus {
 // convertToStatusCondition will convert to a v1 VerticaDBCondition from a v1beta1 version
 func convertToStatusCondition(src VerticaDBCondition) v1.VerticaDBCondition {
 	return v1.VerticaDBCondition{
-		Type:               v1.VerticaDBConditionType(src.Type),
+		Type:               convertToStatusConditionType(src.Type),
 		Status:             src.Status,
 		LastTransitionTime: src.LastTransitionTime,
 	}
@@ -456,7 +450,7 @@ func convertToStatusCondition(src VerticaDBCondition) v1.VerticaDBCondition {
 // convertFromStatusCondition will convert from a v1 VerticaDBCondition to a v1beta1 version
 func convertFromStatusCondition(src v1.VerticaDBCondition) VerticaDBCondition {
 	return VerticaDBCondition{
-		Type:               VerticaDBConditionType(src.Type),
+		Type:               convertFromStatusConditionType(src.Type),
 		Status:             src.Status,
 		LastTransitionTime: src.LastTransitionTime,
 	}
@@ -472,4 +466,20 @@ func convertToSubclusterType(src *Subcluster) string {
 		return v1.TransientSubcluster
 	}
 	return v1.SecondarySubcluster
+}
+
+// convertToStatusConditionType will convert to a v1 VerticaDBConditionType from a v1beta1 version
+func convertToStatusConditionType(srcType VerticaDBConditionType) v1.VerticaDBConditionType {
+	if srcType == ImageChangeInProgress {
+		return v1.UpgradeInProgress
+	}
+	return v1.VerticaDBConditionType(srcType)
+}
+
+// convertFromStatusConditionType will convert from a v1 VerticaDBConditionType to a v1beta1 version
+func convertFromStatusConditionType(srcType v1.VerticaDBConditionType) VerticaDBConditionType {
+	if srcType == v1.UpgradeInProgress {
+		return ImageChangeInProgress
+	}
+	return VerticaDBConditionType(srcType)
 }

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -27,3 +27,25 @@ patchesStrategicMerge:
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
   - kustomizeconfig.yaml
+
+patches:
+  # We add a patch to the CRD to add an additional printer column. Normally this
+  # is added as a kubebuilder annotation in verticadb_types.go. However, we need
+  # access to annotations and the way to access that breaks the parser in
+  # controller-gen.
+- target:
+    kind: CustomResourceDefinition
+    name: verticadbs.vertica.com
+  patch: |-
+    - op: add
+      path: /spec/versions/0/additionalPrinterColumns/1
+      value:
+        jsonPath: .metadata.annotations.vertica\.com\/version
+        name: Version
+        type: string
+    - op: add
+      path: /spec/versions/0/additionalPrinterColumns/2
+      value:
+        jsonPath: .metadata.annotations.vertica\.com\/ready-status
+        name: Ready
+        type: string

--- a/pkg/controllers/vdb/dbremovenode_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovenode_reconciler_test.go
@@ -100,8 +100,9 @@ var _ = Describe("dbremovenode_reconcile", func() {
 	It("should skip remove node and requeue because pod we need to remove node from isn't running", func() {
 		vdb := vapi.MakeVDB()
 		sc := &vdb.Spec.Subclusters[0]
+		sc.Size = 2
 		vdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: sc.Name, InstallCount: sc.Size, AddedToDBCount: sc.Size},
+			{Name: sc.Name, AddedToDBCount: sc.Size, Detail: []vapi.VerticaDBPodStatus{{Installed: true}, {Installed: true}}},
 		}
 		vdbCopy := vdb.DeepCopy() // Take a copy so that we cleanup with the original size
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
@@ -57,8 +57,8 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 		lookupVdb := vapi.MakeVDB()
 		lookupVdb.Spec.Subclusters[0] = vapi.Subcluster{Name: scNames[0], Size: scSizes[0]}
 		lookupVdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: scNames[0], InstallCount: scSizes[0], AddedToDBCount: scSizes[0]},
-			{Name: scNames[1], InstallCount: scSizes[1], AddedToDBCount: scSizes[1]},
+			{Name: scNames[0], AddedToDBCount: scSizes[0]},
+			{Name: scNames[1], AddedToDBCount: scSizes[1]},
 		}
 
 		fpr := &cmds.FakePodRunner{}

--- a/pkg/controllers/vdb/install_reconciler.go
+++ b/pkg/controllers/vdb/install_reconciler.go
@@ -223,7 +223,7 @@ func (d *InstallReconciler) getInstallTargets(ctx context.Context) ([]*PodFact, 
 		startPodIndex := int32(0)
 		scStatus, ok := d.Vdb.FindSubclusterStatus(sc.Name)
 		if ok {
-			startPodIndex += scStatus.InstallCount
+			startPodIndex += scStatus.InstallCount()
 		}
 		for i := startPodIndex; i < sc.Size; i++ {
 			pn := names.GenPodName(d.Vdb, sc, i)

--- a/pkg/controllers/vdb/install_reconciler_test.go
+++ b/pkg/controllers/vdb/install_reconciler_test.go
@@ -79,7 +79,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		const ScSize = 2
 		vdb.Spec.Subclusters[0].Size = ScSize
 		vdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: vdb.Spec.Subclusters[0].Name, InstallCount: ScSize - 1, Detail: []vapi.VerticaDBPodStatus{}},
+			{Name: vdb.Spec.Subclusters[0].Name, Detail: []vapi.VerticaDBPodStatus{{Installed: true}, {Installed: false}}},
 		}
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
@@ -101,7 +101,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		sc := &vdb.Spec.Subclusters[ScIndex]
 		sc.Size = 2
 		vdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: vdb.Spec.Subclusters[0].Name, InstallCount: sc.Size - 1, Detail: []vapi.VerticaDBPodStatus{}},
+			{Name: vdb.Spec.Subclusters[0].Name, Detail: []vapi.VerticaDBPodStatus{{Installed: true}, {Installed: false}}},
 		}
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -461,7 +461,7 @@ func (p *PodFacts) checkIsInstalled(_ context.Context, vdb *vapi.VerticaDB, pf *
 		// 1.  We have done the install, but haven't yet updated the status field.
 		// 2.  We have done the install, but the admintools.conf was deleted after the fact.
 		// So, we continue after this to further refine the actual install state.
-		pf.isInstalled = scs.InstallCount > pf.podIndex
+		pf.isInstalled = scs.InstallCount() > pf.podIndex
 	}
 	// Nothing else can be gathered if the pod isn't running.
 	if !pf.isPodRunning {

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -387,7 +387,7 @@ var _ = Describe("restart_reconciler", func() {
 		// Update the status to indicate install count includes both pods
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
 		vdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: vdb.Spec.Subclusters[0].Name, InstallCount: ScSize, Detail: []vapi.VerticaDBPodStatus{}},
+			{Name: vdb.Spec.Subclusters[0].Name, Detail: []vapi.VerticaDBPodStatus{{Installed: true}, {Installed: true}}},
 		}
 		Expect(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
 

--- a/pkg/controllers/vdb/status_reconciler.go
+++ b/pkg/controllers/vdb/status_reconciler.go
@@ -23,11 +23,13 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -60,12 +62,23 @@ func (s *StatusReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
+	if err := s.updateStatusFields(ctx); err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := s.updateReadyStatusAnnotation(ctx); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// updateStatusFields will refresh the status fields in the vdb
+func (s *StatusReconciler) updateStatusFields(ctx context.Context) error {
 	// Use all subclusters, even ones that are scheduled for removal.  We keep
 	// reporting status on the deleted ones until the statefulsets are gone.
 	finder := iter.MakeSubclusterFinder(s.Client, s.Vdb)
 	subclusters, err := finder.FindSubclusters(ctx, iter.FindAll)
 	if err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
 
 	refreshStatus := func(vdbChg *vapi.VerticaDB) error {
@@ -89,21 +102,42 @@ func (s *StatusReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl
 		return nil
 	}
 
-	if err := vdbstatus.Update(ctx, s.Client, s.Vdb, refreshStatus); err != nil {
-		return ctrl.Result{}, err
-	}
-	return ctrl.Result{}, nil
+	return vdbstatus.Update(ctx, s.Client, s.Vdb, refreshStatus)
+}
+
+// updateReadyStatusAnnotation will refresh the annotation we keep for ready status
+func (s *StatusReconciler) updateReadyStatusAnnotation(ctx context.Context) error {
+	nm := s.Vdb.ExtractNamespacedName()
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := s.Client.Get(ctx, nm, s.Vdb); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if s.Vdb.Annotations == nil {
+			s.Vdb.Annotations = make(map[string]string, 1)
+		}
+		oldStatus := s.Vdb.Annotations[vmeta.ReadyStatusAnnotation]
+		s.Vdb.Annotations[vmeta.ReadyStatusAnnotation] = fmt.Sprintf("%d/%d",
+			s.Vdb.Status.UpNodeCount, s.Vdb.Status.AddedToDBCount)
+		if oldStatus != s.Vdb.Annotations[vmeta.ReadyStatusAnnotation] {
+			s.Log.Info("Refresh ready status annotation",
+				"status", s.Vdb.Annotations[vmeta.ReadyStatusAnnotation])
+			return s.Client.Update(ctx, s.Vdb)
+		}
+		return nil
+	})
 }
 
 // calculateClusterStatus will roll up the subcluster status.
 func (s *StatusReconciler) calculateClusterStatus(stat *vapi.VerticaDBStatus) {
 	stat.SubclusterCount = 0
-	stat.InstallCount = 0
 	stat.AddedToDBCount = 0
 	stat.UpNodeCount = 0
 	for _, sc := range stat.Subclusters {
 		stat.SubclusterCount++
-		stat.InstallCount += sc.InstallCount
 		stat.AddedToDBCount += sc.AddedToDBCount
 		stat.UpNodeCount += sc.UpNodeCount
 	}
@@ -124,7 +158,6 @@ func (s *StatusReconciler) calculateSubclusterStatus(ctx context.Context, sc *va
 			continue
 		}
 		curStat.Detail[podIndex].UpNode = pf.upNode
-		curStat.Detail[podIndex].ReadOnly = pf.readOnly
 		curStat.Detail[podIndex].Installed = pf.isInstalled
 		curStat.Detail[podIndex].AddedToDB = pf.dbExists
 		if pf.vnodeName != "" {
@@ -135,22 +168,14 @@ func (s *StatusReconciler) calculateSubclusterStatus(ctx context.Context, sc *va
 		}
 	}
 	// Refresh the counts
-	curStat.InstallCount = 0
 	curStat.AddedToDBCount = 0
 	curStat.UpNodeCount = 0
-	curStat.ReadOnlyCount = 0
 	for _, v := range curStat.Detail {
-		if v.Installed {
-			curStat.InstallCount++
-		}
 		if v.AddedToDB {
 			curStat.AddedToDBCount++
 		}
 		if v.UpNode {
 			curStat.UpNodeCount++
-		}
-		if v.ReadOnly {
-			curStat.ReadOnlyCount++
 		}
 	}
 	return nil

--- a/pkg/controllers/vdb/status_reconciler_test.go
+++ b/pkg/controllers/vdb/status_reconciler_test.go
@@ -45,10 +45,10 @@ var _ = Describe("status_reconcile", func() {
 
 		fetchVdb := &vapi.VerticaDB{}
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
-		Expect(fetchVdb.Status.Subclusters[0].InstallCount).Should(Equal(int32(3)))
+		Expect(fetchVdb.Status.Subclusters[0].InstallCount()).Should(Equal(int32(3)))
 
 		// vdb should be updated too
-		Expect(vdb.Status.Subclusters[0].InstallCount).Should(Equal(int32(3)))
+		Expect(vdb.Status.Subclusters[0].InstallCount()).Should(Equal(int32(3)))
 	})
 
 	It("should not fail if no objects exist yet in the crd", func() {
@@ -66,7 +66,7 @@ var _ = Describe("status_reconcile", func() {
 		fetchVdb := &vapi.VerticaDB{}
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
 		stat := &fetchVdb.Status
-		Expect(stat.InstallCount).Should(Equal(int32(0)))
+		Expect(stat.InstallCount()).Should(Equal(int32(0)))
 		Expect(stat.SubclusterCount).Should(Equal(int32(1)))
 	})
 
@@ -86,10 +86,10 @@ var _ = Describe("status_reconcile", func() {
 
 		fetchVdb := &vapi.VerticaDB{}
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
-		Expect(fetchVdb.Status.Subclusters[0].InstallCount).Should(Equal(int32(1)))
+		Expect(fetchVdb.Status.Subclusters[0].InstallCount()).Should(Equal(int32(1)))
 		Expect(fetchVdb.Status.Subclusters[0].AddedToDBCount).Should(Equal(int32(1)))
 		Expect(fetchVdb.Status.Subclusters[0].UpNodeCount).Should(Equal(int32(1)))
-		Expect(fetchVdb.Status.Subclusters[1].InstallCount).Should(Equal(int32(4)))
+		Expect(fetchVdb.Status.Subclusters[1].InstallCount()).Should(Equal(int32(4)))
 		Expect(fetchVdb.Status.Subclusters[1].AddedToDBCount).Should(Equal(int32(4)))
 		Expect(fetchVdb.Status.Subclusters[1].UpNodeCount).Should(Equal(int32(4)))
 	})
@@ -114,7 +114,7 @@ var _ = Describe("status_reconcile", func() {
 
 		fetchVdb := &vapi.VerticaDB{}
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
-		Expect(fetchVdb.Status.Subclusters[ScIndex].InstallCount).Should(Equal(int32(1)))
+		Expect(fetchVdb.Status.Subclusters[ScIndex].InstallCount()).Should(Equal(int32(1)))
 		Expect(fetchVdb.Status.Subclusters[ScIndex].AddedToDBCount).Should(Equal(int32(1)))
 		Expect(fetchVdb.Status.Subclusters[ScIndex].UpNodeCount).Should(Equal(int32(1)))
 	})
@@ -129,7 +129,13 @@ var _ = Describe("status_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		vdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: sc.Name, InstallCount: sc.Size, AddedToDBCount: sc.Size, Detail: make([]vapi.VerticaDBPodStatus, 0)},
+			{Name: sc.Name, AddedToDBCount: sc.Size, Detail: []vapi.VerticaDBPodStatus{
+				{Installed: true, AddedToDB: true},
+				{Installed: true, AddedToDB: true},
+				{Installed: true, AddedToDB: true},
+				{Installed: true, AddedToDB: true},
+				{Installed: true, AddedToDB: true},
+			}},
 		}
 		Expect(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
 
@@ -140,14 +146,14 @@ var _ = Describe("status_reconcile", func() {
 
 		fetchVdb := &vapi.VerticaDB{}
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
-		Expect(fetchVdb.Status.Subclusters[0].InstallCount).Should(Equal(int32(5)))
+		Expect(fetchVdb.Status.Subclusters[0].InstallCount()).Should(Equal(int32(5)))
 
 		test.ScaleDownSubcluster(ctx, k8sClient, vdb, sc, 2)
 		pfacts.Invalidate()
 
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
-		Expect(fetchVdb.Status.Subclusters[0].InstallCount).Should(Equal(int32(2)))
+		Expect(fetchVdb.Status.Subclusters[0].InstallCount()).Should(Equal(int32(2)))
 	})
 
 	It("should preserve old status when subclusters is not running", func() {

--- a/pkg/controllers/vdb/uninstall_reconciler_test.go
+++ b/pkg/controllers/vdb/uninstall_reconciler_test.go
@@ -66,7 +66,10 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		sc := &vdb.Spec.Subclusters[0]
 		sc.Size = 2
 		vdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: vdb.Spec.Subclusters[0].Name, InstallCount: sc.Size, Detail: []vapi.VerticaDBPodStatus{}},
+			{
+				Name:   vdb.Spec.Subclusters[0].Name,
+				Detail: []vapi.VerticaDBPodStatus{{Installed: true}, {Installed: true}},
+			},
 		}
 		vdbCopy := vdb.DeepCopy() // Take a copy so that cleanup with original size
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsNotRunning)

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -110,7 +110,7 @@ func (i *UpgradeManager) isVDBImageDifferent(ctx context.Context) (bool, error) 
 func (i *UpgradeManager) startUpgrade(ctx context.Context) (ctrl.Result, error) {
 	i.Log.Info("Starting upgrade for reconciliation iteration", "ContinuingUpgrade", i.ContinuingUpgrade,
 		"New Image", i.Vdb.Spec.Image)
-	if err := i.toggleImageChangeInProgress(ctx, corev1.ConditionTrue); err != nil {
+	if err := i.toggleUpgradeInProgress(ctx, corev1.ConditionTrue); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -129,7 +129,7 @@ func (i *UpgradeManager) finishUpgrade(ctx context.Context) (ctrl.Result, error)
 		return ctrl.Result{}, err
 	}
 
-	if err := i.toggleImageChangeInProgress(ctx, corev1.ConditionFalse); err != nil {
+	if err := i.toggleUpgradeInProgress(ctx, corev1.ConditionFalse); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -140,12 +140,12 @@ func (i *UpgradeManager) finishUpgrade(ctx context.Context) (ctrl.Result, error)
 	return ctrl.Result{}, nil
 }
 
-// toggleImageChangeInProgress is a helper for updating the
-// ImageChangeInProgress condition's.  We set the ImageChangeInProgress plus the
+// toggleUpgradeInProgress is a helper for updating the
+// UpgradeInProgress condition's.  We set the UpgradeInProgress plus the
 // one defined in i.StatusCondition.
-func (i *UpgradeManager) toggleImageChangeInProgress(ctx context.Context, newVal corev1.ConditionStatus) error {
+func (i *UpgradeManager) toggleUpgradeInProgress(ctx context.Context, newVal corev1.ConditionStatus) error {
 	err := vdbstatus.UpdateCondition(ctx, i.VRec.Client, i.Vdb,
-		vapi.VerticaDBCondition{Type: vapi.ImageChangeInProgress, Status: newVal},
+		vapi.VerticaDBCondition{Type: vapi.UpgradeInProgress, Status: newVal},
 	)
 	if err != nil {
 		return err

--- a/pkg/controllers/vdb/upgrade_test.go
+++ b/pkg/controllers/vdb/upgrade_test.go
@@ -179,13 +179,13 @@ var _ = Describe("upgrade", func() {
 
 		fetchedVdb := &vapi.VerticaDB{}
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
-		Expect(fetchedVdb.Status.Conditions[vapi.ImageChangeInProgressIndex].Status).Should(Equal(corev1.ConditionTrue))
+		Expect(fetchedVdb.Status.Conditions[vapi.UpgradeInProgressIndex].Status).Should(Equal(corev1.ConditionTrue))
 		Expect(fetchedVdb.Status.Conditions[vapi.OfflineUpgradeInProgressIndex].Status).Should(Equal(corev1.ConditionTrue))
 		Expect(fetchedVdb.Status.UpgradeStatus).ShouldNot(Equal(""))
 
 		Expect(mgr.finishUpgrade(ctx)).Should(Equal(ctrl.Result{}))
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
-		Expect(fetchedVdb.Status.Conditions[vapi.ImageChangeInProgressIndex].Status).Should(Equal(corev1.ConditionFalse))
+		Expect(fetchedVdb.Status.Conditions[vapi.UpgradeInProgressIndex].Status).Should(Equal(corev1.ConditionFalse))
 		Expect(fetchedVdb.Status.Conditions[vapi.OfflineUpgradeInProgressIndex].Status).Should(Equal(corev1.ConditionFalse))
 		Expect(fetchedVdb.Status.UpgradeStatus).Should(Equal(""))
 	})

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -27,6 +27,10 @@ const (
 	KubernetesGitCommitAnnotation = "kubernetes.io/gitcommit" // Git commit of the k8s server
 	KubernetesBuildDateAnnotation = "kubernetes.io/buildDate" // Build date of the k8s server
 
+	// A status annotation that shows the number of ready vertica hosts to the
+	// number of total hosts
+	ReadyStatusAnnotation = "vertica.com/ready-status"
+
 	// If this annotation is on any CR, the operator will skip processing. This can
 	// be used to avoid getting in an infinity error-retry loop. Or, if you know
 	// no additional work will ever exist for an object. Just set this to a

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -109,8 +109,11 @@ func ScaleDownSubcluster(ctx context.Context, c client.Client, vdb *vapi.Vertica
 	for i := range vdb.Status.Subclusters {
 		scs := &vdb.Status.Subclusters[i]
 		if scs.Name == sc.Name {
-			scs.InstallCount = newSize
 			scs.AddedToDBCount = newSize
+			scs.Detail = []vapi.VerticaDBPodStatus{}
+			for j := int32(0); j < newSize; j++ {
+				scs.Detail = append(scs.Detail, vapi.VerticaDBPodStatus{Installed: true})
+			}
 			break
 		}
 	}

--- a/tests/e2e-leg-1/autoscale-by-pod/20-assert.yaml
+++ b/tests/e2e-leg-1/autoscale-by-pod/20-assert.yaml
@@ -33,7 +33,5 @@ metadata:
   name: v-autoscale-by-pod
 status:
   subclusters:
-    - installCount: 2
-      addedToDBCount: 2
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 2
+    - addedToDBCount: 1

--- a/tests/e2e-leg-1/autoscale-by-subcluster/20-assert.yaml
+++ b/tests/e2e-leg-1/autoscale-by-subcluster/20-assert.yaml
@@ -25,6 +25,5 @@ metadata:
   name: v-autoscale-by-subcluster
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
   subclusterCount: 1

--- a/tests/e2e-leg-2/restart-sanity/10-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/10-assert.yaml
@@ -15,6 +15,3 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-restart
-status:
-  subclusters:
-    - installCount: 3

--- a/tests/e2e-leg-2/restart-sanity/15-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/15-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-restart
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 2

--- a/tests/e2e-leg-2/restart-sanity/20-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/20-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-restart
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 3

--- a/tests/e2e-leg-2/restart-sanity/25-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/25-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-restart
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 0

--- a/tests/e2e-leg-2/restart-sanity/30-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/30-assert.yaml
@@ -17,7 +17,5 @@ metadata:
   name: v-restart
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 3
-      readOnlyCount: 0

--- a/tests/e2e-leg-2/restart-sanity/35-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/35-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-restart
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 0

--- a/tests/e2e-leg-2/restart-sanity/40-assert.yaml
+++ b/tests/e2e-leg-2/restart-sanity/40-assert.yaml
@@ -17,8 +17,7 @@ metadata:
   name: v-restart
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 3
 ---
 apiVersion: v1

--- a/tests/e2e-leg-2/shared-svc/15-assert.yaml
+++ b/tests/e2e-leg-2/shared-svc/15-assert.yaml
@@ -63,5 +63,4 @@ kind: VerticaDB
 metadata:
   name: v-shared-svc
 status:
-  installCount: 3
   subclusterCount: 3

--- a/tests/e2e-leg-2/shared-svc/20-assert.yaml
+++ b/tests/e2e-leg-2/shared-svc/20-assert.yaml
@@ -16,6 +16,5 @@ kind: VerticaDB
 metadata:
   name: v-shared-svc
 status:
-  installCount: 3
   addedToDBCount: 3
   upNodeCount: 3

--- a/tests/e2e-leg-2/webhook/15-assert.yaml
+++ b/tests/e2e-leg-2/webhook/15-assert.yaml
@@ -25,5 +25,4 @@ metadata:
   name: v-webhook
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1

--- a/tests/e2e-leg-3/mount-certs/40-assert.yaml
+++ b/tests/e2e-leg-3/mount-certs/40-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-mount-certs
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1

--- a/tests/e2e-leg-3/mount-certs/52-assert.yaml
+++ b/tests/e2e-leg-3/mount-certs/52-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-mount-certs
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 0

--- a/tests/e2e-leg-3/mount-certs/55-assert.yaml
+++ b/tests/e2e-leg-3/mount-certs/55-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-mount-certs
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 0

--- a/tests/e2e-leg-3/mount-certs/60-assert.yaml
+++ b/tests/e2e-leg-3/mount-certs/60-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-mount-certs
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1

--- a/tests/e2e-leg-3/readiness-probe-override/15-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/15-assert.yaml
@@ -17,7 +17,3 @@ metadata:
   name: v-readiness-probe-override
 status:
   subclusterCount: 2
-  installCount: 2
-  subclusters:
-    - installCount: 1
-    - installCount: 1

--- a/tests/e2e-leg-3/readiness-probe-override/20-assert.yaml
+++ b/tests/e2e-leg-3/readiness-probe-override/20-assert.yaml
@@ -33,6 +33,5 @@ metadata:
   name: v-readiness-probe-override
 status:
   subclusterCount: 2
-  installCount: 2
   addedToDBCount: 2
   upNodeCount: 2

--- a/tests/e2e-leg-4/createdb-failures/40-assert.yaml
+++ b/tests/e2e-leg-4/createdb-failures/40-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-createdb-failures
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1

--- a/tests/e2e-leg-4/pvc-expansion/15-assert.yaml
+++ b/tests/e2e-leg-4/pvc-expansion/15-assert.yaml
@@ -22,6 +22,3 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-pvc-expansion
-status:
-  subclusters:
-    - installCount: 1

--- a/tests/e2e-leg-4/pvc-expansion/20-assert.yaml
+++ b/tests/e2e-leg-4/pvc-expansion/20-assert.yaml
@@ -25,6 +25,5 @@ metadata:
   name: v-pvc-expansion
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1

--- a/tests/e2e-leg-4/pvc-expansion/35-assert.yaml
+++ b/tests/e2e-leg-4/pvc-expansion/35-assert.yaml
@@ -17,6 +17,5 @@ metadata:
   name: v-pvc-expansion
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1

--- a/tests/e2e-leg-4/restart-with-liveness-probe/15-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/15-assert.yaml
@@ -15,8 +15,6 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-restart-with-liveness-probe
-status:
-  installCount: 3
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e-leg-4/restart-with-liveness-probe/20-assert.yaml
+++ b/tests/e2e-leg-4/restart-with-liveness-probe/20-assert.yaml
@@ -16,7 +16,6 @@ kind: VerticaDB
 metadata:
   name: v-restart-with-liveness-probe
 status:
-  installCount: 3
   addedToDBCount: 3
   upNodeCount: 3
   subclusterCount: 2

--- a/tests/e2e-leg-4/revivedb-3-node/15-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/15-assert.yaml
@@ -22,6 +22,3 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-create-3-node
-status:
-  subclusters:
-    - installCount: 3

--- a/tests/e2e-leg-4/revivedb-3-node/20-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/20-assert.yaml
@@ -25,6 +25,5 @@ metadata:
   name: v-create-3-node
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 3

--- a/tests/e2e-leg-4/revivedb-3-node/30-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/30-assert.yaml
@@ -22,6 +22,3 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-revive-3-node
-status:
-  subclusters:
-    - installCount: 3

--- a/tests/e2e-leg-4/revivedb-3-node/35-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/35-assert.yaml
@@ -30,6 +30,5 @@ spec:
     depotVolume: PersistentVolume
 status:
   subclusters:
-    - installCount: 3
-      addedToDBCount: 3
+    - addedToDBCount: 3
       upNodeCount: 3

--- a/tests/e2e-leg-5-failed/istio/20-assert.yaml
+++ b/tests/e2e-leg-5-failed/istio/20-assert.yaml
@@ -27,7 +27,3 @@ metadata:
 spec:
   annotations:
     sidecar.istio.io/interceptionMode: TPROXY
-status:
-  subclusters:
-    - installCount: 3
-

--- a/tests/e2e-leg-5-failed/istio/25-assert.yaml
+++ b/tests/e2e-leg-5-failed/istio/25-assert.yaml
@@ -25,8 +25,7 @@ metadata:
   name: v-istio-tproxy
 status:
   subclusters:
-    - installCount: 3
-      upNodeCount: 3
+    - upNodeCount: 3
   conditions:
   - type: AutoRestartVertica
     status: "True"

--- a/tests/e2e-leg-5/disable-webhook/15-assert.yaml
+++ b/tests/e2e-leg-5/disable-webhook/15-assert.yaml
@@ -22,6 +22,3 @@ metadata:
   name: v-disable-webhook
   annotations:
     vertica.com/k-safety: "0"
-status:
-  subclusters:
-    - installCount: 1

--- a/tests/e2e-leg-6/http-generated-certs/20-assert.yaml
+++ b/tests/e2e-leg-6/http-generated-certs/20-assert.yaml
@@ -22,6 +22,3 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-http-generated-certs
-status:
-  subclusters:
-    - installCount: 2

--- a/tests/e2e-leg-6/http-generated-certs/25-assert.yaml
+++ b/tests/e2e-leg-6/http-generated-certs/25-assert.yaml
@@ -25,8 +25,7 @@ metadata:
   name: v-http-generated-certs
 status:
   subclusters:
-    - installCount: 2
-      addedToDBCount: 2
+    - addedToDBCount: 2
       upNodeCount: 2
 ---
 # Verify that it generated a new secret that has the TLS certs

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/15-assert.yaml
@@ -16,7 +16,6 @@ kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  installCount: 3
   addedToDBCount: 3
   upNodeCount: 3
 ---

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/25-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/25-assert.yaml
@@ -21,7 +21,7 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "True"
     - type: OfflineUpgradeInProgress
       status: "True"

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/30-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/30-assert.yaml
@@ -16,6 +16,5 @@ kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  installCount: 3
   addedToDBCount: 3
   upNodeCount: 0

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/35-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/35-assert.yaml
@@ -21,10 +21,9 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "False"
     - type: OfflineUpgradeInProgress
       status: "False"
   subclusterCount: 1
-  installCount: 3
   upNodeCount: 3

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/55-kubectl-wait.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/55-kubectl-wait.yaml
@@ -14,7 +14,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl wait --for=condition=ImageChangeInProgress=True vdb/v-base-upgrade --timeout=600s
+  - command: kubectl wait --for=condition=UpgradeInProgress=True vdb/v-base-upgrade --timeout=600s
     namespaced: true
-  - command: kubectl wait --for=condition=ImageChangeInProgress=False vdb/v-base-upgrade --timeout=600s
+  - command: kubectl wait --for=condition=UpgradeInProgress=False vdb/v-base-upgrade --timeout=600s
     namespaced: true

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/15-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/15-assert.yaml
@@ -22,6 +22,3 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-base-upgrade
-status:
-  subclusters:
-    - installCount: 3

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/15-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/15-assert.yaml
@@ -16,6 +16,5 @@ kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  installCount: 1
   addedToDBCount: 1
   upNodeCount: 1

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/20-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/20-assert.yaml
@@ -22,7 +22,7 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "True"
     - type: OfflineUpgradeInProgress
       status: "False"

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/25-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/25-assert.yaml
@@ -21,12 +21,11 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "False"
     - type: OfflineUpgradeInProgress
       status: "False"
     - type: OnlineUpgradeInProgress
       status: "False"
   subclusterCount: 2
-  installCount: 2
   upNodeCount: 1

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/30-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/30-assert.yaml
@@ -17,7 +17,6 @@ metadata:
   name: v-base-upgrade
 status:
   subclusterCount: 2
-  installCount: 2
   addedToDBCount: 2
   upNodeCount: 2
 ---

--- a/tests/e2e-server-upgrade/online-upgrade-drain/15-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/15-assert.yaml
@@ -16,6 +16,5 @@ kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  installCount: 3
   addedToDBCount: 1
   upNodeCount: 1

--- a/tests/e2e-server-upgrade/online-upgrade-drain/20-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/20-assert.yaml
@@ -17,14 +17,11 @@ metadata:
   name: v-base-upgrade
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1
 ---
 apiVersion: v1

--- a/tests/e2e-server-upgrade/online-upgrade-drain/35-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/35-assert.yaml
@@ -22,7 +22,7 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "True"
     - type: OfflineUpgradeInProgress
       status: "False"

--- a/tests/e2e-server-upgrade/online-upgrade-drain/55-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/55-assert.yaml
@@ -21,12 +21,11 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "False"
     - type: OfflineUpgradeInProgress
       status: "False"
     - type: OnlineUpgradeInProgress
       status: "False"
   subclusterCount: 3
-  installCount: 3
   upNodeCount: 3

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/15-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/15-assert.yaml
@@ -16,6 +16,5 @@ kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  installCount: 3
   addedToDBCount: 3
   upNodeCount: 3

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/25-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/25-assert.yaml
@@ -22,7 +22,7 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "True"
     - type: OfflineUpgradeInProgress
       status: "False"

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/50-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/50-assert.yaml
@@ -21,12 +21,11 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "False"
     - type: OfflineUpgradeInProgress
       status: "False"
     - type: OnlineUpgradeInProgress
       status: "False"
   subclusterCount: 1
-  installCount: 3
   upNodeCount: 3

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/15-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/15-assert.yaml
@@ -16,6 +16,5 @@ kind: VerticaDB
 metadata:
   name: v-base-upgrade
 status:
-  installCount: 1
   addedToDBCount: 1
   upNodeCount: 1

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/20-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/20-assert.yaml
@@ -22,7 +22,7 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "True"
     - type: OfflineUpgradeInProgress
       status: "False"

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/50-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/50-assert.yaml
@@ -21,12 +21,11 @@ status:
       status: "True"
     - type: DBInitialized
       status: "True"
-    - type: ImageChangeInProgress
+    - type: UpgradeInProgress
       status: "False"
     - type: OfflineUpgradeInProgress
       status: "False"
     - type: OnlineUpgradeInProgress
       status: "False"
   subclusterCount: 1
-  installCount: 1
   upNodeCount: 1

--- a/tests/e2e-udx/udx-cpp/15-assert.yaml
+++ b/tests/e2e-udx/udx-cpp/15-assert.yaml
@@ -22,6 +22,3 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-udx-cpp
-status:
-  subclusters:
-    - installCount: 1

--- a/tests/e2e-udx/udx-cpp/20-assert.yaml
+++ b/tests/e2e-udx/udx-cpp/20-assert.yaml
@@ -25,6 +25,5 @@ metadata:
   name: v-udx-cpp
 status:
   subclusters:
-    - installCount: 1
-      addedToDBCount: 1
+    - addedToDBCount: 1
       upNodeCount: 1


### PR DESCRIPTION
This updates the status fields for the v1 API. A summary of the changes are:
- Rename ImageChangeInProgress condition variable to UpdateInProgress
- Remove the ReadOnly state, since it no longer needs to be surfaced
- Remove the install count at the cluster and subcluster level. We still track install per pod, but use functions to sum up the count at higher levels

I am also updating the print columns of the VerticaDB when you do get vdb. Sample output looks like this:
```
$ kubectl get vdb
NAME   AGE   VERSION            READY   SUBCLUSTERS
vc     56s   v24.1.0-20231012   3/3     1
```

See #531 to understand why we are making this change. No change is done to the v1beta1 API.