### PR TITLE
Include scrutinize storage in PV

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -197,6 +197,17 @@ func buildVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 		volMnts = append(volMnts, buildHTTPServerVolumeMount()...)
 	}
 
+	if vmeta.UseVClusterOps(vdb.Annotations) {
+		// Include a temp directory to be used by vcluster scrutinize. We want
+		// the temp directory to be large enough to store compressed logs and
+		// such. These can be quite big, so we cannot risk storing those in
+		// local disk on the node, which may fill up and cause the pod to be
+		// rescheduled.
+		volMnts = append(volMnts, corev1.VolumeMount{
+			Name: vapi.LocalDataPVC, SubPath: vdb.GetPVSubPath("scrutinize"), MountPath: paths.ScrutinizeTmp,
+		})
+	}
+
 	volMnts = append(volMnts, buildCertSecretVolumeMounts(vdb)...)
 	volMnts = append(volMnts, vdb.Spec.VolumeMounts...)
 

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -38,6 +38,7 @@ const (
 	HTTPTLSConfFileName       = "httpstls.json"
 	HTTPTLSConfFile           = "/opt/vertica/config/https_certs/httpstls.json"
 	LogPath                   = "/opt/vertica/log"
+	ScrutinizeTmp             = "/tmp/scrutinize"
 	PodInfoPath               = "/etc/podinfo"
 	AdminToolsConf            = "/opt/vertica/config/admintools.conf"
 	AuthParmsFile             = "/home/dbadmin/auth_parms.conf"


### PR DESCRIPTION
For vclusterops deployments, we want to carve out a portion of the PV for use with scrutinize. The directory will be /tmp/scrutinize. We are doing this because we don't want to risk filling up the node's local directory with compressed diagnostics. These can be quite big. If the node's space is used then k8s will simply reschedule the pod, forcing the scrutinize to start over.