### PR TITLE
Fix timing hole that skips drain for scale down

### DIFF
--- a/changes/unreleased/Fixed-20231018-111648.yaml
+++ b/changes/unreleased/Fixed-20231018-111648.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Timing hole that can skip the drain for scale down.
+time: 2023-10-18T11:16:48.945394946-03:00
+custom:
+  Issue: "552"

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler.go
@@ -71,6 +71,21 @@ func (d *DBRemoveSubclusterReconciler) Reconcile(ctx context.Context, _ *ctrl.Re
 		return ctrl.Result{}, err
 	}
 
+	// There is a timing scenario where it's possible to skip the drain and just
+	// proceed to remove the subcluster. This can occur if the vdb scale down
+	// occurs in the middle of a reconciliation.  This scale down will use the
+	// latest info in the vdb, which may be newer than the state that the drain
+	// node reconiler uses. This check has be close to where we decide about the
+	// scale down.
+	if changed, err := d.PFacts.HasVerticaDBChangedSinceCollection(ctx, d.Vdb); changed || err != nil {
+		if changed {
+			d.Log.Info("Requeue because vdb has changed since last pod facts collection",
+				"oldResourceVersion", d.PFacts.VDBResourceVersion,
+				"newResourceVersion", d.Vdb.ResourceVersion)
+		}
+		return ctrl.Result{Requeue: changed}, err
+	}
+
 	return d.removeExtraSubclusters(ctx)
 }
 

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
@@ -32,6 +32,8 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 
 	It("should do nothing if none of the statefulsets were created yet", func() {
 		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
@@ -47,24 +49,26 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 			{Name: scNames[0], Size: scSizes[0]},
 			{Name: scNames[1], Size: scSizes[1]},
 		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		test.CreateSvcs(ctx, k8sClient, vdb)
 		defer test.DeleteSvcs(ctx, k8sClient, vdb)
 
-		// We create a second vdb without one of the subclusters.  We then use
+		// We update the vdb to remove one of the subclusters.  We then use
 		// the finder to discover this additional subcluster.
-		lookupVdb := vapi.MakeVDB()
-		lookupVdb.Spec.Subclusters[0] = vapi.Subcluster{Name: scNames[0], Size: scSizes[0]}
-		lookupVdb.Status.Subclusters = []vapi.SubclusterStatus{
-			{Name: scNames[0], AddedToDBCount: scSizes[0]},
-			{Name: scNames[1], AddedToDBCount: scSizes[1]},
-		}
+		nm := vdb.ExtractNamespacedName()
+		fetchedVdb := &vapi.VerticaDB{}
+		Expect(k8sClient.Get(ctx, nm, fetchedVdb)).Should(Succeed())
+		fetchedVdb.Spec.Subclusters = fetchedVdb.Spec.Subclusters[:len(fetchedVdb.Spec.Subclusters)-1]
+		Expect(k8sClient.Update(ctx, fetchedVdb)).Should(Succeed())
 
 		fpr := &cmds.FakePodRunner{}
 		pfacts := createPodFactsDefault(fpr)
-		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, lookupVdb, fpr, pfacts, dispatcher)
+		Expect(pfacts.Collect(ctx, fetchedVdb)).Should(Succeed())
+		dispatcher := vdbRec.makeDispatcher(logger, fetchedVdb, fpr, TestPassword)
+		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, fetchedVdb, fpr, pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// One command should be AT -t db_remove_subcluster and one should be
 		// changing the default subcluster


### PR DESCRIPTION
This fixes an issue with the drain we do for scale down. There was a small timing window where we would not do the drain. Instead, we proceed to the scale down. Any active connections on the removed nodes would be end without warning.