### PR TITLE
VCluster API Refresh: logging update

### DIFF
--- a/.github/actions/setup-kubectl/action.yaml
+++ b/.github/actions/setup-kubectl/action.yaml
@@ -1,13 +1,13 @@
 name: 'Download kubectl'
-description: 'Will download kubectl into the current shell'
+description: 'Will download tools for k8s into the current shell'
 runs:
   using: "composite"
   steps:
-    - name: Install kubectl
+    # Note: we don't download kubectl because it should already be included in
+    # the GitHub runner as preinstalled software. Just check that it exists.
+    - name: Test kubectl
       shell: bash
       run: |
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
         kubectl version --client
 
     - name: Install kubens

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20231016110639-0487bd60c7d5
+	github.com/vertica/vcluster v0.0.0-20231020105333-fb3153c0ebf5
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20231016110639-0487bd60c7d5 h1:53Lqu//vKCahKicvhNtY9aM2wHdNtXZL50I9Pw2OrOw=
-github.com/vertica/vcluster v0.0.0-20231016110639-0487bd60c7d5/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
+github.com/vertica/vcluster v0.0.0-20231020105333-fb3153c0ebf5 h1:G0Nz4C1yBSid0cuaQ4wGaUMT1IqM9hPzh9Br3TejWXk=
+github.com/vertica/vcluster v0.0.0-20231020105333-fb3153c0ebf5/go.mod h1:7oNKoLThwbNX69xUwZZOdiI3WunMCth3mCF0EXOqtuc=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/vc_errors_test.go
+++ b/pkg/vadmin/vc_errors_test.go
@@ -46,7 +46,6 @@ var _ = Describe("verrors suite", func() {
 		}
 		origErr := rfc7807.New(rfc7807.CommunalStorageNotEmpty).
 			WithDetail("existing db already at /host").
-			WithStatus(500).
 			WithHost("pod-4")
 		wrappedErr := errors.Join(origErr, errors.New("we hit an error"))
 		res, err := vce.LogFailure("test rfc7807", wrappedErr)
@@ -61,7 +60,6 @@ var _ = Describe("verrors suite", func() {
 		}
 		origErr := rfc7807.New(rfc7807.GenericBootstrapCatalogFailure).
 			WithDetail("internal error occurred").
-			WithStatus(500).
 			WithHost("pod-5")
 		res, err := vce.LogFailure("test unknown rfc7807", origErr)
 		Ω(res).Should(Equal(ctrl.Result{}))


### PR DESCRIPTION
This picks up the latest vclusterops package. The key change is the logging for the library now uses the logr.Logger API everywhere. So, all of the logging for the operator and vclusterops should now follow the same format.

I also made a CI change. I noticed that we were having trouble downloading kubectl. This should be already included in the GitHub runners so removing the download step.