### PR TITLE
CI changes for new k8s images

### DIFF
--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -27,7 +27,7 @@ runs:
         find . -name \*.tar
         docker load --input full-vertica-image/full-vertica-image.tar
         docker load --input minimal-vertica-image/minimal-vertica-image.tar
-        docker load --input v2-vertica-image/legacy-vertica-image.tar
+        docker load --input legacy-vertica-image/legacy-vertica-image.tar
         docker load --input operator-image/operator-image.tar
         docker load --input vlogger-image/vlogger-image.tar
         docker image ls -a

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -25,8 +25,6 @@ runs:
       shell: bash
       run: |
         find . -name \*.tar
-        docker load --input full-vertica-image/full-vertica-image.tar
-        docker load --input minimal-vertica-image/minimal-vertica-image.tar
         docker load --input legacy-vertica-image/legacy-vertica-image.tar
         docker load --input operator-image/operator-image.tar
         docker load --input vlogger-image/vlogger-image.tar

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -26,8 +26,8 @@ runs:
       run: |
         find . -name \*.tar
         docker load --input full-vertica-image/full-vertica-image.tar
-        docker load --input nokeys-vertica-image/nokeys-vertica-image.tar
         docker load --input minimal-vertica-image/minimal-vertica-image.tar
+        docker load --input v2-vertica-image/legacy-vertica-image.tar
         docker load --input operator-image/operator-image.tar
         docker load --input vlogger-image/vlogger-image.tar
         docker image ls -a

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -8,15 +8,15 @@ on:
         type: string
         required: true
       full_vertica_image:
-        description: 'Name of an existing full Vertica server image. If blank we will build one using the default name'
+        description: 'Name of an existing full Vertica server v2 image. If blank we will build one using the default name'
+        type: string
+        required: true
+      minimal_vertica_image:
+        description: 'Name of an existing minimal Vertica server v2 image. If blank we will build one using the default name'
         type: string
         required: true
       legacy_vertica_image:
         description: 'Name of an existing full image with admintools and SSH support. Leave blank to build one with the default name'
-        type: string
-        required: true
-      minimal_vertica_image:
-        description: 'Name of an existing minimal Vertica server image. If blank we will build one using the default name'
         type: string
         required: true
       vlogger_image:
@@ -42,12 +42,12 @@ on:
       full-vertica-image:
         description: "The image name of the full vertica server image"
         value: ${{ jobs.build-server-full.outputs.image }}
-      legacy-vertica-image:
-        description: "The image name of the full vertica server image, but with admintools and SSH support"
-        value: ${{ jobs.build-server-nokeys.outputs.image }}
       minimal-vertica-image:
         description: "The image name of the vertica server, but with optional software removed"
         value: ${{ jobs.build-server-minimal.outputs.image }}
+      legacy-vertica-image:
+        description: "The image name of the full vertica server image, but with admintools and SSH support"
+        value: ${{ jobs.build-server-nokeys.outputs.image }}
       vlogger-image:
         description: "The image name of the vertica logger sidecar"
         value: ${{ jobs.build-vlogger.outputs.image }}
@@ -67,12 +67,6 @@ jobs:
       image: ${{ steps.full_vertica_image.outputs.value }}
     steps:
 
-    - name: set lower case owner name
-      env:
-        OWNER: '${{ github.repository_owner }}'
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-
     - name: Pick the name of the image
       uses: spilchen/switch-case-action@v2
       id: full_vertica_image
@@ -83,7 +77,7 @@ jobs:
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
-      if: ${{ github.event_name != 'pull_request' && inputs.full_vertica_image == '' || startsWith(inputs.full_vertica_image, 'ghcr.io') }}
+      if: ${{ github.event_name != 'pull_request' && startsWith(inputs.full_vertica_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -255,23 +249,17 @@ jobs:
       image: ${{ steps.minimal_vertica_image.outputs.value }}
     steps:
 
-    - name: set lower case owner name
-      env:
-        OWNER: '${{ github.repository_owner }}'
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-
     - name: Pick the name of the image
       uses: spilchen/switch-case-action@v2
       id: minimal_vertica_image
       with:
-        default: docker.io/vertica/vertica-k8s-private:latest-master
+        default: docker.io/vertica/vertica-k8s-private:latest-minimal-master
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
-      if: ${{ github.event_name != 'pull_request' && inputs.minimal_vertica_image == '' || startsWith(inputs.minimal_vertica_image, 'ghcr.io') }}
+      if: ${{ github.event_name != 'pull_request' && startsWith(inputs.minimal_vertica_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -11,16 +11,12 @@ on:
         description: 'Name of an existing full Vertica server image. If blank we will build one using the default name'
         type: string
         required: true
-      nokeys_vertica_image:
-        description: 'Name of an existing Vertica server image with no keys inside. If blank we will build one using the default name'
+      legacy_vertica_image:
+        description: 'Name of an existing full image with admintools and SSH support. Leave blank to build one with the default name'
         type: string
         required: true
       minimal_vertica_image:
         description: 'Name of an existing minimal Vertica server image. If blank we will build one using the default name'
-        type: string
-        required: true
-      v2_vertica_image:
-        description: 'Name of a v2 Vertica server image. If blank we will build one using the default name'
         type: string
         required: true
       vlogger_image:
@@ -46,15 +42,12 @@ on:
       full-vertica-image:
         description: "The image name of the full vertica server image"
         value: ${{ jobs.build-server-full.outputs.image }}
-      nokeys-vertica-image:
-        description: "The image name of the vertica server image, but with no keys inside"
+      legacy-vertica-image:
+        description: "The image name of the full vertica server image, but with admintools and SSH support"
         value: ${{ jobs.build-server-nokeys.outputs.image }}
       minimal-vertica-image:
         description: "The image name of the vertica server, but with optional software removed"
         value: ${{ jobs.build-server-minimal.outputs.image }}
-      v2-vertica-image:
-        description: "The image name of the v2 vertica server image"
-        value: ${{ jobs.build-server-v2.outputs.image }}
       vlogger-image:
         description: "The image name of the vertica logger sidecar"
         value: ${{ jobs.build-vlogger.outputs.image }}
@@ -84,10 +77,9 @@ jobs:
       uses: spilchen/switch-case-action@v2
       id: full_vertica_image
       with:
-        default: ghcr.io/${{ env.OWNER_LC }}/vertica-k8s:${{ github.sha }}
+        default: docker.io/vertica/vertica-k8s-private:latest-master
         conditionals-with-values: |
           ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
-          ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
@@ -111,26 +103,16 @@ jobs:
       uses: ./.github/actions/download-rpm
       if: ${{ inputs.full_vertica_image == '' }}
 
-    - name: Build and optionally push full server image
+    - name: Build the full server image
       if: ${{ inputs.full_vertica_image == '' }}
       run: |
-        export VERTICA_IMG=${{ steps.full_vertica_image.outputs.value }}
-        make docker-build-vertica
-        if [ $GITHUB_EVENT_NAME != 'pull_request' ]
-        then
-          make docker-push-vertica
-        fi
-
-    - name: Save the image for consumption by dependent jobs (PRs only)
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        docker save ${{ steps.full_vertica_image.outputs.value }} > full-vertica-image.tar
-
-    - uses: actions/upload-artifact@v3
-      if: ${{ github.event_name == 'pull_request' }}
-      with:
-        name: full-vertica-image
-        path: full-vertica-image.tar
+        # We never push the image we build here because the RPM we use is too
+        # old. The RPM needs to be from at least a 23.3.0 server. So, we build
+        # here only to test the creation of the image. We don't verify this
+        # image in the remaining CI. Pick a dummy image name so as not to
+        # overwrite the output build image that the e2e tests will use.
+        export VERTICA_IMG=vertica-k8s:kind
+        make docker-build-vertica-v2
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.full_vertica_image != '' }}
@@ -186,10 +168,10 @@ jobs:
         echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.full_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
 
-  build-server-nokeys:
+  build-server-legacy:
     runs-on: ubuntu-latest
     outputs:
-      image: ${{ steps.nokeys_vertica_image.outputs.value }}
+      image: ${{ steps.legacy_vertica_image.outputs.value }}
     steps:
 
     - name: set lower case owner name
@@ -200,16 +182,16 @@ jobs:
 
     - name: Pick the name of the image
       uses: spilchen/switch-case-action@v2
-      id: nokeys_vertica_image
+      id: legacy_vertica_image
       with:
-        default: ghcr.io/${{ env.OWNER_LC }}/vertica-k8s:${{ github.sha }}-nokeys
+        default: ghcr.io/${{ env.OWNER_LC }}/vertica-k8s:${{ github.sha }}-legacy
         conditionals-with-values: |
-          ${{ inputs.nokeys_vertica_image != '' }} => ${{ inputs.nokeys_vertica_image }}
-          ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind-nokeys
+          ${{ inputs.legacy_vertica_image != '' }} => ${{ inputs.legacy_vertica_image }}
+          ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind-legacy
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
-      if: ${{ github.event_name != 'pull_request' && inputs.nokeys_vertica_image == '' || startsWith(inputs.nokeys_vertica_image, 'ghcr.io') }}
+      if: ${{ github.event_name != 'pull_request' && inputs.legacy_vertica_image == '' || startsWith(inputs.legacy_vertica_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -217,23 +199,22 @@ jobs:
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2
-      if: ${{ inputs.nokeys_vertica_image != '' && startsWith(inputs.nokeys_vertica_image, 'docker.io') }}
+      if: ${{ inputs.legacy_vertica_image != '' && startsWith(inputs.legacy_vertica_image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - uses: actions/checkout@v3
-      if: ${{ inputs.nokeys_vertica_image == '' }}
+      if: ${{ inputs.legacy_vertica_image == '' }}
 
     - name: Download the RPM
       uses: ./.github/actions/download-rpm
-      if: ${{ inputs.nokeys_vertica_image == '' }}
+      if: ${{ inputs.legacy_vertica_image == '' }}
 
-    - name: Build and optionally push nokeys server image
-      if: ${{ inputs.nokeys_vertica_image == '' }}
+    - name: Build and optionally push legacy server image
+      if: ${{ inputs.legacy_vertica_image == '' }}
       run: |
-        export VERTICA_IMG=${{ steps.nokeys_vertica_image.outputs.value }}
-        export NO_KEYS=yes
+        export VERTICA_IMG=${{ steps.legacy_vertica_image.outputs.value }}
         make docker-build-vertica
         if [ $GITHUB_EVENT_NAME != 'pull_request' ]
         then
@@ -243,103 +224,31 @@ jobs:
     - name: Save the image for consumption by dependent jobs (PRs only)
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        docker save ${{ steps.nokeys_vertica_image.outputs.value }} > nokeys-vertica-image.tar
+        docker save ${{ steps.legacy_vertica_image.outputs.value }} > legacy-vertica-image.tar
 
     - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: nokeys-vertica-image
-        path: nokeys-vertica-image.tar
+        name: legacy-vertica-image
+        path: legacy-vertica-image.tar
 
     - name: Do a local pull of the image if we didn't create it
-      if: ${{ inputs.nokeys_vertica_image != '' }}
+      if: ${{ inputs.legacy_vertica_image != '' }}
       run: |
-        docker pull ${{ inputs.nokeys_vertica_image }}
+        docker pull ${{ inputs.legacy_vertica_image }}
 
     - name: Print a summary of the job
       run: |
-        echo "Image Name: **${{ steps.nokeys_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
-        echo "Was Built: ${{ inputs.nokeys_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
-        echo "Was Pushed: ${{ inputs.nokeys_vertica_image == '' && github.event_name != 'pull_request' && '**Yes**' || '**No**' }}"
+        echo "Image Name: **${{ steps.legacy_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
+        echo "Was Built: ${{ inputs.legacy_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
+        echo "Was Pushed: ${{ inputs.legacy_vertica_image == '' && github.event_name != 'pull_request' && '**Yes**' || '**No**' }}"
         echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
-        echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.nokeys_vertica_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
-        echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.nokeys_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.nokeys_vertica_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
+        echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.legacy_vertica_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
+        echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.legacy_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
+        echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.legacy_vertica_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
         echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
-        echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.nokeys_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
+        echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.legacy_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
         echo "**" >> $GITHUB_STEP_SUMMARY
-
-  build-server-v2:
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.v2_vertica_image.outputs.value }}
-    steps:
-
-    - name: set lower case owner name
-      env:
-        OWNER: '${{ github.repository_owner }}'
-      run: |
-        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
-
-    - name: Pick the name of the image
-      uses: spilchen/switch-case-action@v2
-      id: v2_vertica_image
-      with:
-        default: docker.io/vertica/vertica-k8s-private:latest-master
-        conditionals-with-values: |
-          ${{ inputs.v2_vertica_image != '' }} => ${{ inputs.v2_vertica_image }}
-
-    - name: Login to GitHub Container registry for non-PRs
-      uses: docker/login-action@v2
-      if: ${{ github.event_name != 'pull_request' && inputs.v2_vertica_image == '' || startsWith(inputs.v2_vertica_image, 'ghcr.io') }}
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      if: ${{ inputs.v2_vertica_image != '' && startsWith(inputs.v2_vertica_image, 'docker.io') }}
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - uses: actions/checkout@v3
-      if: ${{ inputs.v2_vertica_image == '' }}
-
-    - name: Download the RPM
-      uses: ./.github/actions/download-rpm
-      if: ${{ inputs.v2_vertica_image == '' }}
-
-    - name: Build the v2 image
-      if: ${{ inputs.v2_vertica_image == '' }}
-      run: |
-        # We never push the image we build here because the RPM we use is too
-        # old. The RPM needs to be from at least a 23.3.0 server. So, we build
-        # here only to test the creation of the image. We don't verify this
-        # image in the remaining CI. Pick a dummy image name so as not to
-        # overwrite the output build image that the e2e tests will use.
-        export VERTICA_IMG=vertica-k8s:kind-v2
-        make docker-build-vertica-v2
-
-    - name: Do a local pull of the image if we didn't create it
-      if: ${{ inputs.v2_vertica_image != '' }}
-      run: |
-        docker pull ${{ inputs.v2_vertica_image }}
-
-    - name: Print a summary of the job
-      run: |
-        echo "Image Name: **${{ steps.v2_vertica_image.outputs.value }}**" >> $GITHUB_STEP_SUMMARY
-        echo "Was Built: ${{ inputs.v2_vertica_image == '' && '**Yes**' || '**No**' }}" >> $GITHUB_STEP_SUMMARY
-        echo "Was Pushed: ${{ inputs.v2_vertica_image == '' && github.event_name != 'pull_request' && '**Yes**' || '**No**' }}"
-        echo "Was Scanned: **No**" >> $GITHUB_STEP_SUMMARY
-        echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.v2_vertica_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
-        echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.v2_vertica_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
-        echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.v2_vertica_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
-        echo -n "Vertica Version: **" >> $GITHUB_STEP_SUMMARY
-        echo -n $(docker inspect --format '{{index .Config.Labels "vertica-version"}}' ${{ steps.v2_vertica_image.outputs.value }}) >> $GITHUB_STEP_SUMMARY
-        echo "**" >> $GITHUB_STEP_SUMMARY
-
   build-server-minimal:
     runs-on: ubuntu-latest
     outputs:
@@ -356,10 +265,9 @@ jobs:
       uses: spilchen/switch-case-action@v2
       id: minimal_vertica_image
       with:
-        default: ghcr.io/${{ env.OWNER_LC }}/vertica-k8s:${{ github.sha }}-minimal
+        default: docker.io/vertica/vertica-k8s-private:latest-master
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
-          ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind-minimal
 
     - name: Login to GitHub Container registry for non-PRs
       uses: docker/login-action@v2
@@ -383,27 +291,17 @@ jobs:
       uses: ./.github/actions/download-rpm
       if: ${{ inputs.minimal_vertica_image == '' }}
 
-    - name: Build and optionally push minimal server image
+    - name: Build the minimal server image
       if: ${{ inputs.minimal_vertica_image == '' }}
       run: |
-        export VERTICA_IMG=${{ steps.minimal_vertica_image.outputs.value }}
+        # We never push the image we build here because the RPM we use is too
+        # old. The RPM needs to be from at least a 23.3.0 server. So, we build
+        # here only to test the creation of the image. We don't verify this
+        # image in the remaining CI. Pick a dummy image name so as not to
+        # overwrite the output build image that the e2e tests will use.
+        export VERTICA_IMG=vertica-k8s:kind-minimal
         export MINIMAL_VERTICA_IMG=yes
-        make docker-build-vertica
-        if [ $GITHUB_EVENT_NAME != 'pull_request' ]
-        then
-          make docker-push-vertica
-        fi
-
-    - name: Save the image for consumption by dependent jobs (PRs only)
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        docker save ${{ steps.minimal_vertica_image.outputs.value }} > minimal-vertica-image.tar
-
-    - uses: actions/upload-artifact@v3
-      if: ${{ github.event_name == 'pull_request' }}
-      with:
-        name: minimal-vertica-image
-        path: minimal-vertica-image.tar
+        make docker-build-vertica-v2 
 
     - name: Do a local pull of the image if we didn't create it
       if: ${{ inputs.minimal_vertica_image != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -47,7 +47,7 @@ on:
         value: ${{ jobs.build-server-minimal.outputs.image }}
       legacy-vertica-image:
         description: "The image name of the full vertica server image, but with admintools and SSH support"
-        value: ${{ jobs.build-server-nokeys.outputs.image }}
+        value: ${{ jobs.build-server-legacy.outputs.image }}
       vlogger-image:
         description: "The image name of the vertica logger sidecar"
         value: ${{ jobs.build-vlogger.outputs.image }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,15 +11,15 @@ on:
         type: string
         required: false
       full_vertica_image:
-        description: 'Name of an existing full vertica image. Leave blank to build one with the default name'
+        description: 'Name of an existing full vertica v2 image. Leave blank to build one with the default name'
+        type: string
+        required: false
+      minimal_vertica_image:
+        description: 'Name of an existing minimal vertica v2 image. Leave blank to build one with the default name'
         type: string
         required: false
       legacy_vertica_image:
         description: 'Name of an existing full image with admintools and SSH support. Leave blank to build one with the default name'
-        type: string
-        required: false
-      minimal_vertica_image:
-        description: 'Name of an existing minimal vertica image. Leave blank to build one with the default name'
         type: string
         required: false
       vlogger_image:
@@ -197,7 +197,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -223,7 +223,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -236,7 +236,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -272,7 +272,6 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      # pass the legacy vertica image
       vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
       vertica-deployment-method: admintools
     secrets:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,16 +14,12 @@ on:
         description: 'Name of an existing full vertica image. Leave blank to build one with the default name'
         type: string
         required: false
-      nokeys_vertica_image:
-        description: 'Name of an existing vertica image with no keys inside. Leave blank to build one with the default name'
+      legacy_vertica_image:
+        description: 'Name of an existing full image with admintools and SSH support. Leave blank to build one with the default name'
         type: string
         required: false
       minimal_vertica_image:
         description: 'Name of an existing minimal vertica image. Leave blank to build one with the default name'
-        type: string
-        required: false
-      v2_vertica_image:
-        description: 'Name of a v2 Vertica server image. If blank we will build one using the default name'
         type: string
         required: false
       vlogger_image:
@@ -84,8 +80,7 @@ jobs:
       operator_image: ${{ inputs.operator_image }}
       minimal_vertica_image: ${{ inputs.minimal_vertica_image }}
       full_vertica_image: ${{ inputs.full_vertica_image }}
-      nokeys_vertica_image: ${{ inputs.nokeys_vertica_image }}
-      v2_vertica_image: ${{ inputs.v2_vertica_image }}
+      legacy_vertica_image: ${{ inputs.legacy_vertica_image }}
       run_security_scan: ${{ inputs.run_security_scan }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -111,7 +106,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -124,7 +119,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.v2-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -137,7 +132,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -150,7 +145,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.v2-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -163,7 +158,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -176,7 +171,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.v2-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -189,7 +184,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.nokeys-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -202,7 +197,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.v2-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -215,7 +210,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -228,7 +223,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.v2-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -241,7 +236,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.v2-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -253,7 +248,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -265,7 +260,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -277,8 +272,8 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      # We must pass the full image since the minimal image cannot run Java UDx's
-      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
+      # pass the legacy vertica image
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -292,7 +287,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       # We must pass the full image since the minimal image cannot run Java UDx's
-      vertica-image: ${{ needs.build.outputs.v2-vertica-image }}
+      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,6 @@ export OLM_CATALOG_IMG
 
 # Set this to YES if you want to create a vertica image of minimal size
 MINIMAL_VERTICA_IMG ?=
-# Set this to YES if you want to create a vertica image with no keys inside
-NO_KEYS ?=
 # Name of the helm release that we will install/uninstall
 HELM_RELEASE_NAME?=vdb-op
 # Can be used to specify additional overrides when doing the helm install.
@@ -355,12 +353,12 @@ endif
 .PHONY: docker-build-vertica
 docker-build-vertica: docker-vertica/Dockerfile ## Build vertica server docker image
 	cd docker-vertica \
-	&& make VERTICA_IMG=${VERTICA_IMG} MINIMAL_VERTICA_IMG=${MINIMAL_VERTICA_IMG} NO_KEYS=${NO_KEYS}
+	&& make VERTICA_IMG=${VERTICA_IMG} MINIMAL_VERTICA_IMG=${MINIMAL_VERTICA_IMG} 
 
 .PHONY: docker-build-vertica-v2
 docker-build-vertica-v2: docker-vertica-v2/Dockerfile ## Build next generation vertica server docker image
 	cd docker-vertica-v2 \
-	&& make VERTICA_IMG=${VERTICA_IMG} MINIMAL_VERTICA_IMG=${MINIMAL_VERTICA_IMG} NO_KEYS=${NO_KEYS}
+	&& make VERTICA_IMG=${VERTICA_IMG} MINIMAL_VERTICA_IMG=${MINIMAL_VERTICA_IMG} 
 
 .PHONY: docker-push-vertica
 docker-push-vertica:  ## Push vertica server image -- either v1 or v2.

--- a/config/samples/v1beta1_verticadb.yaml
+++ b/config/samples/v1beta1_verticadb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: verticadb-sample
 spec:
-  image: "vertica/vertica-k8s:23.3.0-0-minimal"
+  image: "vertica/vertica-k8s:23.3.0-0-legacy"
   communal:
     # path: "s3://<your-bucket>/"
     endpoint: https://s3.amazonaws.com

--- a/config/samples/v1beta1_verticadb.yaml
+++ b/config/samples/v1beta1_verticadb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: verticadb-sample
 spec:
-  image: "vertica/vertica-k8s:23.3.0-0-legacy"
+  image: "vertica/vertica-k8s:23.3.0-0-minimal"
   communal:
     # path: "s3://<your-bucket>/"
     endpoint: https://s3.amazonaws.com

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -6,13 +6,11 @@
 ARG BASE_OS_VERSION="lunar"
 ARG BUILDER_OS_VERSION="stream8"
 ARG MINIMAL=""
-ARG NO_KEYS=""
 ARG S6_OVERLAY_VERSION=3.1.2.1
 FROM quay.io/centos/centos:${BUILDER_OS_VERSION} as builder
 
 ARG VERTICA_RPM="vertica-x86_64.RHEL6.latest.rpm"
 ARG MINIMAL
-ARG NO_KEYS
 ARG DBADMIN_GID=5000
 ARG DBADMIN_UID=5000
 
@@ -80,18 +78,11 @@ COPY dbadmin/.ssh /home/dbadmin/.ssh
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
   && mkdir -p /root/.ssh \
-  && if [[ ${NO_KEYS^^} != "YES" ]] ; then \
-    cp -r /home/dbadmin/.ssh /root; \
-    chmod 700 /root/.ssh; \
-    chmod 600 /root/.ssh/*; \
-  fi \
   && chmod 700 /home/dbadmin/.ssh \
   && chmod 600 /home/dbadmin/.ssh/* \
   && chown -R dbadmin:verticadba /home/dbadmin/ \
   && chmod go-w /etc/ssh/sshd_config.d/* /etc/ssh/ssh_config.d/* \
-  && if [[ ${NO_KEYS^^} == "YES" ]] ; then \
-    rm -rf /home/dbadmin/.ssh/*;  \
-  fi
+  && rm -rf /home/dbadmin/.ssh/*
 
 ##############################################################################################
 FROM ubuntu:${BASE_OS_VERSION} as initial
@@ -116,7 +107,6 @@ ARG DBADMIN_UID=5000
 # "apt-cache search jre | grep jre"
 ARG JRE_PKG=openjdk-8-jre-headless
 ARG MINIMAL
-ARG NO_KEYS
 ARG S6_OVERLAY_VERSION
 
 COPY --from=builder /opt/vertica /opt/vertica
@@ -167,10 +157,6 @@ RUN set -x \
   # Install jre if not minimal
   && if [[ ${MINIMAL^^} != "YES" ]] ; then \
     apt-get install -y --no-install-recommends $JRE_PKG; \
-  fi \
-  # install vim except in the -nokeys image \
-  && if [[ ${NO_KEYS^^} != "YES" ]] ; then \
-    apt-get install -y --no-install-recommends vim-tiny; \
   fi \
   && apt-get clean \
   && apt-get autoremove \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -78,11 +78,13 @@ COPY dbadmin/.ssh /home/dbadmin/.ssh
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
   && mkdir -p /root/.ssh \
+  && cp -r /home/dbadmin/.ssh /root \
+  && chmod 700 /root/.ssh \
+  && chmod 600 /root/.ssh/* \
   && chmod 700 /home/dbadmin/.ssh \
   && chmod 600 /home/dbadmin/.ssh/* \
   && chown -R dbadmin:verticadba /home/dbadmin/ \
   && chmod go-w /etc/ssh/sshd_config.d/* /etc/ssh/ssh_config.d/* \
-  && rm -rf /home/dbadmin/.ssh/*
 
 ##############################################################################################
 FROM ubuntu:${BASE_OS_VERSION} as initial
@@ -136,6 +138,7 @@ RUN set -x \
   # update needed because we just did a clean
   && apt-get -y update \
   && apt-get install -y --no-install-recommends \
+  vim-tiny \
   ca-certificates \
   cron \
   dialog \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -84,7 +84,7 @@ RUN set -x \
   && chmod 700 /home/dbadmin/.ssh \
   && chmod 600 /home/dbadmin/.ssh/* \
   && chown -R dbadmin:verticadba /home/dbadmin/ \
-  && chmod go-w /etc/ssh/sshd_config.d/* /etc/ssh/ssh_config.d/* \
+  && chmod go-w /etc/ssh/sshd_config.d/* /etc/ssh/ssh_config.d/* 
 
 ##############################################################################################
 FROM ubuntu:${BASE_OS_VERSION} as initial

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -3,7 +3,6 @@ BUILDER_OS_VERSION?=stream8
 BASE_OS_VERSION?=lunar
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
-NO_KEYS?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
 VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS?=
 
@@ -20,7 +19,6 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--label vertica-version=${VERTICA_VERSION} \
 		--build-arg MINIMAL=${MINIMAL_VERTICA_IMG} \
 		--build-arg VERTICA_RPM=${VERTICA_RPM} \
-		--build-arg NO_KEYS=${NO_KEYS} \
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
 		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \


### PR DESCRIPTION
There is some image changes for this PR
- remove the nokeys image from the pipeline and NO_KEYS env var usage
- GH actions to stop using latest-master for vcluster tests. Instead use full or minimal, depending on the leg.