### PR TITLE
Add webhook to prevent setting of runAsUser as root

### DIFF
--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -824,6 +824,20 @@ var _ = Describe("verticadb_webhook", func() {
 		allErrs = newVdb.validateImmutableFields(oldVdb)
 		Ω(allErrs).ShouldNot(HaveLen(0))
 	})
+
+	It("should not allow setting of runAsUser as root", func() {
+		oldVdb := MakeVDB()
+		runAsUser := int64(0)
+		oldVdb.Spec.PodSecurityContext = &v1.PodSecurityContext{
+			RunAsUser: &runAsUser,
+		}
+		allErrs := oldVdb.validateVerticaDBSpec()
+		Ω(allErrs).ShouldNot(HaveLen(0))
+
+		runAsUser++ // Make it non-root
+		allErrs = oldVdb.validateVerticaDBSpec()
+		Ω(allErrs).Should(HaveLen(0))
+	})
 })
 
 func createVDBHelper() *VerticaDB {


### PR DESCRIPTION
Vertica cannot run if the user is root (uid == 0). This adds a webhook preventing that setting from even being set.