### PR TITLE
Vertica controllers to add watches for v1 API

### DIFF
--- a/pkg/controllers/et/eventtrigger_controller.go
+++ b/pkg/controllers/et/eventtrigger_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/go-logr/logr"
+	v1vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
@@ -92,7 +93,7 @@ func (r *EventTriggerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		res, err = act.Reconcile(ctx, &req)
 		// Error or a request to requeue will stop the reconciliation.
 		if verrors.IsReconcileAborted(res, err) {
-			log.Info("aborting reconcile of VerticaDB", "result", res, "err", err)
+			log.Info("aborting reconcile of EventTrigger", "result", res, "err", err)
 			return res, err
 		}
 	}
@@ -111,7 +112,7 @@ func (r *EventTriggerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&vapi.EventTrigger{}).
 		Owns(&batchv1.Job{}).
 		Watches(
-			&source.Kind{Type: &vapi.VerticaDB{}},
+			&source.Kind{Type: &v1vapi.VerticaDB{}},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForVerticaDB),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).

--- a/pkg/controllers/vas/verticaautoscaler_controller.go
+++ b/pkg/controllers/vas/verticaautoscaler_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
+	v1vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
@@ -113,6 +114,6 @@ func (r *VerticaAutoscalerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Not a strict ownership, but this is used so that the operator will
 		// reconcile the VerticaAutoscaler for any change in the VerticaDB.
 		// This ensures the status fields are kept up to date.
-		Owns(&vapi.VerticaDB{}).
+		Owns(&v1vapi.VerticaDB{}).
 		Complete(r)
 }


### PR DESCRIPTION
Both the verticaautoscaler and eventtrigger controllers both watch the v1beta1 API. Functionaly this is fine, but it causes deprecation warnings to printed in the operator log like this: [W1024 15:58:00.630253 1 warnings.go:70] vertica.com/v1beta1 VerticaDB is deprecated, use vertica.com/v1 VerticaDB

Changing them to watch the v1 API will silence this message.