### PR TITLE
Change default subcluster type in V1 VerticaDB API

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -602,12 +602,13 @@ type Subcluster struct {
 	// db.licenseSecret parameter.
 	Size int32 `json:"size"`
 
+	// +kubebuilder:default:=primary
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:primary","urn:alm:descriptor:com.tectonic.ui:select:secondary"}
 	// Indicates the type of subcluster it is. Valid values are: primary,
-	// secondary or transient. You must have at least one primary subcluster in
-	// the database. If omitted, the webhook will choose a suitable default;
-	// primary if none exists, otherwise it will default to a secondary.
+	// secondary or transient. Types are case-sensitive.
+	// You must have at least one primary subcluster in the database.
+	// If type is omitted, it will default to a primary.
 	// Transient should only be set internally by the operator during online
 	// upgrade. It is used to indicate a subcluster that exists temporarily to
 	// serve traffic for subclusters that are restarting with a new image.

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/35-modify-actual-transient.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/35-modify-actual-transient.yaml
@@ -20,9 +20,9 @@ metadata:
 spec:
   subclusters:
     - name: pri
-      type: Primary
+      type: primary
       size: 1
     - name: transient
-      type: Transient
+      type: transient
       resources: {}
       size: 1


### PR DESCRIPTION
- Change default subcluster type to `primary` always
- Remove the auto case conversion for the type string (so now when a user provides a type string with upper-case letters, e.g. `Primary`, an error will be reported)

Note: these changes apply to the v1 API. The v1beta1 API was not changed.