### PR TITLE
Redirect startup.log to stdout

### DIFF
--- a/changes/unreleased/Added-20231107-173951.yaml
+++ b/changes/unreleased/Added-20231107-173951.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Redirect startup.log to stdout
+time: 2023-11-07T17:39:51.857496428+01:00
+custom:
+  Issue: "577"

--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -91,6 +91,7 @@ COPY --from=builder /var/spool/cron/ /var/spool/cron/crontabs
 ENV PATH "$PATH:/opt/vertica/bin:/opt/vertica/sbin"
 ENV DEBIAN_FRONTEND noninteractive
 ENV JAVA_HOME "/usr"
+ENV VERTICA_STARTUP_LOG_DUPLICATE "/proc/1/fd/1"
 
 COPY ./packages/init.d.functions /etc/rc.d/init.d/functions
 


### PR DESCRIPTION
In the v2 vertica image, we can now redirect startup.log to stdout by setting `VERTICA_STARTUP_LOG_DUPLICATE` to `/proc/1/fd/1`.
 
An example of a Vertica pod log output via `kubectl logs v-sc0-0`:
```
2023/11/06 14:34:09 New NodeManagementAgent starting
2023/11/06 14:34:09 Checking for existence of directory  /opt/vertica/log
2023/11/06 14:34:09 Moving working directory to  /opt/vertica/log
2023/11/06 14:34:09 Successfully opened file node_management_agent.log. Setting log output to that file.
{
  "goal" : 27,
  "node" : "v_vertdb_node0001",
  "progress" : 0,
  "stage" : "Reading Catalog",
  "text" : "Indexing Objects",
  "timestamp" : "2023-11-06 14:34:18.414"
}
{
  "goal" : 27,
  "node" : "v_vertdb_node0001",
  "progress" : 27,
  "stage" : "Reading Catalog",
  "text" : "Indexing Objects",
  "timestamp" : "2023-11-06 14:34:18.414"
}
{
  "node" : "v_vertdb_node0001",
  "stage" : "Connecting to Spread",
  "text" : "Connecting to spread /tmp/4803",
  "timestamp" : "2023-11-06 14:34:18.437"
}
........
{
  "node" : "v_vertdb_node0001",
  "stage" : "Waiting for Cluster Invite",
  "text" : "Prepare to be invited",
  "timestamp" : "2023-11-06 14:34:20.003"
}
{
  "node" : "v_vertdb_node0001",
  "stage" : "Waiting for Cluster Invite",
  "text" : "Ready to be invited",
  "timestamp" : "2023-11-06 14:34:20.004"
}
{
  "goal" : 1,
  "node" : "v_vertdb_node0001",
  "progress" : 1,
  "stage" : "Invite Cluster",
  "text" : "All nodes present",
  "timestamp" : "2023-11-06 14:34:20.007"
}
{
  "node" : "v_vertdb_node0001",
  "stage" : "Invite Cluster",
  "text" : "Inviting cluster",
  "timestamp" : "2023-11-06 14:34:20.009"
}
{
  "node" : "v_vertdb_node0001",
  "stage" : "Waiting for Cluster Invite",
  "text" : "Invited",
  "timestamp" : "2023-11-06 14:34:23.959"
}
{
  "node" : "v_vertdb_node0001",
  "stage" : "Startup Complete",
  "text" : "Node is UP",
  "timestamp" : "2023-11-06 14:34:24.143"
}
```