### PR TITLE
Added a new annotation: vertica.com/superuser-name

### DIFF
--- a/.github/workflows/e2e-leg-4.yml
+++ b/.github/workflows/e2e-leg-4.yml
@@ -15,6 +15,9 @@ on:
       vertica-deployment-method:
         type: string
         required: false
+      vertica-superuser-name:
+        type: string
+        required: false
     secrets:
       DOCKERHUB_USERNAME:
         description: 'When working with images from docker.io, this is the username for login purposes'
@@ -79,7 +82,7 @@ jobs:
         if [ "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]; then E2E_TEST_DIRS+=" tests/e2e-leg-4-at-only"; fi
         export VERTICA_SUPERUSER_NAME=${{ inputs.vertica-superuser-name }}
         if [ -z "${VERTICA_SUPERUSER_NAME}" -o "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]; then 
-          VERTICA_SUPERUSER_NAME="dbadmin"
+          export VERTICA_SUPERUSER_NAME="dbadmin"
         fi
         # All helm deployments will use cert-manager to create the webhook cert
         export HELM_OVERRIDES="--set webhook.certSource=cert-manager"

--- a/.github/workflows/e2e-leg-4.yml
+++ b/.github/workflows/e2e-leg-4.yml
@@ -18,6 +18,7 @@ on:
       vertica-superuser-name:
         type: string
         required: false
+        default: myadmin
     secrets:
       DOCKERHUB_USERNAME:
         description: 'When working with images from docker.io, this is the username for login purposes'

--- a/.github/workflows/e2e-leg-4.yml
+++ b/.github/workflows/e2e-leg-4.yml
@@ -44,6 +44,11 @@ on:
         options:
         - admintools
         - vclusterops
+      vertica-superuser-name:
+        description: 'Vertica superuser name'
+        type: string
+        required: false
+        default: myadmin
 
 jobs:
 
@@ -72,6 +77,10 @@ jobs:
         export E2E_TEST_DIRS="tests/e2e-leg-4"
         export VERTICA_DEPLOYMENT_METHOD=${{ inputs.vertica-deployment-method }}
         if [ "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]; then E2E_TEST_DIRS+=" tests/e2e-leg-4-at-only"; fi
+        export VERTICA_SUPERUSER_NAME=${{ inputs.vertica-superuser-name }}
+        if [ -z "${VERTICA_SUPERUSER_NAME}" -o "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]; then 
+          VERTICA_SUPERUSER_NAME="dbadmin"
+        fi
         # All helm deployments will use cert-manager to create the webhook cert
         export HELM_OVERRIDES="--set webhook.certSource=cert-manager"
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-s3-ci.txt

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -523,7 +523,7 @@ func (s *SubclusterStatus) InstallCount() int32 {
 	return c
 }
 
-// GetVerticaUser returns the user name associated with the passwordSecret.
+// GetVerticaUser returns the name of Vertica superuser generated in database creation.
 func (v *VerticaDB) GetVerticaUser() string {
-	return "dbadmin"
+	return vmeta.GetSuperuserName(v.Annotations)
 }

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -449,9 +449,6 @@ const (
 	AutoUpgrade UpgradePolicyType = "Auto"
 )
 
-// SuperUser is an automatically-created user in database creation
-const SuperUser = "dbadmin"
-
 type HTTPServerModeType string
 
 const (

--- a/changes/unreleased/Added-20231107-093813.yaml
+++ b/changes/unreleased/Added-20231107-093813.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Ability to control the name of the superuser
+time: 2023-11-07T09:38:13.490515872-04:00
+custom:
+  Issue: "578"

--- a/pkg/cmds/cmds_test.go
+++ b/pkg/cmds/cmds_test.go
@@ -36,25 +36,25 @@ var _ = Describe("k8s/cmds", func() {
 
 	It("should add the password option to vsql command", func() {
 		cmd := []string{"-tAc", "select 1"}
-		fpr := &FakePodRunner{SUPassword: "vertica"}
+		fpr := &FakePodRunner{VerticaSUPassword: "vertica"}
 		podName := types.NamespacedName{Namespace: "default", Name: "vdb-pod"}
 		_, _, _ = fpr.ExecVSQL(ctx, podName, "server", cmd...)
-		lastCall := fpr.FindCommands("vsql", "--password", fpr.SUPassword, "-tAc", "select 1")
+		lastCall := fpr.FindCommands("vsql", "--password", fpr.VerticaSUPassword, "-tAc", "select 1")
 		Expect(len(lastCall)).Should(Equal(1))
 	})
 
 	It("should add password option for db_add_node", func() {
 		cmd := []string{"-t", "db_add_node"}
-		fpr := &FakePodRunner{SUPassword: "vertica"}
+		fpr := &FakePodRunner{VerticaSUPassword: "vertica"}
 		podName := types.NamespacedName{Namespace: "default", Name: "vdb-pod"}
 		_, _, _ = fpr.ExecAdmintools(ctx, podName, "server", cmd...)
-		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node", "--password", fpr.SUPassword)
+		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node", "--password", fpr.VerticaSUPassword)
 		Expect(len(lastCall)).Should(Equal(1))
 	})
 
 	It("should not add password to an admintools' tool which does not support it", func() {
 		cmd := []string{"-t", "list_allnodes"}
-		fpr := &FakePodRunner{SUPassword: "vertica"}
+		fpr := &FakePodRunner{VerticaSUPassword: "vertica"}
 		podName := types.NamespacedName{Namespace: "default", Name: "vdb-pod"}
 		_, _, _ = fpr.ExecAdmintools(ctx, podName, "server", cmd...)
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "list_allnodes")
@@ -63,7 +63,7 @@ var _ = Describe("k8s/cmds", func() {
 
 	It("should not add password to vsql command", func() {
 		cmd := []string{"-tAc", "select 1"}
-		fpr := &FakePodRunner{SUPassword: ""}
+		fpr := &FakePodRunner{VerticaSUPassword: ""}
 		podName := types.NamespacedName{Namespace: "default", Name: "vdb-pod"}
 		_, _, _ = fpr.ExecVSQL(ctx, podName, "server", cmd...)
 		lastCall := fpr.FindCommands("vsql", "-tAc", "select 1")
@@ -72,7 +72,7 @@ var _ = Describe("k8s/cmds", func() {
 
 	It("should not add password to admintools", func() {
 		cmd := []string{"-t", "db_add_node"}
-		fpr := &FakePodRunner{SUPassword: ""}
+		fpr := &FakePodRunner{VerticaSUPassword: ""}
 		podName := types.NamespacedName{Namespace: "default", Name: "vdb-pod"}
 		_, _, _ = fpr.ExecAdmintools(ctx, podName, "server", cmd...)
 		lastCall := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "db_add_node")

--- a/pkg/cmds/fake.go
+++ b/pkg/cmds/fake.go
@@ -35,8 +35,10 @@ type FakePodRunner struct {
 	// The commands that were issue. The commands are in the same order that
 	// commands were received. This is filled in by ExecInPod and can be inspected.
 	Histories []CmdHistory
+	// fake username
+	VerticaSUName string
 	// fake password
-	SUPassword string
+	VerticaSUPassword string
 }
 
 // CmdResults stores the command result.  The key is the pod name.
@@ -76,14 +78,14 @@ func (f *FakePodRunner) ExecInPod(_ context.Context, podName types.NamespacedNam
 // ExecAdmintools calls ExecInPod
 func (f *FakePodRunner) ExecAdmintools(ctx context.Context, podName types.NamespacedName,
 	contName string, command ...string) (stdout, stderr string, err error) {
-	command = UpdateAdmintoolsCmd(f.SUPassword, command...)
+	command = UpdateAdmintoolsCmd(f.VerticaSUPassword, command...)
 	return f.ExecInPod(ctx, podName, contName, command...)
 }
 
 // ExecVSQL calls ExecInPod
 func (f *FakePodRunner) ExecVSQL(ctx context.Context, podName types.NamespacedName,
 	contName string, command ...string) (stdout, stderr string, err error) {
-	command = UpdateVsqlCmd(f.SUPassword, command...)
+	command = UpdateVsqlCmd(f.VerticaSUName, f.VerticaSUPassword, command...)
 	return f.ExecInPod(ctx, podName, contName, command...)
 }
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -124,7 +124,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vmeta.GetSuperuserName(vdb.Annotations), passwd)
+	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vdb.GetVerticaUser(), passwd)
 	// We use the same pod facts for all reconcilers. This allows to reuse as
 	// much as we can. Some reconcilers will purposely invalidate the facts if
 	// it is known they did something to make them stale.

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -124,7 +124,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, passwd)
+	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vmeta.GetSuperuserName(vdb.Annotations), passwd)
 	// We use the same pod facts for all reconcilers. This allows to reuse as
 	// much as we can. Some reconcilers will purposely invalidate the facts if
 	// it is known they did something to make them stale.

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -119,6 +119,14 @@ const (
 	BuildRefAnnotation  = "vertica.com/buildRef"
 	// Annotation for the database's revive_instance_id
 	ReviveInstanceIDAnnotation = "vertica.com/revive-instance-id"
+
+	// Annotation for a customized superuser name. This annotation can be used
+	// when vclusterops annotation is set to true. It can explicitly specify the
+	// name of vertica superuser that is generated in database creation. If this
+	// annotation is not provided or vclusterops annotation is set to false, the
+	// default value "dbadmin" will be used.
+	SuperuserNameAnnotation   = "vertica.com/superuser-name"
+	SuperuserNameDefaultValue = "dbadmin"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -190,6 +198,15 @@ func GetSSHSecretName(annotations map[string]string) string {
 // communal path to make it unique.
 func IncludeUIDInPath(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, IncludeUIDInPathAnnotation, false /* default value */)
+}
+
+// GetSuperuserName returns the name of customized vertica superuser name
+// for vclusterops style of deployments.
+func GetSuperuserName(annotations map[string]string) string {
+	if UseVClusterOps(annotations) {
+		return lookupStringAnnotation(annotations, SuperuserNameAnnotation, SuperuserNameDefaultValue)
+	}
+	return SuperuserNameDefaultValue
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -22,8 +22,8 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
 )
@@ -79,7 +79,7 @@ func (v *VClusterOps) genAddNodeOptions(s *addnode.Parms, certs *HTTPSCerts) vop
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -23,7 +23,6 @@ import (
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addnode"
 )
@@ -79,7 +78,7 @@ func (v *VClusterOps) genAddNodeOptions(s *addnode.Parms, certs *HTTPSCerts) vop
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -20,7 +20,6 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addsc"
 )
@@ -60,7 +59,7 @@ func (v *VClusterOps) genAddSubclusterOptions(s *addsc.Parms) vops.VAddSubcluste
 	opts.IsPrimary = &s.IsPrimary
 
 	// auth options
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -20,7 +20,7 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/addsc"
 )
@@ -60,7 +60,7 @@ func (v *VClusterOps) genAddSubclusterOptions(s *addsc.Parms) vops.VAddSubcluste
 	opts.IsPrimary = &s.IsPrimary
 
 	// auth options
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -22,7 +22,6 @@ import (
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -87,7 +86,7 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	if v.Password != "" {
 		opts.Password = &v.Password
 	}

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -21,8 +21,8 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -87,7 +87,7 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	if v.Password != "" {
 		opts.Password = &v.Password
 	}

--- a/pkg/vadmin/fetch_node_state_vc.go
+++ b/pkg/vadmin/fetch_node_state_vc.go
@@ -20,7 +20,7 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -68,7 +68,7 @@ func (v *VClusterOps) genFetchNodeStateOptions(s *fetchnodestate.Parms) vops.VFe
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))
 
 	// auth options
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/fetch_node_state_vc.go
+++ b/pkg/vadmin/fetch_node_state_vc.go
@@ -20,7 +20,6 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/fetchnodestate"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -68,7 +67,7 @@ func (v *VClusterOps) genFetchNodeStateOptions(s *fetchnodestate.Parms) vops.VFe
 	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))
 
 	// auth options
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -96,7 +97,7 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -23,7 +23,6 @@ import (
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/reip"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -97,7 +96,7 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -20,7 +20,6 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
 )
@@ -66,7 +65,7 @@ func (v *VClusterOps) genRemoveNodeOptions(s *removenode.Parms, certs *HTTPSCert
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -20,7 +20,7 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removenode"
 )
@@ -66,7 +66,7 @@ func (v *VClusterOps) genRemoveNodeOptions(s *removenode.Parms, certs *HTTPSCert
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -22,7 +22,6 @@ import (
 	"github.com/vertica/vcluster/rfc7807"
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
 )
@@ -81,7 +80,7 @@ func (v *VClusterOps) genRemoveSubclusterOptions(s *removesc.Parms, certs *HTTPS
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vertica/vcluster/rfc7807"
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/removesc"
 )
@@ -81,7 +81,7 @@ func (v *VClusterOps) genRemoveSubclusterOptions(s *removesc.Parms, certs *HTTPS
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -21,7 +21,6 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,7 +52,7 @@ func (v *VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Optio
 }
 
 func (v *VClusterOps) genRestartNodeOptions(s *restartnode.Parms, certs *HTTPSCerts) *vops.VRestartNodesOptions {
-	su := vmeta.GetSuperuserName(v.VDB.Annotations)
+	su := v.VDB.GetVerticaUser()
 	honorUserInput := true
 	opts := vops.VRestartNodesOptions{
 		DatabaseOptions: vops.DatabaseOptions{

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -21,7 +21,7 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restartnode"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,7 +53,7 @@ func (v *VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Optio
 }
 
 func (v *VClusterOps) genRestartNodeOptions(s *restartnode.Parms, certs *HTTPSCerts) *vops.VRestartNodesOptions {
-	su := vapi.SuperUser
+	su := vmeta.GetSuperuserName(v.VDB.Annotations)
 	honorUserInput := true
 	opts := vops.VRestartNodesOptions{
 		DatabaseOptions: vops.DatabaseOptions{

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -23,6 +23,7 @@ import (
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,7 +85,7 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -23,7 +23,6 @@ import (
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/startdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -85,7 +84,7 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -20,7 +20,6 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 )
@@ -58,7 +57,7 @@ func (v *VClusterOps) genStopDBOptions(s *stopdb.Parms) vops.VStopDatabaseOption
 	opts.IsEon = vstruct.MakeNullableBool(v.VDB.IsEON())
 
 	// auth options
-	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
+	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -20,7 +20,7 @@ import (
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/stopdb"
 )
@@ -58,7 +58,7 @@ func (v *VClusterOps) genStopDBOptions(s *stopdb.Parms) vops.VStopDatabaseOption
 	opts.IsEon = vstruct.MakeNullableBool(v.VDB.IsEON())
 
 	// auth options
-	*opts.UserName = vapi.SuperUser
+	*opts.UserName = vmeta.GetSuperuserName(v.VDB.Annotations)
 	opts.Password = &v.Password
 	*opts.HonorUserInput = true
 

--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -77,6 +77,10 @@ if [ -z "${VERTICA_DEPLOYMENT_METHOD}" ]; then
     VERTICA_DEPLOYMENT_METHOD=admintools
 fi
 
+if [ -z "${VERTICA_SUPERUSER_NAME}" ]; then
+    VERTICA_SUPERUSER_NAME=dbadmin
+fi
+
 if [ -z "${VERTICA_IMG}" ]; then
     VERTICA_IMG=$(cd $REPO_DIR && make echo-images | grep ^VERTICA_IMG= | cut -d'=' -f2)
 fi
@@ -126,6 +130,7 @@ if [ -n "$PRIVATE_REG_SERVER" ]; then echo "YES"; else echo "NO"; fi
 echo -n "Add server mounts: "
 if [ -n "$USE_SERVER_MOUNT_PATCH" ]; then echo "YES"; else echo "NO"; fi
 echo "Deployment method: $VERTICA_DEPLOYMENT_METHOD"
+echo "Vertica superuser name: $VERTICA_SUPERUSER_NAME"
 
 function create_vdb_kustomization {
     BASE_DIR=$1
@@ -193,6 +198,15 @@ EOF
     - op: add
       path: /metadata/annotations/vertica.com~1vcluster-ops
       value: "false"
+EOF
+        fi
+        
+        if [ "$VERTICA_DEPLOYMENT_METHOD" == "vclusterops" -a "$VERTICA_SUPERUSER_NAME" != "dbadmin" ]
+        then
+            cat <<EOF >> kustomization.yaml
+    - op: add
+      path: /metadata/annotations/vertica.com~1superuser-name
+      value: $VERTICA_SUPERUSER_NAME
 EOF
         fi
     fi

--- a/tests/e2e-leg-4/revivedb-1-node/27-create-et.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/27-create-et.yaml
@@ -21,7 +21,7 @@ data:
     set -o errexit
     set -o xtrace
 
-    kubectl exec -it svc/v-revive-1-node-sc1 -- vsql -U dbadmin -c "SELECT * FROM NODES;" -w superuser
+    kubectl exec -it svc/v-revive-1-node-sc1 -- vsql -c "SELECT * FROM NODES;" -w superuser
 ---
 apiVersion: vertica.com/v1beta1
 kind: EventTrigger

--- a/tests/kustomize-defaults.cfg
+++ b/tests/kustomize-defaults.cfg
@@ -115,3 +115,8 @@ ALLOW_VOLUME_EXPANSION=
 # values are: admintools or vclusterops. Uncomment this or set this environment
 # in your shell to control the deployment type.
 # VERTICA_DEPLOYMENT_METHOD=
+
+# The name of Vertica superuser generated in database creation. When it is
+# not set, default value "dbadmin" will be used. Uncomment this or set this 
+# environment in your shell to specify Vertica superuser name.
+# VERTICA_SUPERUSER_NAME=


### PR DESCRIPTION
Added a superuser-name annotation. This annotation can be used to customize Vertica superuser name. This should be used with vclusterops. When admintools is used, this annotation will be always set to "dbadmin".