### PR TITLE
Trim nodes in re_ip and start_db to avoid failures from wrong input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20231108015847-c3d5529cfa71
+	github.com/vertica/vcluster v0.0.0-20231109121659-2545b61cde4d
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20231108015847-c3d5529cfa71 h1:cuLE0KC/gZVQYyRXFwkCclcOP6g16mKcT3CMhz/57bc=
-github.com/vertica/vcluster v0.0.0-20231108015847-c3d5529cfa71/go.mod h1:sHCcZgk/CuJvFoYivMo63XGQmbmPsAxtRQCPWA0Xieg=
+github.com/vertica/vcluster v0.0.0-20231109121659-2545b61cde4d h1:UxsoX4ev0Lvgb01mvtXeLFcKMplrQVc4OKLO1dldRmc=
+github.com/vertica/vcluster v0.0.0-20231109121659-2545b61cde4d/go.mod h1:sHCcZgk/CuJvFoYivMo63XGQmbmPsAxtRQCPWA0Xieg=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -98,8 +98,10 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	opts.CaCert = certs.CaCert
 	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
-	opts.TrimReIPList = true
 	*opts.HonorUserInput = true
+
+	// other options
+	opts.TrimReIPList = true
 
 	return opts
 }

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -98,6 +98,7 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	opts.CaCert = certs.CaCert
 	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
+	opts.TrimReIPList = true
 	*opts.HonorUserInput = true
 
 	return opts

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -86,9 +86,10 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	opts.CaCert = certs.CaCert
 	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
+	*opts.TrimHostList = true
 	*opts.HonorUserInput = true
 
 	// timeout option
-	opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
+	*opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
 	return opts, nil
 }

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -86,10 +86,15 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	opts.CaCert = certs.CaCert
 	*opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
-	*opts.TrimHostList = true
 	*opts.HonorUserInput = true
 
 	// timeout option
+	opts.StatePollingTimeout = new(int)
 	*opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
+
+	// other options
+	opts.TrimHostList = new(bool)
+	*opts.TrimHostList = true
+
 	return opts, nil
 }

--- a/pkg/vadmin/start_db_vc_test.go
+++ b/pkg/vadmin/start_db_vc_test.go
@@ -56,7 +56,7 @@ func (m *MockVClusterOps) VStartDatabase(options *vops.VStartDatabaseOptions) er
 	}
 
 	// verify timeout
-	if options.StatePollingTimeout != TestTimeout {
+	if *options.StatePollingTimeout != TestTimeout {
 		return fmt.Errorf("failed to retrieve timeout")
 	}
 


### PR DESCRIPTION
This PR synced the new changes from `vclusterops` and set the "trim node" options to be true in `re_ip` and `start_db` to avoid possible wrong input in case the operators provide more hosts/nodes than needed.