### PR TITLE
Added goroutine ID to reconciler log for debugging purpose

### DIFF
--- a/pkg/controllers/vdb/go_id_helper.go
+++ b/pkg/controllers/vdb/go_id_helper.go
@@ -1,0 +1,50 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Remove this file after VER-89903 is closed since the function
+// goid() inside this file is slow and not recommended by Go.
+package vdb
+
+import (
+	"bytes"
+	"errors"
+	"runtime"
+	"strconv"
+)
+
+const bufferSize = 32
+
+var (
+	goroutinePrefix = []byte("goroutine ")
+	errBadStack     = errors.New("invalid runtime.Stack output")
+)
+
+func goid() (int, error) {
+	buf := make([]byte, bufferSize)
+	n := runtime.Stack(buf, false)
+	buf = buf[:n]
+
+	buf, ok := bytes.CutPrefix(buf, goroutinePrefix)
+	if !ok {
+		return 0, errBadStack
+	}
+
+	i := bytes.IndexByte(buf, ' ')
+	if i < 0 {
+		return 0, errBadStack
+	}
+
+	return strconv.Atoi(string(buf[:i]))
+}

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -97,7 +97,12 @@ func (r *VerticaDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.2/pkg/reconcile
 func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("verticadb", req.NamespacedName)
+	// remove goroutineID after VER-89903 is closed
+	goroutineID, e := goid()
+	if e != nil {
+		return ctrl.Result{}, e
+	}
+	log := r.Log.WithValues("verticadb", req.NamespacedName, "goroutine", goroutineID)
 	log.Info("starting reconcile of VerticaDB")
 
 	vdb := &vapi.VerticaDB{}


### PR DESCRIPTION
This code change is only for debugging intermittent errors in "update-strategy" test of e2e-leg-2. After the issue is fixed, we should revert the changes in this PR since retrieving goroutine ID is not recommended in golang.