### PR TITLE
Remove vcluster pointer initialization on the operator side

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v0.0.0-20231109175558-9c50b53a22d1
+	github.com/vertica/vcluster v0.0.0-20231116112651-bda295c5e7af
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v0.0.0-20231109175558-9c50b53a22d1 h1:jbvhia71f3NDL14loCG6V0EntgSabkBmPys694/y9Vw=
-github.com/vertica/vcluster v0.0.0-20231109175558-9c50b53a22d1/go.mod h1:sHCcZgk/CuJvFoYivMo63XGQmbmPsAxtRQCPWA0Xieg=
+github.com/vertica/vcluster v0.0.0-20231116112651-bda295c5e7af h1:3qYytqEPtDkSgN0Ji+GdwLYoe3sZwcM/f1mTVbYhTuY=
+github.com/vertica/vcluster v0.0.0-20231116112651-bda295c5e7af/go.mod h1:sHCcZgk/CuJvFoYivMo63XGQmbmPsAxtRQCPWA0Xieg=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -89,11 +89,9 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	*opts.HonorUserInput = true
 
 	// timeout option
-	opts.StatePollingTimeout = new(int)
 	*opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
 
 	// other options
-	opts.TrimHostList = new(bool)
 	*opts.TrimHostList = true
 
 	return opts, nil


### PR DESCRIPTION
This PR simply removed the pointer initialization on the operator side for `start_db` as the pointers have been initialized on the vclusterops side.