### PR TITLE
webhook validates deployment type changes

### DIFF
--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -295,6 +295,15 @@ var _ = Describe("verticadb_webhook", func() {
 		vdbUpdate.Spec.Subclusters[0].Type = SecondarySubcluster
 		validateImmutableFields(vdbUpdate, true)
 	})
+	It("should not change deployment type from vclusterops to admintools after creation", func() {
+		vdbOrig := createVDBHelper()
+		vdbOrig.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationTrue
+		vdbUpdate := createVDBHelper()
+		// cannot change from vclusterops to admintools
+		checkErrorsForImmutableFields(vdbOrig, vdbUpdate, true)
+		// can change from admintools to vclusterops
+		checkErrorsForImmutableFields(vdbUpdate, vdbOrig, false)
+	})
 	It("should allow image change if autoRestartVertica is disabled", func() {
 		vdb := createVDBHelper()
 		vdb.Spec.AutoRestartVertica = false


### PR DESCRIPTION
- deployment type cannot change from vclusterops to admintools (the webhook will report this as an error)
- deployment type can change from admintools to vclusterops, assuming image is also changed from v1 to v2 (verified manually by `kubectl edit`)