### PR TITLE
Change upgrade path rules for new server versions

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -30,6 +30,11 @@ type Info struct {
 	Components        // The same version as VdbVer but broken down into individual components
 }
 
+const (
+	LTSMinor = 4
+	LTSPatch = 0
+)
+
 // UpgradePaths has all of the vertica releases supported by the operator.  For
 // each release, the next release that must be upgrade too.  Use this map to
 // know if a new version is the next supported version by Vertica.
@@ -44,24 +49,23 @@ var UpgradePaths = map[Components]Info{
 	{11, 0, 2}: {"v11.1.x", Components{11, 1, 0}},
 	{11, 1, 0}: {"v12.0.x", Components{12, 0, 0}},
 	{11, 1, 1}: {"v12.0.x", Components{12, 0, 0}},
-	{12, 0, 0}: {"v23.3.x", Components{23, 3, 0}},
-	{12, 0, 1}: {"v23.3.x", Components{23, 3, 0}},
-	{12, 0, 2}: {"v23.3.x", Components{23, 3, 0}},
-	{12, 0, 3}: {"v23.3.x", Components{23, 3, 0}},
-	{12, 0, 4}: {"v23.3.x", Components{23, 3, 0}},
-	// From here upwards the x.4.0 release (4th quarter release)
-	// is the LTS version so all releases will have the closest x.4.0
-	// as their next release they can be upgraded to.
-	// example:
-	//	- {23, 4, 0}: {"v24.4.x", Components{24, 4, 0}}
-	//	- {24, 1, 0}: {"v24.4.x", Components{24, 4, 0}}
-	{23, 3, 0}: {"v23.4.x", Components{23, 4, 0}},
+	{12, 0, 0}: {"v23.3.x", Components{23, 4, 0}},
+	{12, 0, 1}: {"v23.3.x", Components{23, 4, 0}},
+	{12, 0, 2}: {"v23.3.x", Components{23, 4, 0}},
+	{12, 0, 3}: {"v23.3.x", Components{23, 4, 0}},
+	{12, 0, 4}: {"v23.3.x", Components{23, 4, 0}},
 }
 
 // MakeInfoFromStr will construct an Info struct by parsing the version string
 func MakeInfoFromStr(curVer string) (*Info, bool) {
 	ma, mi, pa, ok := parseVersion(curVer)
 	return &Info{curVer, Components{ma, mi, pa}}, ok
+}
+
+// buildVersionStr will build the version string from
+// a Components object
+func (c *Components) buildVersionStr() string {
+	return fmt.Sprintf("v%d.%d.%d", c.VdbMajor, c.VdbMinor, c.VdbPatch)
 }
 
 // IsEqualOrNewer returns true if the version in the Vdb is is equal or newer
@@ -115,11 +119,39 @@ func (i *Info) IsEqualExceptPatch(other *Info) bool {
 	return other.VdbMajor == i.VdbMajor && other.VdbMinor == i.VdbMinor
 }
 
-// IsLowerExceptPatch returns true if the receiver's major/minor version
+// IsOlderExceptPatch returns true if the receiver's major/minor version
 // is lower than the given version.
-func (i *Info) IsLowerExceptPatch(other *Info) bool {
+func (i *Info) IsOlderExceptPatch(other *Info) bool {
 	return i.VdbMajor < other.VdbMajor ||
 		(i.VdbMajor == other.VdbMajor && i.VdbMinor < other.VdbMinor)
+}
+
+// IsOlderOrEqualExceptPatch compares two versions major/minor versions to see if the
+// first one is equal or older than the second
+func (i *Info) IsOlderOrEqualExceptPatch(other *Info) bool {
+	return i.IsEqualExceptPatch(other) || i.IsOlderExceptPatch(other)
+}
+
+// isLTSRelease returns true if the release is LTS
+// meaning its version has the format x.4.x
+func (i *Info) isLTSRelease() bool {
+	return i.VdbMinor == LTSMinor
+}
+
+// getNextLTSVersion given a release returns the next
+// LTS realease version
+func (i *Info) getNextLTSVersion() Info {
+	nextLTSVersion := Info{
+		VdbVer: i.VdbVer,
+	}
+	nextLTSVersion.VdbMajor = i.VdbMajor
+	nextLTSVersion.VdbMinor = LTSMinor
+	nextLTSVersion.VdbPatch = LTSPatch
+	if i.isLTSRelease() {
+		nextLTSVersion.VdbMajor++
+		nextLTSVersion.VdbVer = nextLTSVersion.buildVersionStr()
+	}
+	return nextLTSVersion
 }
 
 // IsValidUpgradePath will return true if the current version is allowed to
@@ -151,12 +183,13 @@ func (i *Info) IsValidUpgradePath(targetVer string) (ok bool, failureReason stri
 	// version to the next released version, but patches are allowed to be skipped.
 	nextVer, ok := UpgradePaths[i.Components]
 	if !ok {
-		// The version isn't found in the upgrade path.  This path may be
-		// unsafe, but we aren't going to block this incase we are using a
-		// version of vertica that came out after the version of this operator.
-		return true, ""
+		// The version isn't found in the upgrade path. It must be a version
+		// newer that v12.0.4. Since from that point our release versions are
+		// more predictable, we can get the max version the current version
+		// can be upgraded to from the next LTS release version,
+		nextVer = i.getNextLTSVersion()
 	}
-	if t.IsEqualExceptPatch(&nextVer) || t.IsLowerExceptPatch(&nextVer) {
+	if t.IsOlderOrEqualExceptPatch(&nextVer) {
 		return true, ""
 	}
 	return false,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -109,6 +109,13 @@ func (i *Info) IsEqualExceptPatch(other *Info) bool {
 	return other.VdbMajor == i.VdbMajor && other.VdbMinor == i.VdbMinor
 }
 
+// IsLowerExceptPatch returns true if the receiver's major/minor version
+// is lower than the given version.
+func (i *Info) IsLowerExceptPatch(other *Info) bool {
+	return i.VdbMajor < other.VdbMajor ||
+		(i.VdbMajor == other.VdbMajor && i.VdbMinor < other.VdbMinor)
+}
+
 // IsValidUpgradePath will return true if the current version is allowed to
 // upgrade to targetVer.  This will return false if the path isn't compatible.
 func (i *Info) IsValidUpgradePath(targetVer string) (ok bool, failureReason string) {
@@ -143,7 +150,7 @@ func (i *Info) IsValidUpgradePath(targetVer string) (ok bool, failureReason stri
 		// version of vertica that came out after the version of this operator.
 		return true, ""
 	}
-	if t.IsEqualExceptPatch(&nextVer) {
+	if t.IsEqualExceptPatch(&nextVer) || t.IsLowerExceptPatch(&nextVer) {
 		return true, ""
 	}
 	return false,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -49,6 +49,10 @@ var UpgradePaths = map[Components]Info{
 	{12, 0, 2}: {"v23.3.x", Components{23, 3, 0}},
 	{12, 0, 3}: {"v23.3.x", Components{23, 3, 0}},
 	{12, 0, 4}: {"v23.3.x", Components{23, 3, 0}},
+	// From here upwards the x.4.0 release (4th quarter release)
+	// is the LTS version so all releases will have the closest x.4.0
+	// as their next release they can be upgraded to. If the next x.4.0
+	// is not out yet then it will be the latest release.
 	{23, 3, 0}: {"v23.4.x", Components{23, 4, 0}},
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,8 +51,10 @@ var UpgradePaths = map[Components]Info{
 	{12, 0, 4}: {"v23.3.x", Components{23, 3, 0}},
 	// From here upwards the x.4.0 release (4th quarter release)
 	// is the LTS version so all releases will have the closest x.4.0
-	// as their next release they can be upgraded to. If the next x.4.0
-	// is not out yet then it will be the latest release.
+	// as their next release they can be upgraded to.
+	// example:
+	//	- {23, 4, 0}: {"v24.4.x", Components{24, 4, 0}}
+	//	- {24, 1, 0}: {"v24.4.x", Components{24, 4, 0}}
 	{23, 3, 0}: {"v23.4.x", Components{23, 4, 0}},
 }
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -43,12 +43,36 @@ var _ = Describe("version", func() {
 		ok, _ = cur.IsValidUpgradePath("v11.2.2")
 		Expect(ok).Should(BeFalse()) // Fail because it skips v11.1.x
 
-		cur, ok = MakeInfoFromStr("v15.1.1")
+		cur, ok = MakeInfoFromStr("v12.0.3")
 		Expect(ok).Should(BeTrue())
-		ok, _ = cur.IsValidUpgradePath("v14.0.2")
+		ok, _ = cur.IsValidUpgradePath("v12.0.4")
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v23.3.0")
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v23.4.0")
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v24.1.0")
 		Expect(ok).Should(BeFalse())
-		ok, _ = cur.IsValidUpgradePath("v16.1.3")
+		ok, _ = cur.IsValidUpgradePath("v24.4.0")
+		Expect(ok).Should(BeFalse()) // Fail because it skips v23.4.0
+
+		cur, ok = MakeInfoFromStr("v23.3.0")
 		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v23.4.0")
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v24.2.0")
+		Expect(ok).Should(BeFalse())
+		ok, _ = cur.IsValidUpgradePath("v24.3.0")
+		Expect(ok).Should(BeFalse()) // Fail because it skips v23.4.0
+
+		cur, ok = MakeInfoFromStr("v23.4.0")
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v24.1.0")
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v24.4.0")
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v25.1.0")
+		Expect(ok).Should(BeFalse()) // Fail because it skips v24.4.0
 	})
 
 	It("should return values for IsOlder", func() {


### PR DESCRIPTION
With the new server versions, the minor is changing quite frequently. Each release is essentially a minor version change. And that is happening every quarter. So we added a rule so that the x.4.0 cannot be skipped but intermediate ones can. For instance. If someone is on 23.4.0, they can directly to 24.4.0 skipping 24.1.0, 24.2.0 and 24.3.0 