### PR TITLE
Run legs against previously released vertica image

### DIFF
--- a/.github/workflows/e2e-leg-1.yml
+++ b/.github/workflows/e2e-leg-1.yml
@@ -12,7 +12,7 @@ on:
       vertica-image:
         type: string
         required: false
-      artifact-version:
+      artifact-suffix:
         type: string
         required: false
       vertica-deployment-method:
@@ -39,8 +39,8 @@ on:
         description: 'Name of the vertica server image'
         type: string
         required: false
-      artifact-version:
-        description: 'Version of the artifact file'
+      artifact-suffix:
+        description: 'Version of the suffix artifact file'
         type: string
         required: false
       vertica-deployment-method:
@@ -86,5 +86,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: logs-e2e-leg-1-${{ inputs.vertica-deployment-method }}-${{ inputs.artifact-version }}
+        name: logs-e2e-leg-1-${{ inputs.vertica-deployment-method }}${{ inputs.artifact-suffix }}
         path: ${{ github.workspace }}/int-tests-output/*

--- a/.github/workflows/e2e-leg-1.yml
+++ b/.github/workflows/e2e-leg-1.yml
@@ -12,6 +12,9 @@ on:
       vertica-image:
         type: string
         required: false
+      artifact-version:
+        type: string
+        required: false
       vertica-deployment-method:
         type: string
         required: false
@@ -34,6 +37,10 @@ on:
         required: false
       vertica-image:
         description: 'Name of the vertica server image'
+        type: string
+        required: false
+      artifact-version:
+        description: 'Version of the artifact file'
         type: string
         required: false
       vertica-deployment-method:
@@ -79,5 +86,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: logs-e2e-leg-1-${{ inputs.vertica-deployment-method }}
+        name: logs-e2e-leg-1-${{ inputs.vertica-deployment-method }}-${{ inputs.artifact-version }}
         path: ${{ github.workspace }}/int-tests-output/*

--- a/.github/workflows/e2e-leg-2.yml
+++ b/.github/workflows/e2e-leg-2.yml
@@ -12,6 +12,9 @@ on:
       vertica-image:
         type: string
         required: false
+      artifact-version:
+        type: string
+        required: false
       vertica-deployment-method:
         type: string
         required: false
@@ -34,6 +37,10 @@ on:
         required: false
       vertica-image:
         description: 'Name of the vertica server image'
+        type: string
+        required: false
+      artifact-version:
+        description: 'Version of the artifact file'
         type: string
         required: false
       vertica-deployment-method:
@@ -80,5 +87,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: logs-e2e-leg-2-${{ inputs.vertica-deployment-method }}
+        name: logs-e2e-leg-2-${{ inputs.vertica-deployment-method }}-${{ inputs.artifact-version }}
         path: ${{ github.workspace }}/int-tests-output/*

--- a/.github/workflows/e2e-leg-2.yml
+++ b/.github/workflows/e2e-leg-2.yml
@@ -12,7 +12,7 @@ on:
       vertica-image:
         type: string
         required: false
-      artifact-version:
+      artifact-suffix:
         type: string
         required: false
       vertica-deployment-method:
@@ -39,8 +39,8 @@ on:
         description: 'Name of the vertica server image'
         type: string
         required: false
-      artifact-version:
-        description: 'Version of the artifact file'
+      artifact-suffix:
+        description: 'Version of the suffix artifact file'
         type: string
         required: false
       vertica-deployment-method:
@@ -87,5 +87,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: logs-e2e-leg-2-${{ inputs.vertica-deployment-method }}-${{ inputs.artifact-version }}
+        name: logs-e2e-leg-2-${{ inputs.vertica-deployment-method }}${{ inputs.artifact-suffix }}
         path: ${{ github.workspace }}/int-tests-output/*

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,7 +107,6 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
-      artifact-version: "release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -121,7 +120,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:23.4.0-0-minimal"
-      artifact-version: "previous-release"
+      artifact-version: "23.4.0-release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -148,7 +147,6 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
-      artifact-version: "release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -162,7 +160,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:12.0.4-0-minimal"
-      artifact-version: "previous-release"
+      artifact-version: "12.0.4-release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,7 +106,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
+      vertica-image: "vertica/vertica-k8s:23.4.0-0-minimal"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -132,7 +132,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
+      vertica-image: "vertica/vertica-k8s:12.0.4-0-minimal"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,8 +106,22 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
+      artifact-version: "release"
+      vertica-deployment-method: admintools
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  
+  e2e-leg-1-admintools-previous-release:
+    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 1' || inputs.e2e_test_suites == '' }}
+    needs: [build] 
+    uses: ./.github/workflows/e2e-leg-1.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:23.4.0-0-minimal"
-      artifact-version: "23.4.0"
+      artifact-version: "previous-release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -121,7 +135,6 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: ${{ needs.build.outputs.full-vertica-image }}
-      artifact-version: "release"
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -134,8 +147,22 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
+      artifact-version: "release"
+      vertica-deployment-method: admintools
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  e2e-leg-2-admintools-previous-release:
+    if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 2' || inputs.e2e_test_suites == '' }}
+    needs: [build] 
+    uses: ./.github/workflows/e2e-leg-2.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:12.0.4-0-minimal"
-      artifact-version: "12.0.4"
+      artifact-version: "previous-release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -149,7 +176,6 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
-      artifact-version: "release"
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,7 +120,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:23.4.0-0-minimal"
-      artifact-version: "23.4.0-release"
+      artifact-suffix: "-23.4.0-release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -160,7 +160,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:12.0.4-0-minimal"
-      artifact-version: "12.0.4-release"
+      artifact-suffix: "-12.0.4-release"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:23.4.0-0-minimal"
+      artifact-version: "23.4.0"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -120,6 +121,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: ${{ needs.build.outputs.full-vertica-image }}
+      artifact-version: "release"
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -133,6 +135,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: "vertica/vertica-k8s:12.0.4-0-minimal"
+      artifact-version: "12.0.4"
       vertica-deployment-method: admintools
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -146,6 +149,7 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+      artifact-version: "release"
       vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
This PR adds two previously images,` vertica/vertica-k8s:23.4.0-0-minimal` and `vertica/vertica-k8s:12.0.4-0-minimal`, in the available e2e-leg*.yml files. Additionally, a parameter `artifact_suffix` is introduced to avoid duplicating the artifact file for each run of the leg.