### PR TITLE
Operator mounts NMA certs in a volume by default

### DIFF
--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -279,6 +279,13 @@ var _ = Describe("builder", func() {
 		Expect(NMACertsVolumeExists(vdb, ps.Volumes)).Should(BeTrue())
 		Expect(NMACertsVolumeMountExists(&c)).Should(BeTrue())
 		Expect(NMACertsEnvVarsExist(vdb, &c)).Should(BeTrue())
+		// test default value (which should be true)
+		delete(vdb.Annotations, vmeta.MountNMACerts)
+		ps = buildPodSpec(vdb, &vdb.Spec.Subclusters[0])
+		c = makeServerContainer(vdb, &vdb.Spec.Subclusters[0])
+		Expect(NMACertsVolumeExists(vdb, ps.Volumes)).Should(BeTrue())
+		Expect(NMACertsVolumeMountExists(&c)).Should(BeTrue())
+		Expect(NMACertsEnvVarsExist(vdb, &c)).Should(BeTrue())
 	})
 })
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -145,7 +145,7 @@ func UseVClusterOps(annotations map[string]string) bool {
 // UseNMACertsMount returns true if the NMA reads certs from the mounted secret
 // volume rather than directly from k8s secret store.
 func UseNMACertsMount(annotations map[string]string) bool {
-	return lookupBoolAnnotation(annotations, MountNMACerts, false /* default value */)
+	return lookupBoolAnnotation(annotations, MountNMACerts, true /* default value */)
 }
 
 // UseGCPSecretManager returns true if access to the communal secret should go through


### PR DESCRIPTION
- The operator respects the `vertica.com/mount-nma-certs` annotation when it is provided
- When it is not provided the operator assumes its value is `true` which means the NMA will read certs from a mounted secret volume (and proper env vars will be available in the db node containers)
- `serviceaccount_reconciler` skips role/rolebinding lookup and creation if `vertica.com/mount-nma-certs` is `true` or not provided (which will default to `true`), as that role is merely serving the purpose of granting the `get` and `list` permissions for secrets, which is only required when the NMA actually reads certs from k8s secrets directly.