### PR TITLE
Deduce the secret location is GSM with secret path reference

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -536,3 +536,31 @@ func (v *VerticaDB) GetEncryptSpreadComm() string {
 	}
 	return v.Spec.EncryptSpreadComm
 }
+
+const gsmPrefix = "sm://"
+
+// ReadSUPwdFromGSM returns true if superuser password has the prefix "sm://". The prefix "sm://" will
+// tell the operator to fetch superuser password from Google's secret manager instead of k8s meta-data.
+func (v *VerticaDB) ReadSUPwdFromGSM() bool {
+	return strings.HasPrefix(v.Spec.PasswordSecret, gsmPrefix)
+}
+
+// GetSUPwdSecretName returns secret name of the one that stores superuser password. If the secret name
+// has prefix "sm://", we will remove it. This function will be used for processing GSM secrets.
+func (v *VerticaDB) GetSUPwdSecretName() string {
+	return strings.TrimPrefix(v.Spec.PasswordSecret, gsmPrefix)
+}
+
+// ReadCommunalCredsFromGSM returns true if communal access credentials has the prefix "sm://".
+// The prefix "sm://" will tell the operator to fetch communal access credentials from Google's
+// secret manager instead of k8s meta-data.
+func (v *VerticaDB) ReadCommunalCredsFromGSM() bool {
+	return strings.HasPrefix(v.Spec.Communal.CredentialSecret, gsmPrefix)
+}
+
+// GetCommunalCredsSecretName returns secret name of the one that stores communal access credentials.
+// If the secret name has prefix "sm://", we will remove it. This function will be used for processing
+// GSM secrets.
+func (v *VerticaDB) GetCommunalCredsSecretName() string {
+	return strings.TrimPrefix(v.Spec.Communal.CredentialSecret, gsmPrefix)
+}

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -537,29 +537,29 @@ func (v *VerticaDB) GetEncryptSpreadComm() string {
 	return v.Spec.EncryptSpreadComm
 }
 
-const gsmPrefix = "sm://"
+const gsmPrefix = "gsm://"
 
-// ReadSUPwdFromGSM returns true if superuser password has the prefix "sm://". The prefix "sm://" will
+// ReadSUPwdFromGSM returns true if superuser password has the prefix "gsm://". The prefix "gsm://" will
 // tell the operator to fetch superuser password from Google's secret manager instead of k8s meta-data.
 func (v *VerticaDB) ReadSUPwdFromGSM() bool {
 	return strings.HasPrefix(v.Spec.PasswordSecret, gsmPrefix)
 }
 
 // GetSUPwdSecretName returns secret name of the one that stores superuser password. If the secret name
-// has prefix "sm://", we will remove it. This function will be used for processing GSM secrets.
+// has prefix "gsm://", we will remove it. This function will be used for processing GSM secrets.
 func (v *VerticaDB) GetSUPwdSecretName() string {
 	return strings.TrimPrefix(v.Spec.PasswordSecret, gsmPrefix)
 }
 
-// ReadCommunalCredsFromGSM returns true if communal access credentials has the prefix "sm://".
-// The prefix "sm://" will tell the operator to fetch communal access credentials from Google's
+// ReadCommunalCredsFromGSM returns true if communal access credentials has the prefix "gsm://".
+// The prefix "gsm://" will tell the operator to fetch communal access credentials from Google's
 // secret manager instead of k8s meta-data.
 func (v *VerticaDB) ReadCommunalCredsFromGSM() bool {
 	return strings.HasPrefix(v.Spec.Communal.CredentialSecret, gsmPrefix)
 }
 
 // GetCommunalCredsSecretName returns secret name of the one that stores communal access credentials.
-// If the secret name has prefix "sm://", we will remove it. This function will be used for processing
+// If the secret name has prefix "gsm://", we will remove it. This function will be used for processing
 // GSM secrets.
 func (v *VerticaDB) GetCommunalCredsSecretName() string {
 	return strings.TrimPrefix(v.Spec.Communal.CredentialSecret, gsmPrefix)

--- a/changes/unreleased/Added-20231121-133042.yaml
+++ b/changes/unreleased/Added-20231121-133042.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Added a feature to allow the source of secrets to be specified with a secret
+  path reference
+time: 2023-11-21T13:30:42.7821693-06:00
+custom:
+  Issue: "597"

--- a/changes/unreleased/Removed-20231121-081101.yaml
+++ b/changes/unreleased/Removed-20231121-081101.yaml
@@ -1,0 +1,5 @@
+kind: Removed
+body: Removed the annotation "vertica.com/use-gcp-secret-manager"
+time: 2023-11-21T08:11:01.3320553-06:00
+custom:
+  Issue: "597"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -646,11 +646,11 @@ func makeCanaryQueryProbe(vdb *vapi.VerticaDB) *corev1.Probe {
 // the readiness or startup probes. Only returns the default timeouts for the
 // probe. Caller is responsible for adusting those.
 func makeDefaultReadinessOrStartupProbe(vdb *vapi.VerticaDB) *corev1.Probe {
-	// If using GSM, then the superuses password is not a k8s secret. We cannot
+	// If using GSM, then the superuser password is not a k8s secret. We cannot
 	// use the canary query then because that depends on having the password
 	// mounted in the file system. Default to just checking if the client port
 	// is being listened on.
-	if vmeta.UseGCPSecretManager(vdb.Annotations) {
+	if vdb.ReadSUPwdFromGSM() {
 		return makeVerticaClientPortProbe()
 	}
 	return makeCanaryQueryProbe(vdb)
@@ -1008,8 +1008,8 @@ func BuildStorageClass(allowVolumeExpansion bool) *storagev1.StorageClass {
 	}
 }
 
-// BuildS3CommunalCredSecret is a test helper to build up the Secret spec to store communal credentials
-func BuildS3CommunalCredSecret(vdb *vapi.VerticaDB, accessKey, secretKey string) *corev1.Secret {
+// BuildCommunalCredSecret is a test helper to build up the Secret spec to store communal credentials
+func BuildCommunalCredSecret(vdb *vapi.VerticaDB, accessKey, secretKey string) *corev1.Secret {
 	nm := names.GenCommunalCredSecretName(vdb)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -222,7 +222,7 @@ var _ = Describe("builder", func() {
 
 	It("should not use canary query probe if using GSM", func() {
 		vdb := vapi.MakeVDB()
-		vdb.Spec.PasswordSecret = "sm://project/team/dbadmin/secret/1"
+		vdb.Spec.PasswordSecret = "gsm://project/team/dbadmin/secret/1"
 		vdb.Spec.Communal.Path = "gs://vertica-fleeting/mydb"
 		c := buildPodSpec(vdb, &vdb.Spec.Subclusters[0])
 		Expect(isPasswdIncludedInPodInfo(vdb, &c)).Should(BeFalse())

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -222,11 +222,8 @@ var _ = Describe("builder", func() {
 
 	It("should not use canary query probe if using GSM", func() {
 		vdb := vapi.MakeVDB()
-		vdb.Spec.PasswordSecret = "project/team/dbadmin/secret/1"
+		vdb.Spec.PasswordSecret = "sm://project/team/dbadmin/secret/1"
 		vdb.Spec.Communal.Path = "gs://vertica-fleeting/mydb"
-		vdb.Annotations = map[string]string{
-			vmeta.GcpGsmAnnotation: "true",
-		}
 		c := buildPodSpec(vdb, &vdb.Spec.Subclusters[0])
 		Expect(isPasswdIncludedInPodInfo(vdb, &c)).Should(BeFalse())
 	})

--- a/pkg/controllers/vdb/config.go
+++ b/pkg/controllers/vdb/config.go
@@ -207,7 +207,8 @@ func (g *ConfigParamsGenerator) setAuthFromGCSSecret(ctx context.Context) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	gcpCred, err := cloud.ReadFromGSM(ctx, g.Vdb.Spec.Communal.CredentialSecret)
+	communalCredsSecret := g.Vdb.GetCommunalCredsSecretName()
+	gcpCred, err := cloud.ReadFromGSM(ctx, communalCredsSecret)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to read GCS credentials from GSM: %w", err)
 	}
@@ -217,14 +218,14 @@ func (g *ConfigParamsGenerator) setAuthFromGCSSecret(ctx context.Context) (ctrl.
 	accessKey, ok := gcpCred[cloud.CommunalAccessKeyName]
 	if !ok {
 		g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
-			"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalAccessKeyName)
+			"The communal credential secret '%s' does not have a key named '%s'", communalCredsSecret, cloud.CommunalAccessKeyName)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
 	secretKey, ok := gcpCred[cloud.CommunalSecretKeyName]
 	if !ok {
 		g.VRec.Eventf(g.Vdb, corev1.EventTypeWarning, events.CommunalCredsWrongKey,
-			"The communal credential secret '%s' does not have a key named '%s'", g.Vdb.Spec.Communal.CredentialSecret, cloud.CommunalSecretKeyName)
+			"The communal credential secret '%s' does not have a key named '%s'", communalCredsSecret, cloud.CommunalSecretKeyName)
 		return ctrl.Result{Requeue: true}, nil
 	}
 
@@ -236,7 +237,7 @@ func (g *ConfigParamsGenerator) setAuthFromGCSSecret(ctx context.Context) (ctrl.
 // setGCloudAuthParms adds the auth parms to the config parms map when we are
 // connecting to google cloud storage.
 func (g *ConfigParamsGenerator) setGCloudAuthParms(ctx context.Context) (ctrl.Result, error) {
-	if meta.UseGCPSecretManager(g.Vdb.Annotations) {
+	if g.Vdb.ReadCommunalCredsFromGSM() {
 		res, err := g.setAuthFromGCSSecret(ctx)
 		if verrors.IsReconcileAborted(res, err) {
 			return res, err

--- a/pkg/controllers/vdb/init_db_test.go
+++ b/pkg/controllers/vdb/init_db_test.go
@@ -165,6 +165,46 @@ var _ = Describe("init_db", func() {
 		contructAuthParmsHelper(ctx, vdb, "GCSAuth", "")
 	})
 
+	It("should read communal credentials from correct places", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Communal.Path = "gs://test/mydb"
+		secretName := "gcp-secret"
+		// Operator will try to read communal credentials from GSM. We will
+		// get a read error since we cannot access the secret in the unit test.
+		// But that error will indicate we are reading the credentials from
+		// the correct place.
+		vdb.Spec.Communal.CredentialSecret = "sm://" + secretName
+
+		fpr := &cmds.FakePodRunner{}
+		g := GenericDatabaseInitializer{
+			PRunner: fpr,
+			ConfigParamsGenerator: ConfigParamsGenerator{
+				VRec:                vdbRec,
+				Log:                 logger,
+				Vdb:                 vdb,
+				ConfigurationParams: types.MakeCiMap(),
+			},
+		}
+
+		res, err := g.ConstructConfigParms(ctx)
+		ExpectWithOffset(1, err).Should(MatchError(ContainSubstring("failed to read GCS credentials from GSM")))
+		ExpectWithOffset(1, res).Should(Equal(ctrl.Result{}))
+		_, ok := g.ConfigurationParams.Get("GCSAuth")
+		Expect(ok).Should(BeFalse())
+
+		// Operator will read communal credentials from a secret in k8s if
+		// the secret name does not have the prefix "sm://".
+		g.Vdb.Spec.Communal.CredentialSecret = secretName
+		createK8sCredSecret(ctx, g.Vdb)
+		defer deleteCommunalCredSecret(ctx, g.Vdb)
+		res, err = g.ConstructConfigParms(ctx)
+		ExpectWithOffset(1, err).Should(Succeed())
+		ExpectWithOffset(1, res).Should(Equal(ctrl.Result{}))
+		v, ok := g.ConfigurationParams.Get("GCSAuth")
+		Expect(ok).Should(BeTrue())
+		Expect(v).Should(Equal(fmt.Sprintf("%s:%s", testAccessKey, testSecretKey)))
+	})
+
 	It("should set azure parms in config parms map when using azb:// scheme and accountKey", func() {
 		vdb := vapi.MakeVDB()
 		vdb.Spec.Communal.Path = "azb://account/container/path1"

--- a/pkg/controllers/vdb/init_db_test.go
+++ b/pkg/controllers/vdb/init_db_test.go
@@ -173,7 +173,7 @@ var _ = Describe("init_db", func() {
 		// get a read error since we cannot access the secret in the unit test.
 		// But that error will indicate we are reading the credentials from
 		// the correct place.
-		vdb.Spec.Communal.CredentialSecret = "sm://" + secretName
+		vdb.Spec.Communal.CredentialSecret = "gsm://" + secretName
 
 		fpr := &cmds.FakePodRunner{}
 		g := GenericDatabaseInitializer{
@@ -193,7 +193,7 @@ var _ = Describe("init_db", func() {
 		Expect(ok).Should(BeFalse())
 
 		// Operator will read communal credentials from a secret in k8s if
-		// the secret name does not have the prefix "sm://".
+		// the secret name does not have the prefix "gsm://".
 		g.Vdb.Spec.Communal.CredentialSecret = secretName
 		createK8sCredSecret(ctx, g.Vdb)
 		defer deleteCommunalCredSecret(ctx, g.Vdb)

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -192,7 +192,11 @@ const testSecretKey = "dummy"
 const testClientKey = "dummy"
 
 func createS3CredSecret(ctx context.Context, vdb *vapi.VerticaDB) {
-	secret := builder.BuildS3CommunalCredSecret(vdb, testAccessKey, testSecretKey)
+	createK8sCredSecret(ctx, vdb)
+}
+
+func createK8sCredSecret(ctx context.Context, vdb *vapi.VerticaDB) {
+	secret := builder.BuildCommunalCredSecret(vdb, testAccessKey, testSecretKey)
 	Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
 }
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -263,8 +263,8 @@ func (r *VerticaDBReconciler) GetSuperuserPassword(ctx context.Context, vdb *vap
 		return "", nil
 	}
 
-	if vmeta.UseGCPSecretManager(vdb.Annotations) {
-		secretCnts, err := cloud.ReadFromGSM(ctx, vdb.Spec.PasswordSecret)
+	if vdb.ReadCommunalCredsFromGSM() {
+		secretCnts, err := cloud.ReadFromGSM(ctx, vdb.GetSUPwdSecretName())
 		if err != nil {
 			return "", fmt.Errorf("failed to read superuser password from GSM: %w", err)
 		}

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -52,10 +52,6 @@ const (
 	MountNMACertsTrue  = "true"
 	MountNMACertsFalse = "false"
 
-	// This is a feature flag for accessing the secrets configured in Google Secret Manager.
-	// The value of this annotation is treated as a boolean.
-	GcpGsmAnnotation = "vertica.com/use-gcp-secret-manager"
-
 	// Two annotations that are set by the operator when creating objects.
 	OperatorDeploymentMethodAnnotation = "vertica.com/operator-deployment-method"
 	OperatorVersionAnnotation          = "vertica.com/operator-version"
@@ -146,12 +142,6 @@ func UseVClusterOps(annotations map[string]string) bool {
 // volume rather than directly from k8s secret store.
 func UseNMACertsMount(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, MountNMACerts, false /* default value */)
-}
-
-// UseGCPSecretManager returns true if access to the communal secret should go through
-// Google's secret manager rather the fetching the secret from k8s meta-data.
-func UseGCPSecretManager(annotations map[string]string) bool {
-	return lookupBoolAnnotation(annotations, GcpGsmAnnotation, false /* default value */)
 }
 
 // IgnoreClusterLease returns true if revive/start should ignore the cluster lease


### PR DESCRIPTION
Removed the annotation "vertica.com/use-gcp-secret-manager" in the operator. Instead, to read from GSM, the operator will check if the secrets of superuser password and communal access credentials have the prefix "gsm://".