### PR TITLE
Add feature flag to control whether NMA runs in monolithic or sidecar container

### DIFF
--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -267,20 +267,20 @@ var _ = Describe("builder", func() {
 	It("should mount or not mount NMA certs volume according to annotation", func() {
 		vdb := vapi.MakeVDBForHTTP("v-nma-tls-abcde")
 		vdb.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationTrue
-		vdb.Annotations[vmeta.MountNMACerts] = vmeta.MountNMACertsFalse
+		vdb.Annotations[vmeta.MountNMACertsAnnotation] = vmeta.MountNMACertsAnnotationFalse
 		ps := buildPodSpec(vdb, &vdb.Spec.Subclusters[0])
 		c := makeServerContainer(vdb, &vdb.Spec.Subclusters[0])
 		Expect(NMACertsVolumeExists(vdb, ps.Volumes)).Should(BeFalse())
 		Expect(NMACertsVolumeMountExists(&c)).Should(BeFalse())
 		Expect(NMACertsEnvVarsExist(vdb, &c)).Should(BeTrue())
-		vdb.Annotations[vmeta.MountNMACerts] = vmeta.MountNMACertsTrue
+		vdb.Annotations[vmeta.MountNMACertsAnnotation] = vmeta.MountNMACertsAnnotationTrue
 		ps = buildPodSpec(vdb, &vdb.Spec.Subclusters[0])
 		c = makeServerContainer(vdb, &vdb.Spec.Subclusters[0])
 		Expect(NMACertsVolumeExists(vdb, ps.Volumes)).Should(BeTrue())
 		Expect(NMACertsVolumeMountExists(&c)).Should(BeTrue())
 		Expect(NMACertsEnvVarsExist(vdb, &c)).Should(BeTrue())
 		// test default value (which should be true)
-		delete(vdb.Annotations, vmeta.MountNMACerts)
+		delete(vdb.Annotations, vmeta.MountNMACertsAnnotation)
 		ps = buildPodSpec(vdb, &vdb.Spec.Subclusters[0])
 		c = makeServerContainer(vdb, &vdb.Spec.Subclusters[0])
 		Expect(NMACertsVolumeExists(vdb, ps.Volumes)).Should(BeTrue())

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -173,6 +173,9 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Always start with a status reconcile in case the prior reconcile failed.
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
+		// Check NMA running mode and report error when configured to run in a sidecar
+		// as this is not supported yet
+		MakeNMARunningModeReconciler(r, log, vdb),
 		// Report any pods that have low disk space
 		MakeLocalDataCheckReconciler(r, vdb, pfacts),
 		// Handle upgrade actions for any k8s objects created in prior versions

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -83,6 +83,7 @@ const (
 	MgmtFailedDiskFull              = "MgmtFailedDiskfull"
 	LowLocalDataAvailSpace          = "LowLocalDataAvailSpace"
 	WrongImage                      = "WrongImage"
+	NMAInSidecarNotSupported        = "NMAInSidecarNotSupported"
 )
 
 // Constants for VerticaAutoscaler reconciler

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -48,9 +48,17 @@ const (
 	// This is a feature flag for mounting NMA certs as a secret volume in server containers
 	// if deployment method is vclusterops. When set to true the NMA reads certs from this mounted
 	// volume, when set to false it reads certs directly from k8s secret store.
-	MountNMACerts      = "vertica.com/mount-nma-certs"
-	MountNMACertsTrue  = "true"
-	MountNMACertsFalse = "false"
+	MountNMACertsAnnotation      = "vertica.com/mount-nma-certs"
+	MountNMACertsAnnotationTrue  = "true"
+	MountNMACertsAnnotationFalse = "false"
+
+	// This is a feature flag for running NMA process in a monolithic container together with
+	// vertica main process. When set to true the NMA process runs in a monolithic container
+	// together with vertica main process, when set to false it runs in a separate sidecar
+	// container.
+	RunNMAInMonolithicContainerAnnotation      = "vertica.com/run-nma-in-monolithic-container"
+	RunNMAInMonolithicContainerAnnotationTrue  = "true"
+	RunNMAInMonolithicContainerAnnotationFalse = "false"
 
 	// This is a feature flag for accessing the secrets configured in Google Secret Manager.
 	// The value of this annotation is treated as a boolean.
@@ -145,7 +153,11 @@ func UseVClusterOps(annotations map[string]string) bool {
 // UseNMACertsMount returns true if the NMA reads certs from the mounted secret
 // volume rather than directly from k8s secret store.
 func UseNMACertsMount(annotations map[string]string) bool {
-	return lookupBoolAnnotation(annotations, MountNMACerts, true /* default value */)
+	return lookupBoolAnnotation(annotations, MountNMACertsAnnotation, true /* default value */)
+}
+
+func RunNMAInMonolithicContainerMode(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, RunNMAInMonolithicContainerAnnotation, false /* default value */)
 }
 
 // UseGCPSecretManager returns true if access to the communal secret should go through

--- a/pkg/meta/annotations_test.go
+++ b/pkg/meta/annotations_test.go
@@ -49,7 +49,7 @@ var _ = Describe("annotations", func() {
 	})
 
 	It("should treat mountNMACerts annotation as a bool", func() {
-		ann := map[string]string{MountNMACerts: MountNMACertsTrue}
+		ann := map[string]string{MountNMACertsAnnotation: MountNMACertsAnnotationTrue}
 		Ω(UseNMACertsMount(ann)).Should(BeTrue())
 	})
 })


### PR DESCRIPTION
- Add feature flag `vertica.com/run-nma-in-monolithic-container` which controls running mode of NMA, i.e. whether the NMA process runs in a monolithic container together with the main vertica process (which is the current behavior) or it runs in a sidecar container within the same pod as the server container (which will be supported in the future)
- The default value of this feature flag would be `false`
- Add logic in `setup-kustomize.sh` to explicitly set the flag to true for existing e2e tests to work