### PR TITLE
Improve stability of client-access e2e test

### DIFF
--- a/tests/e2e-leg-1/client-access/17-assert.yaml
+++ b/tests/e2e-leg-1/client-access/17-assert.yaml
@@ -28,3 +28,17 @@ status:
     - installCount: 2
       addedToDBCount: 2
       upNodeCount: 2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-client-access-sc1-0
+  labels:
+    vertica.com/client-routing: "true"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-client-access-sc1-1
+  labels:
+    vertica.com/client-routing: "true"


### PR DESCRIPTION
I saw a case where we fail in step 30 of client-access with this error:
+ CLUSTER_IP=v-client-access-sc1
+ vsql -U dbadmin -h v-client-access-sc1 -c 'drop table if exists t1' vsql: could not connect to server: Connection refused
    Is the server running on host "v-client-access-sc1" and accepting
    TCP/IP connections on port 5433?

I think this error occurs due to timing -- we try to access the service object before it has the necessary labels for routing.