### PR TITLE
Enable e2e-server-upgrade with vcluster

### DIFF
--- a/.github/workflows/e2e-server-upgrade.yml
+++ b/.github/workflows/e2e-server-upgrade.yml
@@ -12,6 +12,9 @@ on:
       vertica-image:
         type: string
         required: false
+      vertica-deployment-method:
+        type: string
+        required: false
     secrets:
       DOCKERHUB_USERNAME:
         description: 'When working with images from docker.io, this is the username for login purposes'
@@ -33,6 +36,14 @@ on:
         description: 'Name of the vertica server image'
         type: string
         required: false
+      vertica-deployment-method:
+        description: 'Vertica deployment method'
+        type: choice
+        required: false
+        default: admintools
+        options:
+        - admintools
+        - vclusterops
 
 jobs:
 
@@ -61,6 +72,7 @@ jobs:
         export VERTICA_IMG=${{ inputs.vertica-image }}
         export OPERATOR_IMG=${{ inputs.operator-image }}
         export VLOGGER_IMG=${{ inputs.vlogger-image }}
+        export VERTICA_DEPLOYMENT_METHOD=${{ inputs.vertica-deployment-method }}
         export BASE_VERTICA_IMG=$(scripts/guess-server-upgrade-base-image.sh $VERTICA_IMG)
         echo "Upgrading server from image: $BASE_VERTICA_IMG"
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-server-upgrade-ci.txt
@@ -68,6 +80,6 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: logs-e2e-server-upgrade
+        name: logs-e2e-server-upgrade-${{ inputs.vertica-deployment-method }}
         path: ${{ github.workspace }}/int-tests-output/*
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,7 @@ on:
         - vcluster leg 4
         - vcluster leg 5
         - vcluster leg 6
+        - vcluster server upgrade
         - vcluster udx
       run_security_scan:
         description: 'What images to scan?'
@@ -269,7 +270,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  e2e-server-upgrade:
+  e2e-server-upgrade-admintools:
     if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools server upgrade' || inputs.e2e_test_suites == '' }}
     needs: [build]
     uses: ./.github/workflows/e2e-server-upgrade.yml
@@ -277,6 +278,20 @@ jobs:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
       vertica-image: ${{ needs.build.outputs.legacy-vertica-image }}
+      vertica-deployment-method: admintools
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  e2e-server-upgrade-vcluster:
+    if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster server upgrade' || inputs.e2e_test_suites == '')}}
+    needs: [build]
+    uses: ./.github/workflows/e2e-server-upgrade.yml
+    with:
+      vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+      operator-image: ${{ needs.build.outputs.operator-image }}
+      vertica-image: ${{ needs.build.outputs.full-vertica-image }}
+      vertica-deployment-method: vclusterops
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/scripts/guess-server-upgrade-base-image.sh
+++ b/scripts/guess-server-upgrade-base-image.sh
@@ -95,6 +95,17 @@ VERTICA_REPO="vertica"
 TARGET_IMAGE=${@:$OPTIND:1}
 PUBLIC_IMAGE=vertica-k8s
 PRIVATE_IMAGE=${PUBLIC_IMAGE}-private
+
+# This is temporary because v2 images are still not public
+# and we still do not build them in the CI. Once it is the case,
+# we are going to remove this and update the existing logic
+# to handle v2 images too 
+if [[ $VERTICA_DEPLOYMENT_METHOD == vclusterops ]]
+then
+    echo "${VERTICA_REPO}/${PRIVATE_IMAGE}:36ee8c3de77d43c6ad7bbef252302977952ac9d6-minimal"
+    exit 0
+fi
+
 LAST_RELEASED_IMAGE=$(printVerticaK8sImg $PUBLIC_IMAGE 23 3 0)
 # Next two variables define the version that is built nightly from the server
 # master branch. Update this as the server repo changes the version.


### PR DESCRIPTION
Now we have all the tools to run e2e-server-upgrade with vclusterops. For now we a picking a static v2 image as base image but once we start building a v2 image in CI we are going to use a logic similar as admintools'.