### PR TITLE
Fix intermittent test failure

### DIFF
--- a/tests/e2e-leg-3/revive-with-different-local-paths/50-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/50-assert.yaml
@@ -15,8 +15,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: v-revive-2-main
-status:
-  replicas: 3
 ---
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB


### PR DESCRIPTION
I saw a flaky test failure in revive-with-different-local-paths. At step 50, we make sure a StatefulSet exists with 3 replicas and we haven't yet updated the VerticaDB to correct its paths. In the failure I saw, there was only about a 4 second window where these conditions hold. The pods were late to start. So, I suspect kuttl never checked the assertion for step 50 in that window. I'm changing the assertion so that it is easier to hit.