### PR TITLE
Deploy operator with single YAML manifest

### DIFF
--- a/changes/unreleased/Added-20231130-121009.yaml
+++ b/changes/unreleased/Added-20231130-121009.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Deploy the operator with kubectl command
+time: 2023-11-30T12:10:09.870483929-04:00
+custom:
+  Issue: "611"

--- a/scripts/undeploy.sh
+++ b/scripts/undeploy.sh
@@ -82,6 +82,10 @@ elif kubectl get subscription --all-namespaces=true | grep -cqe "verticadb-opera
 then
     $SCRIPT_DIR/undeploy-olm.sh
     remove_cluster_objects
+elif kubectl get deployment -n verticadb-operator -l control-plane=controller-manager | grep -cqe "verticadb-operator-controller-manager" 2> /dev/null
+then
+    kubectl delete -f $REPO_DIR/config/release-manifests/operator.yaml || true
+    remove_cluster_objects
 else
     remove_cluster_objects
     echo "** No operator deployment detected"

--- a/tests/e2e-leg-5/deploy-with-manifest/05-create-creds.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/05-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-5/deploy-with-manifest/10-assert.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/10-assert.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: controller-manager
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: verticadb-operator
+  name: verticadb-operator-manager-config
+data:
+  DEPLOY_WITH: yaml

--- a/tests/e2e-leg-5/deploy-with-manifest/10-deploy-operator.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/10-deploy-operator.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && make undeploy-operator || true"
+  - command: kubectl delete ns verticadb-operator
+  - command: sh -c "cd ../../.. && make install"  # Add the CRDs
+  - command: sh -c "cd ../../.. && kubectl apply -f config/release-manifests/operator.yaml"
+  - command: kubectl wait pod --namespace verticadb-operator -l control-plane=controller-manager --for=condition=Ready=True

--- a/tests/e2e-leg-5/deploy-with-manifest/15-assert.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/15-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-deploy-with-manifest-sc1
+status:
+  replicas: 1

--- a/tests/e2e-leg-5/deploy-with-manifest/15-setup-vdb.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-5/deploy-with-manifest/90-delete-cr.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/90-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-5/deploy-with-manifest/90-errors.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/90-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-5/deploy-with-manifest/95-errors.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: verticadb-operator

--- a/tests/e2e-leg-5/deploy-with-manifest/95-uninstall-operator.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/95-uninstall-operator.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "cd ../../.. && kubectl delete -f config/release-manifests/operator.yaml"

--- a/tests/e2e-leg-5/deploy-with-manifest/98-assert.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/98-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-5/deploy-with-manifest/98-cleanup-storage.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/98-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-5/deploy-with-manifest/98-errors.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/98-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-5/deploy-with-manifest/99-delete-ns.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-5/deploy-with-manifest/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-5/deploy-with-manifest/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,34 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-deploy-with-manifest
+  annotations:
+    vertica.com/include-uid-in-path: "true"
+    vertica.com/k-safety: "0"
+spec:
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  communal: {}
+  local:
+    requestSize: 100Mi
+  dbName: blog
+  subclusters:
+    - name: sc1
+      size: 1
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
Now that our operator is cluster scoped, we can deploy it using simple `kubectl apply -f ...` commands. This adds that manifest to our release artifacts. This will be published on GitHub in our 2.0.0 release. Once released the command will be:

```
# Install CRDs
kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/verticadbs.vertica.com-crd.yaml
kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/verticaautoscalers.vertica.com-crd.yaml
kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/eventtriggers.vertica.com-crd.yaml
# Deploy the operator
kubectl apply -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/operator.yaml
```