### PR TITLE
Fix intermittent e2e test failure

### DIFF
--- a/tests/e2e-leg-3/revive-with-different-local-paths/50-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/50-assert.yaml
@@ -11,11 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: v-revive-2-main
----
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:


### PR DESCRIPTION
This is another attempt at fixing the timing scenario in revive-with-different-local-paths. I suspect that the assertion for step 50 has a small timing window -- we need to provision the pods and still see the paths as invalid in the VerticaDB, but the operator can update the paths pretty quick. I am just going to check for the paths and not bother with verifying the pods any more.