### PR TITLE
capture-scrutinize.sh to use IP instead of host

### DIFF
--- a/scripts/capture-scrutinize.sh
+++ b/scripts/capture-scrutinize.sh
@@ -148,7 +148,7 @@ function scrutinizeForVClusterOps() {
 
     logInfo "VClusterOps deployment detected"
     set -o xtrace
-    mapfile -t host_list < <(kubectl get pods -n $ns --selector app.kubernetes.io/instance=$v -o jsonpath='{range .items[*]}{.metadata.name}.{.spec.subdomain}.{.metadata.namespace}.svc{"\n"}{end}')
+    mapfile -t host_list < <(kubectl get pods -n $ns --selector app.kubernetes.io/instance=$v -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}')
     hosts=$(IFS=, ; echo "${host_list[*]}")
     superuser_op=$(kubectl get vdb -n $ns $v -o jsonpath='{.metadata.annotations.vertica\.com/superuser-name}')
     superuser=${superuser_op:-dbadmin}


### PR DESCRIPTION
We have a helper script called capture-scrutinize.sh that will gather scrutinize during e2e runs. A few e2e tests use it and require that scrutinize be successful. One of those testcases, nma-cert-mounts, has failed because it couldn't talk to the NMA. It was running this right after a restart, but it was sending the request to an old IP. We pass in the host name to scrutinize. I suspect it resloved the host using a stale DNS cache and got the old IP. I am changing the script to use IPs instead of hosts.