### PR TITLE
Fix error communal storage path is invalid

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -189,17 +189,17 @@ func (v *VerticaDB) GetPVSubPath(subPath string) string {
 
 // GetDBDataPath get the data path for the current database
 func (v *VerticaDB) GetDBDataPath() string {
-	return fmt.Sprintf("%s/%s", v.Spec.Local.DataPath, v.Spec.DBName)
+	return fmt.Sprintf("%s/%s", strings.TrimSuffix(v.Spec.Local.DataPath, "/"), v.Spec.DBName)
 }
 
 // GetCatalogPath gets the catalog path for the current database
 func (v *VerticaDB) GetDBCatalogPath() string {
-	return fmt.Sprintf("%s/%s", v.Spec.Local.GetCatalogPath(), v.Spec.DBName)
+	return fmt.Sprintf("%s/%s", strings.TrimSuffix(v.Spec.Local.GetCatalogPath(), "/"), v.Spec.DBName)
 }
 
 // GetDBDepotPath gets the depot path for the current database
 func (v *VerticaDB) GetDBDepotPath() string {
-	return fmt.Sprintf("%s/%s", v.Spec.Local.DepotPath, v.Spec.DBName)
+	return fmt.Sprintf("%s/%s", strings.TrimSuffix(v.Spec.Local.DepotPath, "/"), v.Spec.DBName)
 }
 
 // GetCommunalPath returns the path to use for communal storage
@@ -211,7 +211,7 @@ func (v *VerticaDB) GetCommunalPath() string {
 	if !v.IncludeUIDInPath() {
 		return v.Spec.Communal.Path
 	}
-	return fmt.Sprintf("%s/%s", v.Spec.Communal.Path, v.UID)
+	return fmt.Sprintf("%s/%s", strings.TrimSuffix(v.Spec.Communal.Path, "/"), v.UID)
 }
 
 // GenCompatibleFQDN returns a name of the subcluster that is


### PR DESCRIPTION
We include the UID in the communal path to generate a unique path for each new instance of vdb. To do that, we append the UID to the path this way `path/uid`. The problem is if the path ends with `/` like `s3://vertica-fleeting/k8s/`, we end up with 2 slashes like `s3://vertica-fleeting/k8s//uid` which will fail vclusterops communal storage path check with error: `communal storage path is invalid: use an absolute local path or a correct remote url path`.
So I removed the trailing slash from the path before appending the UID.