### PR TITLE
Allow custom superuser name for admintools deployments

### DIFF
--- a/pkg/cmds/exec.go
+++ b/pkg/cmds/exec.go
@@ -148,7 +148,7 @@ func (c *ClusterPodRunner) ExecVSQL(ctx context.Context, podName types.Namespace
 // ExecAdmintools appends options to the admintools command and calls ExecInPod
 func (c *ClusterPodRunner) ExecAdmintools(ctx context.Context, podName types.NamespacedName,
 	contName string, command ...string) (stdout, stderr string, err error) {
-	command = UpdateAdmintoolsCmd(c.VerticaSUPassword, command...)
+	command = UpdateAdmintoolsCmd(c.VerticaSUName, c.VerticaSUPassword, command...)
 	return c.ExecInPod(ctx, podName, contName, command...)
 }
 
@@ -178,8 +178,8 @@ func UpdateVsqlCmd(suName, passwd string, cmd ...string) []string {
 }
 
 // UpdateAdmintoolsCmd generates an admintools command appending the options we need
-func UpdateAdmintoolsCmd(passwd string, cmd ...string) []string {
-	// We are running as dbadmin, but we need to do this 'sudo su dbadmin --'
+func UpdateAdmintoolsCmd(suname, passwd string, cmd ...string) []string {
+	// We are running as the superuser, but we need to do this 'sudo su `suname` --'
 	// stuff so that we have the proper ulimits set.  When you exec into a pod,
 	// the ulimits you use are for the container runtime.  This can differ from
 	// the actual limits for the pod/container.  So we need this extra bit to
@@ -188,7 +188,7 @@ func UpdateAdmintoolsCmd(passwd string, cmd ...string) []string {
 	//
 	// The --preserve-env option is required so that environment variables flow
 	// through to the vertica process.
-	prefix := []string{"sudo", "--preserve-env", "su", "dbadmin", "--", "/opt/vertica/bin/admintools"}
+	prefix := []string{"sudo", "--preserve-env", "su", suname, "--", "/opt/vertica/bin/admintools"}
 	cmd = append(prefix, cmd...)
 	if passwd == "" {
 		return cmd

--- a/pkg/cmds/fake.go
+++ b/pkg/cmds/fake.go
@@ -78,7 +78,7 @@ func (f *FakePodRunner) ExecInPod(_ context.Context, podName types.NamespacedNam
 // ExecAdmintools calls ExecInPod
 func (f *FakePodRunner) ExecAdmintools(ctx context.Context, podName types.NamespacedName,
 	contName string, command ...string) (stdout, stderr string, err error) {
-	command = UpdateAdmintoolsCmd(f.VerticaSUPassword, command...)
+	command = UpdateAdmintoolsCmd(f.VerticaSUName, f.VerticaSUPassword, command...)
 	return f.ExecInPod(ctx, podName, contName, command...)
 }
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -129,6 +129,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vdb.GetVerticaUser(), passwd)
+	log.Info("Superuser user", "name", vdb.GetVerticaUser())
 	// We use the same pod facts for all reconcilers. This allows to reuse as
 	// much as we can. Some reconcilers will purposely invalidate the facts if
 	// it is known they did something to make them stale.

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -137,8 +137,7 @@ const (
 	// Annotation for a customized superuser name. This annotation can be used
 	// when vclusterops annotation is set to true. It can explicitly specify the
 	// name of vertica superuser that is generated in database creation. If this
-	// annotation is not provided or vclusterops annotation is set to false, the
-	// default value "dbadmin" will be used.
+	// annotation is not provided the default value "dbadmin" will be used.
 	SuperuserNameAnnotation   = "vertica.com/superuser-name"
 	SuperuserNameDefaultValue = "dbadmin"
 )
@@ -215,10 +214,7 @@ func IncludeUIDInPath(annotations map[string]string) bool {
 // GetSuperuserName returns the name of customized vertica superuser name
 // for vclusterops style of deployments.
 func GetSuperuserName(annotations map[string]string) string {
-	if UseVClusterOps(annotations) {
-		return lookupStringAnnotation(annotations, SuperuserNameAnnotation, SuperuserNameDefaultValue)
-	}
-	return SuperuserNameDefaultValue
+	return lookupStringAnnotation(annotations, SuperuserNameAnnotation, SuperuserNameDefaultValue)
 }
 
 // IsKSafetyCheckStrict returns whether the k-safety check is relaxed.


### PR DESCRIPTION
This allows a custom superuser name to be used. It builds on the work done in #578. That issue was specifically for vclusterops deployments, this fixes a few code that were specific to admintools based deployments. The admintools image hard codes the superuser name as dbadmin, so you will still need a custom image. This change is strictly for the operator.