### PR TITLE
Switched server container from ubuntu to rockylinux

### DIFF
--- a/changes/unreleased/Changed-20231207-104501.yaml
+++ b/changes/unreleased/Changed-20231207-104501.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Switched server container from ubuntu to rockylinux 9
+time: 2023-12-07T10:45:01.174348775-04:00
+custom:
+  Issue: "624"

--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -80,6 +80,7 @@ RUN set -x \
   glibc-locale-source \
   iproute-tc \
   krb5-workstation \
+  libxcrypt-compat \
   openssl \
   procps \
   sysstat \

--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -3,7 +3,8 @@
 # Copyright (c) 2021 Vertica
 #
 
-ARG BASE_OS_VERSION="lunar"
+ARG BASE_OS_NAME
+ARG BASE_OS_VERSION
 ARG BUILDER_OS_VERSION="8"
 ARG MINIMAL=""
 ARG S6_OVERLAY_VERSION=3.1.2.1
@@ -61,33 +62,59 @@ RUN set -x \
   && sh /tmp/cleanup.sh
 
 ##############################################################################################
-FROM ubuntu:${BASE_OS_VERSION} as initial
+FROM ${BASE_OS_NAME}:${BASE_OS_VERSION} as initial
 
+# Controls the version of jre to be installed. The list of all available jre
+# packages can be queried through dnf. For instance, "dnf search openjdk"
+ARG JRE_PKG=java-1.8.0-openjdk-headless
+ARG MINIMAL
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
-  # Update is needed to be confident that we're picking up
-  # fixed libraries.
-  && apt-get -y update \
-  && apt-get -y upgrade \
-  && apt-get clean \
-  && apt-get autoremove \
-  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old
+  # update needed because we just did a clean
+  && yum -y check-update \
+  && yum install -y \
+  ca-certificates \
+  dnf-plugins-core \
+  gdb \
+  glibc-locale-source \
+  iproute-tc \
+  krb5-workstation \
+  openssl \
+  procps \
+  sysstat \
+  which \
+  # Install jre if not minimal
+  && if [[ ${MINIMAL^^} != "YES" ]] ; then \
+    yum install -y $JRE_PKG; \
+  fi \ 
+  && yum clean all \
+  && /bin/rm -rf /var/cache/yum \
+  # Fixes unsupported locale character encoding: use a utf8 locale, not a
+  # ANSI_X3.4-1968 locale
+  && localedef -i en_US -f UTF-8 en_US.UTF-8 \
+  # Set JAVA_HOME environment variable if not minimal, this will be loaded to all shells
+  && if [[ ${MINIMAL^^} != "YES" ]] ; then \
+    echo "JAVA_HOME=/usr" >> /etc/environment; \
+  fi \
+  # Cannot set sudo because the ID we run the container may not exist in the
+  # passwd file. Set a simple root password so you can do some commands as root
+  # if you need be. This isn't a security violation per se since you can control
+  # at the pod level or above if the container is allowed to have elevated privileges.
+  && echo "root:root" | chpasswd \
+  && echo "* -       nofile  65536" >> /etc/security/limits.conf \
+  && echo 'export PS1="[\H] \w\$ "' >> /etc/bash.bashrc
 
 # this squashes the image
 FROM scratch
 COPY --from=initial / /
 
-# Controls the version of jre to be installed by apt-get. The list of all
-# available jre packages can be queried through apt-cache. For instance,
-# "apt-cache search jre | grep jre"
-ARG JRE_PKG=openjdk-8-jre-headless
-ARG MINIMAL
 ARG S6_OVERLAY_VERSION
 
 COPY --from=builder /opt/vertica /opt/vertica
 COPY --from=builder /home/dbadmin /home/dbadmin
 
 ENV PATH "$PATH:/opt/vertica/bin:/opt/vertica/sbin"
-ENV DEBIAN_FRONTEND noninteractive
 ENV JAVA_HOME "/usr"
 ENV VERTICA_STARTUP_LOG_DUPLICATE "/proc/1/fd/1"
 
@@ -105,42 +132,6 @@ COPY s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
-  # update needed because we just did a clean
-  && apt-get -y update \
-  && apt-get install -y --no-install-recommends \
-  ca-certificates \
-  curl \
-  dialog \
-  gdb \
-  iproute2 \
-  krb5-user \
-  less \
-  libkeyutils1\
-  libz-dev \
-  locales \
-  ntp \
-  openssl \
-  procps \
-  sysstat \
-  vim-tiny \
-  # Install jre if not minimal
-  && if [[ ${MINIMAL^^} != "YES" ]] ; then \
-    apt-get install -y --no-install-recommends $JRE_PKG; \
-  fi \
-  && apt-get clean \
-  && apt-get autoremove \
-  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
-  # Make the "en_US.UTF-8" locale so vertica will be utf-8 enabled by default
-  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-  # Cannot set sudo because the ID we run the container may not exist in the
-  # passwd file. Set a simple root password so you can do some commands as root
-  # if you need be. This isn't a security violation per se since you can control
-  # at the pod level or above if the container is allowed to have elevated privileges.
-  && echo "root:root" | chpasswd \
-  && echo "* -       nofile  65536" >> /etc/security/limits.conf \
-  && echo 'export PS1="[\H] \w\$ "' >> /etc/bash.bashrc \
-  # Create a symlink to python3 interpreter in vertica
-  && update-alternatives --install /usr/bin/python python /opt/vertica/oss/python3/bin/python3 1 \
   # Untar the init program that was downloaded earlier
   && tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz \
   && tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz
@@ -154,8 +145,8 @@ EXPOSE 8443
 # Choosing a system user that isn't root to avoid a twistlock violation. The
 # actual user is selected at runtime by setting the UID/GID in the pod spec.
 USER daemon
-LABEL os-family="ubuntu"
-LABEL image-name="vertica_k8s"
+LABEL os-family="rockylinux"
+LABEL image-name="vertica-k8s"
 LABEL maintainer="K8s Team"
 LABEL org.opencontainers.image.source=https://github.com/vertica/vertica-kubernetes/tree/main/docker-vertica-v2 \
       org.opencontainers.image.title='Vertica Server' \

--- a/docker-vertica-v2/Makefile
+++ b/docker-vertica-v2/Makefile
@@ -1,6 +1,7 @@
 VERTICA_RPM?=$(notdir $(wildcard packages/vertica*.rpm))
 BUILDER_OS_VERSION?=8
-BASE_OS_VERSION?=lunar
+BASE_OS_NAME?=rockylinux
+BASE_OS_VERSION?=9
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
@@ -10,7 +11,7 @@ all: docker-build-vertica
 
 .PHONY: docker-build-vertica
 docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
-	docker pull ubuntu:$(BASE_OS_VERSION) ## make sure we use the latest ubuntu image
+	docker pull ${BASE_OS_NAME}:$(BASE_OS_VERSION) ## make sure we use the latest base image
 	docker buildx build \
 		--load \
 		-f Dockerfile \
@@ -19,6 +20,7 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--label vertica-version=${VERTICA_VERSION} \
 		--build-arg MINIMAL=${MINIMAL_VERTICA_IMG} \
 		--build-arg VERTICA_RPM=${VERTICA_RPM} \
+		--build-arg BASE_OS_NAME=${BASE_OS_NAME} \
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
 		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -3,7 +3,8 @@
 # Copyright (c) 2021 Vertica
 #
 
-ARG BASE_OS_VERSION="lunar"
+ARG BASE_OS_NAME
+ARG BASE_OS_VERSION
 ARG BUILDER_OS_VERSION="8"
 ARG MINIMAL=""
 ARG S6_OVERLAY_VERSION=3.1.2.1
@@ -87,16 +88,54 @@ RUN set -x \
   && chmod go-w /etc/ssh/sshd_config.d/* /etc/ssh/ssh_config.d/* 
 
 ##############################################################################################
-FROM ubuntu:${BASE_OS_VERSION} as initial
+FROM ${BASE_OS_NAME}:${BASE_OS_VERSION} as initial
 
+# Controls the version of jre to be installed. The list of all available jre
+# packages can be queried through dnf. For instance, "dnf search openjdk"
+ARG JRE_PKG=java-1.8.0-openjdk-headless
+ARG MINIMAL
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
-  # Update is needed to be confident that we're picking up
-  # fixed libraries.
-  && apt-get -y update \
-  && apt-get -y upgrade \
-  && apt-get clean \
-  && apt-get autoremove \
-  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old
+  # update needed because we just did a clean
+  && yum -y check-update \
+  && yum install -y \
+  ca-certificates \
+  cronie \
+  dialog \
+  dnf-plugins-core \
+  gdb \
+  glibc-locale-source \
+  iproute-tc \
+  krb5-workstation \
+  logrotate \
+  openssh-clients \
+  openssh-server \
+  openssl \
+  procps \
+  sysstat \
+  sudo \
+  which \
+  # Install jre if not minimal
+  && if [[ ${MINIMAL^^} != "YES" ]] ; then \
+    yum install -y $JRE_PKG; \
+  fi \ 
+  && yum clean all \
+  && /bin/rm -rf /var/cache/yum \
+  # Fixes unsupported locale character encoding: use a utf8 locale, not a
+  # ANSI_X3.4-1968 locale
+  && localedef -i en_US -f UTF-8 en_US.UTF-8 \
+  # Set JAVA_HOME environment variable if not minimal, this will be loaded to all shells
+  && if [[ ${MINIMAL^^} != "YES" ]] ; then \
+    echo "JAVA_HOME=/usr" >> /etc/environment; \
+  fi \
+  # delete old host keys
+  && rm -rf /etc/ssh/ssh_host* \
+  # Permit ssh connections
+  && rm -rf /run/nologin \
+  # Create a symlink to the rsync for use with vbr. This works around a problem
+  # seen in some deployments where vbr cannot find rsync.
+  && ln -s /opt/vertica/bin/rsync /usr/bin/rsync
 
 # this squashes the image
 FROM scratch
@@ -104,11 +143,6 @@ COPY --from=initial / /
 
 ARG DBADMIN_GID=5000
 ARG DBADMIN_UID=5000
-# Controls the version of jre to be installed by apt-get. The list of all
-# available jre packages can be queried through apt-cache. For instance,
-# "apt-cache search jre | grep jre"
-ARG JRE_PKG=openjdk-8-jre-headless
-ARG MINIMAL
 ARG S6_OVERLAY_VERSION
 
 COPY --from=builder /opt/vertica /opt/vertica
@@ -119,7 +153,6 @@ COPY --from=builder /etc/ssh/sshd_config.d/* /etc/ssh/sshd_config.d/
 COPY --from=builder /etc/ssh/ssh_config.d/* /etc/ssh/ssh_config.d/
 
 ENV PATH "$PATH:/opt/vertica/bin:/opt/vertica/sbin"
-ENV DEBIAN_FRONTEND noninteractive
 
 COPY ./packages/init.d.functions /etc/rc.d/init.d/functions
 
@@ -135,58 +168,14 @@ COPY s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
-  # update needed because we just did a clean
-  && apt-get -y update \
-  && apt-get install -y --no-install-recommends \
-  vim-tiny \
-  ca-certificates \
-  cron \
-  dialog \
-  gdb \
-  iproute2 \
-  krb5-user \
-  less \
-  libkeyutils1\
-  libz-dev \
-  locales \
-  logrotate \
-  ntp \
-  openssh-client \
-  openssh-server \
-  openssl \
-  procps \
-  sysstat \
-  sudo \
-  # Install jre if not minimal
-  && if [[ ${MINIMAL^^} != "YES" ]] ; then \
-    apt-get install -y --no-install-recommends $JRE_PKG; \
-  fi \
-  && apt-get clean \
-  && apt-get autoremove \
-  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
-  # Make the "en_US.UTF-8" locale so vertica will be utf-8 enabled by default
-  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-  && mkdir -p /run/sshd \
   && /usr/sbin/groupadd -r verticadba --gid ${DBADMIN_GID} \
   && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba --uid ${DBADMIN_UID} dbadmin \
   # Allow passwordless sudo access from dbadmin
   && echo "dbadmin ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers \
   && echo "dbadmin -       nofile  65536" >> /etc/security/limits.conf \
-  # Set JAVA_HOME environment variable if not minimal, this will be loaded to all shells
-  && if [[ ${MINIMAL^^} != "YES" ]] ; then \
-    echo "JAVA_HOME=/usr" >> /etc/environment; \
-  fi \
-  # Create a symlink to python3 interpreter in vertica
-  && update-alternatives --install /usr/bin/python python /opt/vertica/oss/python3/bin/python3 1 \
-  && chmod u+s /usr/sbin/cron \
   # Untar the init program that was downloaded earlier
   && tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz \
-  && tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
-  # delete old host keys
-  && rm -rf /etc/ssh/ssh_host* \
-  # Create a symlink to the rsync for use with vbr. This works around a problem
-  # seen in some deployments where vbr cannot find rsync.
-  && ln -s /opt/vertica/bin/rsync /usr/bin/rsync
+  && tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz
 
 ENTRYPOINT [ "/init" ]
 
@@ -195,8 +184,8 @@ EXPOSE 5433
 # vertica-http port
 EXPOSE 8443
 USER dbadmin
-LABEL os-family="ubuntu"
-LABEL image-name="vertica_k8s"
+LABEL os-family="rockylinux"
+LABEL image-name="vertica-k8s"
 LABEL maintainer="K8s Team"
 LABEL org.opencontainers.image.source=https://github.com/vertica/vertica-kubernetes/tree/main/docker-vertica \
       org.opencontainers.image.title='Vertica Server' \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -108,6 +108,7 @@ RUN set -x \
   glibc-locale-source \
   iproute-tc \
   krb5-workstation \
+  libxcrypt-compat \
   logrotate \
   openssh-clients \
   openssh-server \

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -1,6 +1,7 @@
 VERTICA_RPM?=$(notdir $(wildcard packages/vertica*.rpm))
 BUILDER_OS_VERSION?=8
-BASE_OS_VERSION?=lunar
+BASE_OS_NAME?=rockylinux
+BASE_OS_VERSION?=9
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
@@ -10,7 +11,7 @@ all: docker-build-vertica
 
 .PHONY: docker-build-vertica
 docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
-	docker pull ubuntu:$(BASE_OS_VERSION) ## make sure we use the latest ubuntu image
+	docker pull ${BASE_OS_NAME}:$(BASE_OS_VERSION) ## make sure we use the latest base image
 	docker buildx build \
 		--load \
 		-f Dockerfile \
@@ -19,6 +20,7 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--label vertica-version=${VERTICA_VERSION} \
 		--build-arg MINIMAL=${MINIMAL_VERTICA_IMG} \
 		--build-arg VERTICA_RPM=${VERTICA_RPM} \
+		--build-arg BASE_OS_NAME=${BASE_OS_NAME} \
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
 		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \

--- a/docker-vertica/s6-rc.d/cron/run
+++ b/docker-vertica/s6-rc.d/cron/run
@@ -1,2 +1,2 @@
 #!/command/execlineb -P
-/usr/sbin/cron -f
+/usr/sbin/crond -n

--- a/tests/e2e-leg-3/revive-with-different-local-paths/30-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/30-assert.yaml
@@ -11,13 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: v-revive-1-main
-status:
-  replicas: 2
----
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
@@ -28,6 +21,3 @@ spec:
     depotPath: /not/sure/depot
     catalogPath: /not/sure/catalog
   shardCount: 5
-status:
-  subclusters:
-    - installCount: 2

--- a/tests/e2e-leg-6/verify-server-logrotate/08-upload-files.yaml
+++ b/tests/e2e-leg-6/verify-server-logrotate/08-upload-files.yaml
@@ -5,3 +5,6 @@ commands:
   - command: kubectl -n $NAMESPACE cp ./sql-input/logrotate.sql v-verify-server-logrotate-main-0:/tmp
   # upload the expected outputs of executing sql files
   - command: kubectl -n $NAMESPACE cp ./expected-output/logrotateTimerServiceOut.txt v-verify-server-logrotate-main-0:/tmp
+  # Install packages in the pod that are needed to run and verify the test
+  - command: kubectl -n $NAMESPACE cp setup-env-runtime.sh v-verify-server-logrotate-main-0:/tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE exec -it v-verify-server-logrotate-main-0 -- bash /tmp/setup-env-runtime.sh

--- a/tests/e2e-leg-6/verify-server-logrotate/setup-env-runtime.sh
+++ b/tests/e2e-leg-6/verify-server-logrotate/setup-env-runtime.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+
+for i in $(seq 1 5)
+do
+    # v1 images only have sudo and no root password. v2 images don't have sudo but
+    # set a hard coded password for root. This scripts works for both images.
+    if which sudo  # v1 image
+    then
+        if which apt-get # ubuntu / apt-get
+        then
+           echo "Nothing for ubuntu images"
+        else # yum package manager
+           sudo yum install -y diffutils && break || sleep 60
+        fi
+    else  # v2 image
+        if which apt-get # ubuntu / apt-get
+        then
+           echo "Nothing for ubuntu images"
+        else # yum package manager
+            echo root | su root sh -c 'yum install -y diffutils' && break || sleep 60
+        fi
+    fi
+done

--- a/tests/e2e-udx/udx-cpp/setup-env-runtime.sh
+++ b/tests/e2e-udx/udx-cpp/setup-env-runtime.sh
@@ -18,7 +18,7 @@ do
            #   library in the test-verify-cpp-filter test
            # - test-verify-cpp-apportion-load depends on python being in the
            #   container. python3 is there, so just creating a symlink.
-           sudo yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl libxcrypt-compat diffutils && ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0 && break || sleep 60
+           sudo yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl diffutils && ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0 && break || sleep 60
         fi
     else  # v2 image
         if which apt-get # ubuntu / apt-get
@@ -27,7 +27,7 @@ do
         else # yum package manager
             # The GitHub hosted runners are ubuntu, so we need to account for
             # some OS differences. See comment above to understand rationale.
-            echo root | su root sh -c 'yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl libxcrypt-compat diffutils && ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0' && break || sleep 60
+            echo root | su root sh -c 'yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl diffutils && ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0' && break || sleep 60
         fi
     fi
 done

--- a/tests/e2e-udx/udx-cpp/setup-env-runtime.sh
+++ b/tests/e2e-udx/udx-cpp/setup-env-runtime.sh
@@ -3,17 +3,31 @@
 set -o errexit
 set -o xtrace
 
-# v1 images only have sudo and no root password. v2 images don't have sudo but
-# set a hard coded password for root. This scripts works for both images.
-if which sudo  # v1 image
-then
-    for i in $(seq 1 5)
-    do
-       sudo apt-get update && sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev bzip2 && break || sleep 60
-   done
-else  # v2 image
-    for i in $(seq 1 5)
-    do
-        echo root | su root sh -c 'apt-get update && apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev bzip2' && break || sleep 60
-    done
-fi
+for i in $(seq 1 5)
+do
+    # v1 images only have sudo and no root password. v2 images don't have sudo but
+    # set a hard coded password for root. This scripts works for both images.
+    if which sudo  # v1 image
+    then
+        if which apt-get # ubuntu / apt-get
+        then
+           sudo apt-get update && sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev bzip2 perl && break || sleep 60
+        else # yum package manager
+           # The GitHub hosted runners are ubuntu, so we need to account for some OS differences.
+           # - /usr/lib64/libbz2.so.1.0 exists on ubuntu and is a shared
+           #   library in the test-verify-cpp-filter test
+           # - test-verify-cpp-apportion-load depends on python being in the
+           #   container. python3 is there, so just creating a symlink.
+           sudo yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl libxcrypt-compat diffutils && ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0 && break || sleep 60
+        fi
+    else  # v2 image
+        if which apt-get # ubuntu / apt-get
+        then
+            echo root | su root sh -c 'apt-get update && apt-get install -y libboost-all-dev libcurl4-openssl-dev libbz2-dev bzip2 perl' && break || sleep 60
+        else # yum package manager
+            # The GitHub hosted runners are ubuntu, so we need to account for
+            # some OS differences. See comment above to understand rationale.
+            echo root | su root sh -c 'yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl libxcrypt-compat diffutils && ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0' && break || sleep 60
+        fi
+    fi
+done

--- a/tests/e2e-udx/udx-cpp/setup-env-runtime.sh
+++ b/tests/e2e-udx/udx-cpp/setup-env-runtime.sh
@@ -18,7 +18,7 @@ do
            #   library in the test-verify-cpp-filter test
            # - test-verify-cpp-apportion-load depends on python being in the
            #   container. python3 is there, so just creating a symlink.
-           sudo yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl diffutils && ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0 && break || sleep 60
+           sudo yum install -y boost-devel libcurl-devel bzip2-devel bzip2 perl diffutils && sudo ln -s /usr/bin/python3 /usr/bin/python && sudo ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0 && break || sleep 60
         fi
     else  # v2 image
         if which apt-get # ubuntu / apt-get

--- a/tests/e2e-udx/udx-java/30-upload-files.yaml
+++ b/tests/e2e-udx/udx-java/30-upload-files.yaml
@@ -8,3 +8,6 @@ commands:
   - command: kubectl -n $NAMESPACE cp ../../../sdk/examples/build v-udx-java-sc1-0:/opt/vertica/sdk/examples
   # upload the expected outputs of executing sql files
   - command: kubectl -n $NAMESPACE cp ./expected-outputs v-udx-java-sc1-0:/opt/vertica/sdk/examples
+  # Install packages in the pod that are needed to run the examples.
+  - command: kubectl -n $NAMESPACE cp setup-env-runtime.sh v-udx-java-sc1-0:/tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE exec -it v-udx-java-sc1-0 -- bash /tmp/setup-env-runtime.sh

--- a/tests/e2e-udx/udx-java/setup-env-runtime.sh
+++ b/tests/e2e-udx/udx-java/setup-env-runtime.sh
@@ -13,14 +13,14 @@ do
         then
            echo "Nothing for ubuntu images"
         else # yum package manager
-           sudo yum install -y libxcrypt-compat diffutils perl && break || sleep 60
+           sudo yum install -y diffutils perl && break || sleep 60
         fi
     else  # v2 image
         if which apt-get # ubuntu / apt-get
         then
            echo "Nothing for ubuntu images"
         else # yum package manager
-            echo root | su root sh -c 'yum install -y libxcrypt-compat diffutils perl' && break || sleep 60
+            echo root | su root sh -c 'yum install -y diffutils perl' && break || sleep 60
         fi
     fi
 done

--- a/tests/e2e-udx/udx-java/setup-env-runtime.sh
+++ b/tests/e2e-udx/udx-java/setup-env-runtime.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+
+for i in $(seq 1 5)
+do
+    # v1 images only have sudo and no root password. v2 images don't have sudo but
+    # set a hard coded password for root. This scripts works for both images.
+    if which sudo  # v1 image
+    then
+        if which apt-get # ubuntu / apt-get
+        then
+           echo "Nothing for ubuntu images"
+        else # yum package manager
+           sudo yum install -y libxcrypt-compat diffutils perl && break || sleep 60
+        fi
+    else  # v2 image
+        if which apt-get # ubuntu / apt-get
+        then
+           echo "Nothing for ubuntu images"
+        else # yum package manager
+            echo root | su root sh -c 'yum install -y libxcrypt-compat diffutils perl' && break || sleep 60
+        fi
+    fi
+done

--- a/tests/e2e-udx/udx-python/30-upload-files.yaml
+++ b/tests/e2e-udx/udx-python/30-upload-files.yaml
@@ -5,3 +5,6 @@ commands:
   - command: kubectl -n $NAMESPACE exec -it v-udx-python-sc1-0 -- bash -c "echo root | su root sh -c 'chmod -R a+w /opt/vertica/sdk/examples || true'"
     ignoreFailure: true
   - command: kubectl -n $NAMESPACE cp ./expected-outputs v-udx-python-sc1-0:/opt/vertica/sdk/examples
+  # Install packages in the pod that are needed to run the examples.
+  - command: kubectl -n $NAMESPACE cp setup-env-runtime.sh v-udx-python-sc1-0:/tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE exec -it v-udx-python-sc1-0 -- bash /tmp/setup-env-runtime.sh

--- a/tests/e2e-udx/udx-python/setup-env-runtime.sh
+++ b/tests/e2e-udx/udx-python/setup-env-runtime.sh
@@ -13,14 +13,14 @@ do
         then
            echo "Nothing for ubuntu images"
         else # yum package manager
-           sudo yum install -y libxcrypt-compat diffutils perl && break || sleep 60
+           sudo yum install -y diffutils perl && break || sleep 60
         fi
     else  # v2 image
         if which apt-get # ubuntu / apt-get
         then
            echo "Nothing for ubuntu images"
         else # yum package manager
-            echo root | su root sh -c 'yum install -y libxcrypt-compat diffutils perl' && break || sleep 60
+            echo root | su root sh -c 'yum install -y diffutils perl' && break || sleep 60
         fi
     fi
 done

--- a/tests/e2e-udx/udx-python/setup-env-runtime.sh
+++ b/tests/e2e-udx/udx-python/setup-env-runtime.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+
+for i in $(seq 1 5)
+do
+    # v1 images only have sudo and no root password. v2 images don't have sudo but
+    # set a hard coded password for root. This scripts works for both images.
+    if which sudo  # v1 image
+    then
+        if which apt-get # ubuntu / apt-get
+        then
+           echo "Nothing for ubuntu images"
+        else # yum package manager
+           sudo yum install -y libxcrypt-compat diffutils perl && break || sleep 60
+        fi
+    else  # v2 image
+        if which apt-get # ubuntu / apt-get
+        then
+           echo "Nothing for ubuntu images"
+        else # yum package manager
+            echo root | su root sh -c 'yum install -y libxcrypt-compat diffutils perl' && break || sleep 60
+        fi
+    fi
+done


### PR DESCRIPTION
This switches the v1 and v2 container from being built on ubuntu to rockylinux 9. This will make it easier built custom images since RHEL based distros are more commonly used for enterprise deployments. Some e2e test updates to account for the different set of packages that was installed.