### PR TITLE
Fix restart reconciler requeue logic for vclusterops

### DIFF
--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -470,6 +470,12 @@ func getPathToVerifyCatalogExists(pf *PodFact) string {
 func (p *PodFacts) checkIsInstalled(_ context.Context, vdb *vapi.VerticaDB, pf *PodFact, gs *GatherState) error {
 	pf.isInstalled = false
 
+	// VClusterOps don't have an installed state, so we can handle that without
+	// checking if the pod is running.
+	if vmeta.UseVClusterOps(vdb.Annotations) {
+		return p.checkIsInstalledForVClusterOps(pf)
+	}
+
 	scs, ok := vdb.FindSubclusterStatus(pf.subclusterName)
 	if ok {
 		// Set the install indicator first based on the install count in the status
@@ -487,8 +493,6 @@ func (p *PodFacts) checkIsInstalled(_ context.Context, vdb *vapi.VerticaDB, pf *
 	switch {
 	case vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly:
 		return p.checkIsInstalledScheduleOnly(vdb, pf, gs)
-	case vmeta.UseVClusterOps(vdb.Annotations):
-		return p.checkIsInstalledForVClusterOps(pf)
 	default:
 		return p.checkIsInstalledForAdmintools(pf, gs)
 	}
@@ -995,14 +999,22 @@ func (p *PodFacts) countRunningAndInstalled() int {
 	})
 }
 
-// countInstalledAndNotRestartable returns number of installed pods that aren't yet restartable
-func (p *PodFacts) countInstalledAndNotRestartable() int {
+// countNonRunningPodsNeededByRestart returns number of pods that aren't yet
+// running but the restart reconciler needs to handle them.
+func (p *PodFacts) countNonRunningPodsNeededByRestart(vclusterOps bool) int {
 	return p.countPods(func(v *PodFact) int {
-		// We don't count non-running pods that aren't yet managed by the parent
-		// sts.  The sts needs to be created or sized first.
-		// We need the pod to have the DC table annotations since the DC
+		// Non-restartable pods are pods that aren't yet running, or don't have
+		// the necesseary DC table annotations, but need to be handled by the
+		// restart reconciler. A couple of notes about certain edge cases:
+		// - We don't count pods that aren't yet managed by the parent sts. The
+		// sts needs to be created or sized first.
+		// - We need the pod to have the DC table annotations since the DC
 		// collection is done at start, so these need to set prior to starting.
-		if v.isInstalled && v.managedByParent && (!v.isPodRunning || !v.hasDCTableAnnotations) {
+		// - We check install state only for admintools deployments because
+		// installed pods are in admintools.conf and need the restart reconciler
+		// to update its IP.
+		if ((!vclusterOps && v.isInstalled) || v.dbExists) && v.managedByParent &&
+			(!v.isPodRunning || !v.hasDCTableAnnotations) {
 			return 1
 		}
 		return 0

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -999,12 +999,12 @@ func (p *PodFacts) countRunningAndInstalled() int {
 	})
 }
 
-// countNonRunningPodsNeededByRestart returns number of pods that aren't yet
+// countNotRestartablePods returns number of pods that aren't yet
 // running but the restart reconciler needs to handle them.
-func (p *PodFacts) countNonRunningPodsNeededByRestart(vclusterOps bool) int {
+func (p *PodFacts) countNotRestartablePods(vclusterOps bool) int {
 	return p.countPods(func(v *PodFact) int {
 		// Non-restartable pods are pods that aren't yet running, or don't have
-		// the necesseary DC table annotations, but need to be handled by the
+		// the necessary DC table annotations, but need to be handled by the
 		// restart reconciler. A couple of notes about certain edge cases:
 		// - We don't count pods that aren't yet managed by the parent sts. The
 		// sts needs to be created or sized first.

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -147,7 +147,7 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 	}
 	// Check if cluster start needs to include all of the pods.
 	if r.Vdb.IsKSafety0() &&
-		r.PFacts.countNonRunningPodsNeededByRestart(vmeta.UseVClusterOps(r.Vdb.Annotations)) > 0 {
+		r.PFacts.countNotRestartablePods(vmeta.UseVClusterOps(r.Vdb.Annotations)) > 0 {
 		// For k-safety 0, we need all of the pods because the absence of one
 		// will cause us not to have enough pods for cluster quorum.
 		r.Log.Info("Waiting for all installed pods to be running before attempt a cluster restart")
@@ -616,7 +616,7 @@ func (r *RestartReconciler) setInitiatorPod(findFunc func() (*PodFact, bool)) bo
 // whether a requeue of the reconcile is necessary because some pods are not yet
 // running.
 func (r *RestartReconciler) shouldRequeueIfPodsNotRunning() bool {
-	if r.PFacts.countNonRunningPodsNeededByRestart(vmeta.UseVClusterOps(r.Vdb.Annotations)) > 0 {
+	if r.PFacts.countNotRestartablePods(vmeta.UseVClusterOps(r.Vdb.Annotations)) > 0 {
 		r.Log.Info("Requeue since some pods needed by restart are not yet running.")
 		return true
 	}


### PR DESCRIPTION
This is to fix intermittent failures in the pending-pod e2e testcase when run in vclusterops mode. The restart reconciler needs to requeue if pods that it needs aren't running. We were too aggressive with vclusterops because we triggered on installed state, which may or may set correctly. This changes the check for vclusterops and only looks at dbExists state. It also correctly sets the installed state for vclusterops in all cases.