### PR TITLE
Online upgrade to account for terminating pods

### DIFF
--- a/changes/unreleased/Fixed-20231213-101202.yaml
+++ b/changes/unreleased/Fixed-20231213-101202.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Online upgrade to account for terminating pods
+time: 2023-12-13T10:12:02.33874853-04:00
+custom:
+  Issue: "633"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -553,7 +553,7 @@ func buildDepotVolume() corev1.Volume {
 
 // buildPodSpec creates a PodSpec for the statefulset
 func buildPodSpec(vdb *vapi.VerticaDB, sc *vapi.Subcluster) corev1.PodSpec {
-	termGracePeriod := int64(0)
+	termGracePeriod := int64(vmeta.GetTerminationGracePeriodSeconds(vdb.Annotations))
 	return corev1.PodSpec{
 		NodeSelector:                  sc.NodeSelector,
 		Affinity:                      GetK8sAffinity(sc.Affinity),

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler.go
@@ -111,7 +111,7 @@ func (c *ClientRoutingLabelReconciler) reconcilePod(ctx context.Context, pn type
 			return err
 		}
 
-		if c.ApplyMethod == AddNodeApplyMethod && c.Vdb.IsEON() && pf.upNode && pf.shardSubscriptions == 0 && !pf.pendingDelete {
+		if c.ApplyMethod == AddNodeApplyMethod && c.Vdb.IsEON() && pf.upNode && pf.shardSubscriptions == 0 && !pf.isPendingDelete {
 			c.Log.Info("Will requeue reconciliation because pod does not have any shard subscriptions yet", "name", pf.name)
 			res.Requeue = true
 		}
@@ -141,13 +141,13 @@ func (c *ClientRoutingLabelReconciler) manipulateRoutingLabelInPod(pod *corev1.P
 	// entire subcluster, so pending delete isn't checked.
 	switch c.ApplyMethod {
 	case AddNodeApplyMethod, PodRescheduleApplyMethod:
-		if !labelExists && pf.upNode && (pf.shardSubscriptions > 0 || !c.Vdb.IsEON()) && !pf.pendingDelete {
+		if !labelExists && pf.upNode && (pf.shardSubscriptions > 0 || !c.Vdb.IsEON()) && !pf.isPendingDelete {
 			pod.Labels[vmeta.ClientRoutingLabel] = vmeta.ClientRoutingVal
 			c.Log.Info("Adding client routing label", "pod",
 				pod.Name, "label", fmt.Sprintf("%s=%s", vmeta.ClientRoutingLabel, vmeta.ClientRoutingVal))
 		}
 	case DelNodeApplyMethod:
-		if labelExists && pf.pendingDelete {
+		if labelExists && pf.isPendingDelete {
 			delete(pod.Labels, vmeta.ClientRoutingLabel)
 			c.Log.Info("Removing client routing label", "pod",
 				pod.Name, "label", fmt.Sprintf("%s=%s", vmeta.ClientRoutingLabel, vmeta.ClientRoutingVal))

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
@@ -152,7 +152,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		Expect(ok).Should(BeTrue())
 		Expect(v).Should(Equal(vmeta.ClientRoutingVal))
 
-		pfacts.Detail[pn].pendingDelete = true
+		pfacts.Detail[pn].isPendingDelete = true
 		r.ApplyMethod = DelNodeApplyMethod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 

--- a/pkg/controllers/vdb/drainnode_reconciler.go
+++ b/pkg/controllers/vdb/drainnode_reconciler.go
@@ -57,7 +57,7 @@ func (s *DrainNodeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (c
 	// Note: this reconciler depends on the clien routing reconciler to have run
 	// and directed traffic away from pending delete pods.
 	for _, pf := range s.PFacts.Detail {
-		if pf.pendingDelete && pf.upNode {
+		if pf.isPendingDelete && pf.upNode {
 			if res, err := s.reconcilePod(ctx, pf); verrors.IsReconcileAborted(res, err) {
 				return res, err
 			}

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -69,9 +69,9 @@ type PodFact struct {
 	// true means the pod exists in k8s.  false means it hasn't been created yet.
 	exists bool
 
-	// true means the pod has been bound to a node, and all of the containers
-	// have been created. At least one container is still running, or is in the
-	// process of starting or restarting.
+	// true means the pod has been bound to a node, not in the process of being
+	// process, and all of the containers have been created. At least one
+	// container is still running, or is in the process of starting or restarting.
 	isPodRunning bool
 
 	// true means the statefulset exists and its size includes this pod.  The
@@ -84,7 +84,11 @@ type PodFact struct {
 	// exists and is managed by a statefulset.  The pod is pending delete in
 	// that once the statefulset is sized according to the subcluster the pod
 	// will get deleted.
-	pendingDelete bool
+	isPendingDelete bool
+
+	// true means a delete request has been made to delete the pod, but it is
+	// still running.
+	isTerminating bool
 
 	// Have we run install for this pod?
 	isInstalled bool
@@ -305,11 +309,16 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		// The remaining fields we set in this block only make sense when the
 		// pod exists.
 		pf.exists = true // Success from the Get() implies pod exists in API server
-		pf.isPodRunning = pod.Status.Phase == corev1.PodRunning
+		pf.isTerminating = pod.DeletionTimestamp != nil
+		// We don't consider a pod running if it is in the middle of being
+		// terminated. Technically, the pod is running, but it is seconds away
+		// from being deleted. So, it doesn't make sense to exec into the pod to
+		// perform actions.
+		pf.isPodRunning = pod.Status.Phase == corev1.PodRunning && !pf.isTerminating
 		pf.dnsName = fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.Namespace)
 		pf.podIP = pod.Status.PodIP
 		pf.isTransient, _ = strconv.ParseBool(pod.Labels[vmeta.SubclusterTransientLabel])
-		pf.pendingDelete = podIndex >= sc.Size
+		pf.isPendingDelete = podIndex >= sc.Size
 		pf.image = pod.Spec.Containers[ServerContainerIndex].Image
 		pf.hasDCTableAnnotations = p.checkDCTableAnnotations(pod)
 		pf.catalogPath = p.getCatalogPathFromPod(vdb, pod)
@@ -339,6 +348,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		}
 	}
 
+	p.VRec.Log.Info("pod fact", "name", pf.name, "details", fmt.Sprintf("%+v", pf))
 	p.Detail[pf.name] = &pf
 	return nil
 }
@@ -845,7 +855,7 @@ func (p *PodFacts) findPodToRunAdminCmdAny() (*PodFact, bool) {
 	// - up and read-only
 	// - has vertica installation
 	if pod, ok := p.findFirstPodSorted(func(v *PodFact) bool {
-		return v.upNode && !v.readOnly && !v.pendingDelete
+		return v.upNode && !v.readOnly && !v.isPendingDelete
 	}); ok {
 		return pod, ok
 	}

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -69,9 +69,12 @@ type PodFact struct {
 	// true means the pod exists in k8s.  false means it hasn't been created yet.
 	exists bool
 
-	// true means the pod has been bound to a node, not in the process of being
-	// process, and all of the containers have been created. At least one
-	// container is still running, or is in the process of starting or restarting.
+	// True indicates that the pod has been:
+	// - Bound to a node
+	// - Not in the process of being terminated
+	// - All of its containers have been created
+	// - At least one container is still running, or is in the process of
+	//   starting or restarting
 	isPodRunning bool
 
 	// true means the statefulset exists and its size includes this pod.  The

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -316,13 +316,13 @@ var _ = Describe("podfacts", func() {
 		By("finding up, not read-only and not pending delete")
 		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
-			dnsName: "p1", dbExists: true, upNode: true, readOnly: false, pendingDelete: true,
+			dnsName: "p1", dbExists: true, upNode: true, readOnly: false, isPendingDelete: true,
 		}
 		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
-			dnsName: "p2", dbExists: true, upNode: true, readOnly: true, pendingDelete: false,
+			dnsName: "p2", dbExists: true, upNode: true, readOnly: true, isPendingDelete: false,
 		}
 		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
-			dnsName: "p3", dbExists: true, upNode: true, readOnly: false, pendingDelete: false,
+			dnsName: "p3", dbExists: true, upNode: true, readOnly: false, isPendingDelete: false,
 		}
 		p, ok := pf.findPodToRunAdminCmdAny()
 		Expect(ok).Should(BeTrue())

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -140,6 +140,9 @@ const (
 	// annotation is not provided the default value "dbadmin" will be used.
 	SuperuserNameAnnotation   = "vertica.com/superuser-name"
 	SuperuserNameDefaultValue = "dbadmin"
+
+	// Annotation to control the termination grace period for vertica pods.
+	TerminationGracePeriodSecondsAnnotaton = "vertica.com/termination-grace-period-seconds"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -224,6 +227,13 @@ func GetSuperuserName(annotations map[string]string) string {
 // in the cluster.
 func IsKSafetyCheckStrict(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, StrictKSafetyCheckAnnotation, true /* default value */)
+}
+
+// GetTerminationGracePeriodSeconds returns the value we will use for
+// termination grace period in vertica pods. This is the amount of time k8s will
+// wait before forcibly removing the pod.
+func GetTerminationGracePeriodSeconds(annotations map[string]string) int {
+	return lookupIntAnnotation(annotations, TerminationGracePeriodSecondsAnnotaton)
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/setup-vdb/base/setup-vdb.yaml
@@ -15,6 +15,8 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-base-upgrade
+  annotations:
+    vertica.com/termination-grace-period-seconds: "10"
 spec:
   image: kustomize-vertica-image
   communal:


### PR DESCRIPTION
The controller was not handling terminating pods correctly. This could lead to problems during online upgrades, such as not properly restarting primaries before taking down secondaries.

The issue occurs when the operator deletes pods with the old image. If the pod is still running immediately after the deletion, the operator may skip the restart and move on to the next phase of the upgrade. This is a small window because the termination grace period is 0 seconds, but we still see it occasionally in the e2e runs.

To test this issue, I added a new annotation (vertica.com/termination-grace-period-seconds) that makes it easier to hit this timing scenario. This annotation causes the pod to be in the termination step for a longer period of time.

The solution was to check for pod termination in podfacts and treat the pod as not running if it is set.