### PR TITLE
Fix upgrades across deployments when ignoring upgrade paths

### DIFF
--- a/changes/unreleased/Fixed-20231220-093626.yaml
+++ b/changes/unreleased/Fixed-20231220-093626.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Allow upgrades across deployments when ignoring upgrade paths
+time: 2023-12-20T09:36:26.291743925-04:00
+custom:
+  Issue: "644"

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -486,6 +487,51 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		routingSc = r.getSubclusterForTemporaryRouting(ctx, &vdb.Spec.Subclusters[1], scMap)
 		Expect(routingSc.Name).Should(Equal(PriScName))
 	})
+
+	It("should delete old STS of secondary if online upgrade and changing deployments", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "sc1", Type: vapi.PrimarySubcluster, Size: 1},
+			{Name: "sc2", Type: vapi.SecondarySubcluster, Size: 1},
+		}
+		vdb.Spec.Image = OldImage
+		vdb.Spec.UpgradePolicy = vapi.OnlineUpgrade
+		vdb.ObjectMeta.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationFalse
+		vdb.ObjectMeta.Annotations[vmeta.IgnoreUpgradePathAnnotation] = vmeta.IgnoreUpgradePathAnntationTrue
+
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		// Verify we created the sts for the secondary
+		sts := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[1]), sts)).Should(Succeed())
+
+		// Trigger an upgrade and change the deployment type to vclusterops
+		vdb.Spec.Image = NewImageName
+		vdb.ObjectMeta.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationTrue
+		Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		r := createOnlineUpgradeReconciler(ctx, vdb)
+
+		// Setup the podfacts so that primary is down with new image and
+		// secondary is up with old image.
+		ppn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		r.PFacts.Detail[ppn].admintoolsExists = false
+		r.PFacts.Detail[ppn].upNode = false
+		spn := names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0)
+		r.PFacts.Detail[spn].admintoolsExists = true
+		r.PFacts.Detail[spn].upNode = true
+
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+
+		// Verify reconciler deleted the old sts
+		err := k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[1]), sts)
+		Expect(err).ShouldNot(Succeed())
+		Expect(errors.IsNotFound(err)).Should(BeTrue())
+	})
+
 })
 
 // createOnlineUpgradeReconciler is a helper to run the OnlineUpgradeReconciler.

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -74,7 +74,9 @@ const (
 	// vertica version that we follow the upgrade path.  The Vertica upgrade
 	// path means you cannot downgrade a Vertica release, nor can you skip any
 	// released Vertica versions when upgrading.
-	IgnoreUpgradePathAnnotation = "vertica.com/ignore-upgrade-path"
+	IgnoreUpgradePathAnnotation     = "vertica.com/ignore-upgrade-path"
+	IgnoreUpgradePathAnntationTrue  = "true"
+	IgnoreUpgradePathAnntationFalse = "false"
 
 	// The timeout, in seconds, to use when the operator restarts a node or the
 	// entire cluster.  If omitted, we use the default timeout of 20 minutes.


### PR DESCRIPTION
In a previous change, we transition from an online to an offline upgrade if you attempt do to an upgrade across deployments. Across deployments means you are changing from admintools to vclusterops.  The original fix worked, but we mistakenly bypass it if we are also ignoring upgrade paths. This change ensures we handle things properly if also ignoring upgrade paths.