### PR TITLE
Generate prometheus_metrics_latest.json

### DIFF
--- a/prometheus_metrics_latest.json
+++ b/prometheus_metrics_latest.json
@@ -1,0 +1,306 @@
+{
+    "generatedWith": "parse_prometheus_metrics.py",
+    "info": "Recreate by extracting output in kuttl test 'kubectl test --test metrics-no-auth'",
+    "metrics": [
+        {
+            "description": "Number of currently used workers per controller",
+            "name": "controller_runtime_active_workers",
+            "type": "gauge"
+        },
+        {
+            "description": "Maximum number of concurrent reconciles per controller",
+            "name": "controller_runtime_max_concurrent_reconciles",
+            "type": "gauge"
+        },
+        {
+            "description": "Total number of reconciliation errors per controller",
+            "name": "controller_runtime_reconcile_errors_total",
+            "type": "counter"
+        },
+        {
+            "description": "Length of time per reconciliation per controller",
+            "name": "controller_runtime_reconcile_time_seconds",
+            "type": "histogram"
+        },
+        {
+            "description": "Total number of reconciliations per controller",
+            "name": "controller_runtime_reconcile_total",
+            "type": "counter"
+        },
+        {
+            "description": "Histogram of the latency of processing admission requests",
+            "name": "controller_runtime_webhook_latency_seconds",
+            "type": "histogram"
+        },
+        {
+            "description": "Current number of admission requests being served.",
+            "name": "controller_runtime_webhook_requests_in_flight",
+            "type": "gauge"
+        },
+        {
+            "description": "Total number of admission requests by HTTP status code.",
+            "name": "controller_runtime_webhook_requests_total",
+            "type": "counter"
+        },
+        {
+            "description": "A summary of the pause duration of garbage collection cycles.",
+            "name": "go_gc_duration_seconds",
+            "type": "summary"
+        },
+        {
+            "description": "Number of goroutines that currently exist.",
+            "name": "go_goroutines",
+            "type": "gauge"
+        },
+        {
+            "description": "Information about the Go environment.",
+            "name": "go_info",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes allocated and still in use.",
+            "name": "go_memstats_alloc_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Total number of bytes allocated, even if freed.",
+            "name": "go_memstats_alloc_bytes_total",
+            "type": "counter"
+        },
+        {
+            "description": "Number of bytes used by the profiling bucket hash table.",
+            "name": "go_memstats_buck_hash_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Total number of frees.",
+            "name": "go_memstats_frees_total",
+            "type": "counter"
+        },
+        {
+            "description": "Number of bytes used for garbage collection system metadata.",
+            "name": "go_memstats_gc_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of heap bytes allocated and still in use.",
+            "name": "go_memstats_heap_alloc_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of heap bytes waiting to be used.",
+            "name": "go_memstats_heap_idle_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of heap bytes that are in use.",
+            "name": "go_memstats_heap_inuse_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of allocated objects.",
+            "name": "go_memstats_heap_objects",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of heap bytes released to OS.",
+            "name": "go_memstats_heap_released_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of heap bytes obtained from system.",
+            "name": "go_memstats_heap_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of seconds since 1970 of last garbage collection.",
+            "name": "go_memstats_last_gc_time_seconds",
+            "type": "gauge"
+        },
+        {
+            "description": "Total number of pointer lookups.",
+            "name": "go_memstats_lookups_total",
+            "type": "counter"
+        },
+        {
+            "description": "Total number of mallocs.",
+            "name": "go_memstats_mallocs_total",
+            "type": "counter"
+        },
+        {
+            "description": "Number of bytes in use by mcache structures.",
+            "name": "go_memstats_mcache_inuse_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes used for mcache structures obtained from system.",
+            "name": "go_memstats_mcache_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes in use by mspan structures.",
+            "name": "go_memstats_mspan_inuse_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes used for mspan structures obtained from system.",
+            "name": "go_memstats_mspan_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of heap bytes when next garbage collection will take place.",
+            "name": "go_memstats_next_gc_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes used for other system allocations.",
+            "name": "go_memstats_other_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes in use by the stack allocator.",
+            "name": "go_memstats_stack_inuse_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes obtained from system for stack allocator.",
+            "name": "go_memstats_stack_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of bytes obtained from system.",
+            "name": "go_memstats_sys_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of OS threads created.",
+            "name": "go_threads",
+            "type": "gauge"
+        },
+        {
+            "description": "Total user and system CPU time spent in seconds.",
+            "name": "process_cpu_seconds_total",
+            "type": "counter"
+        },
+        {
+            "description": "Maximum number of open file descriptors.",
+            "name": "process_max_fds",
+            "type": "gauge"
+        },
+        {
+            "description": "Number of open file descriptors.",
+            "name": "process_open_fds",
+            "type": "gauge"
+        },
+        {
+            "description": "Resident memory size in bytes.",
+            "name": "process_resident_memory_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Start time of the process since unix epoch in seconds.",
+            "name": "process_start_time_seconds",
+            "type": "gauge"
+        },
+        {
+            "description": "Virtual memory size in bytes.",
+            "name": "process_virtual_memory_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "Maximum amount of virtual memory available in bytes.",
+            "name": "process_virtual_memory_max_bytes",
+            "type": "gauge"
+        },
+        {
+            "description": "The number of times we attempted a full cluster restart",
+            "name": "vertica_cluster_restart_attempted_total",
+            "type": "counter"
+        },
+        {
+            "description": "The number of times we failed when attempting a full cluster restart",
+            "name": "vertica_cluster_restart_failed_total",
+            "type": "counter"
+        },
+        {
+            "description": "The number of seconds it took to do a full cluster restart",
+            "name": "vertica_cluster_restart_seconds",
+            "type": "histogram"
+        },
+        {
+            "description": "The number of times we attempted to restart down nodes",
+            "name": "vertica_nodes_restart_attempted_total",
+            "type": "counter"
+        },
+        {
+            "description": "The number of times we failed when trying to restart down nodes",
+            "name": "vertica_nodes_restart_failed_total",
+            "type": "counter"
+        },
+        {
+            "description": "The number of seconds it took to restart down nodes",
+            "name": "vertica_nodes_restart_seconds",
+            "type": "histogram"
+        },
+        {
+            "description": "The number of nodes that have a running pod associated with it",
+            "name": "vertica_running_nodes_count",
+            "type": "gauge"
+        },
+        {
+            "description": "The number of subclusters that exist",
+            "name": "vertica_subclusters_count",
+            "type": "gauge"
+        },
+        {
+            "description": "The number of nodes that currently exist",
+            "name": "vertica_total_nodes_count",
+            "type": "gauge"
+        },
+        {
+            "description": "The number of nodes that have vertica running and can accept connections",
+            "name": "vertica_up_nodes_count",
+            "type": "gauge"
+        },
+        {
+            "description": "The number of times the operator performed an upgrade caused by an image change",
+            "name": "vertica_upgrade_total",
+            "type": "counter"
+        },
+        {
+            "description": "Total number of adds handled by workqueue",
+            "name": "workqueue_adds_total",
+            "type": "counter"
+        },
+        {
+            "description": "Current depth of workqueue",
+            "name": "workqueue_depth",
+            "type": "gauge"
+        },
+        {
+            "description": "How many seconds has the longest running processor for workqueue been running.",
+            "name": "workqueue_longest_running_processor_seconds",
+            "type": "gauge"
+        },
+        {
+            "description": "How long in seconds an item stays in workqueue before being requested",
+            "name": "workqueue_queue_duration_seconds",
+            "type": "histogram"
+        },
+        {
+            "description": "Total number of retries handled by workqueue",
+            "name": "workqueue_retries_total",
+            "type": "counter"
+        },
+        {
+            "description": "How many seconds of work has been done that is in progress and hasn't been observed by work_duration. Large values indicate stuck threads. One can deduce the number of stuck threads by observing the rate at which this increases.",
+            "name": "workqueue_unfinished_work_seconds",
+            "type": "gauge"
+        },
+        {
+            "description": "How long in seconds processing an item from workqueue takes.",
+            "name": "workqueue_work_duration_seconds",
+            "type": "histogram"
+        }
+    ]
+}

--- a/scripts/parse_prometheus_metrics.py
+++ b/scripts/parse_prometheus_metrics.py
@@ -1,0 +1,54 @@
+# This script is used to parse Prometheus formatted text and generating a JSON
+# document with all of the metrics included. This file is then stored in the
+# repo and can be used to figure out what metrics exist without having to setup
+# a running instance.
+
+import argparse
+import json
+import re
+import os
+
+
+def setup_for_metric(metrics, metric_name):
+    if metric_name not in metrics:
+        metrics[metric_name] = {"name": metric_name}
+
+
+def parse_metrics(ip_file):
+    metric_help_re = re.compile(r"^# HELP ([\w]+) (.+)")
+    metric_type_re = re.compile(r"^# TYPE ([\w]+) (\w+)")
+
+    metrics = {}
+    with open(ip_file, 'r') as f:
+        for ln in f:
+            help_match = metric_help_re.match(ln)
+            if help_match:
+                setup_for_metric(metrics, help_match.group(1))
+                metrics[help_match.group(1)]["description"] = help_match.group(2)
+            type_match = metric_type_re.match(ln)
+            if type_match:
+                setup_for_metric(metrics, type_match.group(1))
+                metrics[type_match.group(1)]["type"] = type_match.group(2)
+
+    # Convert dict to list then sort by name as we want a consistent order
+    metrics = list(metrics.values()) 
+    metrics.sort(key=lambda m: m['name'])
+    # Pretty print the metrics in json so that it can be consumed by other
+    # scripts
+    j = {"generatedWith": os.path.basename(__file__),
+         "info": "Recreate using 'make http_test'",
+         "metrics": metrics}
+    print(json.dumps(j, sort_keys=True, indent=4))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog="parse_prometheus_metrics.py",
+        description="construct a JSON document of all of the prometheus "
+                    "metrics passed in")
+    parser.add_argument(
+        "filename",
+        help="The name of a file with Prometheus metrics. Must be in the "
+             "text-based Prometheus exposition format")
+    args = parser.parse_args()
+    parse_metrics(args.filename)

--- a/tests/e2e-leg-5/metrics-no-auth/15-setup-repo-cm.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/15-setup-repo-cm.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create configmap repo-contents --from-file=parse_prometheus_metrics.py=parse_prometheus_metrics.py --from-file=prometheus_metrics_latest.json=../../../prometheus_metrics_latest.json
+    namespaced: true

--- a/tests/e2e-leg-5/metrics-no-auth/20-assert.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/20-assert.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-metrics-no-auth

--- a/tests/e2e-leg-5/metrics-no-auth/20-setup-vdb.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/20-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-5/metrics-no-auth/25-wait-for-createdb.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/25-wait-for-createdb.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl wait --for=condition=DBInitialized=True vdb/v-metrics-no-auth --timeout=600s
+    namespaced: true

--- a/tests/e2e-leg-5/metrics-no-auth/30-assert.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/30-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-dump-metrics
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e-leg-5/metrics-no-auth/30-compare-metric-output.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/30-compare-metric-output.yaml
@@ -1,0 +1,65 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This will validate that prometheus_metrics_latest.json in the repo has the
+# latest metric information. Doc writers uses this file to help generate the
+# external docs. Anytime a new metric is added, we need to ensure
+# prometheus_metrics_latest.json. This test helps verify that part.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-dump-metrics
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+
+    set -o xtrace
+    set -o errexit
+    set -o pipefail
+
+    RAW_METRICS=/tmp/raw-metrics.txt
+    curl http://verticadb-operator-metrics-service:8443/metrics | tee $RAW_METRICS
+    FMT_METRICS=/tmp/fmt-metrics.json
+    python3 /repo/parse_prometheus_metrics.py $RAW_METRICS | tee $FMT_METRICS
+    diff -U2 /repo/prometheus_metrics_latest.json $FMT_METRICS
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-dump-metrics
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: quay.io/helmpack/chart-testing:v3.3.1
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+        - name: repo-contents
+          mountPath: /repo
+          readOnly: true
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-dump-metrics
+    - name: repo-contents
+      configMap:
+        name: repo-contents

--- a/tests/e2e-leg-5/metrics-no-auth/80-delete-cr.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/80-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-5/metrics-no-auth/80-errors.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/80-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-5/metrics-no-auth/85-assert.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/85-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-5/metrics-no-auth/85-cleanup-storage.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/85-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-5/metrics-no-auth/85-errors.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/85-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-5/metrics-no-auth/parse_prometheus_metrics.py
+++ b/tests/e2e-leg-5/metrics-no-auth/parse_prometheus_metrics.py
@@ -1,0 +1,76 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to parse Prometheus formatted text and generating a JSON
+# document with all of the metrics included. This file is then stored in the
+# repo and can be used to figure out what metrics exist without having to setup
+# a running instance.
+
+import argparse
+import json
+import re
+import os
+
+
+def setup_for_metric(metrics, metric_name):
+    if metric_name not in metrics:
+        metrics[metric_name] = {"name": metric_name}
+
+
+def include_metric(metric_name):
+    ignore_metrics = ["certwatcher_", "rest_", "leader_"]
+    for m in ignore_metrics:
+        if metric_name.startswith(m):
+            return False
+    return True
+
+
+def parse_metrics(ip_file):
+    metric_help_re = re.compile(r"^# HELP ([\w]+) (.+)")
+    metric_type_re = re.compile(r"^# TYPE ([\w]+) (\w+)")
+
+    metrics = {}
+    with open(ip_file, 'r') as f:
+        for ln in f:
+            help_match = metric_help_re.match(ln)
+            if help_match and include_metric(help_match.group(1)):
+                setup_for_metric(metrics, help_match.group(1))
+                metrics[help_match.group(1)]["description"] = help_match.group(2)
+            type_match = metric_type_re.match(ln)
+            if type_match and include_metric(type_match.group(1)):
+                setup_for_metric(metrics, type_match.group(1))
+                metrics[type_match.group(1)]["type"] = type_match.group(2)
+
+    # Convert dict to list then sort by name as we want a consistent order
+    metrics = list(metrics.values())
+    metrics.sort(key=lambda m: m['name'])
+    # Pretty print the metrics in json so that it can be consumed by other
+    # scripts
+    j = {"generatedWith": os.path.basename(__file__),
+         "info": "Recreate by extracting output in kuttl test " +
+         "'kubectl test --test metrics-no-auth'",
+         "metrics": metrics}
+    print(json.dumps(j, sort_keys=True, indent=4))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog="parse_prometheus_metrics.py",
+        description="construct a JSON document of all of the prometheus "
+                    "metrics passed in")
+    parser.add_argument(
+        "filename",
+        help="The name of a file with Prometheus metrics. Must be in the "
+             "text-based Prometheus exposition format")
+    args = parser.parse_args()
+    parse_metrics(args.filename)

--- a/tests/e2e-leg-5/metrics-no-auth/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-5/metrics-no-auth/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,34 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-metrics-no-auth
+  annotations:
+    vertica.com/k-safety: "0"
+    vertica.com/include-uid-in-path: "true"
+spec:
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  dbName: metricsnoauth
+  communal: {}
+  local:
+    requestSize: 100Mi
+  subclusters:
+    - name: s_c
+      size: 1
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
This adds a file to the repo called prometheus_metrics_latest.json. It is a summary of all of the metrics exposed by the operator. The purpose of this file is for doc writers to use it to include details about the metrics found in the operator.

There is an e2e test (metrics-no-auth) that will ensure this file stays up to date.

@rs-vertica I included some metrics in the json that the operator inherits from the SDK. Here is some more detail about those metrics here: https://book.kubebuilder.io/reference/metrics-reference. It looks like it is just a summary of the help text. I can omit those and just include the ones we add. We don't have any control over the help text. So, if the ones we inherit have any spelling and/or grammatical errors then we would need to manually fix them. Let me know if you want me to omit some.