### PR TITLE
Fix CVE-2023-48795

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,8 @@ OLM_TEST_CATALOG_SOURCE=e2e-test-catalog
 # Name of the namespace to deploy the operator in
 NAMESPACE?=verticadb-operator
 
+# The Go version that we will build the operator with
+GO_VERSION?=1.20
 GOPATH?=${HOME}/go
 TMPDIR?=$(PWD)
 HELM_UNITTEST_VERSION?=3.9.3-0.2.11
@@ -320,7 +322,12 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build-operator
 docker-build-operator: manifests generate fmt vet ## Build operator docker image with the manager.
-	docker buildx build --tag ${OPERATOR_IMG} --load -f docker-operator/Dockerfile .
+	docker pull golang:${GO_VERSION} # Ensure we have the latest Go lang version
+	docker buildx build \
+		--tag ${OPERATOR_IMG} \
+		--load \
+		--build-arg GO_VERSION=${GO_VERSION} \
+		-f docker-operator/Dockerfile .
 
 .PHONY: docker-build-vlogger
 docker-build-vlogger:  ## Build vertica logger docker image

--- a/changes/unreleased/Security-20231220-172216.yaml
+++ b/changes/unreleased/Security-20231220-172216.yaml
@@ -1,0 +1,5 @@
+kind: Security
+body: Fix for CVE-2023-48795
+time: 2023-12-20T17:22:16.849604885-04:00
+custom:
+  Issue: "646"

--- a/docker-operator/Dockerfile
+++ b/docker-operator/Dockerfile
@@ -1,5 +1,6 @@
-# Build the manager binary
-FROM golang:1.20 as builder
+# Build the manager binary.
+ARG GO_VERSION
+FROM golang:${GO_VERSION} as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	golang.org/x/crypto v0.16.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
-golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
This uplifts a package that the operator uses to resolve the [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) vulnerability.