### PR TITLE
Fixes for flaky tests

### DIFF
--- a/pkg/secrets/client.go
+++ b/pkg/secrets/client.go
@@ -77,3 +77,24 @@ func (s *StandardK8sClient) loadClientSet() error {
 	s.Clientset, err = kubernetes.NewForConfig(s.Config)
 	return err
 }
+
+func (s *StandardK8sClient) createNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
+	if err := s.loadClientSet(); err != nil {
+		return nil, err
+	}
+	nmClient := s.Clientset.CoreV1().Namespaces()
+	namespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	return nmClient.Create(ctx, &namespace, metav1.CreateOptions{})
+}
+
+func (s *StandardK8sClient) deleteNamespace(ctx context.Context, name string) error {
+	if err := s.loadClientSet(); err != nil {
+		return err
+	}
+	nmClient := s.Clientset.CoreV1().Namespaces()
+	return nmClient.Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/pkg/secrets/fetcher_test.go
+++ b/pkg/secrets/fetcher_test.go
@@ -30,7 +30,12 @@ var _ = Describe("secrets/fetcher", func() {
 	ctx := context.Background()
 
 	It("should read secret from k8s", func() {
-		const SecretNamespace = "default"
+		const SecretNamespace = "my-secret"
+		k8sClient := makeStandardK8sClient()
+		_, err := k8sClient.createNamespace(ctx, SecretNamespace)
+		Ω(err).Should(Succeed())
+		defer func() { Ω(k8sClient.deleteNamespace(ctx, SecretNamespace)) }()
+
 		const SecretName = "secret-1"
 		const SecretContent = "supersecret"
 		secret := corev1.Secret{
@@ -46,8 +51,7 @@ var _ = Describe("secrets/fetcher", func() {
 			Name:      SecretName,
 			Namespace: SecretNamespace,
 		}
-		k8sClient := makeStandardK8sClient()
-		_, err := k8sClient.CreateSecret(ctx, nm, &secret)
+		_, err = k8sClient.CreateSecret(ctx, nm, &secret)
 		Ω(err).Should(Succeed())
 		defer func() { Ω(k8sClient.DeleteSecret(ctx, nm)).Should(Succeed()) }()
 		fetcher := MultiSourceSecretFetcher{

--- a/tests/e2e-leg-1/crash-before-createdb/10-assert.yaml
+++ b/tests/e2e-leg-1/crash-before-createdb/10-assert.yaml
@@ -10,16 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
-metadata:
-  name: v-crash-before-createdb
-status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 0
-      upNodeCount: 0
----
 apiVersion: v1
 kind: Pod
 metadata:

--- a/tests/e2e-leg-1/crash-before-createdb/15-assert.yaml
+++ b/tests/e2e-leg-1/crash-before-createdb/15-assert.yaml
@@ -11,12 +11,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1beta1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-crash-before-createdb
+  name: v-crash-before-createdb-defsc-0
 status:
-  subclusters:
-    - installCount: 3
-      addedToDBCount: 0
-      upNodeCount: 0
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-crash-before-createdb-defsc-1
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-crash-before-createdb-defsc-2
+status:
+  phase: Running


### PR DESCRIPTION
After monitoring the test results over the last week, I noticed two things that I am fixing:
- the e2e test crash-before-createdb, is suppose to kill pods in the middle of a create db. But sometimes the database is created before the kills if it is really quick. I am improving the testcase so that it can tolerate this.
- unit test for secrets package can sometimes fail because a namespace it depends on doesn't exist. I am changing the testcase so that it explicitly creates the namespace it needs.