### PR TITLE
VCluster API refresh: allow create db to proceed if db is already running

### DIFF
--- a/changes/unreleased/Fixed-20240103-104435.yaml
+++ b/changes/unreleased/Fixed-20240103-104435.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Improve resilency of create db in low resource environments.
+time: 2024-01-03T10:44:35.555140619-04:00
+custom:
+  Issue: "652"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.0.0
+	github.com/vertica/vcluster v1.0.1-0.20240104123029-09a503fb0ccc
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -94,5 +94,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/vertica/vcluster => github.com/spilchen/vcluster v0.0.0-20240103125154-fd2e51d30204

--- a/go.mod
+++ b/go.mod
@@ -94,3 +94,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/vertica/vcluster => github.com/spilchen/vcluster v0.0.0-20240103125154-fd2e51d30204

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spilchen/vcluster v0.0.0-20240103125154-fd2e51d30204 h1:R/7g/FvA1WKIk1A2MGW4BrEG88HO8otuu9vK9za4fWE=
-github.com/spilchen/vcluster v0.0.0-20240103125154-fd2e51d30204/go.mod h1:mr87BZeipS9HMaL1vKST7lbJ1+SytCbruTF+8tsdK78=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -320,6 +318,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
+github.com/vertica/vcluster v1.0.1-0.20240104123029-09a503fb0ccc h1:gcp1uM4y1JkXncmKcG0xA/AOyjxi5cGHA3glQ4QMwio=
+github.com/vertica/vcluster v1.0.1-0.20240104123029-09a503fb0ccc/go.mod h1:mr87BZeipS9HMaL1vKST7lbJ1+SytCbruTF+8tsdK78=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spilchen/vcluster v0.0.0-20240103125154-fd2e51d30204 h1:R/7g/FvA1WKIk1A2MGW4BrEG88HO8otuu9vK9za4fWE=
+github.com/spilchen/vcluster v0.0.0-20240103125154-fd2e51d30204/go.mod h1:mr87BZeipS9HMaL1vKST7lbJ1+SytCbruTF+8tsdK78=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -318,8 +320,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.0.0 h1:6hA6IsGNaqG88JSfhVbnx7on67IqcXh0UayNqI8EgpM=
-github.com/vertica/vcluster v1.0.0/go.mod h1:hp42yMzgW1Lancd+8O0+a+M21l/a4/5pGNEICoXRU2k=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -145,6 +145,16 @@ const (
 
 	// Annotation to control the termination grace period for vertica pods.
 	TerminationGracePeriodSecondsAnnotaton = "vertica.com/termination-grace-period-seconds"
+
+	// During the create database process, if we discover that Vertica is
+	// already running, we can either treat this as an error or continue.
+	// Continuing may be the best option if we have already progressed far
+	// enough in the create database process to have created the catalog. We can
+	// then continue to start any nodes that may be down in order to bring the
+	// cluster online.
+	FailCreateDBIfVerticaIsRunningAnnotation      = "vertica.com/fail-create-db-if-vertica-is-running"
+	FailCreateDBIfVerticaIsRunningAnnotationTrue  = "true"
+	FailCreateDBIfVerticaIsRunningAnnotationFalse = "false"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -236,6 +246,12 @@ func IsKSafetyCheckStrict(annotations map[string]string) bool {
 // wait before forcibly removing the pod.
 func GetTerminationGracePeriodSeconds(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, TerminationGracePeriodSecondsAnnotaton)
+}
+
+// FailCreateDBIfVerticaIsRunning returns how to handle failures during create
+// db if vertica is found to be running.
+func FailCreateDBIfVerticaIsRunning(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, FailCreateDBIfVerticaIsRunningAnnotation, false /* default value */)
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -248,8 +248,9 @@ func GetTerminationGracePeriodSeconds(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, TerminationGracePeriodSecondsAnnotaton)
 }
 
-// FailCreateDBIfVerticaIsRunning returns how to handle failures during create
-// db if vertica is found to be running.
+// FailCreateDBIfVerticaIsRunning is used to see how to handle failures during create
+// db if vertica is found to be running. It returns true if an error indicating
+// vertica is running should be ignored.
 func FailCreateDBIfVerticaIsRunning(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, FailCreateDBIfVerticaIsRunningAnnotation, false /* default value */)
 }

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -198,8 +198,9 @@ func BuildTLSSecret(vdb *vapi.VerticaDB, name, key, cert, rootca string) *corev1
 }
 
 func DeleteSecret(ctx context.Context, c client.Client, name string) {
+	nm := vapi.MakeVDBName() // The secret is expected to be created in the same namespace as the test standard vdb
 	secret := &corev1.Secret{}
-	err := c.Get(ctx, types.NamespacedName{Name: name}, secret)
+	err := c.Get(ctx, types.NamespacedName{Namespace: nm.Namespace, Name: name}, secret)
 	if !kerrors.IsNotFound(err) {
 		Expect(c.Delete(ctx, secret))
 	}

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -17,11 +17,13 @@ package vadmin
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	vops "github.com/vertica/vcluster/vclusterops"
 	"github.com/vertica/vcluster/vclusterops/vstruct"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/createdb"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -47,6 +49,21 @@ func (v *VClusterOps) CreateDB(ctx context.Context, opts ...createdb.Option) (ct
 	vopts := v.genCreateDBOptions(&s, certs)
 	vdb, err := v.VCreateDatabase(&vopts)
 	if err != nil {
+		// If it is determined that vertica is already running, we may allow the
+		// failure to continue. This could be a result of a previous failed
+		// create db that was able to partially complete but ultimately failed
+		// before updating the status condition to indicate that the create db
+		// was finished. By ignoring the error this time, we will be able to
+		// update the status condition and start any nodes that may be down in
+		// order to bring the cluster online.
+		dbIsRunningError := &vops.DBIsRunningError{}
+		if ok := errors.As(err, &dbIsRunningError); ok {
+			failCreateDB := vmeta.FailCreateDBIfVerticaIsRunning(v.VDB.Annotations)
+			v.Log.Info("DB create failed because vertica is running", "failCreateDB", failCreateDB)
+			if !failCreateDB {
+				return ctrl.Result{}, nil
+			}
+		}
 		return v.logFailure("VCreateDatabase", events.CreateDBFailed, err)
 	}
 

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -54,21 +54,17 @@ func (v *VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Optio
 func (v *VClusterOps) genStartNodeOptions(s *restartnode.Parms, certs *HTTPSCerts) *vops.VStartNodesOptions {
 	su := v.VDB.GetVerticaUser()
 	honorUserInput := true
-	opts := vops.VStartNodesOptions{
-		DatabaseOptions: vops.DatabaseOptions{
-			DBName:         &v.VDB.Spec.DBName,
-			RawHosts:       []string{s.InitiatorIP},
-			Ipv6:           vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP)),
-			Key:            certs.Key,
-			Cert:           certs.Cert,
-			CaCert:         certs.CaCert,
-			UserName:       &su,
-			Password:       &v.Password,
-			HonorUserInput: &honorUserInput,
-		},
-		Nodes: s.RestartHosts,
-	}
-	// timeout option
+	opts := vops.VStartNodesOptionsFactory()
+	opts.DBName = &v.VDB.Spec.DBName
+	opts.RawHosts = []string{s.InitiatorIP}
+	opts.Ipv6 = vstruct.MakeNullableBool(net.IsIPv6(s.InitiatorIP))
+	opts.Key = certs.Key
+	opts.Cert = certs.Cert
+	opts.CaCert = certs.CaCert
+	opts.UserName = &su
+	opts.Password = &v.Password
+	opts.HonorUserInput = &honorUserInput
+	opts.Nodes = s.RestartHosts
 	opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
 	return &opts
 }


### PR DESCRIPTION
This builds on a change made in vclusterops. It can now emit a specific error if it discovers that the database is already running. We add a feature flag to tolerate this (the default is true). This can allow us to proceed if we are in an environment with few resources available, which can cause instability during the creation process. If we have previously progressed far enough that Vertica is running, we will skip the create db step and proceed to the next reconciler. This will update the status condition to indicate that the database has been initialized.
