### PR TITLE
Upgrade path detection will now only prevent downgrades

### DIFF
--- a/changes/unreleased/Changed-20240104-142619.yaml
+++ b/changes/unreleased/Changed-20240104-142619.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Upgrade path detection now only blocks downgrades.
+time: 2024-01-04T14:26:19.176420747-04:00
+custom:
+  Issue: "653"

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -72,8 +72,7 @@ const (
 
 	// When set to False, this parameter will ensure that when changing the
 	// vertica version that we follow the upgrade path.  The Vertica upgrade
-	// path means you cannot downgrade a Vertica release, nor can you skip any
-	// released Vertica versions when upgrading.
+	// path means you cannot downgrade a Vertica release.
 	IgnoreUpgradePathAnnotation     = "vertica.com/ignore-upgrade-path"
 	IgnoreUpgradePathAnntationTrue  = "true"
 	IgnoreUpgradePathAnntationFalse = "false"

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -29,7 +29,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = Describe("version", func() {
-	It("should block some version transitions", func() {
+	It("should block downgrades", func() {
 		cur, ok := MakeInfoFromStr("v11.0.1")
 		Expect(ok).Should(BeTrue())
 		ok, _ = cur.IsValidUpgradePath("v11.0.0")
@@ -38,10 +38,8 @@ var _ = Describe("version", func() {
 		Expect(ok).Should(BeFalse())
 		ok, _ = cur.IsValidUpgradePath("v11.1.0")
 		Expect(ok).Should(BeTrue())
-		ok, _ = cur.IsValidUpgradePath("v11.0.2")
-		Expect(ok).Should(BeTrue())
 		ok, _ = cur.IsValidUpgradePath("v11.2.2")
-		Expect(ok).Should(BeFalse()) // Fail because it skips v11.1.x
+		Expect(ok).Should(BeTrue())
 
 		cur, ok = MakeInfoFromStr("v12.0.3")
 		Expect(ok).Should(BeTrue())
@@ -49,21 +47,10 @@ var _ = Describe("version", func() {
 		Expect(ok).Should(BeTrue())
 		ok, _ = cur.IsValidUpgradePath("v23.3.0")
 		Expect(ok).Should(BeTrue())
-		ok, _ = cur.IsValidUpgradePath("v23.4.0")
-		Expect(ok).Should(BeTrue())
-		ok, _ = cur.IsValidUpgradePath("v24.1.0")
-		Expect(ok).Should(BeFalse())
 		ok, _ = cur.IsValidUpgradePath("v24.4.0")
-		Expect(ok).Should(BeFalse()) // Fail because it skips v23.4.0
-
-		cur, ok = MakeInfoFromStr("v23.3.0")
 		Expect(ok).Should(BeTrue())
-		ok, _ = cur.IsValidUpgradePath("v23.4.0")
-		Expect(ok).Should(BeTrue())
-		ok, _ = cur.IsValidUpgradePath("v24.2.0")
+		ok, _ = cur.IsValidUpgradePath("v12.0.2")
 		Expect(ok).Should(BeFalse())
-		ok, _ = cur.IsValidUpgradePath("v24.3.0")
-		Expect(ok).Should(BeFalse()) // Fail because it skips v23.4.0
 
 		cur, ok = MakeInfoFromStr("v23.4.0")
 		Expect(ok).Should(BeTrue())
@@ -72,7 +59,9 @@ var _ = Describe("version", func() {
 		ok, _ = cur.IsValidUpgradePath("v24.4.0")
 		Expect(ok).Should(BeTrue())
 		ok, _ = cur.IsValidUpgradePath("v25.1.0")
-		Expect(ok).Should(BeFalse()) // Fail because it skips v24.4.0
+		Expect(ok).Should(BeTrue())
+		ok, _ = cur.IsValidUpgradePath("v23.3.11")
+		Expect(ok).Should(BeFalse())
 	})
 
 	It("should return values for IsOlder", func() {


### PR DESCRIPTION
This operator update removes logic that prevented upgrades if the user skipped too many releases. This change is consistent with a recent update to the Vertica documentation, which no longer requires users to upgrade through all intermediate releases.

The old documentation stated that "Vertica upgrades must be performed in a linear fashion, with each release upgraded before the next." However, this requirement has been removed. Users can now upgrade to any supported release, regardless of whether they have skipped intermediate releases.

The only restriction that the operator still enforces is that users cannot downgrade.
