### PR TITLE
Include omitted release manifests

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build Release yaml
       run: |
-        make config-transformer
+        IMG_REPO=docker.io/vertica/ make config-transformer
         ls -lhrt config/release-manifests
 
     - name: Build Bundle
@@ -53,11 +53,11 @@ jobs:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/verticadb-operator/crds/*-crd.yaml 
 
-    - name: Upload RBAC to run Operator
+    - name: Upload YAMLs in release artifacts directory
       uses: actions/upload-artifact@v3
       with:
         name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/operator-rbac.yaml
+        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/*yaml
 
     - name: Upload Helm Charts
       uses: actions/upload-artifact@v3
@@ -70,41 +70,6 @@ jobs:
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/bin/vdb-gen
-
-    - name: Upload ClusterRole to allow auth proxy to lookup access privileges
-      uses: actions/upload-artifact@v3
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-proxy-role-cr.yaml
-
-
-    - name: Upload ClusterRoleBinding to bind a ServiceAccount to the role allowing access privilege lookups
-      uses: actions/upload-artifact@v3
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-proxy-rolebinding-crb.yaml
-
-
-    - name: Upload ClusterRole for non-resource access of the /metrics endpoint
-      uses: actions/upload-artifact@v3
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-reader-cr.yaml
-
-
-    - name: Upload ClusterRoleBinding to bind non-resource access of the /metrics endpoint
-      uses: actions/upload-artifact@v3
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-reader-crb.yaml
-
-
-    - name: Upload ServiceMonitor object for integration with Prometheus operator
-      uses: actions/upload-artifact@v3
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/verticadb-operator-metrics-monitor-servicemonitor.yaml
-
 
     - name: Upload Bundle
       uses: actions/upload-artifact@v3

--- a/scripts/config-transformer.sh
+++ b/scripts/config-transformer.sh
@@ -48,11 +48,6 @@ $SCRIPT_DIR/template-helm-chart.sh $TEMPLATE_DIR
 
 # Create a single manifest that will install all components of the operator.
 # This can be used to deploy the operator via kubectl.
-#
-# First, we format the repo for the operator image. If a repo is not specified,
-# we need to supply null. And it can't have a trailing slash.
-REPO=${IMG_REPO:-null}
-REPO=${REPO%/}
 DEPLOY_MANIFEST=$REPO_DIR/config/release-manifests/operator.yaml
 cat <<EOF > $DEPLOY_MANIFEST
 apiVersion: v1
@@ -60,5 +55,8 @@ kind: Namespace
 metadata:
   name: verticadb-operator
 EOF
-helm template -n verticadb-operator rel $REPO_DIR/helm-charts/verticadb-operator --set image.repo=$REPO --set image.name=${OPERATOR_IMG} >> $DEPLOY_MANIFEST
+set -o xtrace
+# Setting image.repo to null under the assumption that the OPERATOR_IMG will
+# have repositories in it if needed.
+helm template -n verticadb-operator rel $REPO_DIR/helm-charts/verticadb-operator --set image.repo=null --set image.name=${OPERATOR_IMG} >> $DEPLOY_MANIFEST
 sed -i 's/DEPLOY_WITH: helm/DEPLOY_WITH: yaml/g' $DEPLOY_MANIFEST


### PR DESCRIPTION
The build release assets workflow was not including all of the manifests that we wanted to include with the operator GitHub release. This has been corrected. Additionally, the operator.yaml that we generate for the release was not using the correct image name for our public operator image. This has also been fixed. These issues were discovered while releasing the 2.0.0 of the operator.