### PR TITLE
Fixes for the verify-public-artifact workflow

### DIFF
--- a/.github/workflows/verify-public-artifacts.yml
+++ b/.github/workflows/verify-public-artifacts.yml
@@ -55,11 +55,12 @@ jobs:
     - name: Deploy the verticadb operator with olm
       if: github.event.inputs.deploy_with == 'olm'
       run: |
-        curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.21.2/install.sh | bash -s v0.21.2
+        curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.26.0/install.sh | bash -s v0.26.0
         kubectl create -f https://operatorhub.io/install/verticadb-operator.yaml
         echo "Waiting for verticadb-operator CSV to be created..."
-        timeout 5m bash -c -- "while ! kubectl get csv -n my-verticadb-operator --selector operators.coreos.com/verticadb-operator.my-verticadb-operator="" | grep -cq Succeeded; do sleep 5; done"
+        timeout 5m bash -c -- "while ! kubectl get csv | grep 'VerticaDB Operator' | grep -cq Succeeded; do sleep 5; done"
         echo "DONE!"
+        kubectl create namespace my-verticadb-operator
 
     - name: Deploy the verticadb operator with helm
       if: github.event.inputs.deploy_with == 'helm'
@@ -84,7 +85,7 @@ jobs:
 
     - name: Create a VerticaDB CR
       run: |
-        kubectl apply --namespace my-verticadb-operator -f config/samples/v1beta1_verticadb.yaml
+        kubectl apply --namespace my-verticadb-operator -f config/samples/verticadb_sample.yaml
         kubectl wait --for=condition=DBInitialized=True --namespace my-verticadb-operator vdb/verticadb-sample --timeout=10m
         kubectl get pods --namespace my-verticadb-operator --selector app.kubernetes.io/instance=verticadb-sample
 

--- a/config/samples/verticadb_sample.yaml
+++ b/config/samples/verticadb_sample.yaml
@@ -11,6 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: This file is used to verify the public artifacts through the GitHub CI.
+# When making changes to this file, ensure you run the verify-public-artifact
+# workflow. See: .github/workflows/verify-public-artifacts.yml
+
 apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
@@ -22,10 +26,10 @@ metadata:
     # than 24.1.0 (e.g. 23.x.0, 12.0.x, etc.) will want this to set false so
     # the operator treats it as an admintools deployment. Server versions that
     # are 24.1.0 or newer will want this set to true to deploy with vclusterops.
-    vertica.com/vcluster-ops: "false"
+    vertica.com/vcluster-ops: "true"
 spec:
-  image: "vertica/vertica-k8s:23.3.0-0-minimal" # ensure vertica.com/vcluster-ops is false
-  #image: "vertica/vertica-k8s:24.1.0-0-minimal" # ensure vertica.com/vcluster-ops is true
+  image: "vertica/vertica-k8s:latest" # ensure vertica.com/vcluster-ops is true
+  #image: "vertica/vertica-k8s:23.3.0-0-minimal" # ensure vertica.com/vcluster-ops is false
   communal:
     path: "s3://nimbusdb/db"
     endpoint: "http://minio"


### PR DESCRIPTION
We have this workflow that we use to validate after every operator release. This was broken in the last release. Included in here are fixes to get that working again.