### PR TITLE
Fix udx tests to run with NMA sidecar

### DIFF
--- a/.github/workflows/e2e-udx.yml
+++ b/.github/workflows/e2e-udx.yml
@@ -71,6 +71,7 @@ jobs:
         export VLOGGER_IMG=${{ inputs.vlogger-image }}
         export E2E_TEST_DIRS=tests/e2e-udx
         export VERTICA_DEPLOYMENT_METHOD=${{ inputs.vertica-deployment-method }}
+        export NMA_RUNNING_MODE=sidecar
         # Setup the udx environment by compiling examples in the vertica image.
         # This downloads packages, so to improve its reliability we retry in
         # case any intermittent network issues arise.

--- a/tests/e2e-udx/udx-cpp/30-upload-files.yaml
+++ b/tests/e2e-udx/udx-cpp/30-upload-files.yaml
@@ -2,13 +2,13 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # In v2 image, we need to allow write access to the sdk/examples directory
-  - command: kubectl -n $NAMESPACE exec -it v-udx-cpp-sc1-0 -- bash -c "echo root | su root sh -c 'chmod -R a+w /opt/vertica/sdk/examples || true'"
+  - command: kubectl -n $NAMESPACE exec -i v-udx-cpp-sc1-0 -c server -- bash -c "echo root | su root sh -c 'chmod -R a+w /opt/vertica/sdk/examples || true'"
     ignoreFailure: true
   # upload the built library binaries
-  - command: kubectl -n $NAMESPACE cp ../../../sdk/examples/build v-udx-cpp-sc1-0:/opt/vertica/sdk/examples
+  - command: kubectl -n $NAMESPACE cp -c server ../../../sdk/examples/build v-udx-cpp-sc1-0:/opt/vertica/sdk/examples
   # upload the expected outputs of executing sql files
-  - command: kubectl -n $NAMESPACE cp ./expected-outputs v-udx-cpp-sc1-0:/opt/vertica/sdk/examples
+  - command: kubectl -n $NAMESPACE cp -c server ./expected-outputs v-udx-cpp-sc1-0:/opt/vertica/sdk/examples
   # Install packages in the pod that are needed to run the C++ examples. We
   # retry to resolve any intermittent network issues.
-  - command: kubectl -n $NAMESPACE cp setup-env-runtime.sh v-udx-cpp-sc1-0:/tmp/setup-env-runtime.sh
-  - command: kubectl -n $NAMESPACE exec -it v-udx-cpp-sc1-0 -- bash /tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE cp -c server setup-env-runtime.sh v-udx-cpp-sc1-0:/tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE exec -i v-udx-cpp-sc1-0 -c server -- bash /tmp/setup-env-runtime.sh

--- a/tests/e2e-udx/udx-java/30-upload-files.yaml
+++ b/tests/e2e-udx/udx-java/30-upload-files.yaml
@@ -2,12 +2,12 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # In v2 image, we need to allow write access to the sdk/examples directory
-  - command: kubectl -n $NAMESPACE exec -it v-udx-java-sc1-0 -- bash -c "echo root | su root sh -c 'chmod -R a+w /opt/vertica/sdk/examples || true'"
+  - command: kubectl -n $NAMESPACE exec -i v-udx-java-sc1-0 -c server -- bash -c "echo root | su root sh -c 'chmod -R a+w /opt/vertica/sdk/examples || true'"
     ignoreFailure: true
   # upload the built library binaries
-  - command: kubectl -n $NAMESPACE cp ../../../sdk/examples/build v-udx-java-sc1-0:/opt/vertica/sdk/examples
+  - command: kubectl -n $NAMESPACE cp -c server ../../../sdk/examples/build v-udx-java-sc1-0:/opt/vertica/sdk/examples
   # upload the expected outputs of executing sql files
-  - command: kubectl -n $NAMESPACE cp ./expected-outputs v-udx-java-sc1-0:/opt/vertica/sdk/examples
+  - command: kubectl -n $NAMESPACE cp -c server ./expected-outputs v-udx-java-sc1-0:/opt/vertica/sdk/examples
   # Install packages in the pod that are needed to run the examples.
-  - command: kubectl -n $NAMESPACE cp setup-env-runtime.sh v-udx-java-sc1-0:/tmp/setup-env-runtime.sh
-  - command: kubectl -n $NAMESPACE exec -it v-udx-java-sc1-0 -- bash /tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE cp -c server setup-env-runtime.sh v-udx-java-sc1-0:/tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE exec -i v-udx-java-sc1-0 -c server -- bash /tmp/setup-env-runtime.sh

--- a/tests/e2e-udx/udx-python/30-upload-files.yaml
+++ b/tests/e2e-udx/udx-python/30-upload-files.yaml
@@ -2,9 +2,9 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # upload the expected outputs of executing sql files. In v2 image, we need to allow write access to the sdk/examples directory
-  - command: kubectl -n $NAMESPACE exec -it v-udx-python-sc1-0 -- bash -c "echo root | su root sh -c 'chmod -R a+w /opt/vertica/sdk/examples || true'"
+  - command: kubectl -n $NAMESPACE exec -i v-udx-python-sc1-0 -c server -- bash -c "echo root | su root sh -c 'chmod -R a+w /opt/vertica/sdk/examples || true'"
     ignoreFailure: true
-  - command: kubectl -n $NAMESPACE cp ./expected-outputs v-udx-python-sc1-0:/opt/vertica/sdk/examples
+  - command: kubectl -n $NAMESPACE cp -c server ./expected-outputs v-udx-python-sc1-0:/opt/vertica/sdk/examples
   # Install packages in the pod that are needed to run the examples.
-  - command: kubectl -n $NAMESPACE cp setup-env-runtime.sh v-udx-python-sc1-0:/tmp/setup-env-runtime.sh
-  - command: kubectl -n $NAMESPACE exec -it v-udx-python-sc1-0 -- bash /tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE cp -c server setup-env-runtime.sh v-udx-python-sc1-0:/tmp/setup-env-runtime.sh
+  - command: kubectl -n $NAMESPACE exec -i v-udx-python-sc1-0 -c server -- bash /tmp/setup-env-runtime.sh

--- a/tests/manifests/kind-hostpath/server-mount-patch.yaml
+++ b/tests/manifests/kind-hostpath/server-mount-patch.yaml
@@ -69,5 +69,5 @@
       path: /spec/volumeMounts/-
       value:
         name: server
-        mountPath: /opt/vertica/oss/python3/lib/python3.9/site-packages/vertica
+        mountPath: /opt/vertica/oss/python3/lib/python3.11/site-packages/vertica
         subPath: platform/src/vertica


### PR DESCRIPTION
This is a test update for the UDX tests. We need to explicitly specify the container we want to use when setting up the development environment. I have enabled the NMA sidecar when running the UDX test suite in the end-to-end (e2e) tests.