### PR TITLE
Add custom print columns for VerticaRestorePointsQuery

### DIFF
--- a/api/v1beta1/verticarestorepointsquery_types.go
+++ b/api/v1beta1/verticarestorepointsquery_types.go
@@ -66,8 +66,8 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=vertica,shortName=vrpq
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="VerticaDBName",type="string",JSONPath=".spec.verticaDBName"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="DBName",type="string",JSONPath=".spec.verticaDBName"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +operator-sdk:csv:customresourcedefinitions:resources={{VerticaDB,vertica.com/v1beta1,""}}
 

--- a/api/v1beta1/verticarestorepointsquery_types.go
+++ b/api/v1beta1/verticarestorepointsquery_types.go
@@ -1,0 +1,133 @@
+/*
+Copyright [2021-2023] Open Text.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// VerticaRestorePointsQuerySpec defines the desired state of VerticaRestorePointsQuery
+type VerticaRestorePointsQuerySpec struct {
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "make" to regenerate code after modifying this file
+
+	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	// The name of the VerticaDB CR that this VerticaRestorePointsQuery is defined for.  The
+	// VerticaDB object must exist in the same namespace as this object.
+	VerticaDBName string `json:"verticaDBName"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	// Optional parameter that will limit the query to only restore points
+	// from this archvie
+	ArchiveName string `json:"archiveName"`
+}
+
+const (
+	archiveNm = "backup" // constants for test purposes
+)
+
+// VerticaRestorePointsQueryStatus defines the observed state of VerticaRestorePointsQuery
+type VerticaRestorePointsQueryStatus struct {
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// Conditions for VerticaRestorePointsQuery
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// Status message for running query
+	Message string `json:"message"`
+}
+
+const (
+	// Querying indicates whether the operator should query for list restore points
+	Querying = "Querying"
+	// QueryComplete indicates the query has been completed
+	QueryComplete = "QueryComplete"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=vertica,shortName=vrpq
+// +kubebuilder:subresource:status
+// +operator-sdk:csv:customresourcedefinitions:resources={{Job,batch/v1,""}}
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.message"
+
+// VerticaRestorePointsQuery is the Schema for the verticarestorepointsqueries API
+type VerticaRestorePointsQuery struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   VerticaRestorePointsQuerySpec   `json:"spec,omitempty"`
+	Status VerticaRestorePointsQueryStatus `json:"status,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+
+// VerticaRestorePointsQueryList contains a list of VerticaRestorePointsQuery
+type VerticaRestorePointsQueryList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []VerticaRestorePointsQuery `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&VerticaRestorePointsQuery{}, &VerticaRestorePointsQueryList{})
+}
+
+func (vrpq *VerticaRestorePointsQuery) ExtractNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      vrpq.ObjectMeta.Name,
+		Namespace: vrpq.ObjectMeta.Namespace,
+	}
+}
+
+func (vrpq *VerticaRestorePointsQuery) IsStatusConditionTrue(statusCondition string) bool {
+	return meta.IsStatusConditionTrue(vrpq.Status.Conditions, statusCondition)
+}
+
+func (vrpq *VerticaRestorePointsQuery) IsStatusConditionFalse(statusCondition string) bool {
+	return meta.IsStatusConditionFalse(vrpq.Status.Conditions, statusCondition)
+}
+
+func MakeSampleVrpqName() types.NamespacedName {
+	return types.NamespacedName{Name: "vrpq-sample", Namespace: "default"}
+}
+
+// MakeVrpq will make an VerticaRestorePointsQuery for test purposes
+func MakeVrpq() *VerticaRestorePointsQuery {
+	VDBNm := MakeVDBName()
+	nm := MakeSampleVrpqName()
+	return &VerticaRestorePointsQuery{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       RestorePointsQueryKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nm.Name,
+			Namespace: nm.Namespace,
+			UID:       "zxcvbn-ghi-lkm",
+		},
+		Spec: VerticaRestorePointsQuerySpec{
+			VerticaDBName: VDBNm.Name,
+			ArchiveName:   archiveNm,
+		},
+	}
+}

--- a/api/v1beta1/verticarestorepointsquery_types.go
+++ b/api/v1beta1/verticarestorepointsquery_types.go
@@ -66,7 +66,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=vertica,shortName=vrpq
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="DBName",type="string",JSONPath=".spec.verticaDBName"
+// +kubebuilder:printcolumn:name="VerticaDB",type="string",JSONPath=".spec.verticaDBName"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +operator-sdk:csv:customresourcedefinitions:resources={{VerticaDB,vertica.com/v1beta1,""}}

--- a/api/v1beta1/verticarestorepointsquery_types.go
+++ b/api/v1beta1/verticarestorepointsquery_types.go
@@ -53,7 +53,7 @@ type VerticaRestorePointsQueryStatus struct {
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	// Status message for running query
-	Message string `json:"message"`
+	State string `json:"state"`
 }
 
 const (
@@ -66,9 +66,10 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=vertica,shortName=vrpq
 // +kubebuilder:subresource:status
-// +operator-sdk:csv:customresourcedefinitions:resources={{Job,batch/v1,""}}
+// +kubebuilder:printcolumn:name="VerticaDBName",type="string",JSONPath=".spec.verticaDBName"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.state"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.message"
+// +operator-sdk:csv:customresourcedefinitions:resources={{VerticaDB,vertica.com/v1beta1,""}}
 
 // VerticaRestorePointsQuery is the Schema for the verticarestorepointsqueries API
 type VerticaRestorePointsQuery struct {

--- a/pkg/controllers/vrpq/query_reconciler.go
+++ b/pkg/controllers/vrpq/query_reconciler.go
@@ -1,0 +1,144 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vrpq
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	v1 "github.com/vertica/vertica-kubernetes/api/v1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
+	restorepointsquery "github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/restorepointsquery"
+	config "github.com/vertica/vertica-kubernetes/pkg/vdbconfig"
+	vrpqstatus "github.com/vertica/vertica-kubernetes/pkg/vrpqstatus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type QueryReconciler struct {
+	VRec           *VerticaRestorePointsQueryReconciler
+	Vrpq           *vapi.VerticaRestorePointsQuery
+	Log            logr.Logger
+	InitiatorPod   types.NamespacedName // The pod that we run admin commands from
+	InitiatorPodIP string               // The IP of the initiating pod
+	config.ConfigParamsGenerator
+}
+
+func MakeRestorePointsQueryReconciler(r *VerticaRestorePointsQueryReconciler, vrpq *vapi.VerticaRestorePointsQuery,
+	log logr.Logger) controllers.ReconcileActor {
+	return &QueryReconciler{
+		VRec: r,
+		Vrpq: vrpq,
+		Log:  log.WithName("QueryReconciler"),
+		ConfigParamsGenerator: config.ConfigParamsGenerator{
+			VRec: r,
+			Log:  log.WithName("QueryReconciler"),
+		},
+	}
+}
+
+func (q *QueryReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	// no-op if QueryComplete is true
+	isSet := q.Vrpq.IsStatusConditionTrue(vapi.Querying)
+	if isSet {
+		return ctrl.Result{}, nil
+	}
+	// collect information from a VerticaDB.
+	if res, err := q.collectInfoFromVdb(ctx); verrors.IsReconcileAborted(res, err) {
+		return res, err
+	}
+
+	return ctrl.Result{}, q.runListRestorePoints(ctx, req)
+}
+
+// fetch the VerticaDB and collect access information to the communal storage for the VerticaRestorePointsQuery CR,
+func (q *QueryReconciler) collectInfoFromVdb(ctx context.Context) (ctrl.Result, error) {
+	vdb := &v1.VerticaDB{}
+	res := ctrl.Result{}
+
+	opts := []restorepointsquery.Option{
+		restorepointsquery.WithInitiator(q.InitiatorPod, q.InitiatorPodIP),
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var e error
+		if res, e = fetchVDB(ctx, q.VRec, q.Vrpq, vdb); verrors.IsReconcileAborted(res, e) {
+			return e
+		}
+		q.Vdb = vdb
+		// build communal storage params if there is not one
+		if q.ConfigurationParams == nil {
+			res, e = q.ConstructConfigParms(ctx)
+			if verrors.IsReconcileAborted(res, e) {
+				return e
+			}
+		}
+		// extract out the communal and config information to pass down to the vclusterops API.
+		opts = append(opts,
+			restorepointsquery.WithCommunalPath(vdb.GetCommunalPath()),
+			restorepointsquery.WithConfigurationParams(q.ConfigurationParams.GetMap()),
+		)
+
+		return nil
+	})
+
+	return res, err
+}
+
+// setListRestorePointsQueryConditions will update the status condition before and after calling
+// list restore points api
+// Temporarily, runListRestorePoints will not call the ListRestorePoints API
+// since the dispatcher is not set up yet
+func (q *QueryReconciler) runListRestorePoints(ctx context.Context, _ *ctrl.Request) error {
+	// update query message prior to calling vclusterops API
+	err := vrpqstatus.UpdateMessageStatus(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
+		"Query is still in progress")
+	if err != nil {
+		return err
+	}
+
+	// set Querying status condition prior to calling vclusterops API
+	err = vrpqstatus.UpdateCondition(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
+		v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, ""))
+	if err != nil {
+		return err
+	}
+
+	// API should be called to proceed here
+
+	// clear Querying status condition
+	err = vrpqstatus.UpdateCondition(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
+		v1.MakeCondition(vapi.Querying, metav1.ConditionFalse, ""))
+	if err != nil {
+		return err
+	}
+
+	// update query message after calling vclusterops API successfully
+	err = vrpqstatus.UpdateMessageStatus(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
+		"Query has completed successfully")
+	if err != nil {
+		return err
+	}
+
+	// set the QueryComplete if the vclusterops API succeeded
+	return vrpqstatus.UpdateCondition(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
+		v1.MakeCondition(vapi.QueryComplete, metav1.ConditionTrue, ""))
+}

--- a/pkg/controllers/vrpq/query_reconciler.go
+++ b/pkg/controllers/vrpq/query_reconciler.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	querying     = "Querying"
-	successQuery = "Query successful"
+	stateQuerying     = "Querying"
+	stateSuccessQuery = "Query successful"
 )
 
 type QueryReconciler struct {
@@ -115,7 +115,7 @@ func (q *QueryReconciler) collectInfoFromVdb(ctx context.Context) (ctrl.Result, 
 func (q *QueryReconciler) runListRestorePoints(ctx context.Context, _ *ctrl.Request) error {
 	// set Querying status condition and state prior to calling vclusterops API
 	err := vrpqstatus.UpdateConditionAndState(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, "Started"), querying)
+		v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, "Started"), stateQuerying)
 	if err != nil {
 		return err
 	}
@@ -125,12 +125,12 @@ func (q *QueryReconciler) runListRestorePoints(ctx context.Context, _ *ctrl.Requ
 
 	// clear Querying status condition
 	err = vrpqstatus.UpdateConditionAndState(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		v1.MakeCondition(vapi.Querying, metav1.ConditionFalse, "CompletedOrFailed"), querying)
+		v1.MakeCondition(vapi.Querying, metav1.ConditionFalse, "Completed"), stateQuerying)
 	if err != nil {
 		return err
 	}
 
 	// set the QueryComplete if the vclusterops API succeeded
 	return vrpqstatus.UpdateConditionAndState(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		v1.MakeCondition(vapi.QueryComplete, metav1.ConditionTrue, "Completed"), successQuery)
+		v1.MakeCondition(vapi.QueryComplete, metav1.ConditionTrue, "Completed"), stateSuccessQuery)
 }

--- a/pkg/controllers/vrpq/query_reconciler.go
+++ b/pkg/controllers/vrpq/query_reconciler.go
@@ -103,14 +103,14 @@ func (q *QueryReconciler) collectInfoFromVdb(ctx context.Context) (ctrl.Result, 
 	return res, err
 }
 
-// setListRestorePointsQueryConditions will update the status condition before and after calling
+// runListRestorePoints will update the status condition before and after calling
 // list restore points api
 // Temporarily, runListRestorePoints will not call the ListRestorePoints API
 // since the dispatcher is not set up yet
 func (q *QueryReconciler) runListRestorePoints(ctx context.Context, _ *ctrl.Request) error {
 	// update query message prior to calling vclusterops API
 	err := vrpqstatus.UpdateMessageStatus(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		"Query is still in progress")
+		"Querying")
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (q *QueryReconciler) runListRestorePoints(ctx context.Context, _ *ctrl.Requ
 
 	// update query message after calling vclusterops API successfully
 	err = vrpqstatus.UpdateMessageStatus(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		"Query has completed successfully")
+		"Queried successful")
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/vrpq/query_reconciler.go
+++ b/pkg/controllers/vrpq/query_reconciler.go
@@ -115,7 +115,7 @@ func (q *QueryReconciler) collectInfoFromVdb(ctx context.Context) (ctrl.Result, 
 func (q *QueryReconciler) runListRestorePoints(ctx context.Context, _ *ctrl.Request) error {
 	// set Querying status condition and state prior to calling vclusterops API
 	err := vrpqstatus.UpdateConditionAndState(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, ""), querying)
+		v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, "Started"), querying)
 	if err != nil {
 		return err
 	}
@@ -125,12 +125,12 @@ func (q *QueryReconciler) runListRestorePoints(ctx context.Context, _ *ctrl.Requ
 
 	// clear Querying status condition
 	err = vrpqstatus.UpdateConditionAndState(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		v1.MakeCondition(vapi.Querying, metav1.ConditionFalse, ""), querying)
+		v1.MakeCondition(vapi.Querying, metav1.ConditionFalse, "CompletedOrFailed"), querying)
 	if err != nil {
 		return err
 	}
 
 	// set the QueryComplete if the vclusterops API succeeded
 	return vrpqstatus.UpdateConditionAndState(ctx, q.VRec.Client, q.VRec.Log, q.Vrpq,
-		v1.MakeCondition(vapi.QueryComplete, metav1.ConditionTrue, ""), successQuery)
+		v1.MakeCondition(vapi.QueryComplete, metav1.ConditionTrue, "Completed"), successQuery)
 }

--- a/pkg/controllers/vrpq/query_reconciler_test.go
+++ b/pkg/controllers/vrpq/query_reconciler_test.go
@@ -58,24 +58,7 @@ var _ = Describe("query_reconcile", func() {
 		// QueryComplete condition is updated to True
 		Expect(vrpq.IsStatusConditionFalse(vapi.Querying)).Should(BeTrue())
 		Expect(vrpq.IsStatusConditionTrue(vapi.QueryComplete)).Should(BeTrue())
-
-	})
-
-	It("should update query message if the vclusterops API succeeded", func() {
-		vdb := v1.MakeVDB()
-		createS3CredSecret(ctx, vdb)
-		defer deleteCommunalCredSecret(ctx, vdb)
-		test.CreateVDB(ctx, k8sClient, vdb)
-		defer test.DeleteVDB(ctx, k8sClient, vdb)
-
-		vrpq := vapi.MakeVrpq()
-		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
-		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
-		recon := MakeRestorePointsQueryReconciler(vrpqRec, vrpq, logger)
-
-		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
-		// make sure that message is updated to Queried successful
-		Expect(vrpq.Status.State).Should(Equal("Queried successful"))
+		Expect(vrpq.Status.State).Should(Equal(successQuery))
 
 	})
 

--- a/pkg/controllers/vrpq/query_reconciler_test.go
+++ b/pkg/controllers/vrpq/query_reconciler_test.go
@@ -1,0 +1,186 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vrpq
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/vertica/vertica-kubernetes/api/v1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/cloud"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/types"
+	config "github.com/vertica/vertica-kubernetes/pkg/vdbconfig"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("query_reconcile", func() {
+	ctx := context.Background()
+
+	It("should requeue if VerticaDB doesn't exist", func() {
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		req := ctrl.Request{NamespacedName: vapi.MakeSampleVrpqName()}
+		Expect(vrpqRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{Requeue: true}))
+	})
+
+	It("should update query conditions if the vclusterops API succeeded", func() {
+		vdb := v1.MakeVDB()
+		createS3CredSecret(ctx, vdb)
+		defer deleteCommunalCredSecret(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+		recon := MakeRestorePointsQueryReconciler(vrpqRec, vrpq, logger)
+
+		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		// make sure that Quering condition is updated to false and
+		// QueryComplete condition is updated to True
+		Expect(vrpq.IsStatusConditionFalse(vapi.Querying)).Should(BeTrue())
+		Expect(vrpq.IsStatusConditionTrue(vapi.QueryComplete)).Should(BeTrue())
+
+	})
+
+	It("should update query message if the vclusterops API succeeded", func() {
+		vdb := v1.MakeVDB()
+		createS3CredSecret(ctx, vdb)
+		defer deleteCommunalCredSecret(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+		recon := MakeRestorePointsQueryReconciler(vrpqRec, vrpq, logger)
+
+		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		// make sure that message is updated to Queried successful
+		Expect(vrpq.Status.State).Should(Equal("Queried successful"))
+
+	})
+
+	It("should set azure parms in config parms map when using azb:// scheme and accountKey", func() {
+		vdb := v1.MakeVDB()
+		vdb.Spec.Communal.Path = "azb://account/container/path1"
+		createAzureAccountKeyCredSecret(ctx, vdb)
+		defer deleteCommunalCredSecret(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		parms := contructAuthParmsMapForVrpq(ctx, vrpq, "AzureStorageCredentials")
+		ExpectWithOffset(1, parms.GetValue("AzureStorageCredentials")).ShouldNot(ContainSubstring(cloud.AzureSharedAccessSignature))
+		ExpectWithOffset(1, parms.GetValue("AzureStorageCredentials")).Should(ContainSubstring(cloud.AzureAccountKey))
+	})
+
+	It("should set azure parms in config parms map when using azb:// scheme and shared access signature", func() {
+		vdb := v1.MakeVDB()
+		vdb.Spec.Communal.Path = "azb://account/container/path2"
+		createAzureSASCredSecret(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer deleteCommunalCredSecret(ctx, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		params := contructAuthParmsMapForVrpq(ctx, vrpq, "AzureStorageCredentials")
+		ExpectWithOffset(1, params.GetValue("AzureStorageCredentials")).Should(ContainSubstring(cloud.AzureSharedAccessSignature))
+		ExpectWithOffset(1, params.GetValue("AzureStorageCredentials")).ShouldNot(ContainSubstring(cloud.AzureAccountKey))
+	})
+
+	It("should not create an auth parms if no communal path given", func() {
+		vdb := v1.MakeVDB()
+		vdb.Spec.Communal.Path = ""
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		contructAuthParmsHelperForVrpq(ctx, vrpq, "", "")
+	})
+
+	It("should add additional server config parms to config parms map", func() {
+		vdb := v1.MakeVDB()
+		vdb.Spec.Communal.AdditionalConfig = map[string]string{
+			"Parm1": "parm1",
+		}
+		createS3CredSecret(ctx, vdb)
+		defer deleteCommunalCredSecret(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		g := constructVrpqQuery(ctx, vrpq)
+		g.SetAdditionalConfigParms()
+		Expect(g.ConfigurationParams.ContainKeyValuePair("Parm1", "parm1")).Should(Equal(true))
+	})
+})
+
+func contructAuthParmsMapForVrpq(ctx context.Context,
+	vrpq *vapi.VerticaRestorePointsQuery, key string) *types.CiMap {
+	g := constructVrpqQuery(ctx, vrpq)
+	_, ok := g.ConfigurationParams.Get(key)
+	ExpectWithOffset(1, ok).Should(Equal(true))
+	return g.ConfigurationParams
+}
+
+func contructAuthParmsHelperForVrpq(ctx context.Context, vrpq *vapi.VerticaRestorePointsQuery, key, value string) {
+	g := constructVrpqQuery(ctx, vrpq)
+	if g.Vdb.Spec.Communal.Path == "" {
+		ExpectWithOffset(1, g.ConfigurationParams.Size()).Should(Equal(0))
+		return
+	}
+	if value == "" {
+		_, ok := g.ConfigurationParams.Get(key)
+		ExpectWithOffset(1, ok).Should(Equal(true))
+		return
+	}
+	ExpectWithOffset(1, g.ConfigurationParams.ContainKeyValuePair(key, value)).Should(Equal(true))
+}
+
+func constructVrpqQuery(ctx context.Context, vrpq *vapi.VerticaRestorePointsQuery) *QueryReconciler {
+	g := &QueryReconciler{
+		VRec: vrpqRec,
+		Vrpq: vrpq,
+		Log:  logger,
+		ConfigParamsGenerator: config.ConfigParamsGenerator{
+			VRec: vrpqRec,
+			Log:  logger,
+		},
+	}
+
+	res, err := g.collectInfoFromVdb(ctx)
+	ExpectWithOffset(1, err).Should(Succeed())
+	ExpectWithOffset(1, res).Should(Equal(ctrl.Result{}))
+	return g
+}

--- a/pkg/controllers/vrpq/query_reconciler_test.go
+++ b/pkg/controllers/vrpq/query_reconciler_test.go
@@ -56,6 +56,7 @@ var _ = Describe("query_reconcile", func() {
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		// make sure that Quering condition is updated to false and
 		// QueryComplete condition is updated to True
+		// message is updated to "Query successful"
 		Expect(vrpq.IsStatusConditionFalse(vapi.Querying)).Should(BeTrue())
 		Expect(vrpq.IsStatusConditionTrue(vapi.QueryComplete)).Should(BeTrue())
 		Expect(vrpq.Status.State).Should(Equal(successQuery))

--- a/pkg/controllers/vrpq/query_reconciler_test.go
+++ b/pkg/controllers/vrpq/query_reconciler_test.go
@@ -59,7 +59,7 @@ var _ = Describe("query_reconcile", func() {
 		// message is updated to "Query successful"
 		Expect(vrpq.IsStatusConditionFalse(vapi.Querying)).Should(BeTrue())
 		Expect(vrpq.IsStatusConditionTrue(vapi.QueryComplete)).Should(BeTrue())
-		Expect(vrpq.Status.State).Should(Equal(successQuery))
+		Expect(vrpq.Status.State).Should(Equal(stateSuccessQuery))
 
 	})
 

--- a/pkg/vrpqstatus/status.go
+++ b/pkg/vrpqstatus/status.go
@@ -79,7 +79,7 @@ func UpdateCondition(ctx context.Context, clnt client.Client, log logr.Logger,
 func UpdateMessageStatus(ctx context.Context, clnt client.Client, log logr.Logger,
 	vrpq *vapi.VerticaRestorePointsQuery, msg string) error {
 	return Update(ctx, clnt, log, vrpq, func(vrpq *vapi.VerticaRestorePointsQuery) error {
-		vrpq.Status.Message = msg
+		vrpq.Status.State = msg
 		return nil
 	})
 }

--- a/pkg/vrpqstatus/status.go
+++ b/pkg/vrpqstatus/status.go
@@ -64,12 +64,12 @@ func Update(ctx context.Context, clnt client.Client, log logr.Logger, vrpq *vapi
 // This is a no-op if the status condition is already set.  The input vrpq will
 // be updated with the status condition.
 func UpdateConditionAndState(ctx context.Context, clnt client.Client, log logr.Logger,
-	vrpq *vapi.VerticaRestorePointsQuery, condition *metav1.Condition, msg string) error {
+	vrpq *vapi.VerticaRestorePointsQuery, condition *metav1.Condition, state string) error {
 	// refreshConditionInPlace will update the status condition in vrpq.  The update
 	// will be applied in-place.
 	refreshConditionInPlace := func(vrpq *vapi.VerticaRestorePointsQuery) error {
-		if vrpq.Status.State != msg {
-			vrpq.Status.State = msg
+		if vrpq.Status.State != state {
+			vrpq.Status.State = state
 		}
 		meta.SetStatusCondition(&vrpq.Status.Conditions, *condition)
 		return nil

--- a/pkg/vrpqstatus/status.go
+++ b/pkg/vrpqstatus/status.go
@@ -60,7 +60,7 @@ func Update(ctx context.Context, clnt client.Client, log logr.Logger, vrpq *vapi
 	})
 }
 
-// UpdateCondition will update a condition and state status
+// UpdateConditionAndState will update a condition and state status
 // This is a no-op if the status condition is already set.  The input vrpq will
 // be updated with the status condition.
 func UpdateConditionAndState(ctx context.Context, clnt client.Client, log logr.Logger,

--- a/pkg/vrpqstatus/status.go
+++ b/pkg/vrpqstatus/status.go
@@ -60,26 +60,19 @@ func Update(ctx context.Context, clnt client.Client, log logr.Logger, vrpq *vapi
 	})
 }
 
-// UpdateCondition will update a condition status
+// UpdateCondition will update a condition and state status
 // This is a no-op if the status condition is already set.  The input vrpq will
 // be updated with the status condition.
-func UpdateCondition(ctx context.Context, clnt client.Client, log logr.Logger,
-	vrpq *vapi.VerticaRestorePointsQuery, condition *metav1.Condition) error {
+func UpdateConditionAndState(ctx context.Context, clnt client.Client, log logr.Logger,
+	vrpq *vapi.VerticaRestorePointsQuery, condition *metav1.Condition, msg string) error {
 	// refreshConditionInPlace will update the status condition in vrpq.  The update
 	// will be applied in-place.
 	refreshConditionInPlace := func(vrpq *vapi.VerticaRestorePointsQuery) error {
+		if vrpq.Status.State != msg {
+			vrpq.Status.State = msg
+		}
 		meta.SetStatusCondition(&vrpq.Status.Conditions, *condition)
 		return nil
 	}
 	return Update(ctx, clnt, log, vrpq, refreshConditionInPlace)
-}
-
-// UpdateMessageStatus will update the status message. The input vrpq
-// will be updated with the status message.
-func UpdateMessageStatus(ctx context.Context, clnt client.Client, log logr.Logger,
-	vrpq *vapi.VerticaRestorePointsQuery, msg string) error {
-	return Update(ctx, clnt, log, vrpq, func(vrpq *vapi.VerticaRestorePointsQuery) error {
-		vrpq.Status.State = msg
-		return nil
-	})
 }

--- a/pkg/vrpqstatus/status.go
+++ b/pkg/vrpqstatus/status.go
@@ -1,0 +1,85 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vrpqstatus
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Update(ctx context.Context, clnt client.Client, log logr.Logger, vrpq *vapi.VerticaRestorePointsQuery,
+	updateFunc func(*vapi.VerticaRestorePointsQuery) error) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		// Always fetch the latest to minimize the chance of getting a conflict error.
+		nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
+		err := clnt.Get(ctx, nm, vrpq)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.Info("VerticaRestorePointsQuery resource not found.  Ignoring since object must be deleted")
+				return nil
+			}
+			return err
+		}
+		// We will calculate the status for the vrpq object. This update is done in
+		// place. If anything differs from the copy then we will do a single update.
+		vrpqChg := vrpq.DeepCopy()
+		// Refresh the status using the users provided function
+		if err := updateFunc(vrpqChg); err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(vrpq.Status, vrpqChg.Status) {
+			log.Info("Updating vrpq status", "status", vrpq.Status)
+			vrpqChg.Status.DeepCopyInto(&vrpq.Status)
+			if err := clnt.Status().Update(ctx, vrpq); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// UpdateCondition will update a condition status
+// This is a no-op if the status condition is already set.  The input vrpq will
+// be updated with the status condition.
+func UpdateCondition(ctx context.Context, clnt client.Client, log logr.Logger,
+	vrpq *vapi.VerticaRestorePointsQuery, condition *metav1.Condition) error {
+	// refreshConditionInPlace will update the status condition in vrpq.  The update
+	// will be applied in-place.
+	refreshConditionInPlace := func(vrpq *vapi.VerticaRestorePointsQuery) error {
+		meta.SetStatusCondition(&vrpq.Status.Conditions, *condition)
+		return nil
+	}
+	return Update(ctx, clnt, log, vrpq, refreshConditionInPlace)
+}
+
+// UpdateMessageStatus will update the status message. The input vrpq
+// will be updated with the status message.
+func UpdateMessageStatus(ctx context.Context, clnt client.Client, log logr.Logger,
+	vrpq *vapi.VerticaRestorePointsQuery, msg string) error {
+	return Update(ctx, clnt, log, vrpq, func(vrpq *vapi.VerticaRestorePointsQuery) error {
+		vrpq.Status.Message = msg
+		return nil
+	})
+}

--- a/pkg/vrpqstatus/status_test.go
+++ b/pkg/vrpqstatus/status_test.go
@@ -1,0 +1,209 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vrpqstatus
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gtypes "github.com/onsi/gomega/types"
+	v1 "github.com/vertica/vertica-kubernetes/api/v1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var logger logr.Logger
+
+var _ = BeforeSuite(func() {
+	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(logger)
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, cfg).NotTo(BeNil())
+	restCfg := cfg
+
+	err = vapi.AddToScheme(scheme.Scheme)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+})
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "vrpqstatus Suite")
+}
+
+func EqualVerticaRestorePointsQueryCondition(expected interface{}) gtypes.GomegaMatcher {
+	return &representVerticaRestorePointsQueryCondition{
+		expected: expected,
+	}
+}
+
+type representVerticaRestorePointsQueryCondition struct {
+	expected interface{}
+}
+
+func (matcher *representVerticaRestorePointsQueryCondition) Match(actual interface{}) (success bool, err error) {
+	response, ok := actual.(metav1.Condition)
+	if !ok {
+		return false, fmt.Errorf("representVerticaRestorePointsQueryCondition matcher expects a vapi.VerticaRestorePointsQueryCondition")
+	}
+	expectedObj, ok := matcher.expected.(metav1.Condition)
+	if !ok {
+		return false, fmt.Errorf("representVerticaRestorePointsQueryCondition should compare with a metav1.Condition")
+	}
+	// Compare everything except lastTransitionTime
+	return response.Type == expectedObj.Type && response.Status == expectedObj.Status, nil
+}
+
+func (matcher *representVerticaRestorePointsQueryCondition) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto equal\n\t%#v", actual, matcher.expected)
+}
+
+func (matcher *representVerticaRestorePointsQueryCondition) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto not equal\n\t%#v", actual, matcher.expected)
+}
+
+var _ = Describe("status", func() {
+	ctx := context.Background()
+
+	It("should update status condition when no conditions have been set", func() {
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		cond := v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, "")
+		Expect(UpdateCondition(ctx, k8sClient, logger, vrpq, cond)).Should(Succeed())
+		fetchVdb := &vapi.VerticaRestorePointsQuery{}
+		nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
+		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
+		for _, v := range []*vapi.VerticaRestorePointsQuery{vrpq, fetchVdb} {
+			Expect(len(v.Status.Conditions)).Should(Equal(1))
+			Expect(v.Status.Conditions[0]).Should(EqualVerticaRestorePointsQueryCondition(*cond))
+		}
+	})
+
+	It("should be able to change an existing status condition", func() {
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		conds := []metav1.Condition{
+			{Type: vapi.Querying, Status: metav1.ConditionTrue, Reason: v1.UnknownReason},
+			{Type: vapi.Querying, Status: metav1.ConditionFalse, Reason: v1.UnknownReason},
+		}
+		for i := range conds {
+			Expect(UpdateCondition(ctx, k8sClient, logger, vrpq, &conds[i])).Should(Succeed())
+			fetchVdb := &vapi.VerticaRestorePointsQuery{}
+			nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
+			Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
+			for _, v := range []*vapi.VerticaRestorePointsQuery{vrpq, fetchVdb} {
+				Expect(len(v.Status.Conditions)).Should(Equal(1))
+				Expect(v.Status.Conditions[0]).Should(EqualVerticaRestorePointsQueryCondition(conds[i]))
+			}
+		}
+	})
+
+	It("should be able to handle multiple status conditions", func() {
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+
+		conds := []metav1.Condition{
+			{Type: vapi.Querying, Status: metav1.ConditionTrue, Reason: v1.UnknownReason},
+			{Type: vapi.Querying, Status: metav1.ConditionFalse, Reason: v1.UnknownReason},
+			{Type: vapi.QueryComplete, Status: metav1.ConditionTrue, Reason: v1.UnknownReason},
+		}
+
+		for i := range conds {
+			Expect(UpdateCondition(ctx, k8sClient, logger, vrpq, &conds[i])).Should(Succeed())
+		}
+
+		fetchVdb := &vapi.VerticaRestorePointsQuery{}
+		nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
+		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
+		for _, v := range []*vapi.VerticaRestorePointsQuery{vrpq, fetchVdb} {
+			Expect(len(v.Status.Conditions)).Should(Equal(2))
+			Expect(v.Status.Conditions[0]).Should(EqualVerticaRestorePointsQueryCondition(conds[1]))
+			Expect(v.Status.Conditions[1]).Should(EqualVerticaRestorePointsQueryCondition(conds[2]))
+		}
+	})
+
+	It("should change the lastTransitionTime when a status condition is changed", func() {
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+		origTime := metav1.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+		Expect(UpdateCondition(ctx, k8sClient, logger, vrpq,
+			&metav1.Condition{Type: vapi.Querying, Status: metav1.ConditionFalse, LastTransitionTime: origTime,
+				Reason: v1.UnknownReason},
+		)).Should(Succeed())
+		Expect(UpdateCondition(ctx, k8sClient, logger, vrpq,
+			&metav1.Condition{Type: vapi.Querying, Status: metav1.ConditionTrue, LastTransitionTime: origTime,
+				Reason: v1.UnknownReason},
+		)).Should(Succeed())
+		Expect(vrpq.Status.Conditions[0].LastTransitionTime).ShouldNot(Equal(origTime))
+	})
+
+	It("should update the message status", func() {
+		vrpq := vapi.MakeVrpq()
+		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
+		msg := "Query is still in progress"
+		msg1 := "Query has completed successfully"
+
+		Expect(UpdateMessageStatus(ctx, k8sClient, logger, vrpq, msg)).Should(Succeed())
+
+		nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
+		Expect(k8sClient.Get(ctx, nm, vrpq)).Should(Succeed())
+		Expect(vrpq.Status.Message).Should(Equal(msg))
+
+		Expect(UpdateMessageStatus(ctx, k8sClient, logger, vrpq, msg1)).Should(Succeed())
+
+		Expect(k8sClient.Get(ctx, nm, vrpq)).Should(Succeed())
+		Expect(vrpq.Status.Message).Should(Equal(msg1))
+	})
+})

--- a/pkg/vrpqstatus/status_test.go
+++ b/pkg/vrpqstatus/status_test.go
@@ -116,7 +116,7 @@ var _ = Describe("status", func() {
 		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
 
 		cond := v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, "")
-		Expect(UpdateCondition(ctx, k8sClient, logger, vrpq, cond)).Should(Succeed())
+		Expect(UpdateConditionAndState(ctx, k8sClient, logger, vrpq, cond, "")).Should(Succeed())
 		fetchVdb := &vapi.VerticaRestorePointsQuery{}
 		nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
 		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
@@ -136,7 +136,7 @@ var _ = Describe("status", func() {
 			{Type: vapi.Querying, Status: metav1.ConditionFalse, Reason: v1.UnknownReason},
 		}
 		for i := range conds {
-			Expect(UpdateCondition(ctx, k8sClient, logger, vrpq, &conds[i])).Should(Succeed())
+			Expect(UpdateConditionAndState(ctx, k8sClient, logger, vrpq, &conds[i], "")).Should(Succeed())
 			fetchVdb := &vapi.VerticaRestorePointsQuery{}
 			nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
 			Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
@@ -159,7 +159,7 @@ var _ = Describe("status", func() {
 		}
 
 		for i := range conds {
-			Expect(UpdateCondition(ctx, k8sClient, logger, vrpq, &conds[i])).Should(Succeed())
+			Expect(UpdateConditionAndState(ctx, k8sClient, logger, vrpq, &conds[i], "")).Should(Succeed())
 		}
 
 		fetchVdb := &vapi.VerticaRestorePointsQuery{}
@@ -177,13 +177,13 @@ var _ = Describe("status", func() {
 		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
 		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
 		origTime := metav1.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
-		Expect(UpdateCondition(ctx, k8sClient, logger, vrpq,
+		Expect(UpdateConditionAndState(ctx, k8sClient, logger, vrpq,
 			&metav1.Condition{Type: vapi.Querying, Status: metav1.ConditionFalse, LastTransitionTime: origTime,
-				Reason: v1.UnknownReason},
+				Reason: v1.UnknownReason}, "",
 		)).Should(Succeed())
-		Expect(UpdateCondition(ctx, k8sClient, logger, vrpq,
+		Expect(UpdateConditionAndState(ctx, k8sClient, logger, vrpq,
 			&metav1.Condition{Type: vapi.Querying, Status: metav1.ConditionTrue, LastTransitionTime: origTime,
-				Reason: v1.UnknownReason},
+				Reason: v1.UnknownReason}, "",
 		)).Should(Succeed())
 		Expect(vrpq.Status.Conditions[0].LastTransitionTime).ShouldNot(Equal(origTime))
 	})
@@ -192,17 +192,19 @@ var _ = Describe("status", func() {
 		vrpq := vapi.MakeVrpq()
 		Expect(k8sClient.Create(ctx, vrpq)).Should(Succeed())
 		defer func() { Expect(k8sClient.Delete(ctx, vrpq)).Should(Succeed()) }()
-		msg := "Query is still in progress"
-		msg1 := "Query has completed successfully"
+		msg := "Querying"
+		msg1 := "Query successful"
+		cond := v1.MakeCondition(vapi.Querying, metav1.ConditionTrue, "")
 
-		Expect(UpdateMessageStatus(ctx, k8sClient, logger, vrpq, msg)).Should(Succeed())
+		Expect(UpdateConditionAndState(ctx, k8sClient, logger, vrpq,
+			cond, msg)).Should(Succeed())
 
 		nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
 		Expect(k8sClient.Get(ctx, nm, vrpq)).Should(Succeed())
 		Expect(vrpq.Status.State).Should(Equal(msg))
 
-		Expect(UpdateMessageStatus(ctx, k8sClient, logger, vrpq, msg1)).Should(Succeed())
-
+		Expect(UpdateConditionAndState(ctx, k8sClient, logger, vrpq,
+			cond, msg1)).Should(Succeed())
 		Expect(k8sClient.Get(ctx, nm, vrpq)).Should(Succeed())
 		Expect(vrpq.Status.State).Should(Equal(msg1))
 	})

--- a/pkg/vrpqstatus/status_test.go
+++ b/pkg/vrpqstatus/status_test.go
@@ -199,11 +199,11 @@ var _ = Describe("status", func() {
 
 		nm := types.NamespacedName{Namespace: vrpq.Namespace, Name: vrpq.Name}
 		Expect(k8sClient.Get(ctx, nm, vrpq)).Should(Succeed())
-		Expect(vrpq.Status.Message).Should(Equal(msg))
+		Expect(vrpq.Status.State).Should(Equal(msg))
 
 		Expect(UpdateMessageStatus(ctx, k8sClient, logger, vrpq, msg1)).Should(Succeed())
 
 		Expect(k8sClient.Get(ctx, nm, vrpq)).Should(Succeed())
-		Expect(vrpq.Status.Message).Should(Equal(msg1))
+		Expect(vrpq.Status.State).Should(Equal(msg1))
 	})
 })

--- a/tests/e2e-leg-6/verify-vrpq-conditions/10-assert.yaml
+++ b/tests/e2e-leg-6/verify-vrpq-conditions/10-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: vertica.com/v1beta1
+kind: VerticaRestorePointsQuery
+metadata:
+  name: archive-query
+status:
+  state: "Queried successful"

--- a/tests/e2e-leg-6/verify-vrpq-conditions/10-assert.yaml
+++ b/tests/e2e-leg-6/verify-vrpq-conditions/10-assert.yaml
@@ -1,6 +1,21 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wait for the operator to update the sts with the new license
+
 apiVersion: vertica.com/v1beta1
 kind: VerticaRestorePointsQuery
 metadata:
   name: archive-query
 status:
-  state: "Queried successful"
+  state: "Query successful"

--- a/tests/e2e-leg-6/verify-vrpq-conditions/10-verify-conditions.yaml
+++ b/tests/e2e-leg-6/verify-vrpq-conditions/10-verify-conditions.yaml
@@ -18,4 +18,3 @@ kind: TestStep
 commands:
     # verifying type:"QueryComplete", and status:"True"
     - script: kubectl wait --for=condition=QueryComplete=True -n $NAMESPACE vrpq/archive-query --timeout=600s
-    - script: kubectl describe vrpq -n $NAMESPACE archive-query | awk '/Message:.*Queried successful/{print; exit}'

--- a/tests/e2e-leg-6/verify-vrpq-conditions/10-verify-conditions.yaml
+++ b/tests/e2e-leg-6/verify-vrpq-conditions/10-verify-conditions.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wait for the operator to update the sts with the new license
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+    # verifying type:"QueryComplete", and status:"True"
+    - script: kubectl wait --for=condition=QueryComplete=True -n $NAMESPACE vrpq/archive-query --timeout=600s
+    - script: kubectl describe vrpq -n $NAMESPACE archive-query | awk '/Message:.*Queried successful/{print; exit}'


### PR DESCRIPTION
This PR adds custom print columns for the new VerticaRestorePointsQuery CR, so that a kubectl get vrpq command tells you if the query has completed.