### PR TITLE
Fix offline-upgrade-ks-0 e2e test

### DIFF
--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/30-wait-for-bad-image-upgrade-start.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/30-wait-for-bad-image-upgrade-start.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl wait --for=condition=UpgradeInProgress=True vdb/v-base-upgrade --timeout=600s
+    namespaced: true

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/38-wait-for-bad-image-upgrade-start.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/38-wait-for-bad-image-upgrade-start.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl wait --for=condition=UpgradeInProgress=True vdb/v-base-upgrade --timeout=600s
+    namespaced: true

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/46-wait-for-bad-image-upgrade-start.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/46-wait-for-bad-image-upgrade-start.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2023] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl wait --for=condition=UpgradeInProgress=True vdb/v-base-upgrade --timeout=600s
+    namespaced: true


### PR DESCRIPTION
Small fix to a recent change I made to this test for the NMA sidecar feature. I need to ensure we wait appropriately for the operator to acknowledge an upgrade before moving onto the next step. We use to verify this by checking the image, but that was removed because there is another container to check now.