### PR TITLE
Only run e2e-leg-6 in 24.2.0+ server

### DIFF
--- a/.github/workflows/e2e-leg-6.yml
+++ b/.github/workflows/e2e-leg-6.yml
@@ -62,6 +62,14 @@ jobs:
         # Leg 6 is only tested in vclusterops mode. It has tests that depend on
         # features only available with that deployment method.
         export VERTICA_DEPLOYMENT_METHOD=vclusterops
+        # Also, leg 6 is only tested with 24.2.0+. It has tests that depend on
+        # features only available in 24.2.0+. Anytime we run on an older
+        # version we will complete as a no-op.
+        if scripts/is-image.sh -i $VERTICA_IMG older 24.2.0
+        then
+          echo "Old version detected, skipping all of the tests"
+          exit 0
+        fi
         export E2E_TEST_DIRS="tests/e2e-leg-6"
         mkdir -p $GITHUB_WORKSPACE/../host-path
         scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s


### PR DESCRIPTION
This changes e2e-leg-6 so that it only runs on 24.2.0+ server. On older releases some of the testcases fail. This is due to the new NMA container.