### PR TITLE
CI Updates for Node 16 deprecation

### DIFF
--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -31,7 +31,7 @@ runs:
         docker image ls -a
 
     - name: Login to GitHub Container registry for non-PRs
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ github.event_name != 'pull_request' }}
       with:
         registry: ghcr.io

--- a/.github/actions/setup-e2e/action.yaml
+++ b/.github/actions/setup-e2e/action.yaml
@@ -17,7 +17,7 @@ runs:
       uses: ./.github/actions/setup-kubectl
 
     - name: Download all the docker image for PRs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       if: ${{ github.event_name == 'pull_request' }}
 
     - name: Load the docker images for PRs

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -4,6 +4,6 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -76,7 +76,7 @@ jobs:
           ${{ inputs.full_vertica_image != '' }} => ${{ inputs.full_vertica_image }}
 
     - name: Login to GitHub Container registry for non-PRs
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ github.event_name != 'pull_request' && startsWith(inputs.full_vertica_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
@@ -84,13 +84,13 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ inputs.full_vertica_image != '' && startsWith(inputs.full_vertica_image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ inputs.full_vertica_image == '' }}
 
     - name: Download the RPM
@@ -127,7 +127,7 @@ jobs:
         output: 'trivy-results-vertica-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: ${{ always() && inputs.run_security_scan == 'all' && github.event_name != 'pull_request' }}
       with:
         sarif_file: 'trivy-results-vertica-image.sarif'
@@ -143,7 +143,7 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-image.out'
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ always() && inputs.run_security_scan == 'all' }}
       with:
         name: security-scan
@@ -184,7 +184,7 @@ jobs:
           ${{ github.event_name == 'pull_request' }} => vertica-k8s:kind-legacy
 
     - name: Login to GitHub Container registry for non-PRs
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ github.event_name != 'pull_request' && inputs.legacy_vertica_image == '' || startsWith(inputs.legacy_vertica_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
@@ -192,13 +192,13 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ inputs.legacy_vertica_image != '' && startsWith(inputs.legacy_vertica_image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ inputs.legacy_vertica_image == '' }}
 
     - name: Download the RPM
@@ -220,7 +220,7 @@ jobs:
       run: |
         docker save ${{ steps.legacy_vertica_image.outputs.value }} > legacy-vertica-image.tar
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: legacy-vertica-image
@@ -258,7 +258,7 @@ jobs:
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 
     - name: Login to GitHub Container registry for non-PRs
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ github.event_name != 'pull_request' && startsWith(inputs.minimal_vertica_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
@@ -266,13 +266,13 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ inputs.minimal_vertica_image != '' && startsWith(inputs.minimal_vertica_image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ inputs.minimal_vertica_image == '' }}
 
     - name: Download the RPM
@@ -331,14 +331,14 @@ jobs:
           ${{ github.event_name == 'pull_request' }} => verticadb-operator:kind
 
     - name: Login to GitHub Container registry for non-PRs
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ github.event_name != 'pull_request' && inputs.operator_image == '' || startsWith(inputs.operator_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ inputs.operator_image == '' }}
 
     - name: Set up Go
@@ -360,7 +360,7 @@ jobs:
       run: |
         docker save ${{ steps.operator_image.outputs.value }} > operator-image.tar
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: operator-image
@@ -381,7 +381,7 @@ jobs:
         output: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: ${{ always() && inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
@@ -395,7 +395,7 @@ jobs:
         format: 'table'
         output: 'trivy-results-verticadb-operator-image.out'
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ always() && inputs.run_security_scan != 'none' }}
       with:
         name: security-scan
@@ -433,14 +433,14 @@ jobs:
           ${{ github.event_name == 'pull_request' }} => vertica-logger:kind
 
     - name: Login to GitHub Container registry for non-PRs
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ github.event_name != 'pull_request' && inputs.vlogger_image == '' || startsWith(inputs.vlogger_image, 'ghcr.io') }}
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: ${{ inputs.vlogger_image == '' }}
 
     - name: Build and optionally push vlogger image
@@ -458,7 +458,7 @@ jobs:
       run: |
         docker save ${{ steps.vlogger_image.outputs.value }} > vlogger-image.tar
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: vlogger-image
@@ -479,7 +479,7 @@ jobs:
         output: 'trivy-results-vertica-logger-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: ${{ always() && inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         sarif_file: 'trivy-results-vertica-logger-image.sarif'
@@ -493,7 +493,7 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-logger-image.out'
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ always() && inputs.run_security_scan != 'none' }}
       with:
         name: security-scan

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -146,7 +146,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ always() && inputs.run_security_scan == 'all' }}
       with:
-        name: security-scan
+        name: security-scan-server
         path: 'trivy-results-vertica-image.out'
 
     - name: Print a summary of the job
@@ -398,7 +398,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ always() && inputs.run_security_scan != 'none' }}
       with:
-        name: security-scan
+        name: security-scan-operator
         path: 'trivy-results-verticadb-operator-image.out'
 
     - name: Print a summary of the job
@@ -496,7 +496,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ always() && inputs.run_security_scan != 'none' }}
       with:
-        name: security-scan
+        name: security-scan-logger
         path: 'trivy-results-vertica-logger-image.out'
 
     - name: Print a summary of the job

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
       
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up environment
       uses: ./.github/actions/setup-go
@@ -48,31 +48,31 @@ jobs:
         ls -lhrt
     
     - name: Upload CRDs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/verticadb-operator/crds/*-crd.yaml 
 
     - name: Upload YAMLs in release artifacts directory
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/*yaml
 
     - name: Upload Helm Charts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/*.tgz
 
     - name: Upload vdb-gen
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release-artifacts
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/bin/vdb-gen
 
     - name: Upload Bundle
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: olm-bundle
         path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/bundle

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -47,39 +47,13 @@ jobs:
         helm package verticadb-operator
         ls -lhrt
     
-    - name: Upload CRDs
+    - name: Upload files
       uses: actions/upload-artifact@v4
       with:
         name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/verticadb-operator/crds/*-crd.yaml 
-
-    - name: Upload YAMLs in release artifacts directory
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/*yaml
-
-    - name: Upload Helm Charts
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/*.tgz
-
-    - name: Upload vdb-gen
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-artifacts
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/bin/vdb-gen
-
-    - name: Upload Bundle
-      uses: actions/upload-artifact@v4
-      with:
-        name: olm-bundle
-        path: /home/runner/work/vertica-kubernetes/vertica-kubernetes/bundle
-    
-
-    
-
-
-
-        
+        path: |
+          /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/verticadb-operator/crds/*-crd.yaml 
+          /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/*yaml
+          /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/*.tgz
+          /home/runner/work/vertica-kubernetes/vertica-kubernetes/bin/vdb-gen
+          /home/runner/work/vertica-kubernetes/vertica-kubernetes/bundle

--- a/.github/workflows/e2e-leg-1.yml
+++ b/.github/workflows/e2e-leg-1.yml
@@ -59,13 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -83,7 +83,7 @@ jobs:
         if [ "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]; then E2E_TEST_DIRS+=" tests/e2e-leg-1-at-only"; fi
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-azb-ci.txt
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-leg-1-${{ inputs.vertica-deployment-method }}${{ inputs.artifact-suffix }}

--- a/.github/workflows/e2e-leg-2.yml
+++ b/.github/workflows/e2e-leg-2.yml
@@ -59,13 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -84,7 +84,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/../host-path
         scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-leg-2-${{ inputs.vertica-deployment-method }}${{ inputs.artifact-suffix }}

--- a/.github/workflows/e2e-leg-3.yml
+++ b/.github/workflows/e2e-leg-3.yml
@@ -59,13 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -83,7 +83,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/../host-path
         scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-leg-3-${{ inputs.vertica-deployment-method }}${{ inputs.artifact-suffix }}

--- a/.github/workflows/e2e-leg-4.yml
+++ b/.github/workflows/e2e-leg-4.yml
@@ -61,13 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -88,7 +88,7 @@ jobs:
         export HELM_OVERRIDES="--set webhook.certSource=cert-manager"
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-s3-ci.txt
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-leg-4-${{ inputs.vertica-deployment-method }}

--- a/.github/workflows/e2e-leg-5.yml
+++ b/.github/workflows/e2e-leg-5.yml
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -84,7 +84,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/../host-path
         scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-leg-5-${{ inputs.vertica-deployment-method }}

--- a/.github/workflows/e2e-leg-6.yml
+++ b/.github/workflows/e2e-leg-6.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -74,7 +74,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/../host-path
         scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-leg-6-vcluster

--- a/.github/workflows/e2e-leg-7.yml
+++ b/.github/workflows/e2e-leg-7.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -76,7 +76,7 @@ jobs:
         mkdir -p $GITHUB_WORKSPACE/../host-path
         scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-leg-7-vcluster

--- a/.github/workflows/e2e-operator-upgrade.yml
+++ b/.github/workflows/e2e-operator-upgrade.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -65,7 +65,7 @@ jobs:
         scripts/setup-operator-upgrade-testsuite.sh
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-s3-ci.txt
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-operator-upgrade

--- a/.github/workflows/e2e-server-upgrade.yml
+++ b/.github/workflows/e2e-server-upgrade.yml
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
       
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -78,7 +78,7 @@ jobs:
         echo "Upgrading server from image: $BASE_VERTICA_IMG"
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-server-upgrade-ci.txt
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-server-upgrade-${{ inputs.vertica-deployment-method }}

--- a/.github/workflows/e2e-udx.yml
+++ b/.github/workflows/e2e-udx.yml
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up e2e environment
       uses: ./.github/actions/setup-e2e
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: ${{ startsWith(inputs.vertica-image, 'docker.io') }}
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -82,7 +82,7 @@ jobs:
         fi
         scripts/run-k8s-int-tests.sh -s -e tests/external-images-s3-ci.txt
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: logs-e2e-udx-${{ inputs.vertica-deployment-method }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.action == 'change operator version' && inputs.new-operator-version != '' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Change version in the source files
       run: |
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.action == 'generate CHANGELOG' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Save current version to env
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
   create-release:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: vertica-kubernetes
         fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
 
     - name: Login to Docker Hub
       if: ${{ inputs.action == 'upload operator image' || inputs.action == 'all' }}
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/scorecardtests.yml
+++ b/.github/workflows/scorecardtests.yml
@@ -7,7 +7,7 @@ jobs:
   sct:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
         
     - name: Set up Go
       uses: ./.github/actions/setup-go

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@ jobs:
   ut:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: ./.github/actions/setup-go
@@ -27,7 +27,7 @@ jobs:
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       if: ${{ env.DOCKERHUB_USERNAME != '' }}
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/verify-public-artifacts.yml
+++ b/.github/workflows/verify-public-artifacts.yml
@@ -7,7 +7,7 @@ on:
         type: choice
         description: 'Select the deployment method'
         required: true
-        options: ['helm', 'olm']
+        options: ['helm', 'olm', 'kubectl']
         default: 'helm'
       expected_operator_version:
         description: 'The expected operator version to deploy (e.g. 1.5.0)'
@@ -15,6 +15,8 @@ on:
       expected_server_version:
         description: 'The expected server version to deploy (e.g. 11.1.1-0)'
         required: true
+
+run-name: ${{ inputs.deploy_with }} verification
 
 jobs:
 
@@ -60,14 +62,22 @@ jobs:
         echo "Waiting for verticadb-operator CSV to be created..."
         timeout 5m bash -c -- "while ! kubectl get csv | grep 'VerticaDB Operator' | grep -cq Succeeded; do sleep 5; done"
         echo "DONE!"
-        kubectl create namespace my-verticadb-operator
+        kubectl create namespace verticadb-operator
 
     - name: Deploy the verticadb operator with helm
       if: github.event.inputs.deploy_with == 'helm'
       run: |
         helm repo add vertica-charts https://vertica.github.io/charts
         helm repo update vertica-charts
-        helm install vdb-op --wait --namespace my-verticadb-operator --create-namespace vertica-charts/verticadb-operator
+        helm install vdb-op --wait --namespace verticadb-operator --create-namespace vertica-charts/verticadb-operator
+
+    - name: Deploy the verticadb operator with kubectl
+      if: github.event.inputs.deploy_with == 'kubectl'
+      run: |
+        kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/verticadbs.vertica.com-crd.yaml
+        kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/verticaautoscalers.vertica.com-crd.yaml
+        kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/eventtriggers.vertica.com-crd.yaml
+        kubectl apply -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/operator.yaml
 
     - name: Install krew
       run: | 
@@ -80,28 +90,28 @@ jobs:
 
     - name: Install the minio Tenant
       run: |
-        kubectl apply --namespace my-verticadb-operator -f config/samples/minio.yaml
-        kubectl wait --for=condition=Complete=True --namespace my-verticadb-operator job/create-s3-bucket --timeout=5m
+        kubectl apply --namespace verticadb-operator -f config/samples/minio.yaml
+        kubectl wait --for=condition=Complete=True --namespace verticadb-operator job/create-s3-bucket --timeout=5m
 
     - name: Create a VerticaDB CR
       run: |
-        kubectl apply --namespace my-verticadb-operator -f config/samples/verticadb_sample.yaml
-        kubectl wait --for=condition=DBInitialized=True --namespace my-verticadb-operator vdb/verticadb-sample --timeout=10m
-        kubectl get pods --namespace my-verticadb-operator --selector app.kubernetes.io/instance=verticadb-sample
+        kubectl apply --namespace verticadb-operator -f config/samples/verticadb_sample.yaml
+        kubectl wait --for=condition=DBInitialized=True --namespace verticadb-operator vdb/verticadb-sample --timeout=10m
+        kubectl get pods --namespace verticadb-operator --selector app.kubernetes.io/instance=verticadb-sample
 
     - name: Dump the vertica server version
       run: |
-        kubectl exec -it --namespace my-verticadb-operator verticadb-sample-defaultsubcluster-0 -- vsql -c "select version();"
+        kubectl exec -it --namespace verticadb-operator verticadb-sample-defaultsubcluster-0 -- vsql -c "select version();"
 
     - name: Dump the labels/annotations of the vertica pods
       run: |
-        kubectl get pods --namespace my-verticadb-operator --selector app.kubernetes.io/instance=verticadb-sample -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.metadata.labels}{"\n"}{.metadata.annotations}{"\n"}{"\n"}{end}'
+        kubectl get pods --namespace verticadb-operator --selector app.kubernetes.io/instance=verticadb-sample -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{.metadata.labels}{"\n"}{.metadata.annotations}{"\n"}{"\n"}{end}'
 
     - name: Verify the operator version
       run: |
-        kubectl get pods --namespace my-verticadb-operator --selector app.kubernetes.io/version=${{ github.event.inputs.expected_operator_version }} | grep -cq 'verticadb-sample-defaultsubcluster'
+        kubectl get pods --namespace verticadb-operator --selector app.kubernetes.io/version=${{ github.event.inputs.expected_operator_version }} | grep -cq 'verticadb-sample-defaultsubcluster'
 
     - name: Verify the server version
       run: |
-        kubectl exec -it --namespace my-verticadb-operator verticadb-sample-defaultsubcluster-0 -- vsql -c "select 1 where version() = 'Vertica Analytic Database v${{ github.event.inputs.expected_server_version }}';" | grep -cq '(1 row)'
+        kubectl exec -it --namespace verticadb-operator verticadb-sample-defaultsubcluster-0 -- vsql -c "select 1 where version() = 'Vertica Analytic Database v${{ github.event.inputs.expected_server_version }}';" | grep -cq '(1 row)'
  

--- a/.github/workflows/verify-public-artifacts.yml
+++ b/.github/workflows/verify-public-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: ./.github/actions/setup-go

--- a/.github/workflows/verify-public-artifacts.yml
+++ b/.github/workflows/verify-public-artifacts.yml
@@ -74,9 +74,7 @@ jobs:
     - name: Deploy the verticadb operator with kubectl
       if: github.event.inputs.deploy_with == 'kubectl'
       run: |
-        kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/verticadbs.vertica.com-crd.yaml
-        kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/verticaautoscalers.vertica.com-crd.yaml
-        kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/eventtriggers.vertica.com-crd.yaml
+        kubectl apply --server-side=true --force-conflicts -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/crds.yaml
         kubectl apply -f https://github.com/vertica/vertica-kubernetes/releases/latest/download/operator.yaml
 
     - name: Install krew

--- a/scripts/config-transformer.sh
+++ b/scripts/config-transformer.sh
@@ -40,7 +40,7 @@ rm $TEMPLATE_DIR/verticadb-operator-openshift-cluster-rolebinding-crb.yaml
 # Generate release artifacts from the split yaml's just generated.  This is
 # done before templating the helm charts so that the yaml's can be used
 # directly with a 'kubectl apply' command.
-$SCRIPT_DIR/gen-release-artifacts.sh $TEMPLATE_DIR
+$SCRIPT_DIR/gen-release-artifacts.sh $TEMPLATE_DIR $CRD_DIR
 
 # Add templating to the manifests in templates/ so that we can use helm
 # parameters to customize the deployment.

--- a/scripts/gen-release-artifacts.sh
+++ b/scripts/gen-release-artifacts.sh
@@ -34,6 +34,19 @@ then
     exit 1
 fi
 
+CRD_DIR=$2
+if [ -z $CRD_DIR ]
+then
+    echo "*** Must specify directory to find the crds"
+    exit 1
+fi
+
+if [ ! -d $CRD_DIR ]
+then
+    echo "*** The directory $CRD_DIR doesn't exist"
+    exit 1
+fi
+
 # Copy out manifests that we will include as release artifacts.  We do this
 # *before* templating so that they can used directly with a 'kubectl apply'
 # command.
@@ -60,3 +73,13 @@ cp $REPO_DIR/config/rbac/verticadb-operator-cr-user-role.yaml $RELEASE_ARTIFACT_
 # Copy the Role that must be linked to the ServiceAccount running the vertica
 # server pods.
 cp $REPO_DIR/config/rbac/vertica-server-role.yaml $RELEASE_ARTIFACT_TARGET_DIR
+
+# Create a single YAML with all of the CRDs.
+megaCRD=$RELEASE_ARTIFACT_TARGET_DIR/crds.yaml
+rm $megaCRD || true
+for f in $CRD_DIR/*-crd.yaml
+do
+    cat $f >> $megaCRD
+    echo "---" >> $megaCRD
+done
+sed -i '$ d' $megaCRD  # Remove the last '---'

--- a/tests/e2e-server-upgrade/online-upgrade-drain/long-running-connection-secondary/base/long-running-connection.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/long-running-connection-secondary/base/long-running-connection.yaml
@@ -52,7 +52,7 @@ metadata:
   labels:
     stern: include
 spec:
-  restartPolicy: Never
+  restartPolicy: OnFailure
   containers:
     - name: test
       image: kustomize-vertica-image


### PR DESCRIPTION
This updates actions used in the CI to new versions that aren't using Node 16. Node 16 was deprecated in GitHub actions, so we have warnings when we have actions using them. There are still a few remaining deprecations, which will be fixed at a later time.

One other notable change. The verify-public-release workflow has been updated so we have the option now to deploy the operator with kubectl.
