### PR TITLE
 Add empty controller and API for VerticaScrutinize

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -59,4 +59,12 @@ resources:
   kind: VerticaRestorePointsQuery
   path: github.com/vertica/vertica-kubernetes/api/v1beta1
   version: v1beta1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: vertica.com
+  kind: VerticaScrutinize
+  path: github.com/vertica/vertica-kubernetes/api/v1beta1
+  version: v1beta1
 version: "3"

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -31,6 +31,7 @@ const (
 	VerticaAutoscalerKind  = "VerticaAutoscaler"
 	EventTriggerKind       = "EventTrigger"
 	RestorePointsQueryKind = "VerticaRestorePointsQuery"
+	VerticaScrutinizeKind  = "VerticaScrutinize"
 )
 
 var (
@@ -48,4 +49,5 @@ var (
 	GkVAS  = schema.GroupKind{Group: Group, Kind: VerticaAutoscalerKind}
 	GkET   = schema.GroupKind{Group: Group, Kind: EventTriggerKind}
 	GkVRPQ = schema.GroupKind{Group: Group, Kind: RestorePointsQueryKind}
+	GkVSCR = schema.GroupKind{Group: Group, Kind: VerticaScrutinizeKind}
 )

--- a/api/v1beta1/helpers.go
+++ b/api/v1beta1/helpers.go
@@ -1,0 +1,40 @@
+/*
+Copyright [2021-2023] Open Text.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import corev1 "k8s.io/api/core/v1"
+
+// Affinity is used instead of corev1.Affinity and behaves the same.
+// This structure is used in some CRs fields to define the "Affinity".
+// corev1.Affinity is composed of 3 fields and for each of them,
+// there is a x-descriptor. However there is not a x-descriptor for corev1.Affinity itself.
+// In this structure, we have the same fields as corev1' but we also added
+// the corresponding x-descriptor to each field. That will be useful for the Openshift web console.
+type Affinity struct {
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:nodeAffinity"
+	// Describes node affinity scheduling rules for the pod.
+	// +optional
+	NodeAffinity *corev1.NodeAffinity `json:"nodeAffinity,omitempty" protobuf:"bytes,1,opt,name=nodeAffinity"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podAffinity"
+	// Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+	// +optional
+	PodAffinity *corev1.PodAffinity `json:"podAffinity,omitempty" protobuf:"bytes,2,opt,name=podAffinity"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podAntiAffinity"
+	// Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+	// +optional
+	PodAntiAffinity *corev1.PodAntiAffinity `json:"podAntiAffinity,omitempty" protobuf:"bytes,3,opt,name=podAntiAffinity"`
+}

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -841,27 +841,6 @@ type Subcluster struct {
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 }
 
-// Affinity is used instead of corev1.Affinity and behaves the same.
-// This structure is used in subcluster to define the "Affinity".
-// corev1.Affinity is composed of 3 fields and for each of them,
-// there is a x-descriptor. However there is not a x-descriptor for corev1.Affinity itself.
-// In this structure, we have the same fields as corev1' but we also added
-// the corresponding x-descriptor to each field. That will be useful for the Openshift web console.
-type Affinity struct {
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:nodeAffinity"
-	// Describes node affinity scheduling rules for the pod.
-	// +optional
-	NodeAffinity *corev1.NodeAffinity `json:"nodeAffinity,omitempty" protobuf:"bytes,1,opt,name=nodeAffinity"`
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podAffinity"
-	// Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-	// +optional
-	PodAffinity *corev1.PodAffinity `json:"podAffinity,omitempty" protobuf:"bytes,2,opt,name=podAffinity"`
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:podAntiAffinity"
-	// Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-	// +optional
-	PodAntiAffinity *corev1.PodAntiAffinity `json:"podAntiAffinity,omitempty" protobuf:"bytes,3,opt,name=podAntiAffinity"`
-}
-
 // VerticaDBStatus defines the observed state of VerticaDB
 type VerticaDBStatus struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status

--- a/api/v1beta1/verticascrutinize_types.go
+++ b/api/v1beta1/verticascrutinize_types.go
@@ -1,0 +1,174 @@
+/*
+Copyright [2021-2023] Open Text.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type VerticaScrutinizeSpec struct {
+
+	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	// The name of the VerticaDB CR that this VerticaScrutinize is defined for.  The
+	// VerticaDB object must exist in the same namespace as this object.
+	VerticaDBName string `json:"verticaDBName"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// This allows the user to select the volume to use for the final destination of the scrutinize tarball and
+	// any intermediate files. The volume must have enough space to store the scrutinize data.
+	// If this is omitted, then a simple emptyDir volume is created to store the scrutinize data.
+	Volume *corev1.Volume `json:"volume,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	// A list of additional init containers to run. These are run after running the init container that collects
+	// the scrutinize command. These can be used to do some kind of post-processing of the tarball, such as uploading it
+	// to some kind of storage.
+	InitContainers []corev1.Container `json:"initContainers,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+	// This defines the resource requests and limits for the scrutinize pod.
+	// It is advisable that the request and limits match as this ensures the
+	// pods are assigned to the guaranteed QoS class. This will reduces the
+	// chance that pods are chosen by the OOM killer.
+	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// A map of label keys and values to restrict scrutinize node scheduling to workers
+	// with matching labels.
+	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Like nodeSelector this allows you to constrain the pod only to certain
+	// pods. It is more expressive than just using node selectors.
+	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+	Affinity Affinity `json:"affinity,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	// The priority class name given to the scrutinize. This affects
+	// where the pod gets scheduled.
+	// More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:advanced"
+	// Any tolerations and taints to use to aid in where to schedule a pod.
+	// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// A list of annotations that will be added to the scrutinize pod.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// A list of labels that will be added to the scrutinize pod.
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// VerticaScrutinizeStatus defines the observed state of VerticaScrutinize
+type VerticaScrutinizeStatus struct {
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +optional
+	// The name of the scrutinize pod that was created.
+	PodName string `json:"podName"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +optional
+	// The UID of the pod name that was created.
+	PodUID types.UID `json:"podUID"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +optional
+	// The name of the scrutinize tarball that was created.
+	TarballName string `json:"tarballName"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// Set of status conditions to know how far along the scrutinize is.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+const (
+	// ScrutinizePodCreated indicates whether the scrutinize pod has been created
+	ScrutinizePodCreated = "ScrutinizePodCreated"
+	// ScrutinizeCollectionFinished indicates whether scrutinize collection is done
+	ScrutinizeCollectionFinished = "ScrutinizeCollectionFinished"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:categories=all;vertica,shortName=vscr
+// +kubebuilder:subresource:status
+// +operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1,""},{VerticaDB,vertica.com/v1beta1,""}}
+
+// VerticaScrutinize is the schema for verticascrutinize API
+type VerticaScrutinize struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   VerticaScrutinizeSpec   `json:"spec,omitempty"`
+	Status VerticaScrutinizeStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// VerticaScrutinizeList contains a list of VerticaScrutinize
+type VerticaScrutinizeList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []VerticaScrutinize `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&VerticaScrutinize{}, &VerticaScrutinizeList{})
+}
+
+func (vscr *VerticaScrutinize) ExtractNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      vscr.ObjectMeta.Name,
+		Namespace: vscr.ObjectMeta.Namespace,
+	}
+}
+
+func MakeSampleVscrName() types.NamespacedName {
+	return types.NamespacedName{Name: "vscr-sample", Namespace: "default"}
+}
+
+// MakeVscr will make an VerticaScrutinize for test purposes
+func MakeVscr() *VerticaScrutinize {
+	VDBNm := MakeVDBName()
+	nm := MakeSampleVscrName()
+	return &VerticaScrutinize{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       VerticaScrutinizeKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nm.Name,
+			Namespace: nm.Namespace,
+			UID:       "abcdef-123-ttt",
+		},
+		Spec: VerticaScrutinizeSpec{
+			VerticaDBName: VDBNm.Name,
+		},
+	}
+}

--- a/api/v1beta1/verticascrutinize_types.go
+++ b/api/v1beta1/verticascrutinize_types.go
@@ -116,7 +116,7 @@ const (
 )
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:categories=all;vertica,shortName=vscr
+// +kubebuilder:resource:path=verticascrutinizers,singular=verticascrutinize,categories=all;vertica,shortName=vscr
 // +kubebuilder:subresource:status
 // +operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1,""},{VerticaDB,vertica.com/v1beta1,""}}
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers/vas"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers/vdb"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers/vrpq"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers/vscr"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/opcfg"
 	"github.com/vertica/vertica-kubernetes/pkg/security"
@@ -138,6 +139,15 @@ func addReconcilersToManager(mgr manager.Manager, restCfg *rest.Config, oc *opcf
 		Log:    ctrl.Log.WithName("controllers").WithName("VerticaRestorePointsQuery"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VerticaRestorePointsQuery")
+		os.Exit(1)
+	}
+	if err := (&vscr.VerticaScrutinizeReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		EVRec:  mgr.GetEventRecorderFor(vmeta.OperatorName),
+		Log:    ctrl.Log.WithName("controllers").WithName("VerticaScrutinize"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VerticaScrutinize")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
@@ -267,6 +277,7 @@ func main() {
 				vapiB1.GkVAS.String():  oc.VerticaAutoscalerConcurrency,
 				vapiB1.GkET.String():   oc.EventTriggerConcurrency,
 				vapiB1.GkVRPQ.String(): oc.VerticaRestorePointsQueryConcurrency,
+				vapiB1.GkVSCR.String(): oc.VerticaScrutinizeConcurrency,
 			},
 		},
 	})

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - bases/vertica.com_verticaautoscalers.yaml
   - bases/vertica.com_eventtriggers.yaml
   - bases/vertica.com_verticarestorepointsqueries.yaml
-  - bases/vertica.com_verticascrutinizes.yaml
+  - bases/vertica.com_verticascrutinizers.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
@@ -15,7 +15,7 @@ patchesStrategicMerge:
   - patches/webhook_in_verticaautoscalers.yaml
   - patches/webhook_in_eventtriggers.yaml
   - patches/webhook_in_verticarestorepointsqueries.yaml
-  - patches/webhook_in_verticascrutinizes.yaml
+  - patches/webhook_in_verticascrutinizers.yaml
   #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
   # [CERTMANAGER] there was an optional patch to include an annotation that

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - bases/vertica.com_verticaautoscalers.yaml
   - bases/vertica.com_eventtriggers.yaml
   - bases/vertica.com_verticarestorepointsqueries.yaml
+  - bases/vertica.com_verticascrutinizes.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
@@ -14,6 +15,7 @@ patchesStrategicMerge:
   - patches/webhook_in_verticaautoscalers.yaml
   - patches/webhook_in_eventtriggers.yaml
   - patches/webhook_in_verticarestorepointsqueries.yaml
+  - patches/webhook_in_verticascrutinizes.yaml
   #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
   # [CERTMANAGER] there was an optional patch to include an annotation that

--- a/config/crd/patches/webhook_in_verticascrutinizers.yaml
+++ b/config/crd/patches/webhook_in_verticascrutinizers.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: verticascrutinizes.vertica.com
+  name: verticascrutinizers.vertica.com
 spec:
   conversion:
     strategy: None

--- a/config/crd/patches/webhook_in_verticascrutinizes.yaml
+++ b/config/crd/patches/webhook_in_verticascrutinizes.yaml
@@ -1,0 +1,8 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: verticascrutinizes.vertica.com
+spec:
+  conversion:
+    strategy: None

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -52,3 +52,4 @@ spec:
         - "--verticaautoscaler-concurrency=1"
         - "--eventtrigger-concurrency=1"
         - "--verticarestorepointsquery-concurrency=1"
+        - "--verticascrutinize-concurrency=1"

--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -2007,7 +2007,7 @@ spec:
     - description: VerticaScrutinize is the schema for verticascrutinize API
       displayName: Vertica Scrutinize
       kind: VerticaScrutinize
-      name: verticascrutinizes.vertica.com
+      name: verticascrutinizers.vertica.com
       resources:
       - kind: Pod
         name: ""

--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -626,6 +626,30 @@ spec:
         path: readinessProbeOverride
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Specifies the restore point details to use with this instance
+          of the VerticaDB.
+        displayName: Restore Point
+        path: restorePoint
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:initPolicy:Revive
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Name of the restore archive to use for bootstrapping. This name
+          refers to an object in the database. This must be specified if initPolicy
+          is Revive and a restore is intended.
+        displayName: Archive
+        path: restorePoint.archive
+      - description: The identifier of the restore point in the restore archive to
+          restore from. Specify either index or id exclusively; one of these fields
+          is mandatory, but both cannot be used concurrently.
+        displayName: ID
+        path: restorePoint.id
+      - description: The (1-based) index of the restore point in the restore archive
+          to restore from. Specify either index or id exclusively; one of these fields
+          is mandatory, but both cannot be used concurrently.
+        displayName: Index
+        path: restorePoint.index
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: "This specifies the order of nodes when doing a revive.  Each
           entry contains an index to a subcluster, which is an index in Subclusters[],
           and a pod count of the number of pods include from the subcluster. \n For
@@ -1422,6 +1446,30 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Specifies the restore point details to use with this instance
+          of the VerticaDB.
+        displayName: Restore Point
+        path: restorePoint
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:initPolicy:Revive
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: Name of the restore archive to use for bootstrapping. This name
+          refers to an object in the database. This must be specified if initPolicy
+          is Revive and a restore is intended.
+        displayName: Archive
+        path: restorePoint.archive
+      - description: The identifier of the restore point in the restore archive to
+          restore from. Specify either index or id exclusively; one of these fields
+          is mandatory, but both cannot be used concurrently.
+        displayName: ID
+        path: restorePoint.id
+      - description: The (1-based) index of the restore point in the restore archive
+          to restore from. Specify either index or id exclusively; one of these fields
+          is mandatory, but both cannot be used concurrently.
+        displayName: Index
+        path: restorePoint.index
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: "This specifies the order of nodes when doing a revive.  Each
           entry contains an index to a subcluster, which is an index in Subclusters[],
           and a pod count of the number of pods include from the subcluster. \n For
@@ -1931,9 +1979,9 @@ spec:
       kind: VerticaRestorePointsQuery
       name: verticarestorepointsqueries.vertica.com
       resources:
-      - kind: Job
+      - kind: VerticaDB
         name: ""
-        version: batch/v1
+        version: vertica.com/v1beta1
       specDescriptors:
       - description: Optional parameter that will limit the query to only restore
           points from this archvie
@@ -1949,9 +1997,111 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
-      - description: RestorePoints used to list out the available restore points.
-        displayName: Restore Points
-        path: restorePoints
+      - description: Conditions for VerticaRestorePointsQuery
+        displayName: Conditions
+        path: conditions
+      - description: Status message for running query
+        displayName: State
+        path: state
+      version: v1beta1
+    - description: VerticaScrutinize is the schema for verticascrutinize API
+      displayName: Vertica Scrutinize
+      kind: VerticaScrutinize
+      name: verticascrutinizes.vertica.com
+      resources:
+      - kind: Pod
+        name: ""
+        version: v1
+      - kind: VerticaDB
+        name: ""
+        version: vertica.com/v1beta1
+      specDescriptors:
+      - description: 'Like nodeSelector this allows you to constrain the pod only
+          to certain pods. It is more expressive than just using node selectors. More
+          info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity'
+        displayName: Affinity
+        path: affinity
+      - description: Describes node affinity scheduling rules for the pod.
+        displayName: Node Affinity
+        path: affinity.nodeAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:nodeAffinity
+      - description: Describes pod affinity scheduling rules (e.g. co-locate this
+          pod in the same node, zone, etc. as some other pod(s)).
+        displayName: Pod Affinity
+        path: affinity.podAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAffinity
+      - description: Describes pod anti-affinity scheduling rules (e.g. avoid putting
+          this pod in the same node, zone, etc. as some other pod(s)).
+        displayName: Pod Anti Affinity
+        path: affinity.podAntiAffinity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podAntiAffinity
+      - description: A list of annotations that will be added to the scrutinize pod.
+        displayName: Annotations
+        path: annotations
+      - description: A list of additional init containers to run. These are run after
+          running the init container that collects the scrutinize command. These can
+          be used to do some kind of post-processing of the tarball, such as uploading
+          it to some kind of storage.
+        displayName: Init Containers
+        path: initContainers
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: A list of labels that will be added to the scrutinize pod.
+        displayName: Labels
+        path: labels
+      - description: 'A map of label keys and values to restrict scrutinize node scheduling
+          to workers with matching labels. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector'
+        displayName: Node Selector
+        path: nodeSelector
+      - description: 'The priority class name given to the scrutinize. This affects
+          where the pod gets scheduled. More info: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass'
+        displayName: Priority Class Name
+        path: priorityClassName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: 'This defines the resource requests and limits for the scrutinize
+          pod. It is advisable that the request and limits match as this ensures the
+          pods are assigned to the guaranteed QoS class. This will reduces the chance
+          that pods are chosen by the OOM killer. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+        displayName: Resources
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: 'Any tolerations and taints to use to aid in where to schedule
+          a pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
+        displayName: Tolerations
+        path: tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: The name of the VerticaDB CR that this VerticaScrutinize is defined
+          for.  The VerticaDB object must exist in the same namespace as this object.
+        displayName: Vertica DBName
+        path: verticaDBName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: This allows the user to select the volume to use for the final
+          destination of the scrutinize tarball and any intermediate files. The volume
+          must have enough space to store the scrutinize data. If this is omitted,
+          then a simple emptyDir volume is created to store the scrutinize data.
+        displayName: Volume
+        path: volume
+      statusDescriptors:
+      - description: Set of status conditions to know how far along the scrutinize
+          is.
+        displayName: Conditions
+        path: conditions
+      - description: The name of the scrutinize pod that was created.
+        displayName: Pod Name
+        path: podName
+      - description: The UID of the pod name that was created.
+        displayName: Pod UID
+        path: podUID
+      - description: The name of the scrutinize tarball that was created.
+        displayName: Tarball Name
+        path: tarballName
       version: v1beta1
   description: |-
     ### What is Vertica?

--- a/config/rbac/verticascrutinize_editor_role.yaml
+++ b/config/rbac/verticascrutinize_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit verticascrutinizes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verticascrutinize-editor-role
+rules:
+- apiGroups:
+  - vertica.com
+  resources:
+  - verticascrutinizes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vertica.com
+  resources:
+  - verticascrutinize/status
+  verbs:
+  - get

--- a/config/rbac/verticascrutinize_editor_role.yaml
+++ b/config/rbac/verticascrutinize_editor_role.yaml
@@ -1,4 +1,4 @@
-# permissions for end users to edit verticascrutinizes.
+# permissions for end users to edit verticascrutinizers.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,7 +7,7 @@ rules:
 - apiGroups:
   - vertica.com
   resources:
-  - verticascrutinizes
+  - verticascrutinizers
   verbs:
   - create
   - delete

--- a/config/rbac/verticascrutinize_viewer_role.yaml
+++ b/config/rbac/verticascrutinize_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view verticascrutinizes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: verticascrutinize-viewer-role
+rules:
+- apiGroups:
+  - vertica.com
+  resources:
+  - verticascrutinizes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - vertica.com
+  resources:
+  - verticascrutinizes/status
+  verbs:
+  - get

--- a/config/rbac/verticascrutinize_viewer_role.yaml
+++ b/config/rbac/verticascrutinize_viewer_role.yaml
@@ -1,4 +1,4 @@
-# permissions for end users to view verticascrutinizes.
+# permissions for end users to view verticascrutinizers.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,7 +7,7 @@ rules:
 - apiGroups:
   - vertica.com
   resources:
-  - verticascrutinizes
+  - verticascrutinizers
   verbs:
   - get
   - list
@@ -15,6 +15,6 @@ rules:
 - apiGroups:
   - vertica.com
   resources:
-  - verticascrutinizes/status
+  - verticascrutinizers/status
   verbs:
   - get

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
 - v1beta1_eventtrigger.yaml
 - v1_verticadb.yaml
 - v1beta1_verticarestorepointsquery.yaml
+- v1beta1_verticascrutinize.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/v1beta1_verticascrutinize.yaml
+++ b/config/samples/v1beta1_verticascrutinize.yaml
@@ -1,0 +1,6 @@
+apiVersion: vertica.com/v1beta1
+kind: VerticaScrutinize
+metadata:
+  name: verticascrutinize-sample
+spec:
+  verticaDBName: verticadb-sample

--- a/helm-charts/verticadb-operator/README.md
+++ b/helm-charts/verticadb-operator/README.md
@@ -24,6 +24,7 @@ This helm chart will install the operator and an admission controller webhook.  
 | reconcileConcurrency.verticaautoscaler | Set this to control the concurrency of reconciliations of VerticaAutoscaler CRs | 1 |
 | reconcileConcurrency.verticadb | Set this to control the concurrency of reconciliations of VerticaDB CRs | 5 |
 | reconcileConcurrency.verticarestorepointsquery | Set this to control the concurrency of reconciliations of VerticaRestorePointsQuery CRs | 1 |
+| reconcileConcurrency.verticascrutinize | Set this to control the concurrency of reconciliations of VerticaScrutinize CRs | 1 |
 | rbac_proxy_image.name | Image name of Kubernetes RBAC proxy. | kubebuilder/kube-rbac-proxy:v0.13.1 |
 | rbac_proxy_image.repo | Repo server hosting rbac_proxy_image.name | gcr.io |
 | resources.\* | The resource requirements for the operator pod. | <pre>limits:<br>  cpu: 100m<br>  memory: 750Mi<br>requests:<br>  cpu: 100m<br>  memory: 20Mi</pre> |

--- a/helm-charts/verticadb-operator/tests/kind-concurrency_test.yaml
+++ b/helm-charts/verticadb-operator/tests/kind-concurrency_test.yaml
@@ -9,6 +9,7 @@ tests:
         verticaautoscaler: 2
         eventtrigger: 3
         verticarestorepointsquery: 2
+        verticascrutinize: 2
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -26,4 +27,8 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             --verticarestorepointsquery-concurrency=2
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content:
+            --verticascrutinize-concurrency=2
 

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -100,6 +100,7 @@ reconcileConcurrency:
   verticaautoscaler: 1
   eventtrigger: 1
   verticarestorepointsquery: 1
+  verticascrutinize: 1
 
 # The resource requirements for the operator pod.  See this for more info:
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/pkg/controllers/vscr/suite_test.go
+++ b/pkg/controllers/vscr/suite_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright [2021-2023] Open Text.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vscr
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	v1vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var vscrRec *VerticaScrutinizeReconciler
+var logger logr.Logger
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "VerticaScrutinize Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(logger)
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = v1vapi.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0", // Disable metrics for the test
+	})
+
+	vscrRec = &VerticaScrutinizeReconciler{
+		Client: k8sClient,
+		Scheme: scheme.Scheme,
+		Log:    logger,
+		EVRec:  mgr.GetEventRecorderFor(vmeta.OperatorName),
+	}
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/controllers/vscr/vertica_scrutinize_controller_test.go
+++ b/pkg/controllers/vscr/vertica_scrutinize_controller_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright [2021-2023] Open Text.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vscr
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("verticarestorepointsquery_controller", func() {
+	ctx := context.Background()
+
+	It("should reconcile successfully if vscr is not found", func() {
+		vscr := vapi.MakeVscr()
+		Expect(vscrRec.Reconcile(ctx, ctrl.Request{NamespacedName: vscr.ExtractNamespacedName()})).Should(Equal(ctrl.Result{}))
+	})
+
+	It("should suspend the reconcile if pause annotation is set", func() {
+		vscr := vapi.MakeVscr()
+		vscr.Annotations = map[string]string{meta.PauseOperatorAnnotation: "1"}
+		Expect(k8sClient.Create(ctx, vscr)).Should(Succeed())
+		defer func() { Expect(k8sClient.Delete(ctx, vscr)).Should(Succeed()) }()
+		Expect(vscrRec.Reconcile(ctx, ctrl.Request{NamespacedName: vscr.ExtractNamespacedName()})).Should(Equal(ctrl.Result{}))
+	})
+})

--- a/pkg/controllers/vscr/vertica_scrutinize_controller_test.go
+++ b/pkg/controllers/vscr/vertica_scrutinize_controller_test.go
@@ -23,7 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var _ = Describe("verticarestorepointsquery_controller", func() {
+var _ = Describe("verticascrutinize_controller", func() {
 	ctx := context.Background()
 
 	It("should reconcile successfully if vscr is not found", func() {

--- a/pkg/controllers/vscr/verticascrutinize_controller.go
+++ b/pkg/controllers/vscr/verticascrutinize_controller.go
@@ -38,9 +38,9 @@ type VerticaScrutinizeReconciler struct {
 	EVRec  record.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizes,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizes/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizes/finalizers,verbs=update
+//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -52,7 +52,7 @@ type VerticaScrutinizeReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *VerticaScrutinizeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("vrpq", req.NamespacedName)
+	log := r.Log.WithValues("vscr", req.NamespacedName)
 	log.Info("starting reconcile of vertica scrutinize")
 
 	vscr := &vapi.VerticaScrutinize{}

--- a/pkg/controllers/vscr/verticascrutinize_controller.go
+++ b/pkg/controllers/vscr/verticascrutinize_controller.go
@@ -1,0 +1,107 @@
+/*
+Copyright [2021-2023] Open Text.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vscr
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
+	"github.com/vertica/vertica-kubernetes/pkg/meta"
+)
+
+// VerticaScrutinizeReconciler reconciles a VerticaScrutinize object
+type VerticaScrutinizeReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Log    logr.Logger
+	EVRec  record.EventRecorder
+}
+
+//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=vertica.com,resources=verticascrutinizes/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the VerticaScrutinize object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+func (r *VerticaScrutinizeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("vrpq", req.NamespacedName)
+	log.Info("starting reconcile of vertica scrutinize")
+
+	vscr := &vapi.VerticaScrutinize{}
+	err := r.Get(ctx, req.NamespacedName, vscr)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, cound have been deleted after reconcile request.
+			log.Info("VerticaScrutinize resource not found.  Ignoring since object must be deleted")
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "failed to get VerticaScrutinize")
+		return ctrl.Result{}, err
+	}
+
+	if meta.IsPauseAnnotationSet(vscr.Annotations) {
+		log.Info(fmt.Sprintf("The pause annotation %s is set. Suspending the iteration", meta.PauseOperatorAnnotation),
+			"result", ctrl.Result{}, "err", nil)
+		return ctrl.Result{}, nil
+	}
+
+	// Iterate over each actor
+	actors := r.constructActors(vscr, log)
+	var res ctrl.Result
+	for _, act := range actors {
+		log.Info("starting actor", "name", fmt.Sprintf("%T", act))
+		res, err = act.Reconcile(ctx, &req)
+		// Error or a request to requeue will stop the reconciliation.
+		if verrors.IsReconcileAborted(res, err) {
+			log.Info("aborting reconcile of VerticaScrutinize", "result", res, "err", err)
+			return res, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VerticaScrutinizeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&vapi.VerticaScrutinize{}).
+		Complete(r)
+}
+
+// constructActors will a list of actors that should be run for the reconcile.
+// Order matters in that some actors depend on the successeful execution of
+// earlier ones.
+func (r *VerticaScrutinizeReconciler) constructActors(_ *vapi.VerticaScrutinize,
+	_ logr.Logger) []controllers.ReconcileActor {
+	// The actors that will be applied, in sequence, to reconcile a vscr.
+	// Temporarily, we set nil value for constructActors
+	return nil
+}

--- a/pkg/opcfg/config.go
+++ b/pkg/opcfg/config.go
@@ -41,6 +41,7 @@ const (
 	DefaultVerticaAutoscalerDBConcurrency       = 1
 	DefaultEventTriggerDBConcurrency            = 1
 	DefaultVerticaRestorePointsQueryConcurrency = 1
+	DefaultVerticaScrutinizeConcurrency         = 1
 )
 
 type OperatorConfig struct {
@@ -62,6 +63,7 @@ type OperatorConfig struct {
 	VerticaAutoscalerConcurrency         int
 	EventTriggerConcurrency              int
 	VerticaRestorePointsQueryConcurrency int
+	VerticaScrutinizeConcurrency         int
 	Logging
 }
 
@@ -113,6 +115,8 @@ func (o *OperatorConfig) SetFlagArgs() {
 		"The amount of concurrency to reconcile EventTrigger CRs")
 	flag.IntVar(&o.VerticaRestorePointsQueryConcurrency, "verticarestorepointsquery-concurrency", DefaultVerticaRestorePointsQueryConcurrency,
 		"The amount of concurrency to reconcile VerticaRestorePointsQuery CRs")
+	flag.IntVar(&o.VerticaScrutinizeConcurrency, "verticascrutinize-concurrency", DefaultVerticaScrutinizeConcurrency,
+		"The amount of concurrency to reconcile VerticaScrutinize CRs")
 }
 
 // getEncoderConfig returns a concrete encoders configuration

--- a/scripts/config-transformer.sh
+++ b/scripts/config-transformer.sh
@@ -33,6 +33,7 @@ mv $TEMPLATE_DIR/verticadbs.vertica.com-crd.yaml $CRD_DIR
 mv $TEMPLATE_DIR/verticaautoscalers.vertica.com-crd.yaml $CRD_DIR
 mv $TEMPLATE_DIR/eventtriggers.vertica.com-crd.yaml $CRD_DIR
 mv $TEMPLATE_DIR/verticarestorepointsqueries.vertica.com-crd.yaml $CRD_DIR
+mv $TEMPLATE_DIR/verticascrutinizes.vertica.com-crd.yaml $CRD_DIR
 
 # Delete openshift clusterRole and clusterRoleBinding files
 rm $TEMPLATE_DIR/verticadb-operator-openshift-cluster-role-cr.yaml 

--- a/scripts/config-transformer.sh
+++ b/scripts/config-transformer.sh
@@ -29,11 +29,7 @@ CRD_DIR=$OPERATOR_CHART/crds
 
 rm $TEMPLATE_DIR/*yaml 2>/dev/null || true
 $KUSTOMIZE build $REPO_DIR/config/default | $KUBERNETES_SPLIT_YAML --outdir $TEMPLATE_DIR -
-mv $TEMPLATE_DIR/verticadbs.vertica.com-crd.yaml $CRD_DIR
-mv $TEMPLATE_DIR/verticaautoscalers.vertica.com-crd.yaml $CRD_DIR
-mv $TEMPLATE_DIR/eventtriggers.vertica.com-crd.yaml $CRD_DIR
-mv $TEMPLATE_DIR/verticarestorepointsqueries.vertica.com-crd.yaml $CRD_DIR
-mv $TEMPLATE_DIR/verticascrutinizes.vertica.com-crd.yaml $CRD_DIR
+mv $TEMPLATE_DIR/*-crd.yaml $CRD_DIR
 
 # Delete openshift clusterRole and clusterRoleBinding files
 rm $TEMPLATE_DIR/verticadb-operator-openshift-cluster-role-cr.yaml 

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -189,6 +189,7 @@ do
     perl -i -0777 -pe 's/(--verticaautoscaler-concurrency=)[0-9]+/$1\{\{ .Values.reconcileConcurrency.verticaautoscaler \}\}/g' $f
     perl -i -0777 -pe 's/(--eventtrigger-concurrency=)[0-9]+/$1\{\{ .Values.reconcileConcurrency.eventtrigger \}\}/g' $f
     perl -i -0777 -pe 's/(--verticarestorepointsquery-concurrency=)[0-9]+/$1\{\{ .Values.reconcileConcurrency.verticarestorepointsquery \}\}/g' $f
+    perl -i -0777 -pe 's/(--verticascrutinize-concurrency=)[0-9]+/$1\{\{ .Values.reconcileConcurrency.verticascrutinize \}\}/g' $f
 done
 
 # 20. Add permissions to manager ClusterRole to allow it to patch the CRD. This

--- a/tests/e2e-leg-5/metrics-disabled/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-disabled/05-assert.yaml
@@ -35,7 +35,7 @@ spec:
     - --verticaautoscaler-concurrency=1
     - --eventtrigger-concurrency=1
     - --verticarestorepointsquery-concurrency=1
-    - --verticascrutinize-concurrency
+    - --verticascrutinize-concurrency=1
 status:
   phase: Running
 ---

--- a/tests/e2e-leg-5/metrics-disabled/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-disabled/05-assert.yaml
@@ -35,6 +35,7 @@ spec:
     - --verticaautoscaler-concurrency=1
     - --eventtrigger-concurrency=1
     - --verticarestorepointsquery-concurrency=1
+    - --verticascrutinize-concurrency
 status:
   phase: Running
 ---

--- a/tests/e2e-leg-5/metrics-no-auth/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/05-assert.yaml
@@ -36,6 +36,7 @@ spec:
     - --verticaautoscaler-concurrency=1
     - --eventtrigger-concurrency=1
     - --verticarestorepointsquery-concurrency=1
+    - --verticascrutinize-concurrency=1
 status:
   phase: Running
 ---

--- a/tests/e2e-leg-5/prometheus-service-monitor/10-assert.yaml
+++ b/tests/e2e-leg-5/prometheus-service-monitor/10-assert.yaml
@@ -36,6 +36,7 @@ spec:
     - --verticaautoscaler-concurrency=1
     - --eventtrigger-concurrency=1
     - --verticarestorepointsquery-concurrency=1
+    - --verticascrutinize-concurrency=1
   - name: kube-rbac-proxy
 status:
   phase: Running

--- a/tests/e2e-leg-5/prometheus-service-monitor/20-assert.yaml
+++ b/tests/e2e-leg-5/prometheus-service-monitor/20-assert.yaml
@@ -36,6 +36,7 @@ spec:
     - --verticaautoscaler-concurrency=1
     - --eventtrigger-concurrency=1
     - --verticarestorepointsquery-concurrency=1
+    - --verticascrutinize-concurrency=1
 status:
   phase: Running
 ---


### PR DESCRIPTION
This PR build out the stub for an empty controller to handle the VerticaScrutinize API. For now The operator can observe the new API, initiate a reconciliation iteration, and take no action, as we have set nil for the actors during this implementation phase