### PR TITLE
Configure createdb timeout by annotation vertica.com/createdb-timeout

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -396,6 +396,11 @@ func (v *VerticaDB) GetRestartTimeout() int {
 	return vmeta.GetRestartTimeout(v.Annotations)
 }
 
+// GetCreateDBNodeStartTimeout returns the timeout value for createdb node startup
+func (v *VerticaDB) GetCreateDBNodeStartTimeout() int {
+	return vmeta.GetCreateDBNodeStartTimeout(v.Annotations)
+}
+
 // IsNMASideCarDeploymentEnabled returns true if the conditions to run NMA
 // in a sidecar are met
 func (v *VerticaDB) IsNMASideCarDeploymentEnabled() bool {

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -173,6 +173,7 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.hasValidProbeOverrides(allErrs)
 	allErrs = v.hasValidPodSecurityContext(allErrs)
 	allErrs = v.hasValidNMAResourceLimit(allErrs)
+	allErrs = v.hasValidCreateDBTimeout(allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -905,6 +906,17 @@ func (v *VerticaDB) hasValidNMAResourceLimit(allErrs field.ErrorList) field.Erro
 		annotationName := vmeta.GenNMAResourcesAnnotationName(v1.ResourceLimitsMemory)
 		err := field.Invalid(field.NewPath("metadata").Child("annotations").Child(annotationName),
 			nmaMemoryLimit, fmt.Sprintf("cannot be less than %s", vmeta.MinNMAMemoryLimit.String()))
+		allErrs = append(allErrs, err)
+	}
+	return allErrs
+}
+
+func (v *VerticaDB) hasValidCreateDBTimeout(allErrs field.ErrorList) field.ErrorList {
+	createDBTimeout := v.GetCreateDBNodeStartTimeout()
+	if createDBTimeout < 0 {
+		annotationName := vmeta.CreateDBTimeoutAnnotation
+		err := field.Invalid(field.NewPath("metadata").Child("annotations").Child(annotationName),
+			createDBTimeout, fmt.Sprintf("%s must be non-negative", annotationName))
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -278,6 +278,13 @@ var _ = Describe("verticadb_webhook", func() {
 		validateSpecValuesHaveErr(vdb, false)
 	})
 
+	It("should not have negative createdb timeout", func() {
+		vdb := MakeVDB()
+		annotationName := vmeta.CreateDBTimeoutAnnotation
+		vdb.Annotations[annotationName] = "-1"
+		validateSpecValuesHaveErr(vdb, true)
+	})
+
 	// validate immutable fields
 	It("should succeed without changing immutable fields", func() {
 		vdb := createVDBHelper()

--- a/changes/unreleased/Added-20240202-082047.yaml
+++ b/changes/unreleased/Added-20240202-082047.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Configure createdb timeout by annotation vertica.com/createdb-timeout
+time: 2024-02-02T08:20:47.779581369-04:00
+custom:
+  Issue: "691"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.1.1-0.20240130155647-29203c00b7b5
+	github.com/vertica/vcluster v1.1.1-0.20240206205339-8e74a02e2bf1
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.1.1-0.20240130155647-29203c00b7b5 h1:yjdOObQt8quqts+2H5RDdGyO0QqjDrtnDQeWYzxZ0B4=
-github.com/vertica/vcluster v1.1.1-0.20240130155647-29203c00b7b5/go.mod h1:R5/qkQRThdC3SJbj3kGV7AknOWVw0qka3QD+a+pkmjE=
+github.com/vertica/vcluster v1.1.1-0.20240206205339-8e74a02e2bf1 h1:95xRtV/cDcFCekDWYpx4wXUDfO0UxSnyMkZkW3AT6m0=
+github.com/vertica/vcluster v1.1.1-0.20240206205339-8e74a02e2bf1/go.mod h1:R5/qkQRThdC3SJbj3kGV7AknOWVw0qka3QD+a+pkmjE=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -86,6 +86,10 @@ const (
 	// entire cluster.  If omitted, we use the default timeout of 20 minutes.
 	RestartTimeoutAnnotation = "vertica.com/restart-timeout"
 
+	// The timeout, in seconds, to use when the operator creates a db and
+	// waits for its startup.  If omitted, we use the default timeout of 5 minutes.
+	CreateDBTimeoutAnnotation = "vertica.com/createdb-timeout"
+
 	// Sets the fault tolerance for the cluster.  Allowable values are 0 or 1.  0 is only
 	// suitable for test environments because we have no fault tolerance and the cluster
 	// can only have between 1 and 3 pods.  If set to 1, which is the default,
@@ -246,6 +250,12 @@ func IgnoreUpgradePath(annotations map[string]string) bool {
 // 0 is returned, this means to use the default.
 func GetRestartTimeout(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, RestartTimeoutAnnotation)
+}
+
+// GetCreateDBNodeStartTimeout returns the timeout to use for create db node startup. If
+// 0 is returned, this means to use the default.
+func GetCreateDBNodeStartTimeout(annotations map[string]string) int {
+	return lookupIntAnnotation(annotations, CreateDBTimeoutAnnotation)
 }
 
 // IsKSafety0 returns true if k-safety is set to 0. False implies 1.

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -115,5 +115,10 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 		opts.Password = &v.Password
 	}
 
+	// Timeout
+	if timeout := v.VDB.GetCreateDBNodeStartTimeout(); timeout != 0 {
+		opts.TimeoutNodeStartupSeconds = &timeout
+	}
+
 	return opts
 }

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -90,7 +90,8 @@ func mockAdmintoolsDispatcher() (*Admintools, *vapi.VerticaDB, *cmds.FakePodRunn
 // MockVClusterOps is used to invoke mock vcluster-ops functions
 type MockVClusterOps struct {
 	// Set this to true if you want VCreateDatabase to return the DBIsRunningError
-	ReturnDBIsRunning bool
+	ReturnDBIsRunning               bool
+	VerifyTimeoutNodeStartupSeconds bool
 }
 
 // const variables used for vcluster-ops unit test


### PR DESCRIPTION
This adds an annotation to be able to control the timeout we wait during create db for the nodes to come up. The annotation value is: `vertica.com/createdb-timeout`.