### PR TITLE
VCluster API Refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.1.1-0.20240206205339-8e74a02e2bf1
+	github.com/vertica/vcluster v1.1.1-0.20240209182023-9b60ae51f6fb
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.1.1-0.20240206205339-8e74a02e2bf1 h1:95xRtV/cDcFCekDWYpx4wXUDfO0UxSnyMkZkW3AT6m0=
-github.com/vertica/vcluster v1.1.1-0.20240206205339-8e74a02e2bf1/go.mod h1:R5/qkQRThdC3SJbj3kGV7AknOWVw0qka3QD+a+pkmjE=
+github.com/vertica/vcluster v1.1.1-0.20240209182023-9b60ae51f6fb h1:u+bCvIRMq8qIWtFn1op1OyJm6ntvDhBlyyMCEhuqkfo=
+github.com/vertica/vcluster v1.1.1-0.20240209182023-9b60ae51f6fb/go.mod h1:R5/qkQRThdC3SJbj3kGV7AknOWVw0qka3QD+a+pkmjE=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/describe_db_vc.go
+++ b/pkg/vadmin/describe_db_vc.go
@@ -51,7 +51,7 @@ func (v *VClusterOps) DescribeDB(ctx context.Context, opts ...describedb.Option)
 	vcOpts := v.genReviveDBOptions(&reviveParms, certs)
 	*vcOpts.DisplayOnly = true // Set flag to indicate we only want to see the cluster info
 
-	op, err := v.VReviveDatabase(vcOpts)
+	op, _, err := v.VReviveDatabase(vcOpts)
 	if err != nil {
 		var res ctrl.Result
 		res, err = v.logFailure("VReviveDatabase", events.ReviveDBFailed, err)

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -196,7 +196,7 @@ type VClusterProvider interface {
 	VCreateDatabase(options *vops.VCreateDatabaseOptions) (vops.VCoordinationDatabase, error)
 	VStopDatabase(options *vops.VStopDatabaseOptions) error
 	VStartDatabase(options *vops.VStartDatabaseOptions) error
-	VReviveDatabase(options *vops.VReviveDatabaseOptions) (string, error)
+	VReviveDatabase(options *vops.VReviveDatabaseOptions) (string, *vops.VCoordinationDatabase, error)
 	VFetchNodeState(options *vops.VFetchNodeStateOptions) ([]vops.NodeInfo, error)
 	VAddSubcluster(options *vops.VAddSubclusterOptions) error
 	VRemoveSubcluster(options *vops.VRemoveScOptions) (vops.VCoordinationDatabase, error)

--- a/pkg/vadmin/revive_db_vc.go
+++ b/pkg/vadmin/revive_db_vc.go
@@ -42,7 +42,7 @@ func (v *VClusterOps) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ct
 	s.Make(opts...)
 
 	vcOpts := v.genReviveDBOptions(&s, certs)
-	_, err = v.VReviveDatabase(vcOpts)
+	_, _, err = v.VReviveDatabase(vcOpts)
 	if err != nil {
 		return v.logFailure("VReviveDatabase", events.ReviveDBFailed, err)
 	}

--- a/pkg/vadmin/revive_db_vc_test.go
+++ b/pkg/vadmin/revive_db_vc_test.go
@@ -35,7 +35,7 @@ func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) 
 	// verify basic options
 	err := m.VerifyDBNameAndIPv6(&options.DatabaseOptions)
 	if err != nil {
-		return "", &vops.VCoordinationDatabase{}, err
+		return "", nil, err
 	}
 
 	// If running with display only, we only use a single host.
@@ -45,20 +45,20 @@ func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) 
 	}
 	err = m.VerifyHosts(&options.DatabaseOptions, expectedHosts)
 	if err != nil {
-		return "", &vops.VCoordinationDatabase{}, err
+		return "", nil, err
 	}
 	err = m.VerifyCerts(&options.DatabaseOptions)
 	if err != nil {
-		return "", &vops.VCoordinationDatabase{}, err
+		return "", nil, err
 	}
 	err = m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.ConfigurationParameters)
 	if err != nil {
-		return "", &vops.VCoordinationDatabase{}, err
+		return "", nil, err
 	}
 	if *options.DisplayOnly {
-		return TestDescribeOutput, &vops.VCoordinationDatabase{}, nil
+		return TestDescribeOutput, nil, nil
 	}
-	return "", &vops.VCoordinationDatabase{}, nil
+	return "", nil, nil
 }
 
 var _ = Describe("revive_db_vc", func() {

--- a/pkg/vadmin/revive_db_vc_test.go
+++ b/pkg/vadmin/revive_db_vc_test.go
@@ -31,11 +31,11 @@ const (
 )
 
 // mock version of VReviveDatabase() that is invoked inside VClusterOps
-func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) (string, error) {
+func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) (string, *vops.VCoordinationDatabase, error) {
 	// verify basic options
 	err := m.VerifyDBNameAndIPv6(&options.DatabaseOptions)
 	if err != nil {
-		return "", err
+		return "", &vops.VCoordinationDatabase{}, err
 	}
 
 	// If running with display only, we only use a single host.
@@ -45,20 +45,20 @@ func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) 
 	}
 	err = m.VerifyHosts(&options.DatabaseOptions, expectedHosts)
 	if err != nil {
-		return "", err
+		return "", &vops.VCoordinationDatabase{}, err
 	}
 	err = m.VerifyCerts(&options.DatabaseOptions)
 	if err != nil {
-		return "", err
+		return "", &vops.VCoordinationDatabase{}, err
 	}
 	err = m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.ConfigurationParameters)
 	if err != nil {
-		return "", err
+		return "", &vops.VCoordinationDatabase{}, err
 	}
 	if *options.DisplayOnly {
-		return TestDescribeOutput, nil
+		return TestDescribeOutput, &vops.VCoordinationDatabase{}, nil
 	}
-	return "", nil
+	return "", &vops.VCoordinationDatabase{}, nil
 }
 
 var _ = Describe("revive_db_vc", func() {


### PR DESCRIPTION
This includes a few updates to the vcluster API. Some notable changes:
- New API to install the packages (`VInstallPackages`)
- Update to function signature for `VReviveDB`; we are returning a new parameter, but it doesn't apply to the operators usage
- Reduced the noise in the log when polling for up nodes
