### PR TITLE
Avoid deploying the operator with default label

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -567,7 +567,7 @@ By default, the memory profiler is disabled. To enable it, add a parameter when 
 1. Use `kubectl edit` to open the running deployment for editing:
 
    ```shell
-   kubectl edit deployment verticadb-operator-controller-manager
+   kubectl edit deployment verticadb-operator-manager
    ```
 
 2. Locate the `args` array that passes values to the deployment manager, and add `--enable-profiler`:
@@ -588,7 +588,7 @@ By default, the memory profiler is disabled. To enable it, add a parameter when 
 4. Port forward 6060 to access the profiler's user interface (UI). The name of the pod differs for each deployment, so make sure that you find the one specific to your cluster:
 
    ```shell
-   kubectl port-forward pod/verticadb-operator-controller-manager-5dd5b54df4-2krcr 6060:6060
+   kubectl port-forward pod/verticadb-operator-manager-5dd5b54df4-2krcr 6060:6060
    ```
 
 5. Use a web browser or the standalone tool to connect to the profiler's UI at `http://localhost:6060/debug/pprof`.

--- a/changes/unreleased/Fixed-20240212-212436.yaml
+++ b/changes/unreleased/Fixed-20240212-212436.yaml
@@ -2,4 +2,4 @@ kind: Fixed
 body: Avoid deploying the operator with default label
 time: 2024-02-12T21:24:36.201941181-04:00
 custom:
-  Issue: "700"
+  Issue: "701"

--- a/changes/unreleased/Fixed-20240212-212436.yaml
+++ b/changes/unreleased/Fixed-20240212-212436.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Avoid deploying the operator with default label
+time: 2024-02-12T21:24:36.201941181-04:00
+custom:
+  Issue: "700"

--- a/config/clusterpermissions/cluster_role_binding.yaml
+++ b/config/clusterpermissions/cluster_role_binding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openshift-cluster-rolebinding
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: verticadb-operator
   namespace: system
 roleRef:
   kind: ClusterRole

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -27,7 +27,7 @@ resources:
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
-# If you want your controller-manager to expose the /metrics
+# If you want your operator to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:
@@ -47,7 +47,7 @@ spec:
         - "--level=info"
         - "--dev=false"
         - "--prefix-name=verticadb-operator"
-        - "--webhook-cert-secret=verticadb-operator-controller-manager-service-cert"
+        - "--webhook-cert-secret=verticadb-operator-service-cert"
         - "--verticadb-concurrency=5"
         - "--verticaautoscaler-concurrency=1"
         - "--eventtrigger-concurrency=1"

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
               configMapKeyRef:
                 name: manager-config
                 key: VERSION
-      serviceAccountName: verticadb-operator
+      serviceAccountName: verticadb-operator-manager
       terminationGracePeriodSeconds: 10
       volumes:
       - name: tmp

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: verticadb-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: verticadb-operator
         app.kubernetes.io/name: verticadb-operator
     spec:
       securityContext:
@@ -64,7 +64,7 @@ spec:
               configMapKeyRef:
                 name: manager-config
                 key: VERSION
-      serviceAccountName: controller-manager
+      serviceAccountName: verticadb-operator
       terminationGracePeriodSeconds: 10
       volumes:
       - name: tmp

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -14,7 +14,7 @@ patchesJson6902:
     group: apps
     version: v1
     kind: Deployment
-    name: controller-manager
+    name: manager
     namespace: system
   patch: |-
     # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
   name: metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: verticadb-operator

--- a/config/rbac/auth_proxy_client_clusterrolebinding.yaml
+++ b/config/rbac/auth_proxy_client_clusterrolebinding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: metrics-reader
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager
   namespace: system
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager
   namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
     vertica.com/svc-type: operator-metrics
   name: metrics-service
   namespace: system
@@ -13,4 +13,4 @@ spec:
     protocol: TCP
     targetPort: metrics
   selector:
-    control-plane: controller-manager
+    control-plane: verticadb-operator

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
+  name: manager
   namespace: system

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: webhook-service
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
     vertica.com/svc-type: webhook
 spec:
   ports:
@@ -13,4 +13,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    control-plane: verticadb-operator

--- a/helm-charts/verticadb-operator/templates/_helpers.tpl
+++ b/helm-charts/verticadb-operator/templates/_helpers.tpl
@@ -12,7 +12,7 @@ Choose the serviceAccount name
 {{- if .Values.serviceAccountNameOverride }}
 {{- .Values.serviceAccountNameOverride }}
 {{- else }}
-{{- include "vdb-op.name" . }}-controller-manager
+{{- include "vdb-op.name" . }}-manager
 {{- end }}
 {{- end }}
 
@@ -38,6 +38,6 @@ it is generated internally)
 {{- else if eq .Values.webhook.certSource "internal" }}
 {{- "" }}
 {{- else }}
-{{- include "vdb-op.name" . }}-controller-manager-service-cert
+{{- include "vdb-op.name" . }}-service-cert
 {{- end }}
 {{- end }}

--- a/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
+++ b/helm-charts/verticadb-operator/tests/image-name-and-tag_test.yaml
@@ -1,6 +1,6 @@
 suite: image tests
 templates:
-  - verticadb-operator-controller-manager-deployment.yaml
+  - verticadb-operator-manager-deployment.yaml
 tests:
   - it: allows the operator image and tag to be specified
     set:

--- a/helm-charts/verticadb-operator/tests/kind-concurrency_test.yaml
+++ b/helm-charts/verticadb-operator/tests/kind-concurrency_test.yaml
@@ -1,6 +1,6 @@
 suite: test that verifies we can control the concurrency of reconcile iterations
 templates:
-  - verticadb-operator-controller-manager-deployment.yaml
+  - verticadb-operator-manager-deployment.yaml
 tests:
   - it: we can specify a concurrency for various CRs
     set:

--- a/helm-charts/verticadb-operator/tests/metric-cert_test.yaml
+++ b/helm-charts/verticadb-operator/tests/metric-cert_test.yaml
@@ -1,6 +1,6 @@
 suite: Metrics certificate tests
 templates:
-  - verticadb-operator-controller-manager-deployment.yaml
+  - verticadb-operator-manager-deployment.yaml
 tests:
   - it: should include the cert if prometheus.tlsSecret is set
     set:

--- a/helm-charts/verticadb-operator/tests/metrics-deployment_test.yaml
+++ b/helm-charts/verticadb-operator/tests/metrics-deployment_test.yaml
@@ -1,6 +1,6 @@
 suite: Metrics deployment tests
 templates:
-  - verticadb-operator-controller-manager-deployment.yaml
+  - verticadb-operator-manager-deployment.yaml
 tests:
   - it: should not include proxy sidecar if expose is disabled
     set:

--- a/helm-charts/verticadb-operator/tests/pod-schedule_test.yaml
+++ b/helm-charts/verticadb-operator/tests/pod-schedule_test.yaml
@@ -1,6 +1,6 @@
 suite: test that control where the operator is scheduled
 templates:
-  - verticadb-operator-controller-manager-deployment.yaml
+  - verticadb-operator-manager-deployment.yaml
 tests:
   - it: we can specify a node selector
     set:

--- a/helm-charts/verticadb-operator/tests/resources_test.yaml
+++ b/helm-charts/verticadb-operator/tests/resources_test.yaml
@@ -1,6 +1,6 @@
 suite: test that resources can be specified for the operator 
 templates:
-  - verticadb-operator-controller-manager-deployment.yaml
+  - verticadb-operator-manager-deployment.yaml
 tests:
   - it: we can override the resources for the pod
     set:

--- a/helm-charts/verticadb-operator/tests/serviceaccount_test.yaml
+++ b/helm-charts/verticadb-operator/tests/serviceaccount_test.yaml
@@ -1,6 +1,6 @@
 suite: ServiceAccount tests
 templates:
-  - verticadb-operator-controller-manager-sa.yaml
+  - verticadb-operator-manager-sa.yaml
 tests:
   - it: should allow you to override the serviceaccount name
     set:

--- a/pkg/kstepgen/kill_operator.go
+++ b/pkg/kstepgen/kill_operator.go
@@ -48,7 +48,7 @@ var killOperatorPodTemplate = `
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl -n {{ .Namespace }} delete pod -l control-plane=controller-manager
+  - command: kubectl -n {{ .Namespace }} delete pod -l control-plane=verticadb-operator
   - command: {{ .ScriptsDir }}/wait-for-webhook.sh -n {{ .Namespace }}
 `
 

--- a/pkg/security/webhook.go
+++ b/pkg/security/webhook.go
@@ -267,7 +267,7 @@ func getWebhookServiceName(prefixName string) string {
 	// We have slightly different names depending on the deployment type since
 	// OLM likes to generate it themselves and tie the CA cert to it.
 	if val, ok := os.LookupEnv(vmeta.OperatorDeploymentMethodEnvVar); ok && val == vmeta.OLMDeploymentType {
-		return fmt.Sprintf("%s-controller-manager-service", prefixName)
+		return fmt.Sprintf("%s-manager-service", prefixName)
 	}
 	return fmt.Sprintf("%s-webhook-service", prefixName)
 }

--- a/scripts/authorize-metrics.sh
+++ b/scripts/authorize-metrics.sh
@@ -23,7 +23,7 @@ set -o pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 REPO_DIR=$(dirname $SCRIPT_DIR)
-OP_SA=verticadb-operator-controller-manager
+OP_SA=verticadb-operator
 UNDO=
 
 function usage() {

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -87,7 +87,7 @@ perl -i -0777 -pe "s/--level=.*/--level={{ .Values.logging.level }}/" $TEMPLATE_
 perl -i -0777 -pe "s/--dev=.*/--dev={{ .Values.logging.dev }}/" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 
 # 9.  Template the serviceaccount, roles and rolebindings
-perl -i -0777 -pe 's/serviceAccountName: verticadb-operator/serviceAccountName: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe 's/serviceAccountName: verticadb-operator-manager/serviceAccountName: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 perl -i -0777 -pe 's/name: .*/name: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-manager-sa.yaml
 cat << EOF >> $TEMPLATE_DIR/verticadb-operator-manager-sa.yaml
 {{- if .Values.serviceAccountAnnotations }}

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -40,24 +40,24 @@ fi
 # 1. Template the namespace
 perl -i -0777 -pe 's/verticadb-operator-system/{{ .Release.Namespace }}/g' $TEMPLATE_DIR/*
 # 2. Template image names
-perl -i -0777 -pe "s|image: controller|image: '{{ with .Values.image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe "s|image: gcr.io/kubebuilder/kube-rbac-proxy:v.*|image: '{{ with .Values.rbac_proxy_image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe "s|image: controller|image: '{{ with .Values.image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe "s|image: gcr.io/kubebuilder/kube-rbac-proxy:v.*|image: '{{ with .Values.rbac_proxy_image }}{{ join \"/\" (list .repo .name) }}{{ end }}'|" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 # 3. Template imagePullPolicy
-perl -i -0777 -pe 's/imagePullPolicy: IfNotPresent/imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe 's/imagePullPolicy: IfNotPresent/imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}/' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 # 4. Append imagePullSecrets
-cat >>$TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml << END
+cat >>$TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml << END
 {{ if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ .Values.imagePullSecrets | toYaml | indent 8 }}
 {{ end }}
 END
 # 5. Template the tls secret name
-for fn in verticadb-operator-controller-manager-deployment.yaml \
+for fn in verticadb-operator-manager-deployment.yaml \
     verticadb-operator-serving-cert-certificate.yaml
 do
   perl -i -0777 -pe 's/secretName: webhook-server-cert/secretName: {{ include "vdb-op.certSecret" . }}/' $TEMPLATE_DIR/$fn
 done
-for fn in $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+for fn in $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 do
   # Include the secret only if not using webhook.certSource=internal
   perl -i -0777 -pe 's/(.*- name: webhook-cert\n.*secret:\n.*defaultMode:.*\n.*secretName:.*)/\{\{- if or (ne .Values.webhook.certSource "internal") (not (empty .Values.webhook.tlsSecret)) \}\}\n$1\n\{\{- end \}\}/g' $fn
@@ -76,20 +76,20 @@ done
 # Include WEBHOOK_CERT_SOURCE in the config map
 perl -i -0777 -pe 's/(\ndata:)/$1\n  WEBHOOK_CERT_SOURCE: {{ include "vdb-op.certSource" . }}/g' $TEMPLATE_DIR/verticadb-operator-manager-config-cm.yaml
 # 7. Template the resource limits and requests
-perl -i -0777 -pe 's/resources: template-placeholder/resources:\n          {{- toYaml .Values.resources | nindent 10 }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe 's/resources: template-placeholder/resources:\n          {{- toYaml .Values.resources | nindent 10 }}/' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 
 # 8.  Template the logging
-perl -i -0777 -pe "s/--filepath=.*/--filepath={{ .Values.logging.filePath }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe "s/--maxfilesize=.*/--maxfilesize={{ .Values.logging.maxFileSize }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe "s/--maxfileage=.*/--maxfileage={{ .Values.logging.maxFileAge }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe "s/--maxfilerotation=.*/--maxfilerotation={{ .Values.logging.maxFileRotation }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe "s/--level=.*/--level={{ .Values.logging.level }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe "s/--dev=.*/--dev={{ .Values.logging.dev }}/" $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe "s/--filepath=.*/--filepath={{ .Values.logging.filePath }}/" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe "s/--maxfilesize=.*/--maxfilesize={{ .Values.logging.maxFileSize }}/" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe "s/--maxfileage=.*/--maxfileage={{ .Values.logging.maxFileAge }}/" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe "s/--maxfilerotation=.*/--maxfilerotation={{ .Values.logging.maxFileRotation }}/" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe "s/--level=.*/--level={{ .Values.logging.level }}/" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe "s/--dev=.*/--dev={{ .Values.logging.dev }}/" $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 
 # 9.  Template the serviceaccount, roles and rolebindings
-perl -i -0777 -pe 's/serviceAccountName: verticadb-operator-controller-manager/serviceAccountName: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe 's/name: .*/name: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-sa.yaml
-cat << EOF >> $TEMPLATE_DIR/verticadb-operator-controller-manager-sa.yaml
+perl -i -0777 -pe 's/serviceAccountName: verticadb-operator/serviceAccountName: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe 's/name: .*/name: {{ include "vdb-op.serviceAccount" . }}/' $TEMPLATE_DIR/verticadb-operator-manager-sa.yaml
+cat << EOF >> $TEMPLATE_DIR/verticadb-operator-manager-sa.yaml
 {{- if .Values.serviceAccountAnnotations }}
   annotations:
     {{- toYaml .Values.serviceAccountAnnotations | nindent 4 }}
@@ -118,7 +118,7 @@ echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-webhook-service-svc.yaml
 # Add in the --use-cert-manager option if we use cert-manager to generate the
 # TLS for the webhook. This is needed to tell the operator to add the
 # appropriate annotation for CA bundle injections.
-perl -i -0777 -pe 's/(--webhook-cert-secret.*)/$1\n{{- if eq .Values.webhook.certSource "cert-manager" }}\n        - --use-cert-manager\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe 's/(--webhook-cert-secret.*)/$1\n{{- if eq .Values.webhook.certSource "cert-manager" }}\n        - --use-cert-manager\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 
 # 11.  Template the prometheus metrics service
 perl -i -pe 's/^/{{- if hasPrefix "Enable" .Values.prometheus.expose -}}\n/ if 1 .. 1' $TEMPLATE_DIR/verticadb-operator-metrics-service-svc.yaml
@@ -141,14 +141,14 @@ perl -i -0777 -pe 's/(.*endpoints:)/$1\n{{- if eq "EnableWithAuthProxy" .Values.
 perl -i -0777 -pe 's/(.*insecureSkipVerify:.*)/$1\n{{- else }}\n  - path: \/metrics\n    port: metrics\n    scheme: http\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-metrics-monitor-servicemonitor.yaml
 
 # 14.  Template the metrics bind address
-perl -i -0777 -pe 's/- --metrics-bind-address=.*/- --metrics-bind-address={{ if eq "EnableWithAuthProxy" .Values.prometheus.expose }}127.0.0.1{{ end }}:{{ if eq "EnableWithAuthProxy" .Values.prometheus.expose }}8080{{ else }}8443{{ end }}/' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe 's/(.*metrics-bind-address.*)/{{- if hasPrefix "Enable" .Values.prometheus.expose }}\n$1\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
-perl -i -0777 -pe 's/(.*ports:\n.*containerPort: 9443\n.*webhook-server.*\n.*)/$1\n{{- if hasPrefix "EnableWithoutAuth" .Values.prometheus.expose }}\n        - name: metrics\n          containerPort: 8443\n          protocol: TCP\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe 's/- --metrics-bind-address=.*/- --metrics-bind-address={{ if eq "EnableWithAuthProxy" .Values.prometheus.expose }}127.0.0.1{{ end }}:{{ if eq "EnableWithAuthProxy" .Values.prometheus.expose }}8080{{ else }}8443{{ end }}/' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe 's/(.*metrics-bind-address.*)/{{- if hasPrefix "Enable" .Values.prometheus.expose }}\n$1\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
+perl -i -0777 -pe 's/(.*ports:\n.*containerPort: 9443\n.*webhook-server.*\n.*)/$1\n{{- if hasPrefix "EnableWithoutAuth" .Values.prometheus.expose }}\n        - name: metrics\n          containerPort: 8443\n          protocol: TCP\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 
 # 15.  Template the rbac container
-perl -i -0777 -pe 's/(.*- args:.*\n.*secure)/{{- if eq .Values.prometheus.expose "EnableWithAuthProxy" }}\n$1/g' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe 's/(.*- args:.*\n.*secure)/{{- if eq .Values.prometheus.expose "EnableWithAuthProxy" }}\n$1/g' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 # We need to put the matching end at the end of the container spec.
-perl -i -0777 -pe 's/(memory: 64Mi)/$1\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+perl -i -0777 -pe 's/(memory: 64Mi)/$1\n{{- end }}/g' $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 
 # 16.  Template places that refer to objects by name.  Do this in all files.
 # In the config/ directory we hardcoded everything to start with
@@ -156,7 +156,7 @@ perl -i -0777 -pe 's/(memory: 64Mi)/$1\n{{- end }}/g' $TEMPLATE_DIR/verticadb-op
 perl -i -0777 -pe 's/verticadb-operator/{{ include "vdb-op.name" . }}/g' $TEMPLATE_DIR/*yaml
 
 # 17.  Mount TLS certs in the rbac proxy
-for f in $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+for f in $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 do
     perl -i -0777 -pe 's/(.*--v=[0-9]+)/$1\n{{- if not (empty .Values.prometheus.tlsSecret) }}\n        - --tls-cert-file=\/cert\/tls.crt\n        - --tls-private-key-file=\/cert\/tls.key\n        - --client-ca-file=\/cert\/ca.crt\n{{- end }}/g' $f
     perl -i -0777 -pe 's/(volumes:)/$1\n{{- if not (empty .Values.prometheus.tlsSecret) }}\n      - name: auth-cert\n        secret:\n          secretName: {{ .Values.prometheus.tlsSecret }}\n{{- end }}/g' $f
@@ -164,7 +164,7 @@ do
 done
 
 # 18.  Add pod scheduling options
-cat << EOF >> $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+cat << EOF >> $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
@@ -183,7 +183,7 @@ cat << EOF >> $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yam
 EOF
 
 # 19. Template the per-CR concurrency parameters
-for f in $TEMPLATE_DIR/verticadb-operator-controller-manager-deployment.yaml
+for f in $TEMPLATE_DIR/verticadb-operator-manager-deployment.yaml
 do
     perl -i -0777 -pe 's/(--verticadb-concurrency=)[0-9]+/$1\{\{ .Values.reconcileConcurrency.verticadb \}\}/g' $f
     perl -i -0777 -pe 's/(--verticaautoscaler-concurrency=)[0-9]+/$1\{\{ .Values.reconcileConcurrency.verticaautoscaler \}\}/g' $f

--- a/scripts/undeploy.sh
+++ b/scripts/undeploy.sh
@@ -82,7 +82,7 @@ elif kubectl get subscription --all-namespaces=true | grep -cqe "verticadb-opera
 then
     $SCRIPT_DIR/undeploy-olm.sh
     remove_cluster_objects
-elif kubectl get deployment -n verticadb-operator -l control-plane=controller-manager | grep -cqe "verticadb-operator-controller-manager" 2> /dev/null
+elif kubectl get deployment -n verticadb-operator -l control-plane=verticadb-operator | grep -cqe "verticadb-operator" 2> /dev/null
 then
     kubectl delete -f $REPO_DIR/config/release-manifests/operator.yaml || true
     remove_cluster_objects

--- a/scripts/wait-for-verticadb-steady-state.sh
+++ b/scripts/wait-for-verticadb-steady-state.sh
@@ -18,19 +18,21 @@
 # namespace of the vdb you want to check.
 
 TIMEOUT=30  # Default, can be overridden
+CONTROL_PLANE_LABEL=verticadb-operator
 
 function usage() {
-    echo "usage: $(basename $0) [-n <namespace>] [-t <timeout>] [<vdb-namespace>]"
+    echo "usage: $(basename $0) [-n <namespace>] [-t <timeout>] [-l <label>] [<vdb-namespace>]"
     echo
     echo "Options:"
     echo "  -n    Namespace the operator is deployed in.  Defaults to current namespace"
     echo "  -t    Timeout in seconds.  Defaults to $TIMEOUT"
+    echo "  -l    The label of control-plane to use to find the operator. Defaults to $CONTROL_PLANE_LABEL"
     echo
     exit 1
 }
 
 OPTIND=1
-while getopts "n:ht:" opt
+while getopts "n:ht:l:" opt
 do
     case $opt in
         n)
@@ -38,6 +40,9 @@ do
             ;;
         t)
             TIMEOUT=$OPTARG
+            ;;
+        l)
+            CONTROL_PLANE_LABEL=$OPTARG
             ;;
         h)
             usage
@@ -67,7 +72,7 @@ then
     NS_OPT="-n $NAMESPACE "
 fi
 
-LOG_CMD="kubectl ${NS_OPT}logs -l control-plane=verticadb-operator -c manager --tail=-1"
+LOG_CMD="kubectl ${NS_OPT}logs -l control-plane=$CONTROL_PLANE_LABEL -c manager --tail=-1"
 WEBHOOK_FILTER="--invert-match -e 'controller-runtime.webhook.webhooks' -e 'verticadb-resource'"
 DEPRECATION_FILTER="--invert-match 'VerticaDB is deprecated'"
 timeout $TIMEOUT bash -c -- "while ! $LOG_CMD | \

--- a/scripts/wait-for-verticadb-steady-state.sh
+++ b/scripts/wait-for-verticadb-steady-state.sh
@@ -67,7 +67,7 @@ then
     NS_OPT="-n $NAMESPACE "
 fi
 
-LOG_CMD="kubectl ${NS_OPT}logs -l control-plane=controller-manager -c manager --tail=-1"
+LOG_CMD="kubectl ${NS_OPT}logs -l control-plane=verticadb-operator -c manager --tail=-1"
 WEBHOOK_FILTER="--invert-match -e 'controller-runtime.webhook.webhooks' -e 'verticadb-resource'"
 DEPRECATION_FILTER="--invert-match 'VerticaDB is deprecated'"
 timeout $TIMEOUT bash -c -- "while ! $LOG_CMD | \

--- a/scripts/wait-for-webhook.sh
+++ b/scripts/wait-for-webhook.sh
@@ -53,13 +53,13 @@ done
 
 logInfo "Wait for operator Deployment object to exist"
 timeout $TIMEOUT bash -c -- "\
-    while ! kubectl get $NAMESPACE_OPT deployments -l control-plane=controller-manager 2> /dev/null; \
+    while ! kubectl get $NAMESPACE_OPT deployments -l control-plane=verticadb-operator 2> /dev/null; \
     do \
       sleep 0.1; \
     done"
 
 logInfo "Ensure that webhook is enabled for the operator"
-WEBHOOK_ENABLED=$(kubectl get $NAMESPACE_OPT deployments -l control-plane=controller-manager -o jsonpath='{.items[0].spec.template.spec.containers[0].env[1].value}')
+WEBHOOK_ENABLED=$(kubectl get $NAMESPACE_OPT deployments -l control-plane=verticadb-operator -o jsonpath='{.items[0].spec.template.spec.containers[0].env[1].value}')
 if [ "$WEBHOOK_ENABLED" == "false" ]
 then
   logWarning "Webhook is not enabled. Skipping wait."

--- a/tests/e2e-leg-1-at-only/auto-restart-vertica/06-assert.yaml
+++ b/tests/e2e-leg-1-at-only/auto-restart-vertica/06-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-1/autoscale-by-pod/10-assert.yaml
+++ b/tests/e2e-leg-1/autoscale-by-pod/10-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
   namespace: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-1/autoscale-by-subcluster/10-assert.yaml
+++ b/tests/e2e-leg-1/autoscale-by-subcluster/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-1/crash-before-createdb/05-assert.yaml
+++ b/tests/e2e-leg-1/crash-before-createdb/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-1/create-and-del-crd/10-assert.yaml
+++ b/tests/e2e-leg-1/create-and-del-crd/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-1/k-safety-0-scaling/10-assert.yaml
+++ b/tests/e2e-leg-1/k-safety-0-scaling/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-1/k-safety-1-scaling/01-assert.yaml
+++ b/tests/e2e-leg-1/k-safety-1-scaling/01-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-1/kill-during-add-node/05-assert.yaml
+++ b/tests/e2e-leg-1/kill-during-add-node/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2-at-only/schedule-only/06-assert.yaml
+++ b/tests/e2e-leg-2-at-only/schedule-only/06-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2/restart-node-multi-sc/10-assert.yaml
+++ b/tests/e2e-leg-2/restart-node-multi-sc/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2/revivedb-failures/06-assert.yaml
+++ b/tests/e2e-leg-2/revivedb-failures/06-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2/scale-down-drain/10-assert.yaml
+++ b/tests/e2e-leg-2/scale-down-drain/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2/shared-svc/05-assert.yaml
+++ b/tests/e2e-leg-2/shared-svc/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2/use-own-serviceaccount/15-assert.yaml
+++ b/tests/e2e-leg-2/use-own-serviceaccount/15-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2/vas-webhook/05-assert.yaml
+++ b/tests/e2e-leg-2/vas-webhook/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-2/vdb-webhook/05-assert.yaml
+++ b/tests/e2e-leg-2/vdb-webhook/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-3-at-only/verify-image/05-assert.yaml
+++ b/tests/e2e-leg-3-at-only/verify-image/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-3/client-access/05-assert.yaml
+++ b/tests/e2e-leg-3/client-access/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-3/revive-with-different-local-paths/10-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-4/createdb-failures/00-assert.yaml
+++ b/tests/e2e-leg-4/createdb-failures/00-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-4/pvc-expansion/10-assert.yaml
+++ b/tests/e2e-leg-4/pvc-expansion/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-4/revivedb-1-node/10-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-4/revivedb-3-node/10-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-4/revivedb-multi-sc/06-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/06-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-4/vdb-gen/10-assert.yaml
+++ b/tests/e2e-leg-4/vdb-gen/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-5-at-only/istio/07-enable-strict-mTLS.yaml
+++ b/tests/e2e-leg-5-at-only/istio/07-enable-strict-mTLS.yaml
@@ -32,4 +32,4 @@ spec:
       mode: PERMISSIVE
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: verticadb-operator

--- a/tests/e2e-leg-5-at-only/istio/10-assert.yaml
+++ b/tests/e2e-leg-5-at-only/istio/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-5-at-only/istio/40-assert.yaml
+++ b/tests/e2e-leg-5-at-only/istio/40-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-5-at-only/kill-controller/10-assert.yaml
+++ b/tests/e2e-leg-5-at-only/kill-controller/10-assert.yaml
@@ -15,6 +15,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-5-at-only/kill-controller/95-errors.yaml
+++ b/tests/e2e-leg-5-at-only/kill-controller/95-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/custom-cert-webhook-cabundle-as-cert-manager/10-assert.yaml
+++ b/tests/e2e-leg-5/custom-cert-webhook-cabundle-as-cert-manager/10-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running
 ---

--- a/tests/e2e-leg-5/custom-cert-webhook-cabundle-as-cert-manager/95-errors.yaml
+++ b/tests/e2e-leg-5/custom-cert-webhook-cabundle-as-cert-manager/95-errors.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator

--- a/tests/e2e-leg-5/custom-cert-webhook-cabundle-in-secret/15-assert.yaml
+++ b/tests/e2e-leg-5/custom-cert-webhook-cabundle-in-secret/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running
 ---

--- a/tests/e2e-leg-5/custom-cert-webhook-cabundle-in-secret/95-errors.yaml
+++ b/tests/e2e-leg-5/custom-cert-webhook-cabundle-in-secret/95-errors.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator

--- a/tests/e2e-leg-5/custom-operator-log-path/10-assert.yaml
+++ b/tests/e2e-leg-5/custom-operator-log-path/10-assert.yaml
@@ -15,6 +15,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-5/custom-operator-log-path/15-add-patch.yaml
+++ b/tests/e2e-leg-5/custom-operator-log-path/15-add-patch.yaml
@@ -16,5 +16,5 @@ kind: TestStep
 commands:
   - script: |
       PN=$(kubectl get pods -n $NAMESPACE --no-headers  -o custom-columns=":metadata.name" | grep verticadb ) \
-      && kubectl patch deployment verticadb-operator-controller-manager -n $NAMESPACE --patch "$(cat test-logging-patch.yaml)" \
+      && kubectl patch deployment verticadb-operator-manager -n $NAMESPACE --patch "$(cat test-logging-patch.yaml)" \
       && kubectl wait --for=delete pod/$PN -n $NAMESPACE --timeout=180s

--- a/tests/e2e-leg-5/custom-operator-log-path/15-assert.yaml
+++ b/tests/e2e-leg-5/custom-operator-log-path/15-assert.yaml
@@ -14,6 +14,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: verticadb-operator-controller-manager
+  name: verticadb-operator-manager
 status:
   readyReplicas: 1

--- a/tests/e2e-leg-5/custom-operator-log-path/90-errors.yaml
+++ b/tests/e2e-leg-5/custom-operator-log-path/90-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service
@@ -30,4 +30,4 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: matt-controller-manager
+  name: matt-manager

--- a/tests/e2e-leg-5/deploy-with-manifest/10-assert.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/10-assert.yaml
@@ -16,7 +16,7 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running
 ---

--- a/tests/e2e-leg-5/deploy-with-manifest/10-deploy-operator.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/10-deploy-operator.yaml
@@ -18,4 +18,4 @@ commands:
   - command: kubectl delete ns verticadb-operator
   - command: sh -c "cd ../../.. && make install"  # Add the CRDs
   - command: sh -c "cd ../../.. && kubectl apply -f config/release-manifests/operator.yaml"
-  - command: kubectl wait pod --namespace verticadb-operator -l control-plane=controller-manager --for=condition=Ready=True
+  - command: kubectl wait pod --namespace verticadb-operator -l control-plane=verticadb-operator --for=condition=Ready=True

--- a/tests/e2e-leg-5/deploy-with-manifest/95-errors.yaml
+++ b/tests/e2e-leg-5/deploy-with-manifest/95-errors.yaml
@@ -16,7 +16,7 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Namespace

--- a/tests/e2e-leg-5/disable-webhook/10-assert.yaml
+++ b/tests/e2e-leg-5/disable-webhook/10-assert.yaml
@@ -15,13 +15,13 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: verticadb-operator-controller-manager
+  name: verticadb-operator-manager
 status:
   readyReplicas: 1

--- a/tests/e2e-leg-5/disable-webhook/90-errors.yaml
+++ b/tests/e2e-leg-5/disable-webhook/90-errors.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator

--- a/tests/e2e-leg-5/helm-nameoverride/15-assert.yaml
+++ b/tests/e2e-leg-5/helm-nameoverride/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running
 ---
@@ -32,7 +32,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: matt-controller-manager
+  name: matt-manager
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tests/e2e-leg-5/helm-nameoverride/15-assert.yaml
+++ b/tests/e2e-leg-5/helm-nameoverride/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: verticadb-operator
+    control-plane: matt
 status:
   phase: Running
 ---

--- a/tests/e2e-leg-5/helm-nameoverride/35-verify-webhook.yaml
+++ b/tests/e2e-leg-5/helm-nameoverride/35-verify-webhook.yaml
@@ -16,4 +16,4 @@ kind: TestStep
 commands:
   - script: kubectl -n $NAMESPACE get verticadb v-helm-nameoverride -o json | jq '.spec.initPolicy="Revive"' | kubectl -n $NAMESPACE replace -f -
     ignoreFailure: true
-  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE $NAMESPACE"
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n $NAMESPACE -l matt $NAMESPACE"

--- a/tests/e2e-leg-5/helm-nameoverride/97-errors.yaml
+++ b/tests/e2e-leg-5/helm-nameoverride/97-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service
@@ -30,4 +30,4 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: matt-controller-manager
+  name: matt-manager

--- a/tests/e2e-leg-5/metrics-auth-proxy-cert/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-auth-proxy-cert/05-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-leg-5/metrics-auth-proxy-cert/90-errors.yaml
+++ b/tests/e2e-leg-5/metrics-auth-proxy-cert/90-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/metrics-auth-proxy-token-helm/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-auth-proxy-token-helm/05-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-leg-5/metrics-auth-proxy-token-helm/90-errors.yaml
+++ b/tests/e2e-leg-5/metrics-auth-proxy-token-helm/90-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/metrics-auth-proxy-token-olm/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-auth-proxy-token-olm/05-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-leg-5/metrics-auth-proxy-token-olm/90-errors.yaml
+++ b/tests/e2e-leg-5/metrics-auth-proxy-token-olm/90-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/metrics-disabled/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-disabled/05-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager
@@ -29,7 +29,7 @@ spec:
     - --level=info
     - --dev=false
     - --prefix-name=verticadb-operator
-    - --webhook-cert-secret=verticadb-operator-controller-manager-service-cert
+    - --webhook-cert-secret=verticadb-operator-service-cert
     - --use-cert-manager
     - --verticadb-concurrency=5
     - --verticaautoscaler-concurrency=1

--- a/tests/e2e-leg-5/metrics-disabled/90-errors.yaml
+++ b/tests/e2e-leg-5/metrics-disabled/90-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/metrics-no-auth/05-assert.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/05-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager
@@ -30,7 +30,7 @@ spec:
     - --level=info
     - --dev=true
     - --prefix-name=verticadb-operator
-    - --webhook-cert-secret=verticadb-operator-controller-manager-service-cert
+    - --webhook-cert-secret=verticadb-operator-service-cert
     - --use-cert-manager
     - --verticadb-concurrency=5
     - --verticaautoscaler-concurrency=1

--- a/tests/e2e-leg-5/metrics-no-auth/90-errors.yaml
+++ b/tests/e2e-leg-5/metrics-no-auth/90-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/online-upgrade-down-cluster/05-assert.yaml
+++ b/tests/e2e-leg-5/online-upgrade-down-cluster/05-assert.yaml
@@ -15,6 +15,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-5/online-upgrade-down-cluster/30-assert.yaml
+++ b/tests/e2e-leg-5/online-upgrade-down-cluster/30-assert.yaml
@@ -15,6 +15,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-5/online-upgrade-down-cluster/95-errors.yaml
+++ b/tests/e2e-leg-5/online-upgrade-down-cluster/95-errors.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator

--- a/tests/e2e-leg-5/operator-metrics/05-assert.yaml
+++ b/tests/e2e-leg-5/operator-metrics/05-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-leg-5/operator-metrics/90-errors.yaml
+++ b/tests/e2e-leg-5/operator-metrics/90-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/operator-pod-scheduling/10-assert.yaml
+++ b/tests/e2e-leg-5/operator-pod-scheduling/10-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-leg-5/operator-pod-scheduling/15-errors.yaml
+++ b/tests/e2e-leg-5/operator-pod-scheduling/15-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/operator-pod-scheduling/20-assert.yaml
+++ b/tests/e2e-leg-5/operator-pod-scheduling/20-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-leg-5/operator-pod-scheduling/25-errors.yaml
+++ b/tests/e2e-leg-5/operator-pod-scheduling/25-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/prometheus-service-monitor/10-assert.yaml
+++ b/tests/e2e-leg-5/prometheus-service-monitor/10-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager
@@ -30,7 +30,7 @@ spec:
     - --level=info
     - --dev=false
     - --prefix-name=verticadb-operator
-    - --webhook-cert-secret=verticadb-operator-controller-manager-service-cert
+    - --webhook-cert-secret=verticadb-operator-service-cert
     - --use-cert-manager
     - --verticadb-concurrency=5
     - --verticaautoscaler-concurrency=1
@@ -60,4 +60,4 @@ spec:
     port: metrics
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: verticadb-operator

--- a/tests/e2e-leg-5/prometheus-service-monitor/15-errors.yaml
+++ b/tests/e2e-leg-5/prometheus-service-monitor/15-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-5/prometheus-service-monitor/20-assert.yaml
+++ b/tests/e2e-leg-5/prometheus-service-monitor/20-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager
@@ -30,7 +30,7 @@ spec:
     - --level=info
     - --dev=false
     - --prefix-name=verticadb-operator
-    - --webhook-cert-secret=verticadb-operator-controller-manager-service-cert
+    - --webhook-cert-secret=verticadb-operator-service-cert
     - --use-cert-manager
     - --verticadb-concurrency=5
     - --verticaautoscaler-concurrency=1
@@ -59,4 +59,4 @@ spec:
     port: metrics
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: verticadb-operator

--- a/tests/e2e-leg-5/prometheus-service-monitor/25-errors.yaml
+++ b/tests/e2e-leg-5/prometheus-service-monitor/25-errors.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 ---
 apiVersion: v1
 kind: Service

--- a/tests/e2e-leg-6/http-custom-certs/15-assert.yaml
+++ b/tests/e2e-leg-6/http-custom-certs/15-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-6/http-generated-certs/15-assert.yaml
+++ b/tests/e2e-leg-6/http-generated-certs/15-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-6/labels-annotations/05-assert.yaml
+++ b/tests/e2e-leg-6/labels-annotations/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-6/nma-certs-mount/05-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-6/readiness-probe-override/10-assert.yaml
+++ b/tests/e2e-leg-6/readiness-probe-override/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-6/update-strategy/10-assert.yaml
+++ b/tests/e2e-leg-6/update-strategy/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-6/verify-server-logrotate/01-assert.yaml
+++ b/tests/e2e-leg-6/verify-server-logrotate/01-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-7/mount-certs/10-assert.yaml
+++ b/tests/e2e-leg-7/mount-certs/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-7/multi-sc-sanity/05-assert.yaml
+++ b/tests/e2e-leg-7/multi-sc-sanity/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-7/pending-pod/10-assert.yaml
+++ b/tests/e2e-leg-7/pending-pod/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-7/restart-kill-sts/10-assert.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-7/restart-sanity/06-assert.yaml
+++ b/tests/e2e-leg-7/restart-sanity/06-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-7/restart-with-liveness-probe/10-assert.yaml
+++ b/tests/e2e-leg-7/restart-with-liveness-probe/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-7/restart-with-sidecars/10-assert.yaml
+++ b/tests/e2e-leg-7/restart-with-sidecars/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/15-assert.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/15-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/15-assert.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/15-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-operator-upgrade-template/from-1.2.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.2.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.2.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.2.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: verticadb-operator
+    control-plane: controller-manager
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.3.1/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.3.1/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.3.1/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.3.1/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: verticadb-operator
+    control-plane: controller-manager
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.4.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.4.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.4.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.4.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: verticadb-operator
+    control-plane: controller-manager
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.6.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.6.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: verticadb-operator
+    control-plane: controller-manager
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.7.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.7.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/from-1.7.0/15-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/from-1.7.0/15-assert.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: verticadb-operator
+    control-plane: controller-manager
 spec:
   containers:
   - name: manager

--- a/tests/e2e-operator-upgrade-template/template/35-errors.yaml
+++ b/tests/e2e-operator-upgrade-template/template/35-errors.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator

--- a/tests/e2e-operator-upgrade-template/template/35-errors.yaml
+++ b/tests/e2e-operator-upgrade-template/template/35-errors.yaml
@@ -15,4 +15,4 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: verticadb-operator
+    control-plane: controller-manager

--- a/tests/e2e-operator-upgrade-template/template/40-assert.yaml
+++ b/tests/e2e-operator-upgrade-template/template/40-assert.yaml
@@ -15,6 +15,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-operator-upgrade-template/template/48-delete-pods.yaml
+++ b/tests/e2e-operator-upgrade-template/template/48-delete-pods.yaml
@@ -14,5 +14,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl delete pod v-from-x-pri1-0 v-from-x-pri1-1 -n $NAMESPACE
+  - command: kubectl delete sts v-from-x-pri1 -n $NAMESPACE
 

--- a/tests/e2e-server-upgrade-at-only/online-upgrade-block-downgrade/10-assert.yaml
+++ b/tests/e2e-server-upgrade-at-only/online-upgrade-block-downgrade/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/offline-upgrade-happy-path/05-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-happy-path/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-0/06-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-0/06-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/offline-upgrade-ks-1/05-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-ks-1/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/10-assert.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/online-upgrade-and-scale-up/10-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-and-scale-up/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/online-upgrade-drain/10-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-drain/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/online-upgrade-kill-transient/05-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-kill-transient/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/05-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-1-sc/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/05-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-no-transient-2-sc/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/10-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-pending-transient/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-server-upgrade/online-upgrade-with-transient/05-assert.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-transient/05-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-udx/udx-cpp/10-assert.yaml
+++ b/tests/e2e-udx/udx-cpp/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-udx/udx-java/10-assert.yaml
+++ b/tests/e2e-udx/udx-java/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running

--- a/tests/e2e-udx/udx-python/10-assert.yaml
+++ b/tests/e2e-udx/udx-python/10-assert.yaml
@@ -16,6 +16,6 @@ kind: Pod
 metadata:
   namespace: verticadb-operator
   labels:
-    control-plane: controller-manager
+    control-plane: verticadb-operator
 status:
   phase: Running


### PR DESCRIPTION
Any operator that is built with the operator-sdk framework will have default selector labels added for the operator like this:
```
  control-plane: controller-manager
```

When the operator is deployed in the same namespace as other operator, that also continue using the default label, then the service object for the operator fails to work. The service object is used by the webhook, so it will route webhook requests to the wrong pod.

This change is to use the following label instead:
```
  control-plane: verticadb-operator
```

I also took the opportunity to rename the operator objects. The deployment object was renamed from `verticadb-operator-controller-manager` to `verticadb-operator-manager`.

Closes #694 