### PR TITLE
Fixes Istio proxy sidecar initialization issue

### DIFF
--- a/changes/unreleased/Fixed-20240213-111303.yaml
+++ b/changes/unreleased/Fixed-20240213-111303.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Fix when istio proxy sidecar is injected as the first container
+time: 2024-02-13T11:13:03.768289581-04:00
+custom:
+  Issue: "702"

--- a/changes/unreleased/Fixed-20240213-111303.yaml
+++ b/changes/unreleased/Fixed-20240213-111303.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: Fix when istio proxy sidecar is injected as the first container
+body: Resolves the issue when Istio proxy sidecar is injected as the first container.
 time: 2024-02-13T11:13:03.768289581-04:00
 custom:
   Issue: "702"

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -32,6 +32,7 @@ import (
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
+	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -411,7 +412,10 @@ func (o *OnlineUpgradeReconciler) isMatchingSubclusterType(sts *appsv1.StatefulS
 // drainSubcluster will reroute traffic away from a subcluster and wait for it to be idle.
 // This is a no-op if the image has already been updated for the subcluster.
 func (o *OnlineUpgradeReconciler) drainSubcluster(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
-	img := sts.Spec.Template.Spec.Containers[names.GetFirstContainerIndex()].Image
+	img, err := vk8s.GetServerImage(sts.Spec.Template.Spec.Containers)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if img != o.Vdb.Spec.Image {
 		scName := sts.Labels[vmeta.SubclusterNameLabel]
@@ -542,7 +546,10 @@ func (o *OnlineUpgradeReconciler) waitForReadOnly(_ context.Context, sts *appsv1
 	if o.PFacts.countUpPrimaryNodes() != 0 {
 		return ctrl.Result{}, nil
 	}
-	newImage := sts.Spec.Template.Spec.Containers[names.GetFirstContainerIndex()].Image
+	newImage, err := vk8s.GetServerImage(sts.Spec.Template.Spec.Containers)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	// If all the pods that are running the old image are read-only we are done
 	// our wait.
 	if o.PFacts.countNotReadOnlyWithOldImage(newImage) == 0 {
@@ -661,7 +668,10 @@ func (o *OnlineUpgradeReconciler) cachePrimaryImages(ctx context.Context) error 
 	for i := range stss.Items {
 		sts := &stss.Items[i]
 		if sts.Labels[vmeta.SubclusterTypeLabel] == vapi.PrimarySubcluster {
-			img := sts.Spec.Template.Spec.Containers[names.GetFirstContainerIndex()].Image
+			img, err := vk8s.GetServerImage(sts.Spec.Template.Spec.Containers)
+			if err != nil {
+				return err
+			}
 			imageFound := false
 			for j := range o.PrimaryImages {
 				imageFound = o.PrimaryImages[j] == img

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -333,9 +334,9 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 
 		sts := &appsv1.StatefulSet{}
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[0]), sts)).Should(Succeed())
-		Expect(sts.Spec.Template.Spec.Containers[names.GetFirstContainerIndex()].Image).Should(Equal(NewImageName))
+		Expect(vk8s.GetServerImage(sts.Spec.Template.Spec.Containers)).Should(Equal(NewImageName))
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[1]), sts)).Should(Succeed())
-		Expect(sts.Spec.Template.Spec.Containers[names.GetFirstContainerIndex()].Image).Should(Equal(NewImageName))
+		Expect(vk8s.GetServerImage(sts.Spec.Template.Spec.Containers)).Should(Equal(NewImageName))
 	})
 
 	It("should have an upgradeStatus set when it fails part way through", func() {

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/metrics"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
+	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,8 +102,11 @@ func (i *UpgradeManager) isVDBImageDifferent(ctx context.Context) (bool, error) 
 	}
 	for inx := range stss.Items {
 		sts := stss.Items[inx]
-		cnts := sts.Spec.Template.Spec.Containers
-		if cnts[names.GetFirstContainerIndex()].Image != i.Vdb.Spec.Image {
+		cntImage, err := vk8s.GetServerImage(sts.Spec.Template.Spec.Containers)
+		if err != nil {
+			return false, err
+		}
+		if cntImage != i.Vdb.Spec.Image {
 			return true, nil
 		}
 	}
@@ -206,13 +210,15 @@ func (i *UpgradeManager) updateImageInStatefulSets(ctx context.Context) (int, er
 func (i *UpgradeManager) updateImageInStatefulSet(ctx context.Context, sts *appsv1.StatefulSet) (bool, error) {
 	stsUpdated := false
 	// Skip the statefulset if it already has the proper image.
-	cnts := sts.Spec.Template.Spec.Containers
-	inx := names.GetServerContainerIndex(i.Vdb)
-	if len(cnts) > inx && cnts[inx].Image != i.Vdb.Spec.Image {
+	svrCnt := vk8s.GetServerContainer(sts.Spec.Template.Spec.Containers)
+	if svrCnt == nil {
+		return false, fmt.Errorf("could not find the server container in the sts %s", sts.Name)
+	}
+	if svrCnt.Image != i.Vdb.Spec.Image {
 		i.Log.Info("Updating image in old statefulset", "name", sts.ObjectMeta.Name)
-		sts.Spec.Template.Spec.Containers[inx].Image = i.Vdb.Spec.Image
-		if i.Vdb.IsNMASideCarDeploymentEnabled() {
-			sts.Spec.Template.Spec.Containers[names.GetNMAContainerIndex()].Image = i.Vdb.Spec.Image
+		svrCnt.Image = i.Vdb.Spec.Image
+		if nmaCnt := vk8s.GetNMAContainer(sts.Spec.Template.Spec.Containers); nmaCnt != nil {
+			nmaCnt.Image = i.Vdb.Spec.Image
 		}
 		// We change the update strategy to OnDelete.  We don't want the k8s
 		// sts controller to interphere and do a rolling update after the
@@ -253,8 +259,11 @@ func (i *UpgradeManager) deletePodsRunningOldImage(ctx context.Context, scName s
 		}
 
 		// Skip the pod if it already has the proper image.
-		cnts := pod.Spec.Containers
-		if cnts[names.GetFirstContainerIndex()].Image != i.Vdb.Spec.Image {
+		cntImage, err := vk8s.GetServerImage(pod.Spec.Containers)
+		if err != nil {
+			return numPodsDeleted, err
+		}
+		if cntImage != i.Vdb.Spec.Image {
 			i.Log.Info("Deleting pod that had old image", "name", pod.ObjectMeta.Name)
 			err = i.VRec.Client.Delete(ctx, pod)
 			if err != nil {
@@ -275,7 +284,11 @@ func (i *UpgradeManager) deleteStsRunningOldImage(ctx context.Context) error {
 	for inx := range stss.Items {
 		sts := &stss.Items[inx]
 
-		if sts.Spec.Template.Spec.Containers[names.GetFirstContainerIndex()].Image != i.Vdb.Spec.Image {
+		cntImage, err := vk8s.GetServerImage(sts.Spec.Template.Spec.Containers)
+		if err != nil {
+			return err
+		}
+		if cntImage != i.Vdb.Spec.Image {
 			i.Log.Info("Deleting sts that had old image", "name", sts.ObjectMeta.Name)
 			err = i.VRec.Client.Delete(ctx, sts)
 			if err != nil {

--- a/pkg/controllers/vdb/upgrade_test.go
+++ b/pkg/controllers/vdb/upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -112,11 +113,14 @@ var _ = Describe("upgrade", func() {
 		Expect(stsChange).Should(Equal(2))
 
 		sts := &appsv1.StatefulSet{}
-		inx := names.GetServerContainerIndex(vdb)
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[0]), sts)).Should(Succeed())
-		Expect(sts.Spec.Template.Spec.Containers[inx].Image).Should(Equal(NewImage))
+		svrCnt := vk8s.GetServerContainer(sts.Spec.Template.Spec.Containers)
+		Expect(svrCnt).ShouldNot(BeNil())
+		Expect(svrCnt.Image).Should(Equal(NewImage))
 		Expect(k8sClient.Get(ctx, names.GenStsName(vdb, &vdb.Spec.Subclusters[1]), sts)).Should(Succeed())
-		Expect(sts.Spec.Template.Spec.Containers[inx].Image).Should(Equal(NewImage))
+		svrCnt = vk8s.GetServerContainer(sts.Spec.Template.Spec.Containers)
+		Expect(svrCnt).ShouldNot(BeNil())
+		Expect(svrCnt.Image).Should(Equal(NewImage))
 	})
 
 	It("should delete pods of all subclusters", func() {

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -20,18 +20,12 @@ import (
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	ServerContainer = "server"
 	NMAContainer    = "nma"
-)
-
-const (
-	firstContainerIndex = iota
-	serverContainerIndex
 )
 
 // GenNamespacedName will take any name and make it a namespace name that uses
@@ -104,35 +98,4 @@ func GenPVName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.N
 	return types.NamespacedName{
 		Name: fmt.Sprintf("pv-%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenCompatibleFQDN(), podIndex),
 	}
-}
-
-// GetServerContainerIndex returns the correct server container
-// index according to the NMA running mode. If there is no nma
-// container, the server will be the first, otherwise the second
-func GetServerContainerIndex(vdb *vapi.VerticaDB) int {
-	if vdb.IsNMASideCarDeploymentEnabled() {
-		return serverContainerIndex
-	}
-	return firstContainerIndex
-}
-
-// GetServerContainerIndexInContainers returns the server index in a given
-// containers slice coming from a Vertica pod
-func GetServerContainerIndexInSlice(cnts []corev1.Container) int {
-	// the server can either be the first or the 2nd container(if nma sidecar is enabled)
-	if cnts[firstContainerIndex].Name == ServerContainer {
-		return firstContainerIndex
-	}
-	return serverContainerIndex
-}
-
-// GetNMAContainerIndex returns the index of
-// the NMA container
-func GetNMAContainerIndex() int {
-	// nma when in a sidecar is always the first container
-	return firstContainerIndex
-}
-
-func GetFirstContainerIndex() int {
-	return firstContainerIndex
 }

--- a/pkg/vk8s/container.go
+++ b/pkg/vk8s/container.go
@@ -1,0 +1,54 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vk8s
+
+import (
+	"errors"
+
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetServerContainer returns a pointer to the container that runs the Vertica
+// server
+func GetServerContainer(cnts []corev1.Container) *corev1.Container {
+	return getNamedContainer(cnts, names.ServerContainer)
+}
+
+// GetNMAContainer returns a pointer to the container that runs the node
+// management agent.
+func GetNMAContainer(cnts []corev1.Container) *corev1.Container {
+	return getNamedContainer(cnts, names.NMAContainer)
+}
+
+func getNamedContainer(cnts []corev1.Container, cntName string) *corev1.Container {
+	for i := range cnts {
+		if cnts[i].Name == cntName {
+			return &cnts[i]
+		}
+	}
+	return nil
+}
+
+// GetServerImage returns the name of the image used for the server container.
+// It returns an error if it cannot find the server container.
+func GetServerImage(cnts []corev1.Container) (string, error) {
+	cnt := GetServerContainer(cnts)
+	if cnt == nil {
+		return "", errors.New("could not find the server container")
+	}
+	return cnt.Image, nil
+}

--- a/pkg/vk8s/container_test.go
+++ b/pkg/vk8s/container_test.go
@@ -1,0 +1,47 @@
+/*
+ (c) Copyright [2021-2023] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vk8s
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("vk8s/container_test", func() {
+	ctx := context.Background()
+
+	It("should find the server container in the spec", func() {
+		vdb := vapi.MakeVDBForHTTP("v-nma-tls-abcde")
+		vdb.Spec.Image = vapi.NMAInSideCarDeploymentMinVersion
+		vdb.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationTrue
+		vdb.Annotations[vmeta.VersionAnnotation] = vapi.NMAInSideCarDeploymentMinVersion
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		pod := corev1.Pod{}
+		Ω(k8sClient.Get(ctx, names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0), &pod)).Should(Succeed())
+		Ω(GetServerContainer(pod.Spec.Containers)).ShouldNot(BeNil())
+		Ω(GetServerImage(pod.Spec.Containers)).Should(Equal(vapi.NMAInSideCarDeploymentMinVersion))
+		Ω(GetNMAContainer(pod.Spec.Containers)).ShouldNot(BeNil())
+	})
+})


### PR DESCRIPTION
Starting in istio 1.17, the istio proxy is now injected as the first container. This breaks some assumptions in the operator code. It assumes that any sidecar is injected at the end and the first two containers are the nma and server. This changes fixes that by referencing containers by their names rather than index. I removed all of the helpers based on index and instead get them by name.
