### PR TITLE
Fix e2e test failures

### DIFF
--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/lithammer/dedent"
@@ -168,6 +169,9 @@ type PodFact struct {
 
 	// The name of the container to run exec commands on.
 	execContainerName string
+
+	// The time that the pod was created.
+	creationTimestamp string
 }
 
 type PodFactDetail map[types.NamespacedName]*PodFact
@@ -343,6 +347,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		pf.isPodRunning = pod.Status.Phase == corev1.PodRunning && !pf.isTerminating
 		pf.dnsName = fmt.Sprintf("%s.%s.%s", pod.Spec.Hostname, pod.Spec.Subdomain, pod.Namespace)
 		pf.podIP = pod.Status.PodIP
+		pf.creationTimestamp = pod.CreationTimestamp.Format(time.DateTime)
 		pf.isTransient, _ = strconv.ParseBool(pod.Labels[vmeta.SubclusterTransientLabel])
 		pf.isPendingDelete = podIndex >= sc.Size
 		// Let's just pick the first container image

--- a/tests/e2e-server-upgrade/online-upgrade-with-transient/verify-vsql-access/base/verify-vsql-access.yaml
+++ b/tests/e2e-server-upgrade/online-upgrade-with-transient/verify-vsql-access/base/verify-vsql-access.yaml
@@ -46,7 +46,10 @@ metadata:
   labels:
     stern: include
 spec:
-  restartPolicy: Never
+  # There can be cache issues when going through the service object where it
+  # still routes to the old pod. So, we always restart the pod to keep
+  # retrying.
+  restartPolicy: Always
   containers:
     - name: test
       image: kustomize-vertica-image


### PR DESCRIPTION
- This improves the online-upgrade-with-transient. There is a step where it verifies that service routing during an online upgrade goes to the correct subcluster. This can sometimes fail, even though there is evidence the service object was updated correctly before the test ran. I suspect there is a k8s cache issue with the service object. So, we will retry the service object validation.
- I am trying to track down a test failure in online-upgrade-kill-transient. We didn't restart the primary subcluster in the order the test expects. So, I am adding debug logic to podfacts to capture when the pod started.