### PR TITLE
Fixes for github actions to release the operator

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -47,7 +47,7 @@ jobs:
         helm package verticadb-operator
         ls -lhrt
     
-    - name: Upload files
+    - name: Upload release-artifacts
       uses: actions/upload-artifact@v4
       with:
         name: release-artifacts
@@ -56,4 +56,10 @@ jobs:
           /home/runner/work/vertica-kubernetes/vertica-kubernetes/config/release-manifests/*yaml
           /home/runner/work/vertica-kubernetes/vertica-kubernetes/helm-charts/*.tgz
           /home/runner/work/vertica-kubernetes/vertica-kubernetes/bin/vdb-gen
+
+    - name: Upload bundle
+      uses: actions/upload-artifact@v4
+      with:
+        name: olm-bundle
+        path: |
           /home/runner/work/vertica-kubernetes/vertica-kubernetes/bundle

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -83,4 +83,7 @@ gh release create v$VERSION \
     --notes-file $TMP_CHANGELOG_FILE \
     --target $VERSION_SHA \
     --title "Vertica Kubernetes $VERSION" \
-    $ARTIFACTS_DIR/*
+    $ARTIFACTS_DIR/bin/* \
+    $ARTIFACTS_DIR/config/*/* \
+    $ARTIFACTS_DIR/helm-charts/*tgz \
+    $ARTIFACTS_DIR/helm-charts/verticadb-operator/crds/*


### PR DESCRIPTION
The recent change to update the version of actions/upload-artifacts from v3 to v4 changed the structure of the artifacts. Updating the release operator procedure to account for that.