### PR TITLE
Fix container index lookup

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -140,17 +140,6 @@ func BuildHlSvc(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.Service {
 	return svc
 }
 
-// HasNMAContainer returns true if the given statefulset spec has the NMA
-// sidecar container.
-func HasNMAContainer(podSpec *corev1.PodSpec) bool {
-	// For test purposes, the container spec could be false. So, it doesn't
-	// matter what we return.
-	if len(podSpec.Containers) == 0 {
-		return false
-	}
-	return podSpec.Containers[0].Name == names.NMAContainer
-}
-
 // buildConfigVolumeMount returns the volume mount for config.
 // If vclusterops flag is enabled we mount only
 // /opt/vertica/config/node_management_agent.pid

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -517,7 +517,7 @@ func (o *ObjReconciler) updateSts(ctx context.Context, curSts, expSts *appsv1.St
 // isNMADeploymentDifferent will return true if one of the statefulsets have a
 // NMA sidecar deployment and the other one doesn't.
 func isNMADeploymentDifferent(sts1, sts2 *appsv1.StatefulSet) bool {
-	return builder.HasNMAContainer(&sts1.Spec.Template.Spec) != builder.HasNMAContainer(&sts2.Spec.Template.Spec)
+	return vk8s.HasNMAContainer(&sts1.Spec.Template.Spec) != vk8s.HasNMAContainer(&sts2.Spec.Template.Spec)
 }
 
 // checkIfReadyForStsUpdate will check whether it is okay to proceed

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -269,7 +269,7 @@ func (p *PodFacts) Invalidate() {
 // know the proper pod spec until we know the Vertica version, but you don't
 // know the Vertica version until the pod runs.
 func getExecContainerName(sts *appsv1.StatefulSet) string {
-	if builder.HasNMAContainer(&sts.Spec.Template.Spec) {
+	if vk8s.HasNMAContainer(&sts.Spec.Template.Spec) {
 		return names.NMAContainer
 	}
 	return names.ServerContainer
@@ -360,7 +360,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		if err != nil {
 			return err
 		}
-		pf.hasNMASidecar = builder.HasNMAContainer(&pod.Spec)
+		pf.hasNMASidecar = vk8s.HasNMAContainer(&pod.Spec)
 	}
 
 	fns := []CheckerFunc{

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -303,7 +303,7 @@ func (i *UpgradeManager) deleteStsRunningOldImage(ctx context.Context) error {
 // upgrading across versions such that we need to deploy the NMA sidecar.
 func (i *UpgradeManager) changeNMASidecarDeploymentIfNeeded(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
 	// Early out if the sts already has an NMA sidecar
-	if builder.HasNMAContainer(&sts.Spec.Template.Spec) {
+	if vk8s.HasNMAContainer(&sts.Spec.Template.Spec) {
 		return ctrl.Result{}, nil
 	}
 	i.Log.Info("Checking if NMA sidecar deployment is changing")

--- a/pkg/vk8s/container.go
+++ b/pkg/vk8s/container.go
@@ -52,3 +52,14 @@ func GetServerImage(cnts []corev1.Container) (string, error) {
 	}
 	return cnt.Image, nil
 }
+
+// HasNMAContainer returns true if the given container spec has the NMA
+// sidecar container.
+func HasNMAContainer(podSpec *corev1.PodSpec) bool {
+	// For test purposes, the container spec could be empty. So, it doesn't
+	// matter what we return.
+	if len(podSpec.Containers) == 0 {
+		return false
+	}
+	return GetNMAContainer(podSpec.Containers) != nil
+}

--- a/pkg/vk8s/container.go
+++ b/pkg/vk8s/container.go
@@ -56,10 +56,5 @@ func GetServerImage(cnts []corev1.Container) (string, error) {
 // HasNMAContainer returns true if the given container spec has the NMA
 // sidecar container.
 func HasNMAContainer(podSpec *corev1.PodSpec) bool {
-	// For test purposes, the container spec could be empty. So, it doesn't
-	// matter what we return.
-	if len(podSpec.Containers) == 0 {
-		return false
-	}
 	return GetNMAContainer(podSpec.Containers) != nil
 }


### PR DESCRIPTION
Found another case where we lookup the container by index rather than name. Index isn't reliable if sidecars are injected, like for istio.