### PR TITLE
Use new opentext docker org

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,7 +122,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: "vertica/vertica-k8s:23.4.0-0-minimal"
+      vertica-image: "opentext/vertica-k8s:23.4.0-0-minimal"
       artifact-suffix: "-23.4.0-release"
       vertica-deployment-method: admintools
     secrets:
@@ -162,7 +162,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: "vertica/vertica-k8s:12.0.4-0-minimal"
+      vertica-image: "opentext/vertica-k8s:12.0.4-0-minimal"
       artifact-suffix: "-12.0.4-release"
       vertica-deployment-method: admintools
     secrets:
@@ -202,7 +202,7 @@ jobs:
     with:
       vlogger-image: ${{ needs.build.outputs.vlogger-image }}
       operator-image: ${{ needs.build.outputs.operator-image }}
-      vertica-image: "vertica/vertica-k8s:24.1.0-0-minimal"
+      vertica-image: "opentext/vertica-k8s:24.1.0-0-minimal"
       artifact-suffix: "-24.1.0-release"
       vertica-deployment-method: vclusterops
     secrets:

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -45,7 +45,7 @@ type VerticaDBSpec struct {
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="vertica/vertica-k8s:24.1.0-0-minimal"
+	// +kubebuilder:default:="opentext/vertica-k8s:24.1.0-0-minimal"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// The docker image name that contains the Vertica server.  Whenever this
 	// changes, the operator treats this as an upgrade.  The upgrade can be done

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -50,7 +50,7 @@ type VerticaDBSpec struct {
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="vertica/vertica-k8s:23.3.0-0-minimal"
+	// +kubebuilder:default:="opentext/vertica-k8s:23.3.0-0-minimal"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// The docker image name that contains the Vertica server.  Whenever this
 	// changes, the operator treats this as an upgrade.  The upgrade can be done

--- a/config/samples/v1_verticadb.yaml
+++ b/config/samples/v1_verticadb.yaml
@@ -3,7 +3,7 @@ kind: VerticaDB
 metadata:
   name: verticadb-sample
 spec:
-  image: "vertica/vertica-k8s:24.1.0-0-minimal"
+  image: "opentext/vertica-k8s:24.1.0-0-minimal"
   communal:
     # path: "s3://<your-bucket>/"
     endpoint: https://s3.amazonaws.com

--- a/config/samples/v1beta1_eventtrigger.yaml
+++ b/config/samples/v1beta1_eventtrigger.yaml
@@ -27,5 +27,5 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: main
-            image: "vertica/vertica-k8s:latest"
+            image: "opentext/vertica-k8s:23.4.0-0-minimal"
             command: ["/opt/vertica/bin/vsql", "-h", "verticadb-sample-defaultsubcluster", "-c", "CREATE TABLE T1 (C1 INT);"]

--- a/config/samples/v1beta1_verticadb.yaml
+++ b/config/samples/v1beta1_verticadb.yaml
@@ -16,7 +16,7 @@ kind: VerticaDB
 metadata:
   name: verticadb-sample
 spec:
-  image: "vertica/vertica-k8s:23.3.0-0-minimal"
+  image: "opentext/vertica-k8s:23.3.0-0-minimal"
   communal:
     # path: "s3://<your-bucket>/"
     endpoint: https://s3.amazonaws.com

--- a/config/samples/verticadb_sample.yaml
+++ b/config/samples/verticadb_sample.yaml
@@ -27,8 +27,10 @@ metadata:
     # are 24.1.0 or newer will want this set to true to deploy with vclusterops.
     vertica.com/vcluster-ops: "true"
 spec:
-  image: "vertica/vertica-k8s:latest" # ensure vertica.com/vcluster-ops is true
-  #image: "vertica/vertica-k8s:23.3.0-0-minimal" # ensure vertica.com/vcluster-ops is false
+  # Let the operator pick the latest image. It will be an image that uses
+  # vclusterOps deployment. If you want to deploy with admintools, uncomment the
+  # next line and update the annotations.
+  #image: "opentext/vertica-k8s:23.3.0-0-minimal" # ensure vertica.com/vcluster-ops is false
   communal:
     path: "s3://nimbusdb/db"
     endpoint: "http://minio"

--- a/docker-vertica-v2/README.md
+++ b/docker-vertica-v2/README.md
@@ -13,7 +13,7 @@ Each tag follows this format: _`<major>.<minor>.<patch>-<hotfix>[-minimal]`_. Fo
 
 The `latest` tag always refers to the minimal image of the most recently released version.
 
-For a comprehensive list, see [Tags](https://hub.docker.com/r/vertica/vertica-k8s/tags).
+For a comprehensive list, see [Tags](https://hub.docker.com/r/opentext/vertica-k8s/tags).
 
 # Quick Reference
 

--- a/docker-vertica/README.md
+++ b/docker-vertica/README.md
@@ -13,7 +13,7 @@ Each tag follows this format: _`<major>.<minor>.<patch>-<hotfix>[-minimal]`_. Fo
 
 The `latest` tag always refers to the minimal image of the most recently released version.
 
-For a comprehensive list, see [Tags](https://hub.docker.com/r/vertica/vertica-k8s/tags).
+For a comprehensive list, see [Tags](https://hub.docker.com/r/opentext/vertica-k8s/tags).
 
 # Quick Reference
 
@@ -32,7 +32,7 @@ https://www.vertica.com/
 
 # How to Use This Image
 
-This image runs the Vertica server that is optimized for use with the [Vertica operator](https://hub.docker.com/r/vertica/verticadb-operator). The operator automates management and administrative tasks for an [Eon Mode](https://www.vertica.com/docs/latest/HTML/Content/Authoring/Eon/Architecture.htm) database in Kubernetes. 
+This image runs the Vertica server that is optimized for use with the [Vertica operator](https://hub.docker.com/r/opentext/verticadb-operator). The operator automates management and administrative tasks for an [Eon Mode](https://www.vertica.com/docs/latest/HTML/Content/Authoring/Eon/Architecture.htm) database in Kubernetes. 
 
 Vertica provides two versions of this image, depending on whether you require the TensorFlow package:
 - If you do not require the TensorFlow package, Vertica recommends downloading the image with the *-minimal* supported tag suffix. Because it does not include the TensorFlow package, it has a reduced size. The *-minimal* image is the default image included in the [Vertica Helm chart](https://github.com/vertica/charts).

--- a/docker-vlogger/README.md
+++ b/docker-vlogger/README.md
@@ -24,7 +24,7 @@ https://www.vertica.com/
 
 # How to Use This Image
 
-This image is used to deploy a sidecar utility container that assists with logging for the [vertica/vertica-k8s](https://hub.docker.com/r/vertica/vertica-k8s/tags?page=1&ordering=last_updated) server image. The sidecar sends logs from vertica.log in the Vertica server to stdout on the host node to simplify log aggregation.
+This image is used to deploy a sidecar utility container that assists with logging for the [opentext/vertica-k8s](https://hub.docker.com/r/opentext/vertica-k8s/tags?page=1&ordering=last_updated) server image. The sidecar sends logs from vertica.log in the Vertica server to stdout on the host node to simplify log aggregation.
 
 For an overview of the sidecar container, see [Containerized Vertica on Kubernetes](https://www.vertica.com/docs/latest/HTML/Content/Authoring/Containers/Kubernetes/ContainerizedVerticaWithK8s.htm). For sidecar implementation details, see [Creating a Custom Resource](https://www.vertica.com/docs/latest/HTML/Content/Authoring/Containers/Kubernetes/Operator/CreatingCustomResource.htm).
 

--- a/pkg/vdbgen/vdb.go
+++ b/pkg/vdbgen/vdb.go
@@ -676,7 +676,7 @@ func (d *DBGenerator) setImage(ctx context.Context) error {
 	// Pick an image we hosted in Docker Hub.  We always publish an image for
 	// hotfix 0. Rarely do we publish one for subsequent hotfixes, so always use
 	// hotfix 0 regardless of what hotfix was currently in use.
-	d.Objs.Vdb.Spec.Image = fmt.Sprintf("vertica/vertica-k8s:%s-0", version)
+	d.Objs.Vdb.Spec.Image = fmt.Sprintf("opentext/vertica-k8s:%s-0", version)
 
 	// Set proper annotation to ensure correct deployment method.
 	return d.setDeploymentMethodAnnotationFromServerVersion("v" + version)

--- a/pkg/vdbgen/vdb_test.go
+++ b/pkg/vdbgen/vdb_test.go
@@ -323,9 +323,9 @@ var _ = Describe("vdb", func() {
 				AddRow("Vertica Analytic Database 11.0.1-0"))
 
 		Expect(dbGen.setImage(ctx)).Should(Succeed())
-		Expect(dbGen.Objs.Vdb.Spec.Image).Should(Equal("vertica/vertica-k8s:12.0.2-0"))
+		Expect(dbGen.Objs.Vdb.Spec.Image).Should(Equal("opentext/vertica-k8s:12.0.2-0"))
 		Expect(dbGen.setImage(ctx)).Should(Succeed())
-		Expect(dbGen.Objs.Vdb.Spec.Image).Should(Equal("vertica/vertica-k8s:11.0.1-0"))
+		Expect(dbGen.Objs.Vdb.Spec.Image).Should(Equal("opentext/vertica-k8s:11.0.1-0"))
 	})
 
 	It("should set default deployment method based on server version if the user doesn't force a deployment method", func() {

--- a/scripts/wait-for-webhook.sh
+++ b/scripts/wait-for-webhook.sh
@@ -96,7 +96,6 @@ metadata:
   labels:
     $SELECTOR_KEY: $SELECTOR_VAL
 spec:
-  image: "vertica/vertica-k8s:latest"
   initPolicy: ScheduleOnly
   subclusters:
   - name: sc1

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/20-pull-images.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/20-pull-images.yaml
@@ -14,6 +14,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl run v12-4 -n $NAMESPACE --image=vertica/vertica-k8s:12.0.4-0-minimal --restart=Never --command -- vertica --version
-  - command: kubectl run v23-4 -n $NAMESPACE --image=vertica/vertica-k8s:23.4.0-0-minimal --restart=Never --command -- vertica --version
-  - command: kubectl run v24-1 -n $NAMESPACE --image=vertica/vertica-k8s:24.1.0-0-minimal --restart=Never --command -- vertica --version
+  - command: kubectl run v12-4 -n $NAMESPACE --image=opentext/vertica-k8s:12.0.4-0-minimal --restart=Never --command -- vertica --version
+  - command: kubectl run v23-4 -n $NAMESPACE --image=opentext/vertica-k8s:23.4.0-0-minimal --restart=Never --command -- vertica --version
+  - command: kubectl run v24-1 -n $NAMESPACE --image=opentext/vertica-k8s:24.1.0-0-minimal --restart=Never --command -- vertica --version

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/25-assert.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/25-assert.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:12.0.4-0-minimal
+        image: opentext/vertica-k8s:12.0.4-0-minimal
 status:
   replicas: 3
 ---
@@ -29,4 +29,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:12.0.4-0-minimal
+  image: opentext/vertica-k8s:12.0.4-0-minimal

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/40-assert.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/40-assert.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:23.4.0-0-minimal
+        image: opentext/vertica-k8s:23.4.0-0-minimal
 status:
   replicas: 3
   readyReplicas: 3
@@ -30,4 +30,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:23.4.0-0-minimal
+  image: opentext/vertica-k8s:23.4.0-0-minimal

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/40-upgrade-to-23-4.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/40-upgrade-to-23-4.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:23.4.0-0-minimal
+  image: opentext/vertica-k8s:23.4.0-0-minimal

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/45-assert.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/45-assert.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:24.1.0-0-minimal
+        image: opentext/vertica-k8s:24.1.0-0-minimal
 status:
   replicas: 3
   readyReplicas: 3
@@ -30,4 +30,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:24.1.0-0-minimal
+  image: opentext/vertica-k8s:24.1.0-0-minimal

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/45-upgrade-to-24-1.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/45-upgrade-to-24-1.yaml
@@ -18,4 +18,4 @@ metadata:
   annotations:
     vertica.com/vcluster-ops: "true"
 spec:
-  image: vertica/vertica-k8s:24.1.0-0-minimal
+  image: opentext/vertica-k8s:24.1.0-0-minimal

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/revive-vdb/base/revive-vdb.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/revive-vdb/base/revive-vdb.yaml
@@ -19,7 +19,7 @@ metadata:
     vertica.com/vcluster-ops: "true"
     vertica.com/ignore-cluster-lease: "true"
 spec:
-  image: vertica/vertica-k8s:24.1.0-0-minimal
+  image: opentext/vertica-k8s:24.1.0-0-minimal
   imagePullPolicy: IfNotPresent
   passwordSecret: su-passwd
   communal: {}

--- a/tests/e2e-leg-8/offline-upgrade-through-vclusterops/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-8/offline-upgrade-through-vclusterops/setup-vdb/base/setup-vdb.yaml
@@ -18,7 +18,7 @@ metadata:
   annotations:
     vertica.com/vcluster-ops: "false"
 spec:
-  image: vertica/vertica-k8s:12.0.4-0-minimal
+  image: opentext/vertica-k8s:12.0.4-0-minimal
   imagePullPolicy: IfNotPresent
   passwordSecret: su-passwd
   communal: {}

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/20-pull-images.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/20-pull-images.yaml
@@ -14,6 +14,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl run v12-4 -n $NAMESPACE --image=vertica/vertica-k8s:12.0.4-0-minimal --restart=Never --command -- vertica --version
-  - command: kubectl run v23-4 -n $NAMESPACE --image=vertica/vertica-k8s:23.4.0-0-minimal --restart=Never --command -- vertica --version
-  - command: kubectl run v24-1 -n $NAMESPACE --image=vertica/vertica-k8s:24.1.0-0-minimal --restart=Never --command -- vertica --version
+  - command: kubectl run v12-4 -n $NAMESPACE --image=opentext/vertica-k8s:12.0.4-0-minimal --restart=Never --command -- vertica --version
+  - command: kubectl run v23-4 -n $NAMESPACE --image=opentext/vertica-k8s:23.4.0-0-minimal --restart=Never --command -- vertica --version
+  - command: kubectl run v24-1 -n $NAMESPACE --image=opentext/vertica-k8s:24.1.0-0-minimal --restart=Never --command -- vertica --version

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/25-assert.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/25-assert.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:12.0.4-0-minimal
+        image: opentext/vertica-k8s:12.0.4-0-minimal
 status:
   replicas: 2
 ---
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:12.0.4-0-minimal
+        image: opentext/vertica-k8s:12.0.4-0-minimal
 status:
   replicas: 1
 ---
@@ -42,4 +42,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:12.0.4-0-minimal
+  image: opentext/vertica-k8s:12.0.4-0-minimal

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/40-assert.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/40-assert.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:23.4.0-0-minimal
+        image: opentext/vertica-k8s:23.4.0-0-minimal
 status:
   replicas: 2
   readyReplicas: 2
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:23.4.0-0-minimal
+        image: opentext/vertica-k8s:23.4.0-0-minimal
 status:
   replicas: 1
   readyReplicas: 1
@@ -44,4 +44,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:23.4.0-0-minimal
+  image: opentext/vertica-k8s:23.4.0-0-minimal

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/40-upgrade-to-23-4.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/40-upgrade-to-23-4.yaml
@@ -16,4 +16,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:23.4.0-0-minimal
+  image: opentext/vertica-k8s:23.4.0-0-minimal

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/45-assert.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/45-assert.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:24.1.0-0-minimal
+        image: opentext/vertica-k8s:24.1.0-0-minimal
 status:
   replicas: 2
   readyReplicas: 2
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: vertica/vertica-k8s:24.1.0-0-minimal
+        image: opentext/vertica-k8s:24.1.0-0-minimal
 status:
   replicas: 1
   readyReplicas: 1
@@ -44,4 +44,4 @@ kind: VerticaDB
 metadata:
   name: v-upgrade-vertica
 spec:
-  image: vertica/vertica-k8s:24.1.0-0-minimal
+  image: opentext/vertica-k8s:24.1.0-0-minimal

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/45-upgrade-to-24-1.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/45-upgrade-to-24-1.yaml
@@ -18,4 +18,4 @@ metadata:
   annotations:
     vertica.com/vcluster-ops: "true"
 spec:
-  image: vertica/vertica-k8s:24.1.0-0-minimal
+  image: opentext/vertica-k8s:24.1.0-0-minimal

--- a/tests/e2e-leg-8/online-upgrade-through-vclusterops/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-8/online-upgrade-through-vclusterops/setup-vdb/base/setup-vdb.yaml
@@ -20,7 +20,7 @@ metadata:
     vertica.com/vcluster-ops: "false"
     vertica.com/k-safety: "0"
 spec:
-  image: vertica/vertica-k8s:12.0.4-0-minimal
+  image: opentext/vertica-k8s:12.0.4-0-minimal
   imagePullPolicy: IfNotPresent
   passwordSecret: su-passwd
   communal: {}

--- a/tests/e2e-server-upgrade-at-only/online-upgrade-block-downgrade/20-initiate-upgrade.yaml
+++ b/tests/e2e-server-upgrade-at-only/online-upgrade-block-downgrade/20-initiate-upgrade.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade vertica/vertica-k8s:11.1.1-0-minimal # This must be an older image than what all the other tests are using
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade opentext/vertica-k8s:11.1.1-0-minimal # This must be an older image than what all the other tests are using

--- a/tests/external-images-server-upgrade-ci.txt
+++ b/tests/external-images-server-upgrade-ci.txt
@@ -1,3 +1,3 @@
 # List of images that we pull during the e2e tests for server-upgrade.
 #
-vertica/vertica-k8s:12.0.2-0-minimal
+opentext/vertica-k8s:12.0.2-0-minimal

--- a/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
+++ b/tests/manifests/image-pull/upgrade-vertica-1/configmap.yaml
@@ -16,4 +16,4 @@ kind: ConfigMap
 metadata:
   name: upgrade-vertica-1
 data:
-  image: vertica/vertica-k8s:12.0.2-0-minimal
+  image: opentext/vertica-k8s:12.0.2-0-minimal


### PR DESCRIPTION
All externally published images for Vertica are now in the opentext docker organization. This updates various spots where we had reference to the vertica docker organization.