### PR TITLE
Add experimental support to run the operator on arm64

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -23,6 +23,11 @@ on:
         description: 'Name of an existing vlogger image. If blank we will build one using the default name'
         type: string
         required: true
+      operator_platform:
+        description: 'If building the operator, this identifies the platforms to build it for. Separate multiple platforms with a comma. Example: linux/arm64,linux/amd64'
+        type: string
+        required: false
+        default: 'linux/amd64,linux/arm64'
       run_security_scan:
         description: 'What images to scan?'
         type: string
@@ -347,10 +352,16 @@ jobs:
       if: ${{ inputs.operator_image == '' }}
       run: |
         export OPERATOR_IMG=${{ steps.operator_image.outputs.value }}
-        make docker-build-operator
+        export PLATFORMS=${{ inputs.operator_platform }}
+        # For pull requests we build the operator locally then pass it around
+        # to dependent stages as an artifact. Otherwise, we will build a
+        # cross-platform operator. The make target we use for that handles
+        # pushing it up to an external repository.
         if [ $GITHUB_EVENT_NAME != 'pull_request' ]
         then
-          make docker-push-operator
+          make docker-build-crossplatform-operator
+        else
+          make docker-build-operator
         fi
 
     - name: Save the image for consumption by dependent jobs (PRs only)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,7 @@ jobs:
     - name: Upload new image
       if: ${{ inputs.action == 'upload operator image' || inputs.action == 'all' }}
       run: |
-        docker pull ghcr.io/vertica/verticadb-operator:$VERSION_SHA
-        for tag in $VERSION latest
-        do
-          docker tag ghcr.io/vertica/verticadb-operator:$VERSION_SHA vertica/verticadb-operator:$tag
-          docker push vertica/verticadb-operator:$tag
-        done
+        docker buildx imagetools create --tag opentext/verticadb-operator:$tag ghcr.io/vertica/verticadb-operator:$VERSION_SHA
 
     - name: Create the release on GitHub
       if: ${{ inputs.action == 'create github release' || inputs.action == 'all' }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ local-kustomize*.cfg
 .envrc
 custom-rbac-overlay/
 sdk
+Dockerfile.cross
 
 # Generated files from setup-kustomize.sh
 overlay/

--- a/changes/unreleased/Added-20240228-172721.yaml
+++ b/changes/unreleased/Added-20240228-172721.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Experimental support to run the operator on arm64
+time: 2024-02-28T17:27:21.499827278-04:00
+custom:
+  Issue: "722"


### PR DESCRIPTION
The operator was initially designed exclusively for the amd64 platform. This modification aims to extend its compatibility to the arm64 platform. It's primarily intended for experimental purposes at this stage.