### PR TITLE
Add required CSV annotations

### DIFF
--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -8,6 +8,16 @@ metadata:
     containerImage: OPERATOR_IMG_PLACEHOLDER
     createdAt: CREATED_AT_PLACEHOLDER
     description: Operator that manages a Vertica Eon Mode database.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://github.com/vertica/vertica-kubernetes
     support: Vertica
   name: verticadb-operator.v0.0.0


### PR DESCRIPTION
When adding the operator to the OpenShift catalog, there is a new requirement of a set of standard annotations that the CSV has. These are being added here. For a description of each of the annotations see this: https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs