### PR TITLE
Allow empty password for vcluster scrutinize

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -839,7 +839,7 @@ func makeScrutinizeInitContainer(vscr *v1beta1.VerticaScrutinize, vdb *vapi.Vert
 	cnt := corev1.Container{
 		Image:        vdb.Spec.Image,
 		Name:         names.ScrutinizeInitContainer,
-		Command:      buildScrutinizeCmd(args, vdb),
+		Command:      buildScrutinizeCmd(args),
 		VolumeMounts: buildScrutinizeVolumeMounts(vscr, vdb),
 		Resources:    vscr.Spec.Resources,
 		Env:          buildCommonEnvVars(vdb),
@@ -1467,18 +1467,12 @@ func buildNMACommand() []string {
 }
 
 // buildScrutinizeCmd returns the full vcluster scrutinize command
-func buildScrutinizeCmd(args []string, vdb *vapi.VerticaDB) []string {
+func buildScrutinizeCmd(args []string) []string {
 	cmd := []string{
 		"/opt/vertica/bin/vcluster",
 		"scrutinize",
 	}
 	cmd = append(cmd, args...)
-	// if there is no password, we need to explicitly
-	// set the password flag with empty string as value,
-	// to still assume password as the authentication method
-	if vdb.Spec.PasswordSecret == "" {
-		cmd = append(cmd, "--password=")
-	}
 	return cmd
 }
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -839,7 +839,7 @@ func makeScrutinizeInitContainer(vscr *v1beta1.VerticaScrutinize, vdb *vapi.Vert
 	cnt := corev1.Container{
 		Image:        vdb.Spec.Image,
 		Name:         names.ScrutinizeInitContainer,
-		Command:      buildScrutinizeCmd(args),
+		Command:      buildScrutinizeCmd(args, vdb),
 		VolumeMounts: buildScrutinizeVolumeMounts(vscr, vdb),
 		Resources:    vscr.Spec.Resources,
 		Env:          buildCommonEnvVars(vdb),
@@ -1467,12 +1467,18 @@ func buildNMACommand() []string {
 }
 
 // buildScrutinizeCmd returns the full vcluster scrutinize command
-func buildScrutinizeCmd(args []string) []string {
+func buildScrutinizeCmd(args []string, vdb *vapi.VerticaDB) []string {
 	cmd := []string{
 		"/opt/vertica/bin/vcluster",
 		"scrutinize",
 	}
 	cmd = append(cmd, args...)
+	// if there is no password, we need to explicitly
+	// set the password flag with empty string as value,
+	// to still assume password as the authorization method
+	if vdb.Spec.PasswordSecret == "" {
+		cmd = append(cmd, "--password=")
+	}
 	return cmd
 }
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1475,7 +1475,7 @@ func buildScrutinizeCmd(args []string, vdb *vapi.VerticaDB) []string {
 	cmd = append(cmd, args...)
 	// if there is no password, we need to explicitly
 	// set the password flag with empty string as value,
-	// to still assume password as the authorization method
+	// to still assume password as the authentication method
 	if vdb.Spec.PasswordSecret == "" {
 		cmd = append(cmd, "--password=")
 	}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -201,11 +201,21 @@ var _ = Describe("builder", func() {
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--hosts")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--db-name")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--db-user")))
+		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--password=")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("h1,h2,h3")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("dbadmin")))
-		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--hosts")))
+		Ω(cnt.Command).Should(ContainElement(ContainSubstring("db")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("/opt/vertica/bin/vcluster")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("scrutinize")))
+
+		vdb.Spec.PasswordSecret = "test-secret"
+		pod = BuildScrutinizePod(vscr, vdb, []string{
+			"--hosts", "h1,h2,h3",
+			"--db-name", "db",
+			"--db-user", "dbadmin",
+		})
+		cnt = pod.Spec.InitContainers[0]
+		Ω(cnt.Command).ShouldNot(ContainElement(ContainSubstring("--password=")))
 	})
 
 	It("should not set any main container resources if none are set for the init container", func() {

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -201,21 +201,11 @@ var _ = Describe("builder", func() {
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--hosts")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--db-name")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--db-user")))
-		Ω(cnt.Command).Should(ContainElement(ContainSubstring("--password=")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("h1,h2,h3")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("dbadmin")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("db")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("/opt/vertica/bin/vcluster")))
 		Ω(cnt.Command).Should(ContainElement(ContainSubstring("scrutinize")))
-
-		vdb.Spec.PasswordSecret = "test-secret"
-		pod = BuildScrutinizePod(vscr, vdb, []string{
-			"--hosts", "h1,h2,h3",
-			"--db-name", "db",
-			"--db-user", "dbadmin",
-		})
-		cnt = pod.Spec.InitContainers[0]
-		Ω(cnt.Command).ShouldNot(ContainElement(ContainSubstring("--password=")))
 	})
 
 	It("should not set any main container resources if none are set for the init container", func() {

--- a/pkg/controllers/vscr/scrutinizepod_reconciler_test.go
+++ b/pkg/controllers/vscr/scrutinizepod_reconciler_test.go
@@ -93,4 +93,21 @@ var _ = Describe("scrutinizepod_reconciler", func() {
 		Expect(err).Should(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
 	})
+
+	It("should append --password= to args if password is empty", func() {
+		vdb := v1.MakeVDB()
+		scrArgs := &ScrutinizeCmdArgs{
+			hosts:       []string{"h1"},
+			username:    "dbadmin",
+			tarballName: "file.tar",
+		}
+		args := scrArgs.buildScrutinizeCmdArgs(vdb)
+		Expect(len(args)).Should(Equal(9))
+		Expect(args).Should(ContainElement(ContainSubstring("--password=")))
+
+		vdb.Spec.PasswordSecret = "test-secret"
+		args = scrArgs.buildScrutinizeCmdArgs(vdb)
+		Expect(len(args)).Should(Equal(8))
+		Expect(args).ShouldNot(ContainElement(ContainSubstring("--password=")))
+	})
 })


### PR DESCRIPTION
When the db doesn't have a password, we append `password=` to scrutinize cmd.