### PR TITLE
Set default region when webhook isn't set

### DIFF
--- a/pkg/vdbconfig/config.go
+++ b/pkg/vdbconfig/config.go
@@ -526,8 +526,9 @@ func (g *ConfigParamsGenerator) setRegion(parmName string) {
 	// always check for the empty string.
 	if g.Vdb.Spec.Communal.Region == "" {
 		g.ConfigurationParams.Set(parmName, vapi.DefaultS3Region)
+	} else {
+		g.ConfigurationParams.Set(parmName, g.Vdb.Spec.Communal.Region)
 	}
-	g.ConfigurationParams.Set(parmName, g.Vdb.Spec.Communal.Region)
 }
 
 // GetEndpointProtocol returns the protocol (HTTPS or HTTP) for the given endpoint

--- a/pkg/vdbconfig/config_test.go
+++ b/pkg/vdbconfig/config_test.go
@@ -84,4 +84,24 @@ var _ = Describe("config", func() {
 		g.SetEncryptSpreadCommConfigIfNecessary()
 		Expect(g.ConfigurationParams.Size()).Should(Equal(0))
 	})
+
+	It("should set default region if not set", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Communal.Region = "" // Clear the region
+		g := ConfigParamsGenerator{
+			VRec:                vdbRec,
+			Log:                 logger,
+			Vdb:                 vdb,
+			ConfigurationParams: types.MakeCiMap(),
+		}
+
+		Expect(g.Setup()).Should(Succeed())
+		g.setRegion(AWSRegionParm)
+		cp := g.GetConfigParms()
+		Expect(cp).ShouldNot(BeNil())
+		Expect(cp.GetValue(AWSRegionParm)).Should(Equal(vapi.DefaultS3Region))
+		vdb.Spec.Communal.Region = "us-west-1"
+		g.setRegion(AWSRegionParm)
+		Expect(cp.GetValue(AWSRegionParm)).Should(Equal(vdb.Spec.Communal.Region))
+	})
 })


### PR DESCRIPTION
If the region that the communal storage should use isn't set, then we normally pick a default. This only works if the webhook is enabled. This fixes a problem getting the default one when the webhook is disabled.