### PR TITLE
Ensure proper service account for webhook rolebindings

### DIFF
--- a/helm-charts/verticadb-operator/tests/serviceaccount-rolebinding_test.yaml
+++ b/helm-charts/verticadb-operator/tests/serviceaccount-rolebinding_test.yaml
@@ -1,0 +1,18 @@
+suite: ServiceAccount tests
+templates:
+  - verticadb-operator-manager-clusterrolebinding-crb.yaml
+  - verticadb-operator-webhook-config-crb.yaml
+  - verticadb-operator-proxy-rolebinding-crb.yaml
+  - verticadb-operator-metrics-reader-crb.yaml
+  - verticadb-operator-leader-election-rolebinding-rb.yaml
+tests:
+  - it: should include the serviceaccount name when an override is set
+    set:
+      serviceAccountNameOverride: special-override-sa
+      prometheus:
+        expose: "EnableWithAuthProxy"
+        createProxyRBAC: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: special-override-sa

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -95,7 +95,8 @@ for f in  \
     verticadb-operator-leader-election-rolebinding-rb.yaml \
     verticadb-operator-proxy-rolebinding-crb.yaml \
     verticadb-operator-metrics-reader-crb.yaml \
-    verticadb-operator-manager-clusterrolebinding-crb.yaml
+    verticadb-operator-manager-clusterrolebinding-crb.yaml \
+    verticadb-operator-webhook-config-crb.yaml
 do
     perl -i -0777 -pe 's/kind: ServiceAccount\n.*name: .*/kind: ServiceAccount\n  name: {{ include "vdb-op.serviceAccount" . }}/g' $TEMPLATE_DIR/$f
 done

--- a/tests/e2e-leg-5/metrics-auth-proxy-cert/05-deploy-operator.yaml
+++ b/tests/e2e-leg-5/metrics-auth-proxy-cert/05-deploy-operator.yaml
@@ -15,4 +15,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: sh -c "cd ../../.. && make undeploy-operator || true"
-  - command: sh -c "cd ../../.. && make deploy-operator DEPLOY_WITH=helm NAMESPACE=$NAMESPACE HELM_OVERRIDES='--set prometheus.tlsSecret=custom-cert,prometheus.expose=EnableWithAuthProxy'"
+  - command: sh -c "cd ../../.. && make deploy-operator DEPLOY_WITH=helm NAMESPACE=$NAMESPACE HELM_OVERRIDES='--set prometheus.tlsSecret=custom-cert,prometheus.expose=EnableWithAuthProxy,serviceAccountNameOverride=special-sa'"


### PR DESCRIPTION
Fixed an issue where deploying the Helm chart with a custom service account caused the operator to fail. This update ensures the correct service account is used for setting up the cluster role binding in the webhook config.