### PR TITLE
Revert changes in some scrutinize related test cases

### DIFF
--- a/tests/e2e-leg-4/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
@@ -17,14 +17,12 @@ metadata:
   name: v-create-1-node
 spec:
   image: kustomize-vertica-image
-  # VER-92471
-  # superuserPasswordSecret: su-passwd
+  superuserPasswordSecret: su-passwd
   communal:
     includeUIDInPath: false
   local:
     requestSize: 100Mi
-  # VER-92471 - CreateSkipPackageInstall
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall
   dbName: vertdb
   subclusters:
     - name: sc1

--- a/tests/e2e-leg-4/revivedb-1-node/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/vdb-to-revive/base/setup-vdb.yaml
@@ -17,8 +17,7 @@ metadata:
   name: v-revive-1-node
 spec:
   image: kustomize-vertica-image
-  # VER-92471
-  # superuserPasswordSecret: su-passwd
+  superuserPasswordSecret: su-passwd
   ignoreClusterLease: true
   communal:
     includeUIDInPath: false

--- a/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
@@ -22,8 +22,7 @@ spec:
       image: kustomize-vlogger-image
   communal:
     includeUIDInPath: false
-  # VER-92471 - CreateSkipPackageInstall
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall
   local:
     dataPath: /data
     depotPath: /depot

--- a/tests/e2e-leg-6/nma-certs-mount/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/setup-vdb/base/setup-vdb.yaml
@@ -19,8 +19,7 @@ metadata:
     vertica.com/vcluster-ops: "true"
     vertica.com/mount-nma-certs: "false"
 spec:
-  # VER-92471 - CreateSkipPackageInstall
-  initPolicy: Create
+  initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
   communal:
     includeUIDInPath: true


### PR DESCRIPTION
Due to some issues to some issues in vcluster scrutinize, we had to update scrutinize-related e2e tests(https://github.com/vertica/vertica-kubernetes/pull/726). This is to undo those changes now that all the issues have been resolved.