### PR TITLE
Resolved Service Annotation Loop Issue in ROSA Environment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
   goconst:
     min-len: 2
-    min-occurrences: 2
+    min-occurrences: 3
   gocritic:
     enabled-tags:
       - diagnostic
@@ -51,6 +51,10 @@ linters-settings:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+  revive:
+    rules:
+    - name: dot-imports
+      disabled: true
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
@@ -106,7 +110,6 @@ linters:
   # - nestif
   # - prealloc
   # - testpackage
-  # - revive
   # - wsl
 
 issues:

--- a/changes/unreleased/Fixed-20240320-101134.yaml
+++ b/changes/unreleased/Fixed-20240320-101134.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Resolved Service Annotation Loop Issue in ROSA Environment
+time: 2024-03-20T10:11:34.949980958-03:00
+custom:
+  Issue: "739"

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -294,11 +294,11 @@ func (o *ObjReconciler) reconcileSvc(ctx context.Context, expSvc *corev1.Service
 		return o.createService(ctx, expSvc, svcName)
 	}
 
-	// We reconcile annotations to include both new and existing entries. If an
-	// annotation is removed from the spec.subclusters[].serviceAnnotations
-	// field, it cannot be automatically removed due to potential ambiguity in
-	// how it was initially added. Certain cloud platforms may employ webhooks
-	// to automatically append their annotations.
+	// Annotations are always additive. We never remove an annotation if it's
+	// not in expSvc. Since we don't know how an annotation was added, we can't
+	// guess if it should be removed. Platforms like OpenShift may add
+	// annotations via a webhook, so removing them could lead to them being
+	// added back automatically.
 	for k, v := range curSvc.Annotations {
 		if _, ok := expSvc.Annotations[k]; !ok {
 			expSvc.Annotations[k] = v

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -294,6 +294,17 @@ func (o *ObjReconciler) reconcileSvc(ctx context.Context, expSvc *corev1.Service
 		return o.createService(ctx, expSvc, svcName)
 	}
 
+	// We reconcile annotations to include both new and existing entries. If an
+	// annotation is removed from the spec.subclusters[].serviceAnnotations
+	// field, it cannot be automatically removed due to potential ambiguity in
+	// how it was initially added. Certain cloud platforms may employ webhooks
+	// to automatically append their annotations.
+	for k, v := range curSvc.Annotations {
+		if _, ok := expSvc.Annotations[k]; !ok {
+			expSvc.Annotations[k] = v
+		}
+	}
+
 	newSvc := reconcileFieldsFunc(curSvc, expSvc, sc)
 
 	if newSvc != nil {

--- a/pkg/controllers/vdb/resizepv_reconciler.go
+++ b/pkg/controllers/vdb/resizepv_reconciler.go
@@ -137,9 +137,7 @@ func (r *ResizePVReconcile) updatePVC(ctx context.Context, pvc *corev1.Persisten
 	if err != nil {
 		k8sError, ok := err.(errors.APIStatus)
 		if ok && k8sError.Status().Reason == metav1.StatusReasonForbidden {
-			r.VRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.SkipPVCExpansion,
-				"Skipping expansion of PVC '%s' because volume expansion is forbidden",
-				pvc.Name)
+			r.Log.Info("Skipping expansion of PVC because volume expansion is forbidden", "pvc", pvc.Name)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -152,9 +150,7 @@ func (r *ResizePVReconcile) updatePVC(ctx context.Context, pvc *corev1.Persisten
 func (r *ResizePVReconcile) updateDepotSize(ctx context.Context, pvc *corev1.PersistentVolumeClaim,
 	pf *PodFact) (ctrl.Result, error) {
 	if r.Vdb.IsDepotVolumeEmptyDir() {
-		r.VRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.SkipDepotResize,
-			"Skipping depot resize for pod '%s' because its volume is an emptyDir.",
-			pf.name.Name)
+		r.Log.Info("Skipping depot resize because its volume is an emptyDir", "pod", pf.name.Name)
 		return ctrl.Result{}, nil
 	}
 	if !pf.upNode {
@@ -162,9 +158,7 @@ func (r *ResizePVReconcile) updateDepotSize(ctx context.Context, pvc *corev1.Per
 		return ctrl.Result{Requeue: true}, nil
 	}
 	if pf.depotDiskPercentSize == "" {
-		r.VRec.Eventf(r.Vdb, corev1.EventTypeWarning, events.SkipDepotResize,
-			"Skipping depot resize for pod '%s' because its size is fixed and not a percentage of the disk space.",
-			pf.name.Name)
+		r.Log.Info("Skipping depot resize because its size is fixed and not a percentage of the disk space.", "pod", pf.name.Name)
 		return ctrl.Result{}, nil
 	}
 	if !strings.HasSuffix(pf.depotDiskPercentSize, "%") {

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -84,8 +84,6 @@ const (
 	StopDBStart                     = "StopDBStart"
 	StopDBSucceeded                 = "StopDBSucceeded"
 	StopDBFailed                    = "StopDBFailed"
-	SkipPVCExpansion                = "SkipPVCExpansion"
-	SkipDepotResize                 = "SkipDepotResize"
 	DepotResized                    = "DepotResized"
 	MgmtFailed                      = "MgmtFailed"
 	MgmtFailedDiskFull              = "MgmtFailedDiskfull"

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/gomega" //nolint:revive,stylecheck
+	. "github.com/onsi/gomega" //nolint:stylecheck
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/names"

--- a/pkg/v1beta1_test/helpers.go
+++ b/pkg/v1beta1_test/helpers.go
@@ -18,7 +18,7 @@ package v1beta1_test
 import (
 	"context"
 
-	. "github.com/onsi/gomega" //nolint:revive,stylecheck
+	. "github.com/onsi/gomega" //nolint:stylecheck
 	v1vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"

--- a/pkg/vadmin/install_packages_at.go
+++ b/pkg/vadmin/install_packages_at.go
@@ -69,7 +69,7 @@ func genInstallPackageStatus(stdout string) *vops.InstallPackageStatus {
 			continue
 		}
 		// "Installing package {p}..." message should be ignored
-		if !strings.Contains(line, "Installing package") {
+		if currPackageStatus != nil && !strings.Contains(line, "Installing package") {
 			currPackageStatus.InstallStatus = line
 		}
 	}

--- a/tests/e2e-leg-6/labels-annotations/55-add-service-annotations.yaml
+++ b/tests/e2e-leg-6/labels-annotations/55-add-service-annotations.yaml
@@ -11,4 +11,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# No event to check if expansion is skipped
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: vdb-label-ant
+  annotations:
+    vertica.com/pause: "0"
+spec:
+  subclusters:
+    - name: cluster1
+      serviceAnnotations:
+        my-custom-annotation-1: "cluster1"
+        my-custom-annotation-2: "nlb"
+---
+# Add annotation directly to Service. Should not be removed by operator
+apiVersion: v1
+kind: Service
+metadata:
+  name: vdb-label-ant-cluster1
+  annotations:
+    my-custom-annotation-3: "manual-add"

--- a/tests/e2e-leg-6/labels-annotations/55-assert.yaml
+++ b/tests/e2e-leg-6/labels-annotations/55-assert.yaml
@@ -11,4 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# No event to check if expansion is skipped
+apiVersion: v1
+kind: Service
+metadata:
+  name: vdb-label-ant-cluster1
+  annotations:
+    gitRef: abcd123
+    my-custom-annotation-1: "cluster1"
+    my-custom-annotation-2: "nlb"
+    my-custom-annotation-3: "manual-add"

--- a/tests/e2e-leg-6/labels-annotations/60-assert.yaml
+++ b/tests/e2e-leg-6/labels-annotations/60-assert.yaml
@@ -11,4 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# No event to check if expansion is skipped
+apiVersion: v1
+kind: Service
+metadata:
+  name: vdb-label-ant-cluster1
+  annotations:
+    gitRef: abcd123
+    my-custom-annotation-1: "cluster1"
+    my-custom-annotation-2: "change-for-step-60"
+    my-custom-annotation-3: "manual-add"

--- a/tests/e2e-leg-6/labels-annotations/60-change-service-annotations.yaml
+++ b/tests/e2e-leg-6/labels-annotations/60-change-service-annotations.yaml
@@ -11,4 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# No event to check if expansion is skipped
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: vdb-label-ant
+spec:
+  subclusters:
+    - name: cluster1
+      serviceAnnotations:
+        my-custom-annotation-1: "cluster1"
+        my-custom-annotation-2: "change-for-step-60"

--- a/tests/e2e-leg-6/labels-annotations/65-wait-for-steadystate.yaml
+++ b/tests/e2e-leg-6/labels-annotations/65-wait-for-steadystate.yaml
@@ -11,4 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# No event to check if expansion is skipped
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"


### PR DESCRIPTION
In ROSA (RedHat OpenShift on AWS), we noticed that when setting up a network LoadBalancer an annotation would automatically be added to the Service object. This caused the operator to start a reconcile loop. It would remove the annotation, only to have OpenShift add it back. So, the operator was in a continuous reconcile loop.

To fix this we now allow manual annotations be added to service objects. The operator will only ensure the annotations that it generates are the correct value. It will ignore any additional annotation that was added outside of the VerticaDB.

I am also cleaning up the PVC expansion events. This can cause quite a lot of noise about skipping expansion if we continuously are doing reconciles. The skip events have been changed to log entries instead.