### PR TITLE
Add replicated upgradePolicy

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -406,7 +406,7 @@ func (v *VerticaDB) GetUpgradePolicyToUse() UpgradePolicyType {
 		return OfflineUpgrade
 	}
 
-	if v.IsKSafety0() {
+	if v.IsAutoUpgradePolicy() && v.IsKSafety0() {
 		return OfflineUpgrade
 	}
 

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -32,6 +32,8 @@ const (
 	NodesHaveReadOnlyStateVersion = "v11.0.2"
 	// The minimum version that allows for online upgrade.
 	OnlineUpgradeVersion = "v11.1.0"
+	// The minimum version that allows for replicated upgrade.
+	ReplicatedUpgradeVersion = "v24.3.0"
 	// The version that added the --force option to reip to handle up nodes
 	ReIPAllowedWithUpNodesVersion = "v11.1.0"
 	// The version of the server that doesn't support cgroup v2

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -415,7 +415,7 @@ const (
 	// Like online upgrade, however it allows for writes. This is done by
 	// splitting the vertica cluster into two replicas, then following a
 	// replication strategy where we failover to one of the replicas while the
-	// other is upgraded.
+	// other is being upgraded.
 	ReplicatedUpgrade UpgradePolicyType = "Replicated"
 	// This automatically picks between offline and online upgrade.  Online
 	// can only be used if (a) a license secret exists since we may need to scale

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -113,8 +113,10 @@ type VerticaDBSpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=Create
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:Create","urn:alm:descriptor:com.tectonic.ui:select:Revive","urn:alm:descriptor:com.tectonic.ui:select:ScheduleOnly"}
-	// The initialization policy defines how to setup the database.  Available
-	// options are to create a new database or revive an existing one.
+	// The initialization policy specifies how the database should be
+	// configured. Options include creating a new database, reviving an existing
+	// one, or simply scheduling pods. Possible values are Create, Revive,
+	// CreateSkipPackageInstall, or ScheduleOnly.
 	InitPolicy CommunalInitPolicy `json:"initPolicy"`
 
 	// +kubebuilder:validation:Optional
@@ -125,16 +127,24 @@ type VerticaDBSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:Auto","urn:alm:descriptor:com.tectonic.ui:select:Online","urn:alm:descriptor:com.tectonic.ui:select:Offline"}
 	// +kubebuilder:default:=Auto
-	// Defines how upgrade will be managed.  Available values are: Offline,
-	// Online and Auto.
-	// - Offline: means we take down the entire cluster then bring it back up
+	// This setting defines how the upgrade process will be managed. The
+	// available values are Offline, Online, Replicated, and Auto.
+	//
+	// Offline: This option involves taking down the entire cluster and then
+	// bringing it back up with the new image.
+	//
+	// Online: With this option, the cluster remains operational for reads
+	// during the upgrade process. However, the data will be in read-only mode
+	// until the Vertica nodes from the primary subcluster re-form the cluster
 	// with the new image.
-	// - Online: will keep the cluster up when the upgrade occurs.  The
-	// data will go into read-only mode until the Vertica nodes from the primary
-	// subcluster reform the cluster with the new image.
-	// - Auto: will pick between Offline or Online.  Online is only chosen if a
-	// license Secret exists, the k-Safety of the database is 1 and we are
-	// running with a Vertica version that supports read-only subclusters.
+	//
+	// Replicated: Similar to Online, this option keeps the cluster operational
+	// throughout the upgrade process but allows writes. The cluster is split
+	// into two replicas, and traffic is redirected to the active replica to
+	// facilitate writes.
+	//
+	// Auto: This option selects one of the above methods automatically based on
+	// compatibility with the version of Vertica you are running.
 	UpgradePolicy UpgradePolicyType `json:"upgradePolicy"`
 
 	// +kubebuilder:validation:Optional
@@ -402,6 +412,11 @@ const (
 	// subcluster comes back up, we restart/remove all of the secondary
 	// subclusters to take them out of read-only mode.
 	OnlineUpgrade UpgradePolicyType = "Online"
+	// Like online upgrade, however it allows for writes. This is done by
+	// splitting the vertica cluster into two replicas, then following a
+	// replication strategy where we failover to one of the replicas while the
+	// other is upgraded.
+	ReplicatedUpgrade UpgradePolicyType = "Replicated"
 	// This automatically picks between offline and online upgrade.  Online
 	// can only be used if (a) a license secret exists since we may need to scale
 	// out, (b) we are already on a minimum Vertica engine version that supports
@@ -792,11 +807,12 @@ const (
 	// DBInitialized indicates the database has been created or revived
 	DBInitialized = "DBInitialized"
 	// UpgradeInProgress indicates if the vertica server is in the process
-	// of having its image change.  We have two additional conditions to
-	// distinguish between online and offline upgrade.
-	UpgradeInProgress        = "UpgradeInProgress"
-	OfflineUpgradeInProgress = "OfflineUpgradeInProgress"
-	OnlineUpgradeInProgress  = "OnlineUpgradeInProgress"
+	// of having its image change.  We have additional conditions to
+	// distinguish between the different types of upgrade it is.
+	UpgradeInProgress           = "UpgradeInProgress"
+	OfflineUpgradeInProgress    = "OfflineUpgradeInProgress"
+	OnlineUpgradeInProgress     = "OnlineUpgradeInProgress"
+	ReplicatedUpgradeInProgress = "ReplicatedUpgradeInProgress"
 	// VerticaRestartNeeded is a condition that when set to true will force the
 	// operator to stop/start the vertica pods.
 	VerticaRestartNeeded = "VerticaRestartNeeded"

--- a/api/v1/verticadb_types_test.go
+++ b/api/v1/verticadb_types_test.go
@@ -142,8 +142,8 @@ var _ = Describe("verticadb_types", func() {
 		vdb.Spec.UpgradePolicy = OfflineUpgrade
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OfflineUpgrade))
 
-		// k-safety 0 should always default to offline
-		vdb.Spec.UpgradePolicy = ReplicatedUpgrade
+		// k-safety 0 with auto should always default to offline
+		vdb.Spec.UpgradePolicy = AutoUpgrade
 		vdb.Annotations[vmeta.KSafetyAnnotation] = "0"
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OfflineUpgrade))
 

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -175,6 +175,7 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.hasValidPodSecurityContext(allErrs)
 	allErrs = v.hasValidNMAResourceLimit(allErrs)
 	allErrs = v.hasValidCreateDBTimeout(allErrs)
+	allErrs = v.hasValidUpgradePolicy(allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -946,6 +947,22 @@ func (v *VerticaDB) hasValidCreateDBTimeout(allErrs field.ErrorList) field.Error
 		err := field.Invalid(field.NewPath("metadata").Child("annotations").Child(annotationName),
 			createDBTimeout, fmt.Sprintf("%s must be non-negative", annotationName))
 		allErrs = append(allErrs, err)
+	}
+	return allErrs
+}
+
+func (v *VerticaDB) hasValidUpgradePolicy(allErrs field.ErrorList) field.ErrorList {
+	switch v.Spec.UpgradePolicy {
+	case "":
+	case AutoUpgrade:
+	case OfflineUpgrade:
+	case OnlineUpgrade:
+	case ReplicatedUpgrade:
+	default:
+		err := field.Invalid(field.NewPath("spec").Child("upgradePolicy"),
+			v.Spec.UpgradePolicy, fmt.Sprintf("must be one of: %s, %s, %s or %s",
+				AutoUpgrade, OfflineUpgrade, OnlineUpgrade, ReplicatedUpgrade))
+		return append(allErrs, err)
 	}
 	return allErrs
 }

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -909,6 +909,14 @@ var _ = Describe("verticadb_webhook", func() {
 		allErrs = vdb.validateVerticaDBSpec()
 		Ω(allErrs).Should(HaveLen(0))
 	})
+
+	It("should check for upgradePolicy", func() {
+		vdb := MakeVDB()
+		vdb.Spec.UpgradePolicy = "NotValid"
+		Ω(vdb.validateVerticaDBSpec()).Should(HaveLen(1))
+		vdb.Spec.UpgradePolicy = ReplicatedUpgrade
+		Ω(vdb.validateVerticaDBSpec()).Should(HaveLen(0))
+	})
 })
 
 func createVDBHelper() *VerticaDB {

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -885,45 +885,14 @@ const (
 	// ImageChangeInProgress indicates if the vertica server is in the process
 	// of having its image change (aka upgrade).  We have two additional conditions to
 	// distinguish between online and offline upgrade.
-	ImageChangeInProgress    VerticaDBConditionType = "ImageChangeInProgress"
-	OfflineUpgradeInProgress VerticaDBConditionType = "OfflineUpgradeInProgress"
-	OnlineUpgradeInProgress  VerticaDBConditionType = "OnlineUpgradeInProgress"
+	ImageChangeInProgress       VerticaDBConditionType = "ImageChangeInProgress"
+	OfflineUpgradeInProgress    VerticaDBConditionType = "OfflineUpgradeInProgress"
+	OnlineUpgradeInProgress     VerticaDBConditionType = "OnlineUpgradeInProgress"
+	ReplicatedUpgradeInProgress VerticaDBConditionType = "ReplicatedUpgradeInProgress"
 	// VerticaRestartNeeded is a condition that when set to true will force the
 	// operator to stop/start the vertica pods.
 	VerticaRestartNeeded VerticaDBConditionType = "VerticaRestartNeeded"
 )
-
-// Fixed index entries for each condition.
-const (
-	AutoRestartVerticaIndex = iota
-	DBInitializedIndex
-	ImageChangeInProgressIndex
-	OfflineUpgradeInProgressIndex
-	OnlineUpgradeInProgressIndex
-	VerticaRestartNeededIndex
-)
-
-// VerticaDBConditionIndexMap is a map of the VerticaDBConditionType to its
-// index in the condition array
-var VerticaDBConditionIndexMap = map[VerticaDBConditionType]int{
-	AutoRestartVertica:       AutoRestartVerticaIndex,
-	DBInitialized:            DBInitializedIndex,
-	ImageChangeInProgress:    ImageChangeInProgressIndex,
-	OfflineUpgradeInProgress: OfflineUpgradeInProgressIndex,
-	OnlineUpgradeInProgress:  OnlineUpgradeInProgressIndex,
-	VerticaRestartNeeded:     VerticaRestartNeededIndex,
-}
-
-// VerticaDBConditionNameMap is the reverse of VerticaDBConditionIndexMap.  It
-// maps an index to the condition name.
-var VerticaDBConditionNameMap = map[int]VerticaDBConditionType{
-	AutoRestartVerticaIndex:       AutoRestartVertica,
-	DBInitializedIndex:            DBInitialized,
-	ImageChangeInProgressIndex:    ImageChangeInProgress,
-	OfflineUpgradeInProgressIndex: OfflineUpgradeInProgress,
-	OnlineUpgradeInProgressIndex:  OnlineUpgradeInProgress,
-	VerticaRestartNeededIndex:     VerticaRestartNeeded,
-}
 
 // VerticaDBCondition defines condition for VerticaDB
 type VerticaDBCondition struct {

--- a/pkg/controllers/vdb/replicatedupgrade_reconciler.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler.go
@@ -1,0 +1,83 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ReplicatedUpgradeReconciler will coordinate an online upgrade that allows
+// write. This is done by splitting the cluster into two separate replicas and
+// using failover strategies to keep the database online.
+type ReplicatedUpgradeReconciler struct {
+	VRec       *VerticaDBReconciler
+	Log        logr.Logger
+	VDB        *vapi.VerticaDB
+	PFacts     *PodFacts
+	Manager    UpgradeManager
+	Dispatcher vadmin.Dispatcher
+}
+
+// MakeReplicatedUpgradeReconciler will build a ReplicatedUpgradeReconciler object
+func MakeReplicatedUpgradeReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
+	vdb *vapi.VerticaDB, pfacts *PodFacts, dispatcher vadmin.Dispatcher) controllers.ReconcileActor {
+	return &ReplicatedUpgradeReconciler{
+		VRec:       vdbrecon,
+		Log:        log.WithName("ReplicatedUpgradeReconciler"),
+		VDB:        vdb,
+		PFacts:     pfacts,
+		Manager:    *MakeUpgradeManager(vdbrecon, log, vdb, vapi.ReplicatedUpgradeInProgress, replicatedUpgradeAllowed),
+		Dispatcher: dispatcher,
+	}
+}
+
+// Reconcile will automate the process of a replicated upgrade.
+func (r *ReplicatedUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
+	if ok, err := r.Manager.IsUpgradeNeeded(ctx); !ok || err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.PFacts.Collect(ctx, r.VDB); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Functions to perform when the image changes.  Order matters.
+	funcs := []func(context.Context) (ctrl.Result, error){
+		// Initiate an upgrade by setting condition and event recording
+		r.Manager.startUpgrade,
+		// Cleanup up the condition and event recording for a completed upgrade
+		r.Manager.finishUpgrade,
+	}
+	for _, fn := range funcs {
+		if res, err := fn(ctx); verrors.IsReconcileAborted(res, err) {
+			// If Reconcile was aborted with a requeue, set the RequeueAfter interval to prevent exponential backoff
+			if err == nil {
+				res.Requeue = false
+				res.RequeueAfter = r.VDB.GetUpgradeRequeueTimeDuration()
+			}
+			return res, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -384,31 +384,18 @@ func (i *UpgradeManager) postNextStatusMsg(ctx context.Context, statusMsgs []str
 	return nil
 }
 
-// onlineUpgradeAllowed returns true if upgrade must be done online
-func onlineUpgradeAllowed(vdb *vapi.VerticaDB) bool {
-	if vdb.Spec.UpgradePolicy == vapi.OfflineUpgrade {
-		return false
-	}
-	// If the field value is missing, we treat it as if Auto was selected.
-	if vdb.Spec.UpgradePolicy == vapi.AutoUpgrade || vdb.Spec.UpgradePolicy == "" {
-		// Online upgrade with a transient subcluster works by scaling out new
-		// subclusters to handle the primaries as they come up with the new
-		// versions.  If we don't have a license, it isn't going to work.
-		if (vdb.RequiresTransientSubcluster() && vdb.Spec.LicenseSecret == "") || vdb.IsKSafety0() {
-			return false
-		}
-	}
-	// Online upgrade can only be done if we are already on a server version
-	// that supports it.  It we are on an older version, we will fallback to
-	// offline even though online may have been specified in the vdb.
-	vinf, ok := vdb.MakeVersionInfo()
-	if ok && vinf.IsEqualOrNewer(vapi.OnlineUpgradeVersion) {
-		return true
-	}
-	return false
-}
-
 // offlineUpgradeAllowed returns true if upgrade must be done offline
 func offlineUpgradeAllowed(vdb *vapi.VerticaDB) bool {
-	return !onlineUpgradeAllowed(vdb)
+	return vdb.GetUpgradePolicyToUse() == vapi.OfflineUpgrade
+}
+
+// onlineUpgradeAllowed returns true if upgrade must be done online
+func onlineUpgradeAllowed(vdb *vapi.VerticaDB) bool {
+	return vdb.GetUpgradePolicyToUse() == vapi.OnlineUpgrade
+}
+
+// replicatedUpgradeAllowed returns true if upgrade must be done with the
+// replicated upgrade strategy.
+func replicatedUpgradeAllowed(vdb *vapi.VerticaDB) bool {
+	return vdb.GetUpgradePolicyToUse() == vapi.ReplicatedUpgrade
 }

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -198,6 +198,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Handles vertica server upgrade (i.e., when spec.image changes)
 		MakeOfflineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeOnlineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
+		MakeReplicatedUpgradeReconciler(r, log, vdb, pfacts, dispatcher),
 		// Stop vertica if the status condition indicates
 		MakeStopDBReconciler(r, vdb, prunner, pfacts, dispatcher),
 		// Check the version information ahead of restart. The version is needed


### PR DESCRIPTION
This introduces a new upgrade policy called Replicated. It only adds infrastructure to support this new upgrade process, which aims to allow writes during the upgrade. An empty reconciler has been added, which will be expanded upon in subsequent changes. Only version 24.3.0 can be used with Replicated; a suitable fallback policy is selected if an older version is detected.

The Auto upgrade policy will not select Replicated until it is fully implemented.

As with other upgrade policies, new status conditions have been incorporated.