### PR TITLE
Update role to grant write permissions for new CRDs

### DIFF
--- a/changes/unreleased/Fixed-20240322-171146.yaml
+++ b/changes/unreleased/Fixed-20240322-171146.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Update role to grant write permissions for new CRDs
+time: 2024-03-22T17:11:46.01870437-03:00
+custom:
+  Issue: "744"

--- a/config/rbac/verticadb-operator-cr-user-role.yaml
+++ b/config/rbac/verticadb-operator-cr-user-role.yaml
@@ -25,6 +25,8 @@ rules:
   - eventtriggers
   - verticaautoscalers
   - verticadbs
+  - verticarestorepointsqueries
+  - verticascrutinizers
   verbs:
   - create
   - delete
@@ -38,6 +40,8 @@ rules:
   - verticadbs/status
   - eventtriggers/status
   - verticautoscalers/status
+  - verticarestorepointsqueries/status
+  - verticascrutinizers/status
   verbs:
   - get
   - list

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/45-assert.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/45-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaRestorePointsQuery
+metadata:
+  name: v-restore-points-query
+spec:
+  verticaDBName: v-non-cluster-admin-deployment

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/45-create-vrpq-as-fred.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/45-create-vrpq-as-fred.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: bash -c "cat setup-vrpq.yaml | kubectl apply -n $NAMESPACE --kubeconfig /tmp/config-$NAMESPACE -f - "

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/50-assert.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/50-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: vertica.com/v1beta1
+kind: VerticaScrutinize
+metadata:
+  name: v-scrutinize
+spec:
+  verticaDBName: v-non-cluster-admin-deployment
+  volume:
+    name: scrutinize-vol
+    emptyDir: {}

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/50-create-vscr-as-fred.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/50-create-vscr-as-fred.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: bash -c "cat setup-vscr.yaml | kubectl apply -n $NAMESPACE --kubeconfig /tmp/config-$NAMESPACE -f - "

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/setup-vrpq.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/setup-vrpq.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaRestorePointsQuery
+metadata:
+  name: v-restore-points-query
+spec:
+  verticaDBName: v-non-cluster-admin-deployment

--- a/tests/e2e-leg-3/non-cluster-admin-deployment/setup-vscr.yaml
+++ b/tests/e2e-leg-3/non-cluster-admin-deployment/setup-vscr.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaScrutinize
+metadata:
+  name: v-scrutinize
+spec:
+  verticaDBName: v-non-cluster-admin-deployment
+  volume:
+    name: scrutinize-vol
+    emptyDir: {}


### PR DESCRIPTION
Add our two new CRDs to the `verticadb-operator-cr-user-role.yaml` manifest. This manifest, included in our release artifacts, allows cluster admins to grant write permissions for creating and modifying any of our CRDs. We overlooked this when initially adding the CRDs.

Additionally, update our end-to-end test for non-cluster admin deployments to ensure creation of the new CRDs as well.