### PR TITLE
Update process check to exclude inactive PIDs

### DIFF
--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -470,7 +470,7 @@ func (p *PodFacts) genGatherScript(vdb *vapi.VerticaDB, pf *PodFact) string {
 		echo -n 'vnodeName: '
 		cd %s/%s/v_%s_node????_catalog 2> /dev/null && basename $(pwd) | rev | cut -c9- | rev || echo ""
 		echo -n 'verticaPIDRunning: '
-		[[ $(pgrep -f "^.*vertica\s-D") ]] && echo true || echo false
+		[[ $(pgrep -f "^.*vertica\s-D" --runstates RDS) ]] && echo true || echo false
 		echo -n 'upNode: '
 		%s 2> /dev/null | grep --quiet 200 2> /dev/null && echo true || echo false
 		echo -n 'startupComplete: '


### PR DESCRIPTION
We have code to check if the Vertica process is running in the pod using the 'ps' command. In some tests, even after deleting the pod in admintools deployments, we noticed the Vertica process still running. This isn't correct because usually, we have to restart it manually. I suspect the Vertica PID might momentarily appear because it's terminated and waiting to be cleared. I'm not completely sure. Therefore, I'm updating the code to only find the PID for processes that are actively running. If a PID is stopped or terminated, it won't be found. This change will hopefully improve the pass rate for some upgrade tests.