### PR TITLE
Operator now defaults endpoints for S3/GCS paths.

### DIFF
--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -339,6 +339,11 @@ func (v *VerticaDB) validateEndpoint(allErrs field.ErrorList) field.ErrorList {
 	if !v.IsS3() && !v.IsGCloud() {
 		return allErrs
 	}
+	// An empty endpoint is allowed. This lets the server pick a suitable
+	// default based on the SDK that is used.
+	if v.Spec.Communal.Endpoint == "" {
+		return allErrs
+	}
 	// communal.endpoint must be prefaced with http:// or https:// to know what protocol to connect with.
 	if !(strings.HasPrefix(v.Spec.Communal.Endpoint, "http://") ||
 		strings.HasPrefix(v.Spec.Communal.Endpoint, "https://")) {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -126,6 +126,12 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Communal.Endpoint = "s3://minio"
 		validateSpecValuesHaveErr(vdb, true)
 	})
+	It("should allow an empty communal endpoint", func() {
+		vdb := createVDBHelper()
+		vdb.Spec.Communal.Endpoint = ""
+		vdb.Spec.Communal.Path = "s3://my-bucket"
+		validateSpecValuesHaveErr(vdb, false)
+	})
 	It("should not have invalid server-side encryption type", func() {
 		vdb := createVDBHelper()
 		vdb.Spec.Communal.S3ServerSideEncryption = "fakessetype"

--- a/changes/unreleased/Changed-20240325-095511.yaml
+++ b/changes/unreleased/Changed-20240325-095511.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Operator now defaults endpoints for S3/GCS paths
+time: 2024-03-25T09:55:11.418549503-03:00
+custom:
+  Issue: "746"

--- a/pkg/vdbconfig/config.go
+++ b/pkg/vdbconfig/config.go
@@ -206,10 +206,14 @@ func (g *ConfigParamsGenerator) setS3AuthParms(ctx context.Context) (ctrl.Result
 		}
 	}
 
+	// If the endpoint isn't provided, we let the server pick an appropriate
+	// default by omitting that config parm.
 	ep := g.GetCommunalEndpoint()
 	if ep != "" {
 		g.ConfigurationParams.Set("awsendpoint", ep)
 	}
+	// Enabling https depends on the endpoint chosen, so this can be empty if
+	// endpoint is empty.
 	enableHTTPS := g.GetEnableHTTPS()
 	if enableHTTPS != "" {
 		g.ConfigurationParams.Set("awsenablehttps", enableHTTPS)
@@ -272,10 +276,14 @@ func (g *ConfigParamsGenerator) setGCloudAuthParms(ctx context.Context) (ctrl.Re
 		return res, err
 	}
 
+	// Let the server pick an appropriate GCS based endpoint if one wasn't
+	// provided.
 	ep := g.GetCommunalEndpoint()
 	if ep != "" {
 		g.ConfigurationParams.Set("GCSEndpoint", ep)
 	}
+	// Enabling https depends on the endpoint chosen, so this can be empty if
+	// endpoint is empty.
 	enableHTTPS := g.GetEnableHTTPS()
 	if enableHTTPS != "" {
 		g.ConfigurationParams.Set("GCSEnableHttps", enableHTTPS)
@@ -446,9 +454,14 @@ func (g *ConfigParamsGenerator) GetS3SseCustomerKeySecret(ctx context.Context) (
 	return getSecret(ctx, g.VRec, g.Vdb, names.GenS3SseCustomerKeySecretName(g.Vdb))
 }
 
-// getCommunalEndpoint get the communal endpoint for inclusion in the auth files.
+// GetCommunalEndpoint get the communal endpoint for inclusion in the auth files.
 // Takes the endpoint from vdb and strips off the protocol.
 func (g *ConfigParamsGenerator) GetCommunalEndpoint() string {
+	// Early out if the endpoint isn't set. For this case, we let the server
+	// pick the endpoint based on the communal path chosen.
+	if g.Vdb.Spec.Communal.Endpoint == "" {
+		return ""
+	}
 	prefix := []string{"https://", "http://"}
 	for _, pref := range prefix {
 		if i := strings.Index(g.Vdb.Spec.Communal.Endpoint, pref); i == 0 {

--- a/pkg/vdbconfig/config.go
+++ b/pkg/vdbconfig/config.go
@@ -206,8 +206,14 @@ func (g *ConfigParamsGenerator) setS3AuthParms(ctx context.Context) (ctrl.Result
 		}
 	}
 
-	g.ConfigurationParams.Set("awsendpoint", g.GetCommunalEndpoint())
-	g.ConfigurationParams.Set("awsenablehttps", g.GetEnableHTTPS())
+	ep := g.GetCommunalEndpoint()
+	if ep != "" {
+		g.ConfigurationParams.Set("awsendpoint", ep)
+	}
+	enableHTTPS := g.GetEnableHTTPS()
+	if enableHTTPS != "" {
+		g.ConfigurationParams.Set("awsenablehttps", enableHTTPS)
+	}
 	g.setRegion(AWSRegionParm)
 	g.setCAFile()
 	return ctrl.Result{}, nil
@@ -266,8 +272,14 @@ func (g *ConfigParamsGenerator) setGCloudAuthParms(ctx context.Context) (ctrl.Re
 		return res, err
 	}
 
-	g.ConfigurationParams.Set("GCSEndpoint", g.GetCommunalEndpoint())
-	g.ConfigurationParams.Set("GCSEnableHttps", g.GetEnableHTTPS())
+	ep := g.GetCommunalEndpoint()
+	if ep != "" {
+		g.ConfigurationParams.Set("GCSEndpoint", ep)
+	}
+	enableHTTPS := g.GetEnableHTTPS()
+	if enableHTTPS != "" {
+		g.ConfigurationParams.Set("GCSEnableHttps", enableHTTPS)
+	}
 	g.setRegion(GCloudRegionParm)
 	g.setCAFile()
 	return ctrl.Result{}, nil
@@ -448,6 +460,10 @@ func (g *ConfigParamsGenerator) GetCommunalEndpoint() string {
 
 // getEnableHTTPS will return "1" if connecting to https otherwise return "0"
 func (g *ConfigParamsGenerator) GetEnableHTTPS() string {
+	// If no endpoint, then we let the server pick the endpoint and decide if HTTPS is enabled.
+	if g.Vdb.Spec.Communal.Endpoint == "" {
+		return ""
+	}
 	if strings.HasPrefix(g.Vdb.Spec.Communal.Endpoint, "https://") {
 		return "1"
 	}


### PR DESCRIPTION
Previously, the operator required specifying an endpoint for S3 and GCS communal paths. This pull request modifies that behavior, allowing the endpoint to be left off. In such cases, the server will automatically select a suitable default. For S3 communal paths, the server defaults to https://s3.amazonaws.com, while for GCS endpoints, it defaults to https://storage.googleapis.com.