### PR TITLE
Clear filters in VerticaRestorePointsQuery sample

### DIFF
--- a/config/samples/v1beta1_verticarestorepointsquery.yaml
+++ b/config/samples/v1beta1_verticarestorepointsquery.yaml
@@ -1,16 +1,6 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaRestorePointsQuery
 metadata:
-  labels:
-    app.kubernetes.io/name: verticarestorepointsquery
-    app.kubernetes.io/instance: verticarestorepointsquery-sample
-    app.kubernetes.io/part-of: verticadb-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: verticadb-operator
   name: verticarestorepointsquery-sample
 spec:
   verticaDBName: verticadb-sample
-  filterOptions:
-    archiveName: archive-name-sample
-    startTimestamp: "2006-01-02 15:04:05"
-    endTimestamp: "2006-01-02 15:04:05"


### PR DESCRIPTION
This PR eliminates filter options and labels from the VerticaRestorePointsQuery sample. The intention is to enhance the user experience on OpenShift when generating this CR from the webUI. OpenShift utilizes this sample to prepopulate fields in the webUI interface.