### PR TITLE
Remove labels in `vrep` sample config

### DIFF
--- a/config/samples/v1beta1_verticareplicator.yaml
+++ b/config/samples/v1beta1_verticareplicator.yaml
@@ -1,12 +1,6 @@
 apiVersion: vertica.com/v1beta1
 kind: VerticaReplicator
 metadata:
-  labels:
-    app.kubernetes.io/name: verticareplicator
-    app.kubernetes.io/instance: verticareplicator-sample
-    app.kubernetes.io/part-of: verticadb-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: verticadb-operator
   name: verticareplicator-sample
 spec:
   foo: "bar"


### PR DESCRIPTION
This PR eliminates labels from the `VerticaReplicator` sample config. The intention is to enhance the user experience on OpenShift when generating this CR from the webUI. OpenShift utilizes this sample to prepopulate fields in the webUI interface.