### PR TITLE
Remove labels in `et` sample config

### DIFF
--- a/config/samples/v1beta1_eventtrigger.yaml
+++ b/config/samples/v1beta1_eventtrigger.yaml
@@ -1,12 +1,6 @@
 apiVersion: vertica.com/v1beta1
 kind: EventTrigger
 metadata:
-  labels:
-    app.kubernetes.io/name: eventtrigger
-    app.kubernetes.io/instance: eventtrigger-sample
-    app.kubernetes.io/part-of: verticadb-operator
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: verticadb-operator
   name: eventtrigger-sample
 spec:
   references:


### PR DESCRIPTION
This PR eliminates labels from the `EventTrigger` sample config. The intention is to enhance the user experience on OpenShift when generating this CR from the webUI. OpenShift utilizes this sample to prepopulate fields in the webUI interface.