### PR TITLE
Fix restart logic for ScheduleOnly init policy

### DIFF
--- a/changes/unreleased/Fixed-20240403-091605.yaml
+++ b/changes/unreleased/Fixed-20240403-091605.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Fix restart logic for ScheduleOnly init policy
+time: 2024-04-03T09:16:05.542018459-03:00
+custom:
+  Issue: "756"

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -754,4 +754,44 @@ var _ = Describe("restart_reconciler", func() {
 		restart := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "restart_node")
 		Expect(len(restart)).Should(Equal(0))
 	})
+
+	It("should requeue if we don't have cluster quorum according to podfacts", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters[0].Size = 3
+		createS3CredSecret(ctx, vdb)
+		defer deleteCommunalCredSecret(ctx, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		sc := &vdb.Spec.Subclusters[0]
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
+		pfacts := createPodFactsDefault(fpr)
+		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
+		for podIndex := int32(0); podIndex < vdb.Spec.Subclusters[0].Size; podIndex++ {
+			podNm := names.GenPodName(vdb, sc, podIndex)
+			// Only 1 of the 3 is up, which means we don't have quorum
+			if podIndex == 0 {
+				pfacts.Detail[podNm].upNode = true
+			} else {
+				pfacts.Detail[podNm].upNode = false
+			}
+			pfacts.Detail[podNm].isInstalled = true
+			pfacts.Detail[podNm].isPodRunning = true
+		}
+
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		r := act.(*RestartReconciler)
+		Expect(r.reconcileNodes(ctx)).Should(Equal(ctrl.Result{Requeue: true, RequeueAfter: time.Second * RequeueWaitTimeInSeconds}))
+
+		// But if we are using schedule-only, then we skip the quorum check and proceed with restart.
+		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		vdb.Spec.InitPolicy = vapi.CommunalInitPolicyScheduleOnly
+		Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
+		Expect(r.reconcileNodes(ctx)).Should(Equal(ctrl.Result{}))
+		listCmd := fpr.FindCommands("restart_node")
+		Expect(len(listCmd)).Should(Equal(1))
+	})
 })


### PR DESCRIPTION
This change is aimed at resolving a specific issue encountered during the deployment of VerticaDB with the ScheduleOnly initialization policy. Previously, when a restart was triggered, the logic in the reconciler would prevent individual nodes from restarting if the cluster lacked quorum based on the pod state. The intention was to let the spread process bring down all remaining nodes before initiating a restart of the entire cluster. However, this approach didn't work with the ScheduleOnly policy because it didn't have a complete view of the cluster; it only had information about the pods running in k8s. There could be other nodes outside of VerticaDB contributing to the cluster's quorum. To address this, I'm refining the logic to perform the quorum check only when the initialization policy isn't ScheduleOnly.

This is a regression that was introduced in version 2.0.0 of the operator. There's an e2e test specifically designed to verify this behavior. However, it was mistakenly disabled. That's what ended up causing this regression in the first place. Another pull request (#751) will be submitted to re-enable this test.