### PR TITLE
Pull in new base for vertica-logger image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export VERSION
 # order to have a different release cadence.
 #
 # When changing this, be sure to update the tags in docker-vlogger/README.md
-VLOGGER_VERSION ?= 1.0.0
+VLOGGER_VERSION ?= 1.0.1
 
 REPO_DIR:=$(dir $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
 
@@ -99,6 +99,8 @@ export BASE_VERTICA_IMG
 # Image URL to use for the logger sidecar
 VLOGGER_IMG ?= $(IMG_REPO)vertica-logger:$(VLOGGER_VERSION)
 export VLOGGER_IMG
+# What version of alpine does the vlogger image use
+VLOGGER_ALPINE_VERSION?=3.19
 # The port number for the local registry
 REG_PORT ?= 5000
 # Image URL to use for the bundle.  We special case kind because to use it with
@@ -384,9 +386,15 @@ docker-build-operator: manifests generate fmt vet ## Build operator docker image
 		--build-arg GO_VERSION=${GO_VERSION} \
 		-f docker-operator/Dockerfile .
 
+
 .PHONY: docker-build-vlogger
 docker-build-vlogger:  ## Build vertica logger docker image
-	docker buildx build -t ${VLOGGER_IMG} --load -f docker-vlogger/Dockerfile .
+	docker pull alpine:${VLOGGER_ALPINE_VERSION} # Ensure we have the latest alpine version
+	docker buildx build \
+		-t ${VLOGGER_IMG} \
+		--load \
+		--build-arg ALPINE_VERSION=${VLOGGER_ALPINE_VERSION} \
+		-f docker-vlogger/Dockerfile .
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker buildx build --platform=linux/arm64 ). However, you must enable docker buildKit for it.

--- a/changes/unreleased/Security-20240403-173910.yaml
+++ b/changes/unreleased/Security-20240403-173910.yaml
@@ -1,0 +1,5 @@
+kind: Security
+body: Resolved security vulnerabilities in vertica-logger image
+time: 2024-04-03T17:39:10.785221143-03:00
+custom:
+  Issue: "758"

--- a/docker-vlogger/Dockerfile
+++ b/docker-vlogger/Dockerfile
@@ -14,7 +14,8 @@
 # A docker container that will tail the vertica.log.  This allows vertica to
 # follow the idiomatic way in Kubernetes of logging to stdout.
 
-FROM alpine:3.18
+ARG ALPINE_VERSION
+FROM alpine:${ALPINE_VERSION}
 
 # Tini - A tiny but valid init for containers
 RUN apk add --no-cache tini

--- a/docker-vlogger/README.md
+++ b/docker-vlogger/README.md
@@ -5,7 +5,8 @@
 
 # Supported Tags
 
-* [1.0.0, latest](https://github.com/vertica/vertica-kubernetes/blob/v1.2.0/docker-vlogger/Dockerfile)
+* [1.0.1, latest](https://github.com/vertica/vertica-kubernetes/blob/v2.1.2/docker-vlogger/Dockerfile)
+* [1.0.0](https://github.com/vertica/vertica-kubernetes/blob/v1.2.0/docker-vlogger/Dockerfile)
 
 # Quick Reference
 


### PR DESCRIPTION
This resolves several security vulnerabilities with the vertica-logger image. It fixes them by pulling in a new version of the base image.