### PR TITLE
Collect sandbox name in podfacts

### DIFF
--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -71,6 +71,8 @@ const (
 	// Starting in v24.2.0, vcluster scrutinize command can read the
 	// database password from secret(k8s, aws, gsm)
 	ScrutinizeDBPasswdInSecretMinVersion = "v24.2.0"
+	// The version that added sandbox state
+	NodesHaveSandboxStateVersion = "v24.2.0"
 )
 
 // GetVerticaVersionStr returns the vertica version, in string form, that is stored

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -36,6 +36,8 @@ const (
 	ReIPAllowedWithUpNodesVersion = "v11.1.0"
 	// The version of the server that doesn't support cgroup v2
 	CGroupV2UnsupportedVersion = "v12.0.0"
+	// The version that added sandbox state
+	NodesHaveSandboxStateVersion = "v12.0.0"
 	// The minimum version that can start Vertica's http server
 	HTTPServerMinVersion = "v12.0.3"
 	// When httpServerMode is Auto, this is the minimum server version that will start Vertica's http server
@@ -71,8 +73,6 @@ const (
 	// Starting in v24.2.0, vcluster scrutinize command can read the
 	// database password from secret(k8s, aws, gsm)
 	ScrutinizeDBPasswdInSecretMinVersion = "v24.2.0"
-	// The version that added sandbox state
-	NodesHaveSandboxStateVersion = "v24.2.0"
 )
 
 // GetVerticaVersionStr returns the vertica version, in string form, that is stored

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -186,29 +186,6 @@ var _ = Describe("podfacts", func() {
 		Expect(pf.readOnly).Should(BeTrue())
 	})
 
-	It("should parse read-only state from node query", func() {
-		readOnly1, oid1, err := parseNodeStateAndReadOnly("v_db_node0001|UP|123456|t\n")
-		Expect(err).Should(Succeed())
-		Expect(readOnly1).Should(BeTrue())
-		Expect(oid1).Should(Equal("123456"))
-
-		readOnly2, oid2, err := parseNodeStateAndReadOnly("v_db_node0001|UP|7890123|f\n")
-		Expect(err).Should(Succeed())
-		Expect(readOnly2).Should(BeFalse())
-		Expect(oid2).Should(Equal("7890123"))
-
-		readOnly3, oid3, err := parseNodeStateAndReadOnly("v_db_node0001|UP|456789\n")
-		Expect(err).Should(Succeed())
-		Expect(readOnly3).Should(BeFalse())
-		Expect(oid3).Should(Equal("456789"))
-
-		_, _, err = parseNodeStateAndReadOnly("")
-		Expect(err).Should(Succeed())
-
-		_, _, err = parseNodeStateAndReadOnly("v_db_node0001|UP|123|t|garbage")
-		Expect(err).Should(Succeed())
-	})
-
 	It("should parse node subscriptions output", func() {
 		pf := &PodFact{}
 		Expect(setShardSubscription("3\n", pf)).Should(Succeed())

--- a/pkg/meta/labels.go
+++ b/pkg/meta/labels.go
@@ -51,6 +51,8 @@ const (
 	OperatorVersion110 = "1.1.0"
 	OperatorVersion120 = "1.2.0"
 	OperatorVersion130 = "1.3.0"
+
+	SandboxNameLabel = "vertica.com/sandbox"
 )
 
 // ProtectedLabels lists all of the internally used label.

--- a/pkg/nodeinfo/fetch_node_state_vsql.go
+++ b/pkg/nodeinfo/fetch_node_state_vsql.go
@@ -1,0 +1,118 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package nodeinfo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+)
+
+func (v *VSQL) FetchNodeState(ctx context.Context) (*NodeInfo, error) {
+	sql := v.buildFetchNodeStateQuery()
+	stdout, err := v.queryNodeStatus(ctx, sql)
+	if err != nil {
+		// Skip parsing that happens next
+		return nil, nil
+	}
+	return parseNodeState(stdout)
+}
+
+// buildFetchNodeStateQuery constructs the query to get the node state
+func (v *VSQL) buildFetchNodeStateQuery() string {
+	// The first two columns are just for informational purposes.
+	cols := "n.node_name, node_state"
+	if v.VDB.IsEON() {
+		cols = fmt.Sprintf("%s, subcluster_oid", cols)
+	} else {
+		cols = fmt.Sprintf("%s, ''", cols)
+	}
+	// The read-only state is a new state added in 11.0.2.  So we can only query
+	// for it on levels 11.0.2+.  Otherwise, we always treat read-only as being
+	// disabled.
+	vinf, ok := v.VDB.MakeVersionInfo()
+	if ok && vinf.IsEqualOrNewer(vapi.NodesHaveReadOnlyStateVersion) {
+		cols = fmt.Sprintf("%s, is_readonly", cols)
+	}
+	if v.VDB.IsEON() && ok && vinf.IsEqualOrNewer(vapi.NodesHaveSandboxStateVersion) {
+		cols = fmt.Sprintf("%s, n.sandbox", cols)
+	}
+	var sql string
+	if v.VDB.IsEON() {
+		sql = fmt.Sprintf(
+			"select %s "+
+				"from nodes as n, subclusters as s "+
+				"where s.node_oid = n.node_id and n.node_name in (select node_name from current_session)",
+			cols)
+	} else {
+		sql = fmt.Sprintf(
+			"select %s "+
+				"from nodes as n "+
+				"where n.node_name in (select node_name from current_session)",
+			cols)
+	}
+	return sql
+}
+
+// queryNodeStatus will query the nodes system table for the following info:
+// node name, node is up, read-only state, subcluster oid and sanbox name.
+// It assumes the database exists and the pod is running.
+func (v *VSQL) queryNodeStatus(ctx context.Context, sql string) (string, error) {
+	cmd := []string{"-tAc", sql}
+	stdout, _, err := v.PRunner.ExecVSQL(ctx, v.PodName, v.ExecContainerName, cmd...)
+	return stdout, err
+}
+
+// parseNodeState will parse query output from node state
+func parseNodeState(stdout string) (*NodeInfo, error) {
+	// For testing purposes we early out with no error if there is no output
+	if stdout == "" {
+		return nil, nil
+	}
+	// The stdout comes in the form like this:
+	// v_vertdb_node0001|UP|41231232423|t|sandbox1
+	// This means upNode is true, subcluster oid is 41231232423 readOnly is
+	// true and the node is part of sanbox1. The node name is included in the output for debug purposes, but
+	// otherwise not used.
+	//
+	// The 2nd column for node state is ignored in here. It is just for
+	// informational purposes. The fact that we got something implies the node
+	// was up.
+	lines := strings.Split(stdout, "\n")
+	cols := strings.Split(lines[0], "|")
+	var err error
+	const MinExpectedCols = 3
+	if len(cols) < MinExpectedCols {
+		err = fmt.Errorf("expected at least %d columns from node query but only got %d", MinExpectedCols, len(cols))
+		return nil, err
+	}
+	ninf := &NodeInfo{}
+	ninf.SubclusterOid = cols[2]
+	// Read-only can be missing on versions that don't support that state.
+	// Return false in those cases.
+	if len(cols) > MinExpectedCols {
+		ninf.ReadOnly = cols[3] == "t"
+		// sandbox can be missing on versions that don't support that state
+		if len(cols) > MinExpectedCols+1 {
+			ninf.SandboxName = cols[4]
+		}
+	} else {
+		ninf.ReadOnly = false
+	}
+	return ninf, nil
+}

--- a/pkg/nodeinfo/fetch_node_state_vsql_test.go
+++ b/pkg/nodeinfo/fetch_node_state_vsql_test.go
@@ -1,0 +1,48 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package nodeinfo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("nodestatevsql", func() {
+	It("should parse read-only and sanbox states from node query", func() {
+		ninf, err := parseNodeState("v_db_node0001|UP|123456|t|sb1\n")
+		Expect(err).Should(Succeed())
+		Expect(ninf.ReadOnly).Should(BeTrue())
+		Expect(ninf.SubclusterOid).Should(Equal("123456"))
+		Expect(ninf.SandboxName).Should(Equal("sb1"))
+
+		ninf, err = parseNodeState("v_db_node0001|UP|7890123|f|sb2\n")
+		Expect(err).Should(Succeed())
+		Expect(ninf.ReadOnly).Should(BeFalse())
+		Expect(ninf.SubclusterOid).Should(Equal("7890123"))
+		Expect(ninf.SandboxName).Should(Equal("sb2"))
+
+		ninf, err = parseNodeState("v_db_node0001|UP|456789\n")
+		Expect(err).Should(Succeed())
+		Expect(ninf.ReadOnly).Should(BeFalse())
+		Expect(ninf.SubclusterOid).Should(Equal("456789"))
+
+		_, err = parseNodeState("")
+		Expect(err).Should(Succeed())
+
+		_, err = parseNodeState("v_db_node0001|UP|123|t|garbage")
+		Expect(err).Should(Succeed())
+	})
+})

--- a/pkg/nodeinfo/interface.go
+++ b/pkg/nodeinfo/interface.go
@@ -24,6 +24,7 @@ import (
 )
 
 type NodeInfoFetcher interface {
+	// FetchNodeState will return information about a specific node
 	FetchNodeState(ctx context.Context) (*NodeInfo, error)
 }
 

--- a/pkg/nodeinfo/interface.go
+++ b/pkg/nodeinfo/interface.go
@@ -1,0 +1,53 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package nodeinfo
+
+import (
+	"context"
+
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type NodeInfoFetcher interface {
+	FetchNodeState(ctx context.Context) (*NodeInfo, error)
+}
+
+type VSQL struct {
+	PRunner           cmds.PodRunner
+	VDB               *vapi.VerticaDB
+	PodName           types.NamespacedName
+	ExecContainerName string
+}
+
+// MakeVSQL will create a nodeInfoFetcher that uses vsql to get a node state
+func MakeVSQL(vdb *vapi.VerticaDB, prunner cmds.PodRunner, pn types.NamespacedName, cnt string) *VSQL {
+	return &VSQL{
+		PRunner:           prunner,
+		VDB:               vdb,
+		PodName:           pn,
+		ExecContainerName: cnt,
+	}
+}
+
+type NodeInfo struct {
+	Name          string
+	State         string
+	SubclusterOid string
+	ReadOnly      bool
+	SandboxName   string
+}


### PR DESCRIPTION
We now collect the sandbox name in podfacts. If vertica is not running we get it from a label on the pod, otherwise 2 paths can be taken:
  - use vsql to get the sandbox from the node state
  - use an HTTP endpoint that returns a node state
For now we are only using vsql but an interface has been added and it will eventually have an implementation for each path.