### PR TITLE
Fix e2e test stability

### DIFF
--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -161,7 +161,7 @@ var _ = Describe("podfacts", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfs := MakePodFacts(vdbRec, fpr)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs := &GatherState{VerticaPIDRunning: true, SpreadPIDRunning: true}
+		gs := &GatherState{VerticaPIDRunning: true}
 		Expect(pfs.checkForSimpleGatherStateMapping(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pf.upNode).Should(BeTrue())
 	})
@@ -179,7 +179,7 @@ var _ = Describe("podfacts", func() {
 		}
 		pfs := MakePodFacts(vdbRec, fpr)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs := &GatherState{VerticaPIDRunning: true, SpreadPIDRunning: true}
+		gs := &GatherState{VerticaPIDRunning: true}
 		Expect(pfs.checkForSimpleGatherStateMapping(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pfs.checkNodeStatus(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pf.upNode).Should(BeTrue())
@@ -237,17 +237,17 @@ var _ = Describe("podfacts", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfs := MakePodFacts(vdbRec, fpr)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs := &GatherState{VerticaPIDRunning: true, SpreadPIDRunning: true, StartupComplete: false}
+		gs := &GatherState{VerticaPIDRunning: true, StartupComplete: false}
 		Expect(pfs.checkIfNodeIsDoingStartup(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pf.startupInProgress).Should(BeTrue())
 
 		pf = &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs = &GatherState{VerticaPIDRunning: false, SpreadPIDRunning: false, StartupComplete: true}
+		gs = &GatherState{VerticaPIDRunning: false, StartupComplete: true}
 		Expect(pfs.checkIfNodeIsDoingStartup(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pf.startupInProgress).Should(BeFalse())
 
 		pf = &PodFact{name: pn, isPodRunning: true, dbExists: true}
-		gs = &GatherState{VerticaPIDRunning: true, SpreadPIDRunning: true, StartupComplete: true}
+		gs = &GatherState{VerticaPIDRunning: true, StartupComplete: true}
 		Expect(pfs.checkIfNodeIsDoingStartup(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pf.startupInProgress).Should(BeFalse())
 	})
@@ -266,7 +266,7 @@ var _ = Describe("podfacts", func() {
 			},
 		}
 		pfs := MakePodFacts(vdbRec, fpr)
-		gs := &GatherState{VerticaPIDRunning: true, SpreadPIDRunning: true}
+		gs := &GatherState{VerticaPIDRunning: true}
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
 		Expect(pfs.checkForSimpleGatherStateMapping(ctx, vdb, pf, gs)).Should(Succeed())
 		Expect(pfs.checkNodeStatus(ctx, vdb, pf, gs)).Should(Succeed())


### PR DESCRIPTION
This is a continuation of issue #750. In summary, we're encountering intermittent test failures. Upon deleting the pod in admintools deployments, we observed that the Vertica process shows up in the `ps` output. A new pod should not have Vertica already running because the operator should be triggering that. Although this doesn't impact the operator's functionality, it disrupts end-to-end tests for upgrades, as they rely on the operator's sequential actions. 

I encountered another instance of this issue while investigating with the debug code introduced in #750. It's evident from the `ps` output that the Vertica process belongs to a previous instance of the pod. One clear indication is that the host IP provided to the Vertica process doesn't match the pod's IP. Therefore, I've implemented this check to address the test failure.