### PR TITLE
Add new leg for 24.3.0 tests

### DIFF
--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -60,6 +60,10 @@ inputs:
     description: 'Whether BASE_VERTICA_IMG is required'
     required: false
     default: 'false'
+  vertica-license:
+    description: 'Contents of a vertica license to use with the tests'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -93,6 +97,11 @@ runs:
         export VERTICA_IMG=${{ inputs.vertica-image }}
         export OPERATOR_IMG=${{ inputs.operator-image }}
         export VLOGGER_IMG=${{ inputs.vlogger-image }}
+
+        if [[ "${{ inputs.vertica-license }}" != "" ]]; then
+          export LICENSE_FILE=/tmp/vertica-license.dat
+          echo -n "${{ inputs.vertica-license }}" > $LICENSE_FILE
+        fi
 
         # Set DEPLOY_WITH
         export DEPLOY_WITH="${{ inputs.deploy-with }}";

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,7 @@ on:
         - vcluster leg 6
         - vcluster leg 7
         - leg 8
+        - vcluster leg 9
         - vcluster server upgrade
         - vcluster udx
       run_security_scan:
@@ -435,6 +436,28 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           minimum-vertica-image: '24.2.0'
+
+  e2e-leg-9-vcluster:
+    if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 9' || inputs.e2e_test_suites == '')}}
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Test
+        uses: ./.github/actions/run-e2e-leg
+        with:
+          leg-identifier: 'leg-9'
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+          operator-image: ${{ needs.build.outputs.operator-image }}
+          vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+          vertica-deployment-method: vclusterops
+          communal-storage-type: s3
+          minimum-vertica-image: '24.3.0'
+          # Include the vertica license so we can test scaling past 3 nodes.
+          vertica-license: ${{ secrets.VERTICA_LICENSE }}
 
   e2e-server-upgrade-admintools:
     if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools server upgrade' || inputs.e2e_test_suites == '' }}

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -30,6 +30,7 @@ testDirs:
   - tests/e2e-leg-6
   - tests/e2e-leg-7
   - tests/e2e-leg-8
+  - tests/e2e-leg-9
   - tests/e2e-udx
   - tests/e2e-server-upgrade
   - tests/e2e-server-upgrade-at-only

--- a/tests/e2e-leg-9/license/05-create-secrets.yaml
+++ b/tests/e2e-leg-9/license/05-create-secrets.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/vertica-license/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-9/license/10-assert.yaml
+++ b/tests/e2e-leg-9/license/10-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-9/license/10-verify-operator.yaml
+++ b/tests/e2e-leg-9/license/10-verify-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-9/license/15-assert.yaml
+++ b/tests/e2e-leg-9/license/15-assert.yaml
@@ -1,0 +1,31 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-license-pri1
+status:
+  currentReplicas: 3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-license-sec1
+status:
+  currentReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-license

--- a/tests/e2e-leg-9/license/15-setup-vdb.yaml
+++ b/tests/e2e-leg-9/license/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/license/20-assert.yaml
+++ b/tests/e2e-leg-9/license/20-assert.yaml
@@ -1,0 +1,39 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-license-pri1
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-license-sec1
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-license
+status:
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+    - addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-9/license/20-wait-for-createdb.yaml
+++ b/tests/e2e-leg-9/license/20-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/license/25-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-9/license/25-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"

--- a/tests/e2e-leg-9/license/95-delete-cr.yaml
+++ b/tests/e2e-leg-9/license/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-9/license/95-errors.yaml
+++ b/tests/e2e-leg-9/license/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-9/license/96-assert.yaml
+++ b/tests/e2e-leg-9/license/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-9/license/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-9/license/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/license/96-errors.yaml
+++ b/tests/e2e-leg-9/license/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-9/license/99-delete-ns.yaml
+++ b/tests/e2e-leg-9/license/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-9/license/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-9/license/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-9/license/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/license/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,39 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-license
+  annotations:
+    vertica.com/include-uid-in-path: true
+spec:
+  image: kustomize-vertica-image
+  dbName: licdb
+  initPolicy: CreateSkipPackageInstall
+  communal: {}
+  local:
+    requestSize: 250Mi
+  # We pick a cluster size that is too big for the CE license. This relies on
+  # having a license, which will be added by kustomize.
+  subclusters:
+    - name: pri1
+      size: 3
+      type: primary
+    - name: sec1
+      size: 3
+      type: secondary
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/manifests/vertica-license/base/kustomization.yaml
+++ b/tests/manifests/vertica-license/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bases:
+  - ../../../kustomize-base


### PR DESCRIPTION
This adds a new leg, e2e-leg-9, to the CI. This is going to be used to test changes done in 24.3.0. One new change with this is that it will use a vertica license so that we can test scaling past 3 nodes. This will be required in order to test out the new replicated upgrade work.