### PR TITLE
Add restart reconciler to sandbox controller

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -718,3 +718,16 @@ func (v *VerticaDB) IsHTTPSTLSConfGenerationEnabled() (bool, error) {
 	}
 	return !inf.IsEqualOrNewer(AutoGenerateHTTPSCertsForNewDatabasesMinVersion), nil
 }
+
+// GetSubclusterSandboxName returns the sandbox the given subcluster belongs to,
+// or an empty string if it does not belong to any
+func (v *VerticaDB) GetSubclusterSandboxName(scName string) string {
+	for i := range v.Spec.Sandboxes {
+		for j := range v.Spec.Sandboxes[i].Subclusters {
+			if scName == v.Spec.Sandboxes[i].Subclusters[j].Name {
+				return v.Spec.Sandboxes[i].Name
+			}
+		}
+	}
+	return ""
+}

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -75,6 +75,8 @@ const (
 	// Starting in v24.2.0, vcluster scrutinize command can read the
 	// database password from secret(k8s, aws, gsm)
 	ScrutinizeDBPasswdInSecretMinVersion = "v24.2.0"
+	// Starting in v24.3.0, sandboxing with vclusterops is supported
+	SandboxSupportedMinVersion = "v24.3.0"
 )
 
 // GetVerticaVersionStr returns the vertica version, in string form, that is stored

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -139,6 +139,7 @@ func addReconcilersToManager(mgr manager.Manager, restCfg *rest.Config) {
 	if err := (&sandbox.SandboxConfigMapReconciler{
 		Client:      mgr.GetClient(),
 		Scheme:      mgr.GetScheme(),
+		Cfg:         restCfg,
 		EVRec:       mgr.GetEventRecorderFor(vmeta.OperatorName),
 		Log:         ctrl.Log.WithName("controllers").WithName("sandbox"),
 		Concurrency: opcfg.GetSandboxConfigMapConcurrency(),

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1247,11 +1247,12 @@ func getStorageClassName(vdb *vapi.VerticaDB) *string {
 // BuildStsSpec builds manifest for a subclusters statefulset
 func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster) *appsv1.StatefulSet {
 	isControllerRef := true
+	sandbox := vdb.GetSubclusterSandboxName(sc.Name)
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      makeLabelsForObject(vdb, sc, false),
+			Labels:      MakeLabelsForStsObject(vdb, sc, sandbox),
 			Annotations: MakeAnnotationsForObject(vdb),
 		},
 		Spec: appsv1.StatefulSetSpec{

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -92,8 +92,12 @@ func MakeLabelsForPodObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string
 }
 
 // MakeLabelsForStsObject constructs the labels that are common for all statefulsets.
-func MakeLabelsForStsObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]string {
-	return makeLabelsForObject(vdb, sc, false)
+func MakeLabelsForStsObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, sandbox string) map[string]string {
+	labels := makeLabelsForObject(vdb, sc, false)
+	if sandbox != "" {
+		labels[vmeta.SandboxNameLabel] = sandbox
+	}
+	return labels
 }
 
 // MakeLabelsForSvcObject will create the set of labels for use with service objects

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler_test.go
@@ -42,7 +42,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pfn1 := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		pfacts.Detail[pfn1].upNode = true
@@ -73,7 +73,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pfn1 := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		pfacts.Detail[pfn1].upNode = true
@@ -103,7 +103,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		sc := &vdb.Spec.Subclusters[0]
 		for i := int32(0); i < sc.Size; i++ {
@@ -137,7 +137,7 @@ var _ = Describe("clientroutinglabel_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		pfacts.Detail[pn].upNode = true

--- a/pkg/controllers/vdb/createdb_reconciler_test.go
+++ b/pkg/controllers/vdb/createdb_reconciler_test.go
@@ -93,7 +93,7 @@ var _ = Describe("createdb_reconciler", func() {
 		vdb.Spec.InitPolicy = vapi.CommunalInitPolicyRevive
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeCreateDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))

--- a/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbaddsubcluster_reconciler_test.go
@@ -37,7 +37,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		a := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := a.(*DBAddSubclusterReconciler)
@@ -93,7 +93,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*DBAddSubclusterReconciler)
@@ -122,7 +122,7 @@ var _ = Describe("dbaddsubcluster_reconcile", func() {
 
 		Expect(vdb.IsEON()).Should(BeFalse())
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBAddSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))

--- a/pkg/controllers/vdb/dbremovenode_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovenode_reconciler_test.go
@@ -39,7 +39,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		recon := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
@@ -124,7 +124,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		sc.Size-- // mimic a pending db_remove_node
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBRemoveNodeReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})
@@ -145,7 +145,7 @@ var _ = Describe("dbremovenode_reconcile", func() {
 		sc.Size = 2 // Set to 2 to mimic a pending uninstall of the last pod
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		removePod := names.GenPodName(vdb, sc, 2)
 		pfacts.Detail[removePod].dbExists = false

--- a/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/dbremovesubcluster_reconciler_test.go
@@ -35,7 +35,7 @@ var _ = Describe("dbremovedsubcluster_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeDBRemoveSubclusterReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))

--- a/pkg/controllers/vdb/drainnode_reconciler_test.go
+++ b/pkg/controllers/vdb/drainnode_reconciler_test.go
@@ -60,7 +60,7 @@ var _ = Describe("drainnode_reconcile", func() {
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		r := MakeDrainNodeReconciler(vdbRec, vdb, fpr, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		cmds := fpr.FindCommands("select count(*) from session")

--- a/pkg/controllers/vdb/imageversion_reconciler_test.go
+++ b/pkg/controllers/vdb/imageversion_reconciler_test.go
@@ -44,7 +44,7 @@ var _ = Describe("k8s/version_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		podName := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr.Results = cmds.CmdResults{
@@ -80,7 +80,7 @@ vertica(v11.1.0) built by @re-docker2 from tag@releases/VER_10_1_RELEASE_BUILD_1
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		podName := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr.Results = cmds.CmdResults{
@@ -104,7 +104,7 @@ vertica(v11.1.0) built by @re-docker2 from tag@releases/VER_10_1_RELEASE_BUILD_1
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 
 		r := MakeImageVersionReconciler(vdbRec, logger, vdb, fpr, &pfacts, true)
@@ -172,7 +172,7 @@ func testNMATLSSecretWithVersion(ctx context.Context, secretName, oldVersion, ne
 	defer test.DeletePods(ctx, k8sClient, vdb)
 
 	fpr := &cmds.FakePodRunner{}
-	pfacts := MakePodFacts(vdbRec, fpr)
+	pfacts := MakePodFacts(vdbRec, fpr, logger)
 	Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 	podName := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 	fpr.Results = cmds.CmdResults{
@@ -201,7 +201,7 @@ func testNMARunningMode(ctx context.Context, badVersion,
 	defer test.DeletePods(ctx, k8sClient, vdb)
 
 	fpr := &cmds.FakePodRunner{}
-	pfacts := MakePodFacts(vdbRec, fpr)
+	pfacts := MakePodFacts(vdbRec, fpr, logger)
 	Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 	podName := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 

--- a/pkg/controllers/vdb/install_reconciler_test.go
+++ b/pkg/controllers/vdb/install_reconciler_test.go
@@ -93,7 +93,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
-		pfact := MakePodFacts(vdbRec, fpr)
+		pfact := MakePodFacts(vdbRec, fpr, logger)
 		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, &pfact)
 		drecon := actor.(*InstallReconciler)
 		drecon.ATWriter = &atconf.FakeWriter{}
@@ -118,7 +118,7 @@ var _ = Describe("k8s/install_reconcile_test", func() {
 		test.SetPodStatus(ctx, k8sClient, 1 /* funcOffset */, names.GenPodName(vdb, sc, 1), ScIndex, PodIndex, test.AllPodsRunning)
 
 		fpr := &cmds.FakePodRunner{}
-		pfact := MakePodFacts(vdbRec, fpr)
+		pfact := MakePodFacts(vdbRec, fpr, logger)
 		actor := MakeInstallReconciler(vdbRec, logger, vdb, fpr, &pfact)
 		drecon := actor.(*InstallReconciler)
 		res, err := drecon.Reconcile(ctx, &ctrl.Request{})

--- a/pkg/controllers/vdb/obj_reconciler_test.go
+++ b/pkg/controllers/vdb/obj_reconciler_test.go
@@ -46,7 +46,7 @@ var _ = Describe("obj_reconcile", func() {
 
 	runReconciler := func(vdb *vapi.VerticaDB, expResult ctrl.Result, mode ObjReconcileModeType) {
 		// Create any dependent objects for the CRD.
-		pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, mode)
 		Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(expResult))
 	}
@@ -171,7 +171,7 @@ var _ = Describe("obj_reconcile", func() {
 			Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 			// Refresh any dependent objects
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			_, err := objr.Reconcile(ctx, &ctrl.Request{})
 			Expect(err).Should(Succeed())
@@ -228,7 +228,7 @@ var _ = Describe("obj_reconcile", func() {
 			svc.Labels[vmeta.OperatorVersionLabel] = vmeta.OperatorVersion100
 			Expect(k8sClient.Update(ctx, svc)).Should(Succeed())
 
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
@@ -416,7 +416,7 @@ var _ = Describe("obj_reconcile", func() {
 			Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 			// Refresh any dependent objects
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			_, err := objr.Reconcile(ctx, &ctrl.Request{})
 			Expect(err).Should(Succeed())
@@ -493,7 +493,7 @@ var _ = Describe("obj_reconcile", func() {
 			createCrd(vdb, false)
 			defer deleteCrd(vdb)
 
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
@@ -504,7 +504,7 @@ var _ = Describe("obj_reconcile", func() {
 			createCrd(vdb, false)
 			defer deleteCrd(vdb)
 
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
@@ -515,7 +515,7 @@ var _ = Describe("obj_reconcile", func() {
 			createCrd(vdb, false)
 			defer deleteCrd(vdb)
 
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			Expect(objr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		})
@@ -578,7 +578,7 @@ var _ = Describe("obj_reconcile", func() {
 			Expect(k8sClient.Get(ctx, nm, sts)).Should(Succeed())
 
 			pn := names.GenPodNameFromSts(vdb, sts, origSize-1)
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 			objr := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 
@@ -608,7 +608,7 @@ var _ = Describe("obj_reconcile", func() {
 			Expect(k8sClient.Get(ctx, nm, svc1)).Should(Succeed())
 
 			standby := vdb.BuildTransientSubcluster("")
-			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+			pfacts := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 			actor := MakeObjReconciler(vdbRec, logger, vdb, &pfacts, ObjReconcileModeAll)
 			objr := actor.(*ObjReconciler)
 			// Force a label change to reconcile with the transient subcluster

--- a/pkg/controllers/vdb/offlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconciler.go
@@ -320,7 +320,7 @@ func (o *OfflineUpgradeReconciler) restartCluster(ctx context.Context) (ctrl.Res
 
 	// The restart reconciler is called after this reconciler.  But we call the
 	// restart reconciler here so that we restart while the status condition is set.
-	r := MakeRestartReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, true, o.Dispatcher)
+	r := MakeRestartReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, true, o.Dispatcher, "")
 	return r.Reconcile(ctx, &ctrl.Request{})
 }
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -575,7 +575,7 @@ func (o *OnlineUpgradeReconciler) waitForReadOnly(_ context.Context, sts *appsv1
 // bringSubclusterOnline will bring up a subcluster and reroute traffic back to the subcluster.
 func (o *OnlineUpgradeReconciler) bringSubclusterOnline(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
 	const DoNotRestartReadOnly = false
-	actor := MakeRestartReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, DoNotRestartReadOnly, o.Dispatcher)
+	actor := MakeRestartReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, DoNotRestartReadOnly, o.Dispatcher, "")
 	o.traceActorReconcile(actor)
 	res, err := actor.Reconcile(ctx, &ctrl.Request{})
 	if verrors.IsReconcileAborted(res, err) {

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -542,7 +542,7 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 // createOnlineUpgradeReconciler is a helper to run the OnlineUpgradeReconciler.
 func createOnlineUpgradeReconciler(ctx context.Context, vdb *vapi.VerticaDB) *OnlineUpgradeReconciler {
 	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
-	pfacts := MakePodFacts(vdbRec, fpr)
+	pfacts := MakePodFacts(vdbRec, fpr, logger)
 	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 	actor := MakeOnlineUpgradeReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 	r := actor.(*OnlineUpgradeReconciler)

--- a/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
+++ b/pkg/controllers/vdb/podannotatelabel_reconciler_test.go
@@ -38,7 +38,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		act := MakeAnnotateAndLabelPodReconciler(vdbRec, logger, vdb, &pfacts)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 
@@ -66,7 +66,7 @@ var _ = Describe("podannotatelabel_reconcile", func() {
 		Expect(k8sClient.Update(ctx, pod)).Should(Succeed())
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		act := MakeAnnotateAndLabelPodReconciler(vdbRec, logger, vdb, &pfacts)
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const sbName = "sb"
+
 var _ = Describe("podfacts", func() {
 	ctx := context.Background()
 	It("should not fail when collecting facts on an non-existent pod", func() {
@@ -54,7 +56,7 @@ var _ = Describe("podfacts", func() {
 
 		nm := names.GenPodName(vdb, sc, 0)
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		vdb.Status.Subclusters = []vapi.SubclusterStatus{
 			{Name: sc.Name, AddedToDBCount: sc.Size, Detail: []vapi.VerticaDBPodStatus{{Installed: true}}},
 		}
@@ -85,7 +87,7 @@ var _ = Describe("podfacts", func() {
 
 		nm := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pf, ok := pfacts.Detail[nm]
 		Expect(ok).Should(BeTrue())
@@ -93,7 +95,7 @@ var _ = Describe("podfacts", func() {
 	})
 
 	It("should verify all doesDBExist return codes", func() {
-		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{dbExists: false, isPodRunning: true, isPrimary: true}
 		Expect(pf.doesDBExist()).Should(BeFalse())
 		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{dbExists: false, isPodRunning: false, isPrimary: true}
@@ -108,7 +110,7 @@ var _ = Describe("podfacts", func() {
 	It("should verify return of countNotReadOnlyWithOldImage", func() {
 		const OldImage = "image:v1"
 		const NewImage = "image:v2"
-		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
 			isPodRunning: true,
 			upNode:       true,
@@ -149,7 +151,7 @@ var _ = Describe("podfacts", func() {
 				},
 			},
 		}
-		pfs := MakePodFacts(vdbRec, fpr)
+		pfs := MakePodFacts(vdbRec, fpr, logger)
 		pf := &PodFact{name: pn, isPodRunning: true}
 		Expect(pfs.checkNodeStatus(ctx, vdb, pf, &GatherState{})).Should(Succeed())
 		Expect(pf.upNode).Should(BeFalse())
@@ -159,7 +161,7 @@ var _ = Describe("podfacts", func() {
 		vdb := vapi.MakeVDB()
 		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		fpr := &cmds.FakePodRunner{}
-		pfs := MakePodFacts(vdbRec, fpr)
+		pfs := MakePodFacts(vdbRec, fpr, logger)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
 		gs := &GatherState{VerticaPIDRunning: true}
 		Expect(pfs.checkForSimpleGatherStateMapping(ctx, vdb, pf, gs)).Should(Succeed())
@@ -177,7 +179,7 @@ var _ = Describe("podfacts", func() {
 				},
 			},
 		}
-		pfs := MakePodFacts(vdbRec, fpr)
+		pfs := MakePodFacts(vdbRec, fpr, logger)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
 		gs := &GatherState{VerticaPIDRunning: true}
 		Expect(pfs.checkForSimpleGatherStateMapping(ctx, vdb, pf, gs)).Should(Succeed())
@@ -212,7 +214,7 @@ var _ = Describe("podfacts", func() {
 
 		pn := names.GenPodName(vdb, sc, 0)
 		fpr := &cmds.FakePodRunner{}
-		pfs := MakePodFacts(vdbRec, fpr)
+		pfs := MakePodFacts(vdbRec, fpr, logger)
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
 		gs := &GatherState{VerticaPIDRunning: true, StartupComplete: false}
 		Expect(pfs.checkIfNodeIsDoingStartup(ctx, vdb, pf, gs)).Should(Succeed())
@@ -242,7 +244,7 @@ var _ = Describe("podfacts", func() {
 				},
 			},
 		}
-		pfs := MakePodFacts(vdbRec, fpr)
+		pfs := MakePodFacts(vdbRec, fpr, logger)
 		gs := &GatherState{VerticaPIDRunning: true}
 		pf := &PodFact{name: pn, isPodRunning: true, dbExists: true}
 		Expect(pfs.checkForSimpleGatherStateMapping(ctx, vdb, pf, gs)).Should(Succeed())
@@ -253,7 +255,7 @@ var _ = Describe("podfacts", func() {
 	})
 
 	It("should return consistent first pod", func() {
-		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
 			dnsName: "p1", dbExists: true,
 		}
@@ -269,7 +271,7 @@ var _ = Describe("podfacts", func() {
 	})
 
 	It("should return filtered pods in vnode sort order", func() {
-		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
 			dnsName: "p1", dbExists: true, vnodeName: "v_db_node0003",
 		}
@@ -291,7 +293,7 @@ var _ = Describe("podfacts", func() {
 
 	It("should return correct pod in findPodToRunAdmintoolsAny", func() {
 		By("finding up, not read-only and not pending delete")
-		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
 			dnsName: "p1", dbExists: true, upNode: true, readOnly: false, isPendingDelete: true,
 		}
@@ -306,7 +308,7 @@ var _ = Describe("podfacts", func() {
 		Expect(p.dnsName).Should(Equal("p3"))
 
 		By("finding up and not read-only")
-		pf = MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf = MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
 			dnsName: "p1", dbExists: true, upNode: true, readOnly: true,
 		}
@@ -321,7 +323,7 @@ var _ = Describe("podfacts", func() {
 		Expect(p.dnsName).Should(Equal("p2"))
 
 		By("finding up and read-only")
-		pf = MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf = MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
 			dnsName: "p1", dbExists: true, upNode: false, readOnly: true,
 		}
@@ -336,7 +338,7 @@ var _ = Describe("podfacts", func() {
 		Expect(p.dnsName).Should(Equal("p2"))
 
 		By("finding a pod with an install")
-		pf = MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf = MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
 			dnsName: "p1", isInstalled: false, isPodRunning: true,
 		}
@@ -355,38 +357,20 @@ var _ = Describe("podfacts", func() {
 	})
 
 	It("should correctly return re-ip pods", func() {
-		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
-		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
-			dnsName: "p1", vnodeName: "node1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true,
-		}
-		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
-			dnsName: "p2", vnodeName: "node2", dbExists: false, exists: true, isPodRunning: true, isInstalled: true,
-		}
-		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
-			dnsName: "p3", vnodeName: "node3", dbExists: false, exists: true, isPodRunning: true, isInstalled: false,
-		}
-		By("finding any installed pod")
-		pods := pf.findReIPPods(dBCheckAny)
-		Ω(pods).Should(HaveLen(2))
-		Ω(pods[0].dnsName).Should(Equal("p1"))
-		Ω(pods[1].dnsName).Should(Equal("p2"))
+		// check main cluster
+		pf := makePodFactsForReIP(false)
+		verifyReIP(&pf, "")
 
-		By("finding pods with a db")
-		pods = pf.findReIPPods(dBCheckOnlyWithDBs)
-		Ω(pods).Should(HaveLen(1))
-		Ω(pods[0].dnsName).Should(Equal("p1"))
-
-		By("finding pods without a db")
-		pods = pf.findReIPPods(dBCheckOnlyWithoutDBs)
-		Ω(pods).Should(HaveLen(1))
-		Ω(pods[0].dnsName).Should(Equal("p2"))
+		// check sandboxed cluster
+		pf = makePodFactsForReIP(true)
+		verifyReIP(&pf, sbName)
 	})
 
 	It("should detect when the vdb has changed since collection", func() {
 		vdb := vapi.MakeVDB()
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
-		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{})
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
 		Ω(pf.Collect(ctx, vdb)).Should(Succeed())
 		Ω(pf.HasVerticaDBChangedSinceCollection(ctx, vdb)).Should(BeFalse())
 
@@ -399,3 +383,48 @@ var _ = Describe("podfacts", func() {
 		Ω(pf.HasVerticaDBChangedSinceCollection(ctx, vdb)).Should(BeTrue())
 	})
 })
+
+func verifyReIP(pf *PodFacts, sandbox string) {
+	By("finding any installed pod")
+	pods := pf.findReIPPods(dBCheckAny, sandbox)
+	Ω(pods).Should(HaveLen(2))
+	Ω(pods[0].dnsName).Should(Equal("p1"))
+	Ω(pods[1].dnsName).Should(Equal("p2"))
+
+	By("finding pods with a db")
+	pods = pf.findReIPPods(dBCheckOnlyWithDBs, sandbox)
+	Ω(pods).Should(HaveLen(1))
+	Ω(pods[0].dnsName).Should(Equal("p1"))
+
+	By("finding pods without a db")
+	pods = pf.findReIPPods(dBCheckOnlyWithoutDBs, sandbox)
+	Ω(pods).Should(HaveLen(1))
+	Ω(pods[0].dnsName).Should(Equal("p2"))
+}
+
+func makePodFactsForReIP(isSandbox bool) PodFacts {
+	sb1 := ""
+	sb2 := sbName
+	if isSandbox {
+		sb1 = sb2
+		sb2 = ""
+	}
+	pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger)
+	pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
+		dnsName: "p1", vnodeName: "node1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true,
+		sandbox: sb1,
+	}
+	pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
+		dnsName: "p2", vnodeName: "node2", dbExists: false, exists: true, isPodRunning: true, isInstalled: true,
+		sandbox: sb1,
+	}
+	pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
+		dnsName: "p3", vnodeName: "node3", dbExists: false, exists: true, isPodRunning: true, isInstalled: false,
+		sandbox: sb1,
+	}
+	pf.Detail[types.NamespacedName{Name: "p4"}] = &PodFact{
+		dnsName: "p4", vnodeName: "node1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true,
+		sandbox: sb2,
+	}
+	return pf
+}

--- a/pkg/controllers/vdb/rebalanceshards_reconciler_test.go
+++ b/pkg/controllers/vdb/rebalanceshards_reconciler_test.go
@@ -40,7 +40,7 @@ var _ = Describe("rebalanceshards_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		pfn := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 		pfacts.Detail[pfn].upNode = true
@@ -66,7 +66,7 @@ var _ = Describe("rebalanceshards_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		for i := range vdb.Spec.Subclusters {
 			pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[i], 0)

--- a/pkg/controllers/vdb/restart_reconciler_test.go
+++ b/pkg/controllers/vdb/restart_reconciler_test.go
@@ -58,9 +58,9 @@ var _ = Describe("restart_reconciler", func() {
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		recon := MakeRestartReconciler(vdbRec, logger, vdb, fpr, &pfacts, RestartProcessReadOnly, dispatcher)
+		recon := MakeRestartReconciler(vdbRec, logger, vdb, fpr, &pfacts, RestartProcessReadOnly, dispatcher, "")
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
 
@@ -88,7 +88,7 @@ var _ = Describe("restart_reconciler", func() {
 		Expect(k8sClient.Get(ctx, downPodNm, downPod)).Should(Succeed())
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -127,7 +127,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(k8sClient.Get(ctx, nm, vdb)).Should(Succeed())
@@ -180,7 +180,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{
@@ -210,7 +210,7 @@ var _ = Describe("restart_reconciler", func() {
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{0, 1}, PodNotReadOnly)
 		setVerticaNodeNameInPodFacts(vdb, sc, pfacts)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 	})
 
@@ -239,7 +239,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -276,7 +276,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		listCmd := fpr.FindCommands("start_db")
 		Expect(len(listCmd)).Should(Equal(1))
@@ -313,7 +313,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: false, RequeueAfter: 22000000000}))
@@ -337,7 +337,7 @@ var _ = Describe("restart_reconciler", func() {
 		initiatorPod := names.GenPodName(vdb, sc, 0)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.restartCluster(ctx, []*PodFact{})).Should(Equal(ctrl.Result{}))
@@ -374,7 +374,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.reconcileNodes(ctx)).Should(Equal(ctrl.Result{}))
@@ -414,7 +414,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -450,7 +450,7 @@ var _ = Describe("restart_reconciler", func() {
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, sc, fpr, []int32{downPodIndex}, PodNotReadOnly)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 
-		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 	})
 
@@ -482,14 +482,14 @@ var _ = Describe("restart_reconciler", func() {
 		}
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartSkipReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartSkipReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		restart := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "restart_node")
 		Expect(len(restart)).Should(Equal(0))
 
-		act = MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act = MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r = act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -522,7 +522,7 @@ var _ = Describe("restart_reconciler", func() {
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, transientSc, fpr, []int32{DownPodIndex}, PodReadOnly)
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		Expect(act.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 		restart := fpr.FindCommands("/opt/vertica/bin/admintools", "-t", "restart_node")
 		Expect(len(restart)).Should(Equal(0))
@@ -553,7 +553,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
 		listCmd := fpr.FindCommands("start_db")
 		Expect(len(listCmd)).Should(Equal(0))
@@ -583,7 +583,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsDefault(fpr)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 
 		pn := names.GenPodName(vdb, sc, 0)
@@ -625,7 +625,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsDefault(fpr)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 
 		const expectedRequeueTime int = 112 // 45 * 10 * 0.25
@@ -663,7 +663,7 @@ var _ = Describe("restart_reconciler", func() {
 		fpr := &cmds.FakePodRunner{Results: make(cmds.CmdResults)}
 		pfacts := createPodFactsWithRestartNeeded(ctx, vdb, &vdb.Spec.Subclusters[0], fpr, []int32{0, 1}, PodNotReadOnly)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		r := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		expectedRequeueTime := int(float64(vdb.Spec.LivenessProbeOverride.PeriodSeconds*vdb.Spec.LivenessProbeOverride.FailureThreshold) *
 			PctOfLivenessProbeWait)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{RequeueAfter: time.Second * time.Duration(expectedRequeueTime)}))
@@ -714,7 +714,7 @@ var _ = Describe("restart_reconciler", func() {
 			},
 		}
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		expectedRequeueTime := int(float64(vdb.Spec.LivenessProbeOverride.PeriodSeconds*vdb.Spec.LivenessProbeOverride.FailureThreshold) *
@@ -755,7 +755,7 @@ var _ = Describe("restart_reconciler", func() {
 			},
 		}
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		r.InitiatorPod = initiatorPod
 		expectedRequeueTime := int(float64(vdb.Spec.LivenessProbeOverride.PeriodSeconds*vdb.Spec.LivenessProbeOverride.FailureThreshold) *
@@ -793,7 +793,7 @@ var _ = Describe("restart_reconciler", func() {
 		}
 
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
-		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher)
+		act := MakeRestartReconciler(vdbRec, logger, vdb, fpr, pfacts, RestartProcessReadOnly, dispatcher, "")
 		r := act.(*RestartReconciler)
 		Expect(r.reconcileNodes(ctx)).Should(Equal(ctrl.Result{Requeue: true, RequeueAfter: time.Second * RequeueWaitTimeInSeconds}))
 

--- a/pkg/controllers/vdb/revivedb_reconciler.go
+++ b/pkg/controllers/vdb/revivedb_reconciler.go
@@ -243,7 +243,7 @@ func (r *ReviveDBReconciler) getPodList() ([]*PodFact, bool) {
 // findPodToRunInit will return a PodFact of the pod that should run the init
 // command from
 func (r *ReviveDBReconciler) findPodToRunInit() (*PodFact, bool) {
-	return r.PFacts.findPodToRunAdminCmdOffline()
+	return r.PFacts.findPodToRunAdminCmdOffline("" /* sandbox name*/)
 }
 
 // genReviveOpts will return the options to use with the revive command

--- a/pkg/controllers/vdb/revivedb_reconciler_test.go
+++ b/pkg/controllers/vdb/revivedb_reconciler_test.go
@@ -44,7 +44,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		vdb.Spec.InitPolicy = vapi.CommunalInitPolicyCreate
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -60,7 +60,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		vdb.Spec.RestorePoint.Index = 1
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 
@@ -112,7 +112,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		vdb := vapi.MakeVDB()
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)
@@ -147,7 +147,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
@@ -176,7 +176,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
@@ -196,7 +196,7 @@ var _ = Describe("revivedb_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		act := MakeReviveDBReconciler(vdbRec, logger, vdb, fpr, &pfacts, dispatcher)
 		r := act.(*ReviveDBReconciler)

--- a/pkg/controllers/vdb/status_reconciler_test.go
+++ b/pkg/controllers/vdb/status_reconciler_test.go
@@ -59,7 +59,7 @@ var _ = Describe("status_reconcile", func() {
 		// We intentionally don't create the pods or sts
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		r := MakeStatusReconciler(k8sClient, scheme.Scheme, logger, vdb, &pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 

--- a/pkg/controllers/vdb/stopdb_reconciler_test.go
+++ b/pkg/controllers/vdb/stopdb_reconciler_test.go
@@ -52,7 +52,7 @@ var _ = Describe("stopdb_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		recon := MakeStopDBReconciler(vdbRec, vdb, fpr, &pfacts, dispatcher)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -122,13 +122,13 @@ func defaultPodFactOverrider(_ context.Context, _ *vapi.VerticaDB, pf *PodFact, 
 
 // createPodFactsDefault will generate the PodFacts for test using the default settings for all.
 func createPodFactsDefault(fpr *cmds.FakePodRunner) *PodFacts {
-	pfacts := MakePodFacts(vdbRec, fpr)
+	pfacts := MakePodFacts(vdbRec, fpr, logger)
 	pfacts.OverrideFunc = defaultPodFactOverrider
 	return &pfacts
 }
 
 func createPodFactsWithNoDB(ctx context.Context, vdb *vapi.VerticaDB, fpr *cmds.FakePodRunner, numPodsToChange int) *PodFacts {
-	pfacts := MakePodFacts(vdbRec, fpr)
+	pfacts := MakePodFacts(vdbRec, fpr, logger)
 	// Change a number of pods to indicate db doesn't exist.  Due to the map that
 	// stores the pod facts, the specific pods we change are non-deterministic.
 	podsChanged := 0
@@ -149,7 +149,7 @@ func createPodFactsWithNoDB(ctx context.Context, vdb *vapi.VerticaDB, fpr *cmds.
 }
 
 func createPodFactsWithInstallNeeded(ctx context.Context, vdb *vapi.VerticaDB, fpr *cmds.FakePodRunner) *PodFacts {
-	pfacts := MakePodFacts(vdbRec, fpr)
+	pfacts := MakePodFacts(vdbRec, fpr, logger)
 	pfacts.OverrideFunc = func(ctx context.Context, vdb *vapi.VerticaDB, pfact *PodFact, gs *GatherState) error {
 		pfact.isPodRunning = true
 		pfact.isInstalled = false

--- a/pkg/controllers/vdb/uninstall_reconciler_test.go
+++ b/pkg/controllers/vdb/uninstall_reconciler_test.go
@@ -37,7 +37,7 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		vdb := vapi.MakeVDB()
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		recon := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		Expect(recon.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
 	})
@@ -77,7 +77,7 @@ var _ = Describe("k8s/uninstall_reconcile", func() {
 		sc.Size = 1 // Set to 1 to mimic a pending uninstall
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr)
+		pfacts := MakePodFacts(vdbRec, fpr, logger)
 		updatePodFactsForUninstall(ctx, &pfacts, vdb, sc, 1, 1)
 		r := MakeUninstallReconciler(vdbRec, logger, vdb, fpr, &pfacts)
 		res, err := r.Reconcile(ctx, &ctrl.Request{})

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -124,7 +124,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// We use the same pod facts for all reconcilers. This allows to reuse as
 	// much as we can. Some reconcilers will purposely invalidate the facts if
 	// it is known they did something to make them stale.
-	pfacts := MakePodFacts(r, prunner)
+	pfacts := MakePodFacts(r, prunner, log)
 	dispatcher := r.makeDispatcher(log, vdb, prunner, passwd)
 	var res ctrl.Result
 
@@ -205,7 +205,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// to properly pick the correct NMA deployment (monolithic vs sidecar).
 		MakeImageVersionReconciler(r, log, vdb, prunner, pfacts, false /* enforceUpgradePath */),
 		// Handles restart + re_ip of vertica
-		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true, dispatcher),
+		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true, dispatcher, ""),
 		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
 		MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Ensure we add labels to any pod rescheduled so that Service objects route traffic to it.


### PR DESCRIPTION
we want to use restart reconciler in both the VerticaDB controller and the sandbox controller. This makes some changes to the restart reconciler in order to achieve that. The sandbox name (empty string if VerticaDB controller) is passed to the reconciler and it uses it to target only pods belonging to that sandbox( or to target only pods belonging to the main cluster if sandbox name is empty)