### PR TITLE
Add stubs for replicated upgrade

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -57,6 +57,20 @@ func MakeVDBName() types.NamespacedName {
 	return types.NamespacedName{Name: "vertica-sample", Namespace: "default"}
 }
 
+// GenerateOwnerReference creates an owner reference for the current VerticaDB
+func (v *VerticaDB) GenerateOwnerReference() metav1.OwnerReference {
+	isController := true
+	blockOwnerDeletion := false
+	return metav1.OwnerReference{
+		APIVersion:         GroupVersion.String(),
+		Kind:               VerticaDBKind,
+		Name:               v.Name,
+		UID:                v.GetUID(),
+		Controller:         &isController,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+	}
+}
+
 // FindTransientSubcluster will return a pointer to the transient subcluster if one exists
 func (v *VerticaDB) FindTransientSubcluster() *Subcluster {
 	for i := range v.Spec.Subclusters {
@@ -378,6 +392,17 @@ func (v *VerticaDB) GetFirstPrimarySubcluster() *Subcluster {
 	}
 	// We should never get here because the webhook prevents a vdb with no primary.
 	return nil
+}
+
+// HasSecondarySubclusters returns true if at least 1 secondary subcluster
+// exists in the database.
+func (v *VerticaDB) HasSecondarySubclusters() bool {
+	for i := range v.Spec.Subclusters {
+		if v.Spec.Subclusters[i].IsSecondary() {
+			return true
+		}
+	}
+	return false
 }
 
 // IsAutoUpgradePolicy returns true
@@ -721,4 +746,28 @@ func (v *VerticaDB) getNumberOfNodes() int {
 		count += int(v.Spec.Subclusters[i].Size)
 	}
 	return count
+}
+
+// GetSubclusterSandboxName returns the sandbox the given subcluster belongs to,
+// or an empty string if it does not belong to any
+func (v *VerticaDB) GetSubclusterSandboxName(scName string) string {
+	for i := range v.Spec.Sandboxes {
+		for j := range v.Spec.Sandboxes[i].Subclusters {
+			if scName == v.Spec.Sandboxes[i].Subclusters[j].Name {
+				return v.Spec.Sandboxes[i].Name
+			}
+		}
+	}
+	return ""
+}
+
+// GetSandbox returns the sandbox given by name. A nil pointer is returned if
+// not found.
+func (v *VerticaDB) GetSandbox(sbName string) *Sandbox {
+	for i := range v.Spec.Sandboxes {
+		if v.Spec.Sandboxes[i].Name == sbName {
+			return &v.Spec.Sandboxes[i]
+		}
+	}
+	return nil
 }

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -771,19 +771,6 @@ func (v *VerticaDB) getNumberOfNodes() int {
 	return count
 }
 
-// GetSubclusterSandboxName returns the sandbox the given subcluster belongs to,
-// or an empty string if it does not belong to any
-func (v *VerticaDB) GetSubclusterSandboxName(scName string) string {
-	for i := range v.Spec.Sandboxes {
-		for j := range v.Spec.Sandboxes[i].Subclusters {
-			if scName == v.Spec.Sandboxes[i].Subclusters[j].Name {
-				return v.Spec.Sandboxes[i].Name
-			}
-		}
-	}
-	return ""
-}
-
 // GetSandbox returns the sandbox given by name. A nil pointer is returned if
 // not found.
 func (v *VerticaDB) GetSandbox(sbName string) *Sandbox {

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1246,7 +1246,6 @@ func getStorageClassName(vdb *vapi.VerticaDB) *string {
 
 // BuildStsSpec builds manifest for a subclusters statefulset
 func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster) *appsv1.StatefulSet {
-	isControllerRef := true
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
@@ -1274,15 +1273,7 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 					ObjectMeta: metav1.ObjectMeta{
 						Name: vapi.LocalDataPVC,
 						// Set the ownerReference so that we get auto-deletion
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: vapi.GroupVersion.String(),
-								Kind:       vapi.VerticaDBKind,
-								Name:       vdb.Name,
-								UID:        vdb.UID,
-								Controller: &isControllerRef,
-							},
-						},
+						OwnerReferences: []metav1.OwnerReference{vdb.GenerateOwnerReference()},
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{
 						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/pkg/controllers/vdb/httpservercertgen_reconciler.go
+++ b/pkg/controllers/vdb/httpservercertgen_reconciler.go
@@ -99,23 +99,12 @@ func (h *HTTPServerCertGenReconciler) getDNSNames() []string {
 }
 
 func (h *HTTPServerCertGenReconciler) createSecret(ctx context.Context, cert, caCert security.Certificate) (*corev1.Secret, error) {
-	isController := true
-	blockOwnerDeletion := false
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   h.Vdb.Namespace,
-			Annotations: builder.MakeAnnotationsForObject(h.Vdb),
-			Labels:      builder.MakeCommonLabels(h.Vdb, nil, false),
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         vapi.GroupVersion.String(),
-					Kind:               vapi.VerticaDBKind,
-					Name:               h.Vdb.Name,
-					UID:                h.Vdb.GetUID(),
-					Controller:         &isController,
-					BlockOwnerDeletion: &blockOwnerDeletion,
-				},
-			},
+			Namespace:       h.Vdb.Namespace,
+			Annotations:     builder.MakeAnnotationsForObject(h.Vdb),
+			Labels:          builder.MakeCommonLabels(h.Vdb, nil, false),
+			OwnerReferences: []metav1.OwnerReference{h.Vdb.GenerateOwnerReference()},
 		},
 		Type: corev1.SecretTypeTLS,
 		Data: map[string][]byte{

--- a/pkg/controllers/vdb/replicatedupgrade_reconciler.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler.go
@@ -437,7 +437,7 @@ func (r *ReplicatedUpgradeReconciler) addNewSubclustersForPrimaries() (bool, err
 // assignSubclustersToReplicaGroupACallback is a callback method to update the
 // VDB. It will assign each subcluster to replica group A by setting an
 // annotation. This is a callback function for updatedVDBWithRetry to prepare
-// the update for an update.
+// the vdb for an update.
 func (r *ReplicatedUpgradeReconciler) assignSubclustersToReplicaGroupACallback() (bool, error) {
 	annotatedAtLeastOnce := false
 	for inx := range r.VDB.Spec.Subclusters {

--- a/pkg/controllers/vdb/replicatedupgrade_reconciler.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler.go
@@ -18,29 +18,38 @@ package vdb
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+// When we generate a sandbox for the upgrade, this is preferred name of that sandbox.
+const preferredSandboxName = "replica-group-b"
 
 // ReplicatedUpgradeReconciler will coordinate an online upgrade that allows
 // write. This is done by splitting the cluster into two separate replicas and
 // using failover strategies to keep the database online.
 type ReplicatedUpgradeReconciler struct {
-	VRec       *VerticaDBReconciler
-	Log        logr.Logger
-	VDB        *vapi.VerticaDB
-	PFacts     *PodFacts
-	Manager    UpgradeManager
-	Dispatcher vadmin.Dispatcher
+	VRec        *VerticaDBReconciler
+	Log         logr.Logger
+	VDB         *vapi.VerticaDB
+	PFacts      *PodFacts
+	Manager     UpgradeManager
+	Dispatcher  vadmin.Dispatcher
+	sandboxName string // name of the sandbox created for replica group B
 }
 
 // MakeReplicatedUpgradeReconciler will build a ReplicatedUpgradeReconciler object
@@ -71,7 +80,7 @@ func (r *ReplicatedUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Req
 		// Initiate an upgrade by setting condition and event recording
 		r.Manager.startUpgrade,
 		// Load up state that is used for the subsequent steps
-		r.loadSubclusterState,
+		r.loadUpgradeState,
 		// Assign subclusters to upgrade to replica group A
 		r.assignSubclustersToReplicaGroupA,
 		r.runObjReconciler,
@@ -84,6 +93,26 @@ func (r *ReplicatedUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Req
 		// Sandbox all of the secondary subclusters that are destined for
 		// replica group B.
 		r.sandboxReplicaGroupB,
+		r.waitForSandboxToFinish,
+		// Upgrade the version in the sandbox to the new version.
+		r.upgradeSandbox,
+		r.waitForSandboxUpgrade,
+		// Pause all connections to replica A. This is to prepare for the
+		// replication below.
+		r.pauseConnectionsAtReplicaGroupA,
+		// Copy any new data that was added since the sandbox from replica group
+		// A to replica group B.
+		r.startReplicationToReplicaGroupB,
+		r.waitForReplicateToReplicaGroupB,
+		// Redirect all of the connections to replica group A to replica group B.
+		r.redirectConnectionsToReplicaGroupB,
+		// Promote the sandbox to the main cluster and discard the pods for the
+		// old main.
+		r.promoteSandboxToMainCluster,
+		// Scale-out secondary subcluster in main cluster. We will recreate the
+		// secondary subcluster in replica group B that existed at the start of
+		// the upgrade.
+		r.scaleOutSecondariesInReplicaGroupB,
 		// Cleanup up the condition and event recording for a completed upgrade
 		r.Manager.finishUpgrade,
 	}
@@ -101,11 +130,16 @@ func (r *ReplicatedUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Req
 	return ctrl.Result{}, nil
 }
 
-// loadSubclusterState will load state into the reconciler that
+// loadUpgradeState will load state into the reconciler that
 // is used in subsequent steps.
-func (r *ReplicatedUpgradeReconciler) loadSubclusterState(ctx context.Context) (ctrl.Result, error) {
+func (r *ReplicatedUpgradeReconciler) loadUpgradeState(ctx context.Context) (ctrl.Result, error) {
 	err := r.Manager.cachePrimaryImages(ctx)
-	return ctrl.Result{}, err
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	r.sandboxName = vmeta.GetReplicatedUpgradeSandbox(r.VDB.Annotations)
+	return ctrl.Result{}, nil
 }
 
 // assignSubclustersToReplicaGroupA will go through all of the subclusters involved
@@ -165,7 +199,204 @@ func (r *ReplicatedUpgradeReconciler) assignSubclustersToReplicaGroupB(ctx conte
 
 // sandboxReplicaGroupB will move all of the subclusters in replica B to a new sandbox
 func (r *ReplicatedUpgradeReconciler) sandboxReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
-	return ctrl.Result{}, errors.New("sandbox of replica group B is not yet implemented")
+	// We can skip this step if the replica sandbox is already created.
+	if r.sandboxName != "" {
+		return ctrl.Result{}, nil
+	}
+
+	_, err := r.Manager.updateVDBWithRetry(ctx, r.moveReplicaGroupBSubclusterToSandbox)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed trying to update VDB for sandboxing: %w", err)
+	}
+	r.sandboxName = vmeta.GetReplicatedUpgradeSandbox(r.VDB.Annotations)
+	if r.sandboxName == "" {
+		return ctrl.Result{}, errors.New("could not find sandbox name in annotations")
+	}
+	r.Log.Info("subclusters in replica group B have been sandboxed", "sandboxName", r.sandboxName)
+	return ctrl.Result{}, nil
+}
+
+// waitForSandboToFinish will block the upgrade until the sandbox controller has
+// sandboxed the subclusters that are part of replica group B.
+func (r *ReplicatedUpgradeReconciler) waitForSandboxToFinish(ctx context.Context) (ctrl.Result, error) {
+	sb := r.VDB.GetSandbox(r.sandboxName)
+	if sb == nil {
+		return ctrl.Result{}, fmt.Errorf("could not find sandbox %q", r.sandboxName)
+	}
+	// If the image in the sandbox matches the image in the spec. We have
+	// already attempted to upgrade the sandbox. So, this implies they have been
+	// created already.
+	if sb.Image == r.VDB.Spec.Image {
+		return ctrl.Result{}, nil
+	}
+
+	// Check if we can skip this step if status already has the replicated
+	// upgrade sandbox and the nodes are up.
+	foundSandboxInStatus, err := r.isReplicatedUpgradeSandboxCreated()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if foundSandboxInStatus {
+		r.Log.Info("sandboxes have been created")
+		// We need to check pod facts of the sandbox to wait here for the nodes
+		// in the sandbox to come up.
+		return ctrl.Result{}, nil
+	}
+	// We will requeue for now. But eventually, we will call necessary
+	// reconcilers here to drive the sandboxing.
+	return ctrl.Result{Requeue: true}, nil
+}
+
+// upgradeSandbox will upgrade the nodes in replica group B (sandbox) to the new version.
+func (r *ReplicatedUpgradeReconciler) upgradeSandbox(ctx context.Context) (ctrl.Result, error) {
+	sb := r.VDB.GetSandbox(r.sandboxName)
+	if sb == nil {
+		return ctrl.Result{}, fmt.Errorf("could not find sandbox %q", r.sandboxName)
+	}
+
+	// We can skip if the image in the sandbox matches the image in the vdb.
+	// This is the new version that we are upgrading too.
+	if sb.Image == r.VDB.Spec.Image {
+		return ctrl.Result{}, nil
+	}
+
+	updated, err := r.Manager.updateVDBWithRetry(ctx, r.setImageInSandbox)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed trying to update image in sandbox: %w", err)
+	}
+	if updated {
+		r.Log.Info("update image in sandbox", "image", r.VDB.Spec.Image)
+	}
+	return ctrl.Result{}, nil
+}
+
+// waitForSandboxUpgrade will wait for the sandbox upgrade to finish. It will
+// continually check if the pods in the sandbox are up.
+func (r *ReplicatedUpgradeReconciler) waitForSandboxUpgrade(ctx context.Context) (ctrl.Result, error) {
+	// The way I think we should do this is to get podfacts for the sandbox.
+	// Then wait for the nodes to be up. Each time we find the nodes aren't up
+	// we should requeue using the upgrade requeue time (see GetUpgradeRequeueTimeDuration).
+	return ctrl.Result{}, errors.New("wait for sandbox upgrade is not yet implemented")
+}
+
+// pauseConnectionsAtReplicaGroupA will pause all connections to replica A. This
+// is to prepare for the replication at the next step. We need to stop writes
+// (momentarily) so that the two replica groups have the same data.
+func (r *ReplicatedUpgradeReconciler) pauseConnectionsAtReplicaGroupA(ctx context.Context) (ctrl.Result, error) {
+	return ctrl.Result{}, errors.New("pause connections at replica group A is not yet implemented")
+}
+
+// startReplicationToReplicaGroupB will copy any new data that was added since
+// the sandbox from replica group A to replica group B.
+func (r *ReplicatedUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
+	// Skip if the VerticaReplicator has already been created.
+	if vmeta.GetReplicatedUpgradeReplicator(r.VDB.Annotations) != "" {
+		return ctrl.Result{}, nil
+	}
+
+	vrep := &v1beta1.VerticaReplicator{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       v1beta1.VerticaReplicatorKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName:    fmt.Sprintf("%s-", r.VDB.Name),
+			Namespace:       r.VDB.Namespace,
+			OwnerReferences: []metav1.OwnerReference{r.VDB.GenerateOwnerReference()},
+		},
+		Spec: v1beta1.VerticaReplicatorSpec{
+			Source: v1beta1.VerticaReplicatorDatabaseInfo{
+				VerticaDB: r.VDB.Name,
+			},
+			Target: v1beta1.VerticaReplicatorDatabaseInfo{
+				VerticaDB:   r.VDB.Name,
+				SandboxName: r.sandboxName,
+			},
+		},
+	}
+	err := r.VRec.Client.Create(ctx, vrep)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create the VerticaReplicator %q: %w", vrep.GenerateName, err)
+	}
+	r.Log.Info("VerticaReplicator created", "name", vrep.Name, "uuid", vrep.UID)
+
+	// Update the vdb with the name of the replicator that was created.
+	annotationUpdate := func() (bool, error) {
+		if r.VDB.Annotations == nil {
+			r.VDB.Annotations = make(map[string]string, 1)
+		}
+		r.VDB.Annotations[vmeta.ReplicatedUpgradeReplicatorAnnotation] = vrep.Name
+		return true, nil
+	}
+	_, err = r.Manager.updateVDBWithRetry(ctx, annotationUpdate)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to add replicator annotation to vdb: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// waitForReplicateToReplicaGroupB will poll the VerticaReplicator waiting for the replication to finish.
+func (r *ReplicatedUpgradeReconciler) waitForReplicateToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
+	vrepName := vmeta.GetReplicatedUpgradeReplicator(r.VDB.Annotations)
+	if vrepName == "" {
+		r.Log.Info("skipping wait for VerticaReplicator because name cannot be found")
+		return ctrl.Result{}, nil
+	}
+
+	vrep := v1beta1.VerticaReplicator{}
+	nm := types.NamespacedName{
+		Name:      vrepName,
+		Namespace: r.VDB.Namespace,
+	}
+	err := r.VRec.Client.Get(ctx, nm, &vrep)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			// Not found is okay since we'll delete the VerticaReplicator once
+			// we see that the replication is finished.
+			r.Log.Info("VerticaReplicator is not found. Skipping wait", "name", vrepName)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed trying to fetche VerticaReplicator: %w", err)
+	}
+
+	if !vrep.IsStatusConditionTrue(v1beta1.ReplicationComplete) {
+		r.Log.Info("Requeue replication is not finished", "vrepName", vrepName)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	r.Log.Info("Replication is completed", "vrepName", vrepName)
+
+	// Delete the VerticaReplicator. We leave the annotation present in the
+	// VerticaDB so that we skip these steps until the upgrade is finished.
+	err = r.VRec.Client.Delete(ctx, &vrep)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete the VerticaReplicator %s: %w", vrepName, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// redirectConnectionsToReplicaGroupB will redirect all of the connections
+// established at replica group A to go to replica group B.
+func (r *ReplicatedUpgradeReconciler) redirectConnectionsToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
+	return ctrl.Result{}, errors.New("redirect connections to replica group B is not yet implemented")
+}
+
+// promoteSandboxToMainCluster will promote the sandbox to the main cluster and
+// discard the pods for the old main.
+func (r *ReplicatedUpgradeReconciler) promoteSandboxToMainCluster(ctx context.Context) (ctrl.Result, error) {
+	return ctrl.Result{}, errors.New("promote sandbox to main cluster is not yet implemented")
+}
+
+// Scale-out secondary subcluster in main cluster. We will recreate the
+// secondary subcluster in replica group B that existed at the start of
+// the upgrade.
+func (r *ReplicatedUpgradeReconciler) scaleOutSecondariesInReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
+	if !r.VDB.HasSecondarySubclusters() {
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, errors.New("scale out secondaries in replica group B is not yet implemented")
 }
 
 // addNewSubclustersForPrimaries will come up with a list of subclusters we
@@ -221,16 +452,61 @@ func (r *ReplicatedUpgradeReconciler) assignSubclustersToReplicaGroupACallback()
 	return annotatedAtLeastOnce, nil
 }
 
+// moveReplicaGroupBSubclusterToSandbox will move all subclusters attached to
+// replica group B into the sandbox.
+func (r *ReplicatedUpgradeReconciler) moveReplicaGroupBSubclusterToSandbox() (bool, error) {
+	oldImage, found := r.Manager.fetchOldImage()
+	if !found {
+		return false, errors.New("Could not find old image")
+	}
+
+	scNames := r.getSubclustersForReplicaGroup(vmeta.ReplicaGroupBValue)
+	if len(scNames) == 0 {
+		return false, errors.New("cound not find any subclusters for replica group B")
+	}
+
+	sandboxName, err := r.getNewSandboxName(preferredSandboxName)
+	if err != nil {
+		return false, fmt.Errorf("failed to generate a unique sandbox name: %w", err)
+	}
+	sandbox := vapi.Sandbox{
+		Name:  sandboxName,
+		Image: oldImage,
+	}
+	for _, nm := range scNames {
+		sandbox.Subclusters = append(sandbox.Subclusters, vapi.SubclusterName{Name: nm})
+	}
+	r.VDB.Annotations[vmeta.ReplicatedUpgradeSandboxAnnotation] = sandboxName
+	r.VDB.Spec.Sandboxes = append(r.VDB.Spec.Sandboxes, sandbox)
+	return true, nil
+}
+
+// setImageInSandbox will set the new image in the sandbox to initiate an upgrade
+func (r *ReplicatedUpgradeReconciler) setImageInSandbox() (bool, error) {
+	sb := r.VDB.GetSandbox(r.sandboxName)
+	if sb == nil {
+		return false, fmt.Errorf("could not find sandbox %q", r.sandboxName)
+	}
+	sb.Image = r.VDB.Spec.Image
+	return true, nil
+}
+
 // countSubclustersForReplicaGroup is a helper to return the number of
 // subclusters assigned to the given replica group.
 func (r *ReplicatedUpgradeReconciler) countSubclustersForReplicaGroup(groupName string) int {
-	count := 0
+	scNames := r.getSubclustersForReplicaGroup(groupName)
+	return len(scNames)
+}
+
+// getSubclustersForReplicaGroup returns the names of the subclusters that are part of a replica group.
+func (r *ReplicatedUpgradeReconciler) getSubclustersForReplicaGroup(groupName string) []string {
+	scNames := []string{}
 	for i := range r.VDB.Spec.Subclusters {
 		if g, found := r.VDB.Spec.Subclusters[i].Annotations[vmeta.ReplicaGroupAnnotation]; found && g == groupName {
-			count++
+			scNames = append(scNames, r.VDB.Spec.Subclusters[i].Name)
 		}
 	}
-	return count
+	return scNames
 }
 
 // genNewSubclusterName is a helper to generate a new subcluster name. The scMap
@@ -247,11 +523,39 @@ func (r *ReplicatedUpgradeReconciler) genNewSubclusterName(baseName string, scMa
 	}
 
 	// Add a uuid suffix.
+	return r.genNameWithUUID(baseName, func(nm string) bool { _, found := scMap[nm]; return found })
+}
+
+// getNewSandboxName returns a unique name to be used for a sandbox. A preferred
+// name can be passed in. If that name is already in use, then we will generate
+// a unique one using a UUID.
+func (r *ReplicatedUpgradeReconciler) getNewSandboxName(preferredName string) (string, error) {
+	sbNames := make(map[string]any)
+	for i := range r.VDB.Spec.Sandboxes {
+		sbNames[r.VDB.Spec.Sandboxes[i].Name] = true
+	}
+
+	// To make this easier to test, we will favor the preferredName as the
+	// sandbox name. If that's available that's our name.
+	if _, found := sbNames[preferredName]; !found {
+		return preferredName, nil
+	}
+
+	// Add a uuid suffix to the preferred name.
+	return r.genNameWithUUID(preferredName, func(nm string) bool { _, found := sbNames[nm]; return found })
+}
+
+// genNameWithUUID will return a unique name with a uuid suffix. The caller has
+// to provide a lookup function to verify the name generated isn't used. If the
+// lookupFunc returns true, that means the name is in use and another one will
+// be generated.
+func (r *ReplicatedUpgradeReconciler) genNameWithUUID(baseName string, lookupFunc func(nm string) bool) (string, error) {
+	// Add a uuid suffix.
 	const maxAttempts = 100
 	for i := 0; i < maxAttempts; i++ {
 		u := uuid.NewString()
 		nm := fmt.Sprintf("%s-%s", baseName, u[0:5])
-		if _, found := scMap[nm]; !found {
+		if !lookupFunc(nm) {
 			return nm, nil
 		}
 	}
@@ -298,4 +602,38 @@ func (r *ReplicatedUpgradeReconciler) duplicateSubclusterForReplicaGroupB(
 	}
 	baseSc.Annotations[vmeta.ChildSubclusterAnnotation] = newSc.Name
 	return newSc
+}
+
+// isReplicatedUpgradeSandboxCreated will check that the sandbox created for
+// replicated upgrade exists in the status.
+func (r *ReplicatedUpgradeReconciler) isReplicatedUpgradeSandboxCreated() (bool, error) {
+	scNames := r.getSubclustersForReplicaGroup(vmeta.ReplicaGroupBValue)
+	if len(scNames) == 0 {
+		return false, errors.New("cound not find any subclusters for replica group B")
+	}
+
+	foundSandbox := false
+	for i := range r.VDB.Status.Sandboxes {
+		sb := r.VDB.Status.Sandboxes[i]
+		if sb.Name != r.sandboxName {
+			continue
+		}
+		foundSandbox = true
+
+		// Sandbox was found. Do additional verification that the subclusters
+		// contained within it are correct.
+		if len(sb.Subclusters) != len(scNames) {
+			return false, fmt.Errorf("wrong subcluster names found: %v vs %v", sb.Subclusters, scNames)
+		}
+		// Sort the subclusters names so that we can simply match entry i with
+		// entry i.
+		sort.Strings(scNames)
+		sort.Strings(sb.Subclusters)
+		for j := range sb.Subclusters {
+			if sb.Subclusters[j] != scNames[j] {
+				return false, fmt.Errorf("unexpected subcluster name found: %s vs %s", sb.Subclusters[j], scNames[j])
+			}
+		}
+	}
+	return foundSandbox, nil
 }

--- a/pkg/controllers/vdb/replicatedupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler_test.go
@@ -21,10 +21,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -112,6 +116,190 @@ var _ = Describe("replicatedupgrade_reconciler", func() {
 		Ω(sc3.Name).Should(HavePrefix("sc1-"))
 		Ω(sc3.Name).ShouldNot(Equal("sc1-sb"))
 	})
+
+	It("should sandbox subclusters in replica group B", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
+			{Name: "pri2", Type: vapi.PrimarySubcluster, Size: 2},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		rr := createReplicatedUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vdb.Spec.Subclusters).Should(HaveLen(4))
+		sbName := vmeta.GetReplicatedUpgradeSandbox(vdb.Annotations)
+		Ω(sbName).Should(Equal(preferredSandboxName))
+		pri1 := vdb.Spec.Subclusters[0]
+		pri2 := vdb.Spec.Subclusters[1]
+		Ω(pri1.Annotations).Should(HaveKey(vmeta.ChildSubclusterAnnotation))
+		Ω(pri2.Annotations).Should(HaveKey(vmeta.ChildSubclusterAnnotation))
+
+		sbMap := genSandboxMap(vdb)
+		sbScs, found := sbMap[sbName]
+		Ω(found).Should(BeTrue())
+		Ω(sbScs).Should(HaveKey(pri1.Annotations[vmeta.ChildSubclusterAnnotation]))
+		Ω(sbScs).Should(HaveKey(pri2.Annotations[vmeta.ChildSubclusterAnnotation]))
+
+		// Should clear annotation at end of upgrade
+		Ω(rr.Manager.finishUpgrade(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vmeta.GetReplicatedUpgradeSandbox(vdb.Annotations)).Should(Equal(""))
+	})
+
+	It("should handle collisions with the sandbox name", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
+			{Name: "sec1", Type: vapi.SecondarySubcluster, Size: 2},
+		}
+		vdb.Spec.Sandboxes = []vapi.Sandbox{
+			{Name: preferredSandboxName, Subclusters: []vapi.SubclusterName{{Name: "sec1"}}},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		rr := createReplicatedUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vdb.Spec.Subclusters).Should(HaveLen(3))
+		sbName := vmeta.GetReplicatedUpgradeSandbox(vdb.Annotations)
+		Ω(sbName).ShouldNot(Equal(preferredSandboxName))
+		sbMap := genSandboxMap(vdb)
+		Ω(sbMap).Should(HaveKey(sbName))
+		Ω(sbMap).Should(HaveKey(preferredSandboxName))
+
+		pri1 := vdb.Spec.Subclusters[0]
+		Ω(pri1.Annotations).Should(HaveKey(vmeta.ChildSubclusterAnnotation))
+		repSb := sbMap[sbName]
+		Ω(repSb).Should(HaveKey(pri1.Annotations[vmeta.ChildSubclusterAnnotation]))
+		firstSb := sbMap[preferredSandboxName]
+		Ω(firstSb).Should(HaveKey("sec1"))
+	})
+
+	It("should wait for sandbox to finish", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
+			{Name: "pri2", Type: vapi.PrimarySubcluster, Size: 2},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		rr := createReplicatedUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		// Wait should requeue since we aren't finished the sandbox yet
+		Ω(rr.waitForSandboxToFinish(ctx)).Should(Equal(ctrl.Result{Requeue: true}))
+
+		// Mock completion of sandbox
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vdb.Spec.Subclusters).Should(HaveLen(4))
+		sbMap := genSandboxMap(vdb)
+		for sbName := range sbMap {
+			sbs := vapi.SandboxStatus{
+				Name: sbName,
+			}
+			for _, scName := range sbMap[sbName] {
+				sbs.Subclusters = append(sbs.Subclusters, scName.Name)
+			}
+			vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, sbs)
+		}
+		Ω(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
+
+		Ω(rr.waitForSandboxToFinish(ctx)).Should(Equal(ctrl.Result{}))
+	})
+
+	It("should upgrade the vertica version in the sandbox", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		oldImageName := vdb.Spec.Image
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		rr := createReplicatedUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vdb.Spec.Sandboxes).Should(HaveLen(1))
+		Ω(vdb.Spec.Sandboxes[0].Image).Should(Equal(oldImageName))
+
+		Ω(rr.upgradeSandbox(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vdb.Spec.Sandboxes).Should(HaveLen(1))
+		Ω(vdb.Spec.Sandboxes[0].Image).Should(Equal(NewImageName))
+	})
+
+	It("should use VerticReplicator CR to handle replication", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		rr := createReplicatedUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.startReplicationToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		replicatorName := vmeta.GetReplicatedUpgradeReplicator(vdb.Annotations)
+		vrep := v1beta1.VerticaReplicator{}
+		vrepNm := types.NamespacedName{
+			Name:      replicatorName,
+			Namespace: vdb.Namespace,
+		}
+		Ω(k8sClient.Get(ctx, vrepNm, &vrep)).Should(Succeed())
+
+		Ω(vrep.Spec.Source.VerticaDB).Should(Equal(vdb.Name))
+		Ω(vrep.Spec.Target.VerticaDB).Should(Equal(vdb.Name))
+		Ω(vrep.Spec.Target.SandboxName).Should(Equal(vmeta.GetReplicatedUpgradeSandbox(vdb.Annotations)))
+
+		Ω(rr.waitForReplicateToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{Requeue: true}))
+
+		// Mock completion of replicaton
+		meta.SetStatusCondition(&vrep.Status.Conditions,
+			*vapi.MakeCondition(v1beta1.ReplicationComplete, metav1.ConditionTrue, "Done"))
+		Ω(k8sClient.Status().Update(ctx, &vrep)).Should(Succeed())
+
+		Ω(rr.waitForReplicateToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		// Verify VerticaReplicator was deleted
+		Ω(k8sClient.Get(ctx, vrepNm, &vrep)).ShouldNot(Succeed())
+
+		// Another attempt through waiting for replicator should not fail
+		Ω(rr.waitForReplicateToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		// Annotations should be cleared when we finish the upgrade
+		Ω(rr.Manager.finishUpgrade(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vmeta.GetReplicatedUpgradeReplicator(vdb.Annotations)).Should(Equal(""))
+	})
 })
 
 func createReplicatedUpgradeReconciler(ctx context.Context, vdb *vapi.VerticaDB) *ReplicatedUpgradeReconciler {
@@ -120,6 +308,30 @@ func createReplicatedUpgradeReconciler(ctx context.Context, vdb *vapi.VerticaDB)
 	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 	actor := MakeReplicatedUpgradeReconciler(vdbRec, logger, vdb, pfacts, dispatcher)
 	r := actor.(*ReplicatedUpgradeReconciler)
-	Ω(r.loadSubclusterState(ctx)).Should(Equal(ctrl.Result{}))
+	Ω(r.loadUpgradeState(ctx)).Should(Equal(ctrl.Result{}))
 	return r
+}
+
+// SandboxMap will map the sandbox name to map of subcluster in that sandbox.
+type sandboxMap = map[string]map[string]*vapi.Subcluster
+
+// GenSandboxMap returns a map of sandboxes to a map of subclusters. This allows
+// you to get all of the subclusters for a sandbox and give you quick access to
+// each of the subclusters.
+func genSandboxMap(vdb *vapi.VerticaDB) sandboxMap {
+	if len(vdb.Spec.Sandboxes) == 0 {
+		return nil
+	}
+	scMap := vdb.GenSubclusterMap()
+	sbMap := sandboxMap{}
+	for i := range vdb.Spec.Sandboxes {
+		sb := vdb.Spec.Sandboxes[i].Name
+		sbMap[sb] = make(map[string]*vapi.Subcluster)
+		for j := range vdb.Spec.Sandboxes[i].Subclusters {
+			if sc, found := scMap[vdb.Spec.Sandboxes[i].Subclusters[j].Name]; found {
+				sbMap[sb][sc.Name] = sc
+			}
+		}
+	}
+	return sbMap
 }

--- a/pkg/controllers/vdb/serviceaccount_reconciler.go
+++ b/pkg/controllers/vdb/serviceaccount_reconciler.go
@@ -90,23 +90,12 @@ func (s *ServiceAccountReconciler) Reconcile(ctx context.Context, _ *ctrl.Reques
 
 // createServiceAccount will create a new service account to be used for the vertica pods
 func (s *ServiceAccountReconciler) createServiceAccount(ctx context.Context) (*corev1.ServiceAccount, error) {
-	isController := true
-	blockOwnerDeletion := false
 	sa := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   s.Vdb.Namespace,
-			Annotations: builder.MakeAnnotationsForObject(s.Vdb),
-			Labels:      builder.MakeCommonLabels(s.Vdb, nil, false),
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         vapi.GroupVersion.String(),
-					Kind:               vapi.VerticaDBKind,
-					Name:               s.Vdb.Name,
-					UID:                s.Vdb.GetUID(),
-					Controller:         &isController,
-					BlockOwnerDeletion: &blockOwnerDeletion,
-				},
-			},
+			Namespace:       s.Vdb.Namespace,
+			Annotations:     builder.MakeAnnotationsForObject(s.Vdb),
+			Labels:          builder.MakeCommonLabels(s.Vdb, nil, false),
+			OwnerReferences: []metav1.OwnerReference{s.Vdb.GenerateOwnerReference()},
 		},
 	}
 	// Only generate a name if one wasn't already specified in the vdb
@@ -154,24 +143,13 @@ func (s *ServiceAccountReconciler) createRoleAndRoleBindingIfNeeded(ctx context.
 
 // createRole will create a Role suitable for running vertica pods. The created role is returned.
 func (s *ServiceAccountReconciler) createRole(ctx context.Context) (*rbacv1.Role, error) {
-	isController := true
-	blockOwnerDeletion := false
 	role := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-role-", s.Vdb.Name),
-			Namespace:    s.Vdb.Namespace,
-			Annotations:  builder.MakeAnnotationsForObject(s.Vdb),
-			Labels:       builder.MakeCommonLabels(s.Vdb, nil, false),
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         vapi.GroupVersion.String(),
-					Kind:               vapi.VerticaDBKind,
-					Name:               s.Vdb.Name,
-					UID:                s.Vdb.GetUID(),
-					Controller:         &isController,
-					BlockOwnerDeletion: &blockOwnerDeletion,
-				},
-			},
+			GenerateName:    fmt.Sprintf("%s-role-", s.Vdb.Name),
+			Namespace:       s.Vdb.Namespace,
+			Annotations:     builder.MakeAnnotationsForObject(s.Vdb),
+			Labels:          builder.MakeCommonLabels(s.Vdb, nil, false),
+			OwnerReferences: []metav1.OwnerReference{s.Vdb.GenerateOwnerReference()},
 		},
 		Rules: []rbacv1.PolicyRule{
 			// Any policy changes here must be kept insync with:
@@ -201,24 +179,13 @@ func (s *ServiceAccountReconciler) createRole(ctx context.Context) (*rbacv1.Role
 // createRoleBinding will create a new RoleBinding that is owned by the
 // operator. It will bind the given Role and ServiceAccount together.
 func (s *ServiceAccountReconciler) createRoleBinding(ctx context.Context, sa *corev1.ServiceAccount, role *rbacv1.Role) error {
-	isController := true
-	blockOwnerDeletion := false
 	rolebinding := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-rolebinding-", s.Vdb.Name),
-			Namespace:    s.Vdb.Namespace,
-			Annotations:  builder.MakeAnnotationsForObject(s.Vdb),
-			Labels:       builder.MakeCommonLabels(s.Vdb, nil, false),
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         vapi.GroupVersion.String(),
-					Kind:               vapi.VerticaDBKind,
-					Name:               s.Vdb.Name,
-					UID:                s.Vdb.GetUID(),
-					Controller:         &isController,
-					BlockOwnerDeletion: &blockOwnerDeletion,
-				},
-			},
+			GenerateName:    fmt.Sprintf("%s-rolebinding-", s.Vdb.Name),
+			Namespace:       s.Vdb.Namespace,
+			Annotations:     builder.MakeAnnotationsForObject(s.Vdb),
+			Labels:          builder.MakeCommonLabels(s.Vdb, nil, false),
+			OwnerReferences: []metav1.OwnerReference{s.Vdb.GenerateOwnerReference()},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
@@ -63,6 +64,9 @@ var _ = BeforeSuite(func() {
 	restCfg = cfg
 
 	err = vapi.AddToScheme(scheme.Scheme)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	err = v1beta1.AddToScheme(scheme.Scheme)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -195,6 +195,14 @@ func (i *UpgradeManager) clearReplicatedUpgradeAnnotationCallback() (updated boo
 			}
 		}
 	}
+
+	// Clear annotations set in the VerticaDB's metadata.annotations.
+	for _, a := range []string{vmeta.ReplicatedUpgradeReplicatorAnnotation, vmeta.ReplicatedUpgradeSandboxAnnotation} {
+		if _, annotationFound := i.Vdb.Annotations[a]; annotationFound {
+			delete(i.Vdb.Annotations, a)
+			updated = true
+		}
+	}
 	return
 }
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -255,6 +255,13 @@ const (
 	// establish the relationship.
 	ParentSubclusterAnnotation = "vertica.com/parent-subcluster"
 	ChildSubclusterAnnotation  = "vertica.com/child-subcluster"
+
+	// During replicated upgrade, we store an annotation in the VerticaDB that
+	// is the name of the sandbox for all subclusters part of replica group B.
+	ReplicatedUpgradeSandboxAnnotation = "vertica.com/replicated-upgrade-sandbox"
+
+	// This is the name of the VerticaReplicator that is generated during a replicated upgrade
+	ReplicatedUpgradeReplicatorAnnotation = "vertica.com/replicated-upgrade-replicator-name"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -480,6 +487,17 @@ func GetScrutinizeMainContainerResource(annotations map[string]string, resourceN
 func GenScrutinizeMainContainerResourcesAnnotationName(resourceName corev1.ResourceName) string {
 	return genResourcesAnnotationName(ScrutinizeMainContainerResourcesPrefixAnnotation,
 		resourceName)
+}
+
+// GetReplicatedUpgradeSandbox returns the name of the sandbox used for replicated upgrade.
+func GetReplicatedUpgradeSandbox(annotations map[string]string) string {
+	return lookupStringAnnotation(annotations, ReplicatedUpgradeSandboxAnnotation, "")
+}
+
+// GetReplicatedUpgradeReplicator returns the name of the VerticaReplicator
+// object used during replicated upgrade.
+func GetReplicatedUpgradeReplicator(annotations map[string]string) string {
+	return lookupStringAnnotation(annotations, ReplicatedUpgradeReplicatorAnnotation, "")
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and


### PR DESCRIPTION
This change adds stubs to the replicated upgrade reconciler. It attempts to have the functions present that are needed to do the upgrade. Due to dependencies, such as sandboxing and replication, comprehensive testing is currently limited to unit tests. While this logic might evolve during integration, it gives a framework for how the upgrade should function.

Additionally, I identified new requirements for state management. Two new annotations have been introduced to the VerticaDB: 
- vertica.com/replicated-upgrade-sandbox: to record the name of the sandbox created for the upgrade
- vertica.com/replicated-upgrade-replicator-name: to track the name of the VerticaReplicator CR utilized for replicating data to the sandbox.

