### PR TITLE
Add a new webhook rule for sandboxes

### DIFF
--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1146,10 +1146,15 @@ func (v *VerticaDB) validateSubclustersInSandboxes(allErrs field.ErrorList) fiel
 	// check if a non-existing subcluster is defined in a sandbox
 	scMap := v.GenSubclusterMap()
 	for sc, i := range seenScWithSbIndex {
-		if _, ok := scMap[sc]; !ok {
+		if scInfo, ok := scMap[sc]; !ok {
 			err := field.Invalid(path.Index(i),
 				sandboxes[i],
 				fmt.Sprintf("subcluster %s does not exist", sc))
+			allErrs = append(allErrs, err)
+		} else if scInfo.IsPrimary() {
+			err := field.Invalid(path.Index(i),
+				sandboxes[i],
+				fmt.Sprintf("subcluster %s is a primary subcluster that is not allowed to be in a sandbox", sc))
 			allErrs = append(allErrs, err)
 		}
 	}

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1106,6 +1106,15 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sandbox2", Image: mainClusterImageVer, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
 		}
 		Ω(vdb.validateVerticaDBSpec()).Should(HaveLen(1))
+
+		// cannot have a primary subcluster defined in a sandbox
+		// change sc1 from a secondary subcluster to a primary subcluster
+		vdb.Spec.Subclusters[1].Type = PrimarySubcluster
+		vdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sandbox1", Image: mainClusterImageVer, Subclusters: []SubclusterName{{Name: "sc1"}}},
+			{Name: "sandbox2", Image: mainClusterImageVer, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+		}
+		Ω(vdb.validateVerticaDBSpec()).Should(HaveLen(1))
 	})
 
 	It("should validate the number of subclusters in each sandbox", func() {


### PR DESCRIPTION
This PR adds a new webhook rule for sandboxes in CRD: cannot have a primary subcluster defined in a sandbox.



