### PR TITLE
Redirect clients to replica group B during replicated upgrade

### DIFF
--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -27,14 +27,12 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
-	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
 	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -251,7 +249,7 @@ func (o *OnlineUpgradeReconciler) createTransientSts(ctx context.Context) (ctrl.
 	}
 
 	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, ObjReconcileModeAll)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	or := actor.(*ObjReconciler)
 
 	return or.reconcileSts(ctx, o.TransientSc)
@@ -265,7 +263,7 @@ func (o *OnlineUpgradeReconciler) installTransientNodes(ctx context.Context) (ct
 	}
 
 	actor := MakeInstallReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
@@ -276,7 +274,7 @@ func (o *OnlineUpgradeReconciler) addTransientSubcluster(ctx context.Context) (c
 	}
 
 	actor := MakeDBAddSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, o.Dispatcher)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	if err := o.PFacts.Collect(ctx, o.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -292,7 +290,7 @@ func (o *OnlineUpgradeReconciler) addTransientNodes(ctx context.Context) (ctrl.R
 	}
 
 	actor := MakeDBAddNodeReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, o.Dispatcher)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	if err := o.PFacts.Collect(ctx, o.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -307,7 +305,7 @@ func (o *OnlineUpgradeReconciler) rebalanceTransientNodes(ctx context.Context) (
 	}
 
 	actor := MakeRebalanceShardsReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, o.TransientSc.Name)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
@@ -319,7 +317,7 @@ func (o *OnlineUpgradeReconciler) addClientRoutingLabelToTransientNodes(ctx cont
 	}
 
 	actor := MakeClientRoutingLabelReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, AddNodeApplyMethod, o.TransientSc.Name)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	// Add the labels.  If there is a node that still has missing subscriptions
 	// that will fail with requeue error.
 	return actor.Reconcile(ctx, &ctrl.Request{})
@@ -437,7 +435,7 @@ func (o *OnlineUpgradeReconciler) drainSubcluster(ctx context.Context, sts *apps
 		}
 
 		o.Log.Info("starting check for active connections in subcluster", "name", scName)
-		return o.isSubclusterIdle(ctx, scName)
+		return o.Manager.isSubclusterIdle(ctx, o.PFacts, scName)
 	}
 	return ctrl.Result{}, nil
 }
@@ -575,7 +573,7 @@ func (o *OnlineUpgradeReconciler) waitForReadOnly(_ context.Context, sts *appsv1
 func (o *OnlineUpgradeReconciler) bringSubclusterOnline(ctx context.Context, sts *appsv1.StatefulSet) (ctrl.Result, error) {
 	const DoNotRestartReadOnly = false
 	actor := MakeRestartReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, DoNotRestartReadOnly, o.Dispatcher)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	res, err := actor.Reconcile(ctx, &ctrl.Request{})
 	if verrors.IsReconcileAborted(res, err) {
 		return res, err
@@ -635,7 +633,7 @@ func (o *OnlineUpgradeReconciler) removeClientRoutingLabelFromTransientNodes(ctx
 	}
 
 	actor := MakeClientRoutingLabelReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, DelNodeApplyMethod, "")
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
@@ -646,7 +644,7 @@ func (o *OnlineUpgradeReconciler) removeTransientSubclusters(ctx context.Context
 	}
 
 	actor := MakeDBRemoveSubclusterReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts, o.Dispatcher)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
@@ -656,7 +654,7 @@ func (o *OnlineUpgradeReconciler) uninstallTransientNodes(ctx context.Context) (
 		return ctrl.Result{}, nil
 	}
 	actor := MakeUninstallReconciler(o.VRec, o.Log, o.Vdb, o.PRunner, o.PFacts)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
@@ -667,7 +665,7 @@ func (o *OnlineUpgradeReconciler) deleteTransientSts(ctx context.Context) (ctrl.
 	}
 
 	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, ObjReconcileModeAll)
-	o.traceActorReconcile(actor)
+	o.Manager.traceActorReconcile(actor)
 	return actor.Reconcile(ctx, &ctrl.Request{})
 }
 
@@ -688,54 +686,33 @@ func (o *OnlineUpgradeReconciler) skipTransientSetup() bool {
 	return !found
 }
 
-func (o *OnlineUpgradeReconciler) traceActorReconcile(actor controllers.ReconcileActor) {
-	o.Log.Info("starting actor for online upgrade", "name", fmt.Sprintf("%T", actor))
-}
-
 // routeClientTraffic will update service objects to route to either the primary
-// or transient.  The subcluster picked is determined by the scCheckFunc the
-// caller provides.  If it returns true for a given subcluster, traffic will be
-// routed to that.
+// or transient.
 func (o *OnlineUpgradeReconciler) routeClientTraffic(ctx context.Context,
 	scName string, setTemporaryRouting bool) error {
-	actor := MakeObjReconciler(o.VRec, o.Log, o.Vdb, o.PFacts, ObjReconcileModeAll)
-	objRec := actor.(*ObjReconciler)
-
 	scMap := o.Vdb.GenSubclusterMap()
-	sc, ok := scMap[scName]
+	sourceSc, ok := scMap[scName]
 	if !ok {
 		return fmt.Errorf("we are routing for a subcluster that isn't in the vdb: %s", scName)
-	}
-
-	// We update the external service object to route traffic to transient or
-	// primary/secondary.  We are only concerned with changing the labels.  So
-	// we will fetch the current service object, then update the labels so that
-	// traffic diverted to the correct statefulset.  Other things, such as
-	// service type, stay the same.
-	svcName := names.GenExtSvcName(o.Vdb, sc)
-	svc := &corev1.Service{}
-	if err := o.VRec.Client.Get(ctx, svcName, svc); err != nil {
-		if errors.IsNotFound(err) {
-			o.Log.Info("Skipping client traffic routing because service object for subcluster not found",
-				"scName", scName, "svc", svcName)
-			return nil
-		}
-		return err
 	}
 
 	// If we are to set temporary routing, we are going to route traffic
 	// to a transient subcluster (if one exists) or to a subcluster
 	// defined in the vdb.
+	var targetSc *vapi.Subcluster
+	var selectorLabels map[string]string
 	if setTemporaryRouting {
-		routingSc := o.getSubclusterForTemporaryRouting(ctx, sc, scMap)
-		if routingSc != nil {
-			svc.Spec.Selector = builder.MakeSvcSelectorLabelsForSubclusterNameRouting(o.Vdb, routingSc)
+		targetSc = o.getSubclusterForTemporaryRouting(ctx, sourceSc, scMap)
+		if targetSc == nil {
+			return nil
 		}
+		selectorLabels = builder.MakeSvcSelectorLabelsForSubclusterNameRouting(o.Vdb, targetSc)
 	} else {
-		svc.Spec.Selector = builder.MakeSvcSelectorLabelsForServiceNameRouting(o.Vdb, sc)
+		// Revert earlier routing and have the svc object route back to the source as before.
+		selectorLabels = builder.MakeSvcSelectorLabelsForServiceNameRouting(o.Vdb, sourceSc)
 	}
-	o.Log.Info("Updating svc", "selector", svc.Spec.Selector)
-	return objRec.reconcileExtSvc(ctx, svc, sc)
+
+	return o.Manager.routeClientTraffic(ctx, o.PFacts, sourceSc, selectorLabels)
 }
 
 // getSubclusterForTemporaryRouting returns a pointer to a subcluster to use for
@@ -817,38 +794,6 @@ func (o *OnlineUpgradeReconciler) pickDefaultSubclusterForTemporaryRouting(offli
 		}
 	}
 	return nil
-}
-
-// isSubclusterIdle will run a query to see the number of connections
-// that are active for a given subcluster.  It returns a requeue error if there
-// are active connections still.
-func (o *OnlineUpgradeReconciler) isSubclusterIdle(ctx context.Context, scName string) (ctrl.Result, error) {
-	pf, ok := o.PFacts.findPodToRunVsql(true, scName)
-	if !ok {
-		o.Log.Info("No pod found to run vsql.  Skipping active connection check")
-		return ctrl.Result{}, nil
-	}
-
-	sql := fmt.Sprintf(
-		"select count(session_id) sessions"+
-			" from v_monitor.sessions join v_catalog.subclusters using (node_name)"+
-			" where session_id not in (select session_id from current_session)"+
-			"       and subcluster_name = '%s';", scName)
-
-	cmd := []string{"-tAc", sql}
-	stdout, _, err := o.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Parse the output.  We requeue if there is an active connection.  This
-	// will rely on the UpgradeRequeueTime that is set to default
-	res := ctrl.Result{Requeue: anyActiveConnections(stdout)}
-	if res.Requeue {
-		o.VRec.Eventf(o.Vdb, corev1.EventTypeWarning, events.DrainSubclusterRetry,
-			"Subcluster '%s' has active connections preventing the drain from succeeding", scName)
-	}
-	return res, nil
 }
 
 // anyActiveConnections will parse the output from vsql to see if there

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -390,11 +390,11 @@ var _ = Describe("onlineupgrade_reconcile", func() {
 		fpr.Results[pn] = []cmds.CmdResult{
 			{Stdout: "  5\n"},
 		}
-		Expect(r.isSubclusterIdle(ctx, vdb.Spec.Subclusters[0].Name)).Should(Equal(ctrl.Result{Requeue: true}))
+		Expect(r.Manager.isSubclusterIdle(ctx, r.PFacts, vdb.Spec.Subclusters[0].Name)).Should(Equal(ctrl.Result{Requeue: true}))
 		fpr.Results[pn] = []cmds.CmdResult{
 			{Stdout: "  0\n"},
 		}
-		Expect(r.isSubclusterIdle(ctx, vdb.Spec.Subclusters[0].Name)).Should(Equal(ctrl.Result{Requeue: false}))
+		Expect(r.Manager.isSubclusterIdle(ctx, r.PFacts, vdb.Spec.Subclusters[0].Name)).Should(Equal(ctrl.Result{Requeue: false}))
 	})
 
 	It("should requeue after a specified UpgradeRequeueAfter time", func() {

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -240,6 +240,18 @@ func MakePodFactsForSandbox(vrec config.ReconcilerInterface, prunner cmds.PodRun
 	return pf
 }
 
+// Clone will make a new copy of the podfacts, but setup for the given sandbox name.
+func (p *PodFacts) Clone(sandbox string) PodFacts {
+	ret := *p
+	// Clear out fields we don't want to copy to the new copy.
+	ret.NeedCollection = true
+	ret.Detail = make(PodFactDetail)
+	// This function is intended to get a PodFacts for a different sandbox, so
+	// use the sandbox name that is passed in.
+	ret.SandboxName = sandbox
+	return ret
+}
+
 // Collect will gather up the for facts if a collection is needed
 // If the facts are already up to date, this function does nothing.
 func (p *PodFacts) Collect(ctx context.Context, vdb *vapi.VerticaDB) error {

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -240,8 +240,8 @@ func MakePodFactsForSandbox(vrec config.ReconcilerInterface, prunner cmds.PodRun
 	return pf
 }
 
-// Clone will make a new copy of the podfacts, but setup for the given sandbox name.
-func (p *PodFacts) Clone(sandbox string) PodFacts {
+// Copy will make a new copy of the podfacts, but setup for the given sandbox name.
+func (p *PodFacts) Copy(sandbox string) PodFacts {
 	ret := *p
 	// Clear out fields we don't want to copy to the new copy.
 	ret.NeedCollection = true

--- a/pkg/controllers/vdb/replicatedupgrade_reconciler.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler.go
@@ -170,7 +170,7 @@ func (r *ReplicatedUpgradeReconciler) runObjReconcilerForMainCluster(ctx context
 }
 
 // runAddSubclusterReconciler will run the reconciler to create any necessary subclusters
-func (r *ReplicatedUpgradeReconciler) runAddSubclusterReconciler(ctx context.Context) (ctrl.Result, error) {
+func (r *ReplicatedUpgradeReconciler) runAddSubclusterReconcilerForMainCluster(ctx context.Context) (ctrl.Result, error) {
 	pf := r.PFacts[vapi.MainCluster]
 	rec := MakeDBAddSubclusterReconciler(r.VRec, r.Log, r.VDB, pf.PRunner, pf, r.Dispatcher)
 	r.Manager.traceActorReconcile(rec)

--- a/pkg/controllers/vdb/replicatedupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -208,23 +209,13 @@ var _ = Describe("replicatedupgrade_reconciler", func() {
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 
-		// Wait should requeue since we aren't finished the sandbox yet
+		// Wait should requeue since we haven't finished the sandbox yet
 		Ω(rr.waitForSandboxToFinish(ctx)).Should(Equal(ctrl.Result{Requeue: true}))
 
 		// Mock completion of sandbox
 		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
 		Ω(vdb.Spec.Subclusters).Should(HaveLen(4))
-		sbMap := genSandboxMap(vdb)
-		for sbName := range sbMap {
-			sbs := vapi.SandboxStatus{
-				Name: sbName,
-			}
-			for _, scName := range sbMap[sbName] {
-				sbs.Subclusters = append(sbs.Subclusters, scName.Name)
-			}
-			vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, sbs)
-		}
-		Ω(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
+		mockCompletionOfSandbox(ctx, vdb)
 
 		Ω(rr.waitForSandboxToFinish(ctx)).Should(Equal(ctrl.Result{}))
 	})
@@ -300,12 +291,162 @@ var _ = Describe("replicatedupgrade_reconciler", func() {
 		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
 		Ω(vmeta.GetReplicatedUpgradeReplicator(vdb.Annotations)).Should(Equal(""))
 	})
+
+	It("should remove the client routing label on replica group A subclusters for the pause", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
+			{Name: "sec1", Type: vapi.SecondarySubcluster, Size: 2},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		rr := createReplicatedUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
+
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+
+		// Before we do the pause, ensure the client routing label is present.
+		groupAScNames := rr.getSubclustersForReplicaGroup(vmeta.ReplicaGroupAValue)
+		Ω(groupAScNames).Should(HaveLen(2))
+		pod := v1.Pod{}
+		scMap := vdb.GenSubclusterMap()
+		for _, scName := range groupAScNames {
+			sc, found := scMap[scName]
+			Ω(found).Should(BeTrue())
+			for i := int32(0); i < sc.Size; i++ {
+				nm := names.GenPodName(vdb, sc, i)
+				Ω(k8sClient.Get(ctx, nm, &pod)).Should(Succeed())
+				Ω(pod.Labels).Should(HaveKeyWithValue(vmeta.ClientRoutingLabel, vmeta.ClientRoutingVal), "podName is %v", nm)
+			}
+		}
+
+		// Do the pause, which will remove the client routing label
+		Ω(rr.pauseConnectionsAtReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
+
+		// Now check that the routing label was removed for the subclusters in
+		// replica group A
+		for _, scName := range groupAScNames {
+			sc, found := scMap[scName]
+			Ω(found).Should(BeTrue())
+			for i := int32(0); i < sc.Size; i++ {
+				nm := names.GenPodName(vdb, sc, i)
+				Ω(k8sClient.Get(ctx, nm, &pod)).Should(Succeed())
+				Ω(pod.Labels).ShouldNot(HaveKey(vmeta.ClientRoutingLabel))
+			}
+		}
+	})
+
+	It("should route connections in replica group A to replica group B", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
+			{Name: "pri2", Type: vapi.PrimarySubcluster, Size: 2},
+			{Name: "pri3", Type: vapi.PrimarySubcluster, Size: 2},
+			{Name: "sec1", Type: vapi.SecondarySubcluster, Size: 2},
+			{Name: "sec2", Type: vapi.SecondarySubcluster, Size: 2},
+			{Name: "sec3", Type: vapi.SecondarySubcluster, Size: 2},
+			{Name: "sec4", Type: vapi.SecondarySubcluster, Size: 2},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		vdb.Spec.Image = NewImageName // Trigger an upgrade
+		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		rr := createReplicatedUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.runObjReconcilerForMainCluster(ctx)).Should(Equal(ctrl.Result{}))
+		defer test.DeleteSvcs(ctx, k8sClient, vdb)
+		// The above obj reconciler will create a statefulset for each new
+		// subcluster. But it doesn't create the pods. That's handled by k8s
+		// controller, which doesn't run in this mock environment. So, lets
+		// create each of the pods for the new statefulset. No defer is needed
+		// for this as we already have a defer to cleanup the pods.
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+
+		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		// Mock completion of sandbox
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		mockCompletionOfSandbox(ctx, vdb)
+
+		Ω(rr.pauseConnectionsAtReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
+		Ω(rr.redirectConnectionsToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
+
+		// Verify the subclusters and the replica groupss
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
+		Ω(vdb.Spec.Subclusters).Should(HaveLen(10))
+		groupAScNames := rr.getSubclustersForReplicaGroup(vmeta.ReplicaGroupAValue)
+		Ω(groupAScNames).Should(HaveLen(7))
+		groupBScNames := rr.getSubclustersForReplicaGroup(vmeta.ReplicaGroupBValue)
+		Ω(groupBScNames).Should(HaveLen(3))
+
+		// Verify that the client routing label is present only for the
+		// subclusters in replica group B.
+		scMap := vdb.GenSubclusterMap()
+		pod := v1.Pod{}
+		for _, scName := range groupAScNames {
+			sc, found := scMap[scName]
+			Ω(found).Should(BeTrue())
+			for i := int32(0); i < sc.Size; i++ {
+				nm := names.GenPodName(vdb, sc, i)
+				Ω(k8sClient.Get(ctx, nm, &pod)).Should(Succeed(), "podName is %v", nm)
+				Ω(pod.Labels).ShouldNot(HaveKey(vmeta.ClientRoutingLabel), "podName is %v", nm)
+			}
+		}
+		for _, scName := range groupBScNames {
+			sc, found := scMap[scName]
+			Ω(found).Should(BeTrue())
+			for i := int32(0); i < sc.Size; i++ {
+				nm := names.GenPodName(vdb, sc, i)
+				Ω(k8sClient.Get(ctx, nm, &pod)).Should(Succeed(), "podName is %v", nm)
+				Ω(pod.Labels).Should(HaveKeyWithValue(vmeta.ClientRoutingLabel, vmeta.ClientRoutingVal), "podName is %v", nm)
+			}
+		}
+
+		// Verify that the service objects for subclusters in replica group A,
+		// route to the pods in replica group B. We build a mapping of each
+		// subclusters expected mapping. The secondaries should round robin the
+		// ones cloned from the primaries.
+		expectedMapping := map[string]string{
+			"pri1": "pri1-sb",
+			"pri2": "pri2-sb",
+			"pri3": "pri3-sb",
+			"sec1": "pri1-sb",
+			"sec2": "pri2-sb",
+			"sec3": "pri3-sb",
+			"sec4": "pri1-sb",
+		}
+		for _, scName := range groupAScNames {
+			sc, found := scMap[scName]
+			Ω(found).Should(BeTrue())
+			expSbTarget, found := expectedMapping[sc.Name]
+			Ω(found).Should(BeTrue())
+			svcNm := names.GenExtSvcName(vdb, sc)
+			svc := v1.Service{}
+			Ω(k8sClient.Get(ctx, svcNm, &svc)).Should(Succeed(), "svc name is %v", svcNm)
+			Ω(svc.Spec.Selector).Should(HaveKeyWithValue(vmeta.SubclusterNameLabel, expSbTarget), "svc name is %v", svcNm)
+			Ω(svc.Spec.Selector).ShouldNot(HaveKey(vmeta.SubclusterSvcNameLabel), "svc name is %v", svcNm)
+		}
+	})
 })
 
 func createReplicatedUpgradeReconciler(ctx context.Context, vdb *vapi.VerticaDB) *ReplicatedUpgradeReconciler {
 	fpr := &cmds.FakePodRunner{Results: cmds.CmdResults{}}
 	pfacts := createPodFactsDefault(fpr)
 	dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
+
+	// Add client-routing labels to all pods that exist
+	cr := MakeClientRoutingLabelReconciler(vdbRec, logger, vdb, pfacts, AddNodeApplyMethod, "")
+	Ω(cr.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+
 	actor := MakeReplicatedUpgradeReconciler(vdbRec, logger, vdb, pfacts, dispatcher)
 	r := actor.(*ReplicatedUpgradeReconciler)
 	Ω(r.loadUpgradeState(ctx)).Should(Equal(ctrl.Result{}))
@@ -334,4 +475,18 @@ func genSandboxMap(vdb *vapi.VerticaDB) sandboxMap {
 		}
 	}
 	return sbMap
+}
+
+func mockCompletionOfSandbox(ctx context.Context, vdb *vapi.VerticaDB) {
+	sbMap := genSandboxMap(vdb)
+	for sbName := range sbMap {
+		sbs := vapi.SandboxStatus{
+			Name: sbName,
+		}
+		for _, scName := range sbMap[sbName] {
+			sbs.Subclusters = append(sbs.Subclusters, scName.Name)
+		}
+		vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, sbs)
+	}
+	Ω(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
 }

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -121,6 +121,7 @@ func defaultPodFactOverrider(_ context.Context, _ *vapi.VerticaDB, pf *PodFact, 
 	pf.startupInProgress = false
 	pf.upNode = true
 	pf.subclusterOid = "123456"
+	pf.shardSubscriptions = 1
 	return nil
 }
 

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -509,7 +509,7 @@ func (i *UpgradeManager) traceActorReconcile(actor controllers.ReconcileActor) {
 
 // isSubclusterIdle will run a query to see the number of connections
 // that are active for a given subcluster.  It returns a requeue error if there
-// are active connections still.
+// are still active connections.
 func (i *UpgradeManager) isSubclusterIdle(ctx context.Context, pfacts *PodFacts, scName string) (ctrl.Result, error) {
 	pf, ok := pfacts.findPodToRunVsql(true, scName)
 	if !ok {

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
@@ -31,6 +32,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -409,7 +411,7 @@ func (i *UpgradeManager) updateVDBWithRetry(ctx context.Context, callbackFn func
 			return nil
 		}
 		err = i.VRec.Update(ctx, i.Vdb)
-		if err != nil {
+		if err == nil {
 			updated = true
 		}
 		return err
@@ -499,4 +501,70 @@ func (i *UpgradeManager) fetchOldImage() (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func (i *UpgradeManager) traceActorReconcile(actor controllers.ReconcileActor) {
+	i.Log.Info("starting actor for upgrade", "name", fmt.Sprintf("%T", actor))
+}
+
+// isSubclusterIdle will run a query to see the number of connections
+// that are active for a given subcluster.  It returns a requeue error if there
+// are active connections still.
+func (i *UpgradeManager) isSubclusterIdle(ctx context.Context, pfacts *PodFacts, scName string) (ctrl.Result, error) {
+	pf, ok := pfacts.findPodToRunVsql(true, scName)
+	if !ok {
+		i.Log.Info("No pod found to run vsql.  Skipping active connection check")
+		return ctrl.Result{}, nil
+	}
+
+	sql := fmt.Sprintf(
+		"select count(session_id) sessions"+
+			" from v_monitor.sessions join v_catalog.subclusters using (node_name)"+
+			" where session_id not in (select session_id from current_session)"+
+			"       and subcluster_name = '%s';", scName)
+
+	cmd := []string{"-tAc", sql}
+	stdout, _, err := pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Parse the output.  We requeue if there is an active connection.  This
+	// will rely on the UpgradeRequeueTime that is set to default
+	res := ctrl.Result{Requeue: anyActiveConnections(stdout)}
+	if res.Requeue {
+		i.VRec.Eventf(i.Vdb, corev1.EventTypeWarning, events.DrainSubclusterRetry,
+			"Subcluster '%s' has active connections preventing the drain from succeeding", scName)
+	}
+	return res, nil
+}
+
+// routeClientTraffic will update service objects for the source subcluster to
+// route to the target subcluster
+func (i *UpgradeManager) routeClientTraffic(ctx context.Context, pfacts *PodFacts, sc *vapi.Subcluster, selectors map[string]string) error {
+	actor := MakeObjReconciler(i.VRec, i.Log, i.Vdb, pfacts, ObjReconcileModeAll)
+	objRec := actor.(*ObjReconciler)
+
+	// We update the external service object to route traffic to the target
+	// subcluster. If sourceSc is the same as targetSc, this will update the
+	// service object so it routes to the source. Kind of like undoing a
+	// temporary routing decision.
+	//
+	// We are only concerned with changing the labels.  So we will fetch the
+	// current service object, then update the labels so that traffic diverted
+	// to the correct statefulset.  Other things, such as service type, stay the same.
+	svcName := names.GenExtSvcName(i.Vdb, sc)
+	svc := &corev1.Service{}
+	if err := i.VRec.Client.Get(ctx, svcName, svc); err != nil {
+		if errors.IsNotFound(err) {
+			i.Log.Info("Skipping client traffic routing because service object for subcluster not found",
+				"scName", sc.Name, "svc", svcName)
+			return nil
+		}
+		return err
+	}
+
+	svc.Spec.Selector = selectors
+	i.Log.Info("Updating svc", "selector", svc.Spec.Selector)
+	return objRec.reconcileExtSvc(ctx, svc, sc)
 }


### PR DESCRIPTION
In the replicated upgrade process, we must pause and redirect client connections from subclusters in replica group A to those in replica group B. This is the initial stage of the change. Currently, pause/redirect semantics are not supported, as they require new server modifications that have not yet been implemented. Therefore, we will perform an old-style drain to pause the process and maintain service labels correctly to point to subclusters in replica group B for redirection.