### PR TITLE
Add event when different upgrade policy is picked

### DIFF
--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -85,6 +85,7 @@ func (o *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 	funcs := []func(context.Context) (ctrl.Result, error){
 		// Initiate an upgrade by setting condition and event recording
 		o.Manager.startUpgrade,
+		o.logEventIfThisUpgradeWasNotChosen,
 		// Load up state that is used for the subsequent steps
 		o.loadSubclusterState,
 		// Figure out all of the status messages that we will report
@@ -128,6 +129,13 @@ func (o *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 	}
 
 	return ctrl.Result{}, o.Manager.logUpgradeSucceeded(sandbox)
+}
+
+// logEventIfThisUpgradeWasNotChosen will write an event log if we are doing this
+// upgrade method as a fall back from a requested policy.
+func (o *OnlineUpgradeReconciler) logEventIfThisUpgradeWasNotChosen(ctx context.Context) (ctrl.Result, error) {
+	o.Manager.logEventIfRequestedUpgradeIsDifferent(vapi.OnlineUpgrade)
+	return ctrl.Result{}, nil
 }
 
 // loadSubclusterState will load state into the OnlineUpgradeReconciler that

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -60,7 +60,7 @@ const (
 	AuthParmsCopyFailed             = "AuthParmsCopyFailed"
 	UpgradeStart                    = "UpgradeStart"
 	UpgradeSucceeded                = "UpgradeSucceeded"
-	IncompatibleOnlineUpgrade       = "IncompatibleOnlineUpgrade"
+	IncompatibleUpgradeRequested    = "IncompatibleUpgradeRequested"
 	ClusterShutdownStarted          = "ClusterShutdownStarted"
 	ClusterShutdownFailed           = "ClusterShutdownFailed"
 	ClusterShutdownSucceeded        = "ClusterShutdownSucceeded"


### PR DESCRIPTION
If we had selected an upgrade method but ended up failing back to a different method because something was incompatible, we are going to log an event. For instance, if we requested something other than offline upgrade, but we end up in the offline upgrade code path we will have an event message like this:
```
 Normal   IncompatibleUpgradeRequested  7m20s                  verticadb-operator  Requested upgrade is incompatible with the Vertica deployment. Falling back to offline upgrade.
```
