### PR TITLE
Add status messages for replicated upgrade

### DIFF
--- a/pkg/controllers/vdb/offlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/offlineupgrade_reconciler.go
@@ -381,7 +381,7 @@ func (o *OfflineUpgradeReconciler) anyPodsRunningWithOldImage(ctx context.Contex
 	return false, nil
 }
 
-// postNextStatusMsg will set the next status message for an online upgrade
+// postNextStatusMsg will set the next status message for an offline upgrade
 // according to msgIndex
 func (o *OfflineUpgradeReconciler) postNextStatusMsg(ctx context.Context, msgIndex int) (ctrl.Result, error) {
 	return ctrl.Result{}, o.Manager.postNextStatusMsg(ctx, OfflineUpgradeStatusMsgs, msgIndex)


### PR DESCRIPTION
This will add a status message to the `.status.upgradeStatus` field in the VerticaDB as the operator goes through the various stages of replicated upgrade. It reuses the same design for the other upgrade methods in that we only advance the status message forward. This means that we need to reconcile an iteration, we won't report the first status message again.