### PR TITLE
Decouple subcluster name from its statefulset name

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -154,7 +154,8 @@ func MakeVDBForScrutinize() *VerticaDB {
 	return vdb
 }
 
-// GenSubclusterMap will organize all of the subclusters into a map for quicker lookup
+// GenSubclusterMap will organize all of the subclusters into a map for quicker lookup.
+// The key is the subcluster name and the value is a pointer to its Subcluster struct.
 func (v *VerticaDB) GenSubclusterMap() map[string]*Subcluster {
 	scMap := map[string]*Subcluster{}
 	for i := range v.Spec.Subclusters {
@@ -175,6 +176,16 @@ func (v *VerticaDB) GenSubclusterSandboxMap() map[string]string {
 		}
 	}
 	return scSbMap
+}
+
+// GenSubclusterIndexMap will organize all of the subclusters into a map so we
+// can quickly find its index in the spec.subclusters[] array.
+func (v *VerticaDB) GenSubclusterIndexMap() map[string]int {
+	m := make(map[string]int)
+	for i := range v.Spec.Subclusters {
+		m[v.Spec.Subclusters[i].Name] = i
+	}
+	return m
 }
 
 func isValidRFC1123DNSSubdomainName(name string) bool {
@@ -284,6 +295,15 @@ func (v *VerticaDB) GetCommunalPath() string {
 func (s *Subcluster) GenCompatibleFQDN() string {
 	m := regexp.MustCompile(`_`)
 	return m.ReplaceAllString(s.Name, "-")
+}
+
+// GetStatefulSetName returns the name of the statefulset for this subcluster
+func (s *Subcluster) GetStatefulSetName(vdb *VerticaDB) string {
+	stsOverrideName := vmeta.GetStsNameOverride(s.Annotations)
+	if stsOverrideName != "" {
+		return stsOverrideName
+	}
+	return fmt.Sprintf("%s-%s", vdb.Name, s.GenCompatibleFQDN())
 }
 
 // GetServiceName returns the name of the service object that route traffic to

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -148,6 +148,7 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 	allErrs = v.checkImmutablePodSecurityContext(oldObj, allErrs)
 	allErrs = v.checkImmutableSubclusterDuringUpgrade(oldObj, allErrs)
 	allErrs = v.checkImmutableSubclusterInSandbox(oldObj, allErrs)
+	allErrs = v.checkImmutableStsName(oldObj, allErrs)
 	return allErrs
 }
 
@@ -463,10 +464,11 @@ func (v *VerticaDB) hasValidSvcAndScName(allErrs field.ErrorList) field.ErrorLis
 	for i := range v.Spec.Subclusters {
 		sc := &v.Spec.Subclusters[i]
 		fieldPrefix := field.NewPath("spec").Child("subclusters").Index(i)
+		stsName := sc.GetStatefulSetName(v)
 		// check subcluster name
-		if !IsValidSubclusterName(sc.GenCompatibleFQDN()) {
+		if !IsValidSubclusterName(stsName) {
 			err := field.Invalid(fieldPrefix.Child("name"),
-				sc.GenCompatibleFQDN(),
+				stsName,
 				fmt.Sprintf("subcluster name is not valid, change it so that 1. its length is greater than 0 and smaller than 254,"+
 					" 2. it matches regex '%s'", RFC1123DNSSubdomainNameRegex))
 			allErrs = append(allErrs, err)
@@ -591,6 +593,14 @@ func (v *VerticaDB) hasDuplicateScName(allErrs field.ErrorList) field.ErrorList 
 				err := field.Invalid(field.NewPath("spec").Child("subclusters").Index(j).Child("name"),
 					v.Spec.Subclusters[j].Name,
 					fmt.Sprintf("duplicates the name of subcluster[%d]", i))
+				allErrs = append(allErrs, err)
+			}
+			// check the statefulset name override annotation for each subcluster.
+			if sc1.GetStatefulSetName(v) == sc2.GetStatefulSetName(v) {
+				err := field.Invalid(field.NewPath("spec").Child("subclusters").Index(j).
+					Child("annotations").Key(vmeta.StsNameOverrideAnnotation),
+					v.Spec.Subclusters[j].Annotations[vmeta.StsNameOverrideAnnotation],
+					fmt.Sprintf("duplicates the %s annotation of subcluster[%d]", vmeta.StsNameOverrideAnnotation, i))
 				allErrs = append(allErrs, err)
 			}
 		}
@@ -1561,14 +1571,8 @@ func (v *VerticaDB) checkImmutableSubclusterInSandbox(oldObj *VerticaDB, allErrs
 	}
 
 	persistScsWithSbIndex := v.findPersistScsInSandbox(oldObj)
-	oldScIndexMap := make(map[string]int)
-	for i := range oldObj.Spec.Subclusters {
-		oldScIndexMap[oldObj.Spec.Subclusters[i].Name] = i
-	}
-	newScIndexMap := make(map[string]int)
-	for i := range v.Spec.Subclusters {
-		newScIndexMap[v.Spec.Subclusters[i].Name] = i
-	}
+	oldScIndexMap := oldObj.GenSubclusterIndexMap()
+	newScIndexMap := v.GenSubclusterIndexMap()
 	oldScMap := oldObj.GenSubclusterMap()
 	newScMap := v.GenSubclusterMap()
 	path := field.NewPath("spec").Child("subclusters")
@@ -1614,6 +1618,39 @@ func (v *VerticaDB) checkImmutableSubclusterInSandbox(oldObj *VerticaDB, allErrs
 		}
 	}
 
+	return allErrs
+}
+
+// checkImmutableStsName ensures the statefulset name of the subcluster stays constant
+func (v *VerticaDB) checkImmutableStsName(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
+	// We have an annotation to control the sts name. We are not going to allow
+	// this annotation to be added to existing subclusters. Otherwise, it will
+	// regenerate a new statefulset and keep the old one around. The statefulset
+	// name can only be set for new subclusters.
+	oldScMap := oldObj.GenSubclusterMap()
+	newScMap := v.GenSubclusterMap()
+	scIndexMap := v.GenSubclusterIndexMap()
+	for scName, oldSc := range oldScMap {
+		// Find the subcluster in the new map.
+		newSc, found := newScMap[scName]
+		// Only concerned with changes of existing subclusters. So, we can skip if
+		// its not found.
+		if !found {
+			continue
+		}
+		oldStsName := oldSc.GetStatefulSetName(oldObj)
+		newStsName := newSc.GetStatefulSetName(v)
+		if oldStsName != newStsName {
+			scInx := scIndexMap[scName]
+			path := field.NewPath("spec").Child("subclusters").Index(scInx).
+				Child("annotations").Key(vmeta.StsNameOverrideAnnotation)
+			err := field.Invalid(path,
+				newStsName,
+				fmt.Sprintf("Unable to rename the statefulset of subcluster %q to %q after creation of the subcluster.",
+					scName, newStsName))
+			allErrs = append(allErrs, err)
+		}
+	}
 	return allErrs
 }
 

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1646,8 +1646,8 @@ func (v *VerticaDB) checkImmutableStsName(oldObj *VerticaDB, allErrs field.Error
 				Child("annotations").Key(vmeta.StsNameOverrideAnnotation)
 			err := field.Invalid(path,
 				newStsName,
-				fmt.Sprintf("Unable to rename the statefulset of subcluster %q to %q after creation of the subcluster.",
-					scName, newStsName))
+				fmt.Sprintf("Renaming the statefulset of subcluster %q after creation of the subcluster is not allowed",
+					scName))
 			allErrs = append(allErrs, err)
 		}
 	}

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1148,6 +1148,24 @@ var _ = Describe("verticadb_webhook", func() {
 		// cannot have a sandbox with more than one subcluster
 		Ω(vdb.validateSandboxSize(field.ErrorList{})).Should(HaveLen(1))
 	})
+
+	It("should prevent the statefulset name from changing for existing subclusters", func() {
+		newVdb := MakeVDB()
+		oldVdb := newVdb.DeepCopy()
+		newVdb.Spec.Subclusters[0].Annotations = map[string]string{
+			vmeta.StsNameOverrideAnnotation: "change-sts-name",
+		}
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
+
+		// should allow it for new subclusters though
+		newVdb.Spec.Subclusters[0].Annotations = oldVdb.Spec.Subclusters[0].Annotations
+		newVdb.Spec.Subclusters = append(newVdb.Spec.Subclusters,
+			Subcluster{
+				Name: "new-name", Size: 1, Annotations: map[string]string{vmeta.StsNameOverrideAnnotation: "override-name"},
+			},
+		)
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+	})
 })
 
 func createVDBHelper() *VerticaDB {

--- a/pkg/iter/sc_finder.go
+++ b/pkg/iter/sc_finder.go
@@ -127,7 +127,13 @@ func (m *SubclusterFinder) FindSubclusters(ctx context.Context, flags FindFlags,
 		// indication the subcluster is being removed.
 		for i := range missingSts.Items {
 			scName := missingSts.Items[i].Labels[vmeta.SubclusterNameLabel]
-			subclusters = append(subclusters, &vapi.Subcluster{Name: scName, Size: 0})
+			subclusters = append(subclusters, &vapi.Subcluster{
+				Name: scName,
+				Size: 0,
+				Annotations: map[string]string{
+					vmeta.StsNameOverrideAnnotation: missingSts.Items[i].ObjectMeta.Name,
+				},
+			})
 		}
 	}
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -262,6 +262,12 @@ const (
 
 	// This is the name of the VerticaReplicator that is generated during a replicated upgrade
 	ReplicatedUpgradeReplicatorAnnotation = "vertica.com/replicated-upgrade-replicator-name"
+
+	// Use this to override the name of the statefulset and its pods. This needs
+	// to be set in the spec.subclusters[].annotations field to take effect. If
+	// omitted, then the name of the subclusters' statefulset will be
+	// `<vdb-name>-<subcluster-name>'
+	StsNameOverrideAnnotation = "vertica.com/statefulset-name-override"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -498,6 +504,12 @@ func GetReplicatedUpgradeSandbox(annotations map[string]string) string {
 // object used during replicated upgrade.
 func GetReplicatedUpgradeReplicator(annotations map[string]string) string {
 	return lookupStringAnnotation(annotations, ReplicatedUpgradeReplicatorAnnotation, "")
+}
+
+// GetStsNameOverride returns the override for the statefulset name. If one is
+// not provided, an empty string is returned.
+func GetStsNameOverride(annotations map[string]string) string {
+	return lookupStringAnnotation(annotations, StsNameOverrideAnnotation, "")
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -57,7 +57,7 @@ func GenHlSvcName(vdb *vapi.VerticaDB) types.NamespacedName {
 
 // GenStsName returns the name of the statefulset object
 func GenStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
-	return GenNamespacedName(vdb, vdb.Name+"-"+sc.GenCompatibleFQDN())
+	return GenNamespacedName(vdb, sc.GetStatefulSetName(vdb))
 }
 
 // GenCommunalCredSecretName returns the name of the secret that has the credentials to access s3
@@ -85,7 +85,8 @@ func GenSUPasswdSecretName(vdb *vapi.VerticaDB) types.NamespacedName {
 // The name of the pod is generated, this function is just a helper for when we need
 // to lookup a pod by its generated name.
 func GenPodName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%d", vdb.Name, sc.GenCompatibleFQDN(), podIndex))
+	stsName := sc.GetStatefulSetName(vdb)
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%d", stsName, podIndex))
 }
 
 // GenPodNameFromSts returns the name of a specific pod in a statefulset
@@ -98,12 +99,12 @@ func GenPodNameFromSts(vdb *vapi.VerticaDB, sts *appsv1.StatefulSet, podIndex in
 
 // GenPVCName returns the name of a specific pod's PVC.  This is for test purposes only.
 func GenPVCName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenCompatibleFQDN(), podIndex))
+	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s-%d", vapi.LocalDataPVC, sc.GetStatefulSetName(vdb), podIndex))
 }
 
 // GenPVName returns the name of a dummy PV for test purposes
 func GenPVName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.NamespacedName {
 	return types.NamespacedName{
-		Name: fmt.Sprintf("pv-%s-%s-%s-%d", vapi.LocalDataPVC, vdb.Name, sc.GenCompatibleFQDN(), podIndex),
+		Name: fmt.Sprintf("pv-%s-%s-%d", vapi.LocalDataPVC, sc.GetStatefulSetName(vdb), podIndex),
 	}
 }

--- a/tests/e2e-leg-7/restart-kill-sts/15-assert.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/15-assert.yaml
@@ -17,3 +17,13 @@ metadata:
   name: v-restart-kill-sts
 status:
   installCount: 3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: subcluster-pri1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: subcluster-sec1

--- a/tests/e2e-leg-7/restart-kill-sts/20-assert.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/20-assert.yaml
@@ -20,3 +20,17 @@ status:
   addedToDBCount: 3
   upNodeCount: 3
   subclusterCount: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: subcluster-pri1
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: subcluster-sec1
+status:
+  readyReplicas: 2

--- a/tests/e2e-leg-7/restart-kill-sts/30-delete-sts.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/30-delete-sts.yaml
@@ -14,5 +14,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl delete sts v-restart-kill-sts-pri1
+  - command: kubectl delete sts subcluster-pri1
     namespaced: true

--- a/tests/e2e-leg-7/restart-kill-sts/35-assert.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/35-assert.yaml
@@ -14,12 +14,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: v-restart-kill-sts-pri1
+  name: subcluster-pri1
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: v-restart-kill-sts-pri1-0
+  name: subcluster-pri1-0
 status:
   containerStatuses:
   - ready: true

--- a/tests/e2e-leg-7/restart-kill-sts/40-delete-sts.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/40-delete-sts.yaml
@@ -14,5 +14,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl delete sts v-restart-kill-sts-pri1
+  - command: kubectl delete sts subcluster-pri1
     namespaced: true

--- a/tests/e2e-leg-7/restart-kill-sts/45-assert.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/45-assert.yaml
@@ -21,3 +21,17 @@ status:
       upNodeCount: 1
     - addedToDBCount: 2
       upNodeCount: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: subcluster-pri1
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: subcluster-sec1
+status:
+  readyReplicas: 2

--- a/tests/e2e-leg-7/restart-kill-sts/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-7/restart-kill-sts/setup-vdb/base/setup-vdb.yaml
@@ -28,9 +28,13 @@ spec:
     - name: pri1
       size: 1
       isPrimary: true
+      annotations:
+        vertica.com/statefulset-name-override: "subcluster-pri1"
     - name: sec1
       size: 2
       isPrimary: false
+      annotations:
+        vertica.com/statefulset-name-override: "subcluster-sec1"
   certSecrets: []
   imagePullSecrets: []
   volumes: []

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
@@ -15,6 +15,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: v-base-upgrade-pri1-sb
+  annotations:
+    vertica.com/statefulset-name-override: "v-base-upgrade-pri1-sb"
 status:
   currentReplicas: 3
   readyReplicas: 3


### PR DESCRIPTION
This adds a new subcluster annotation to control the statefulset name. The new annotation is: `vertica.com/statefulset-name-override`. This is needed for replicated upgrade when the sandbox gets promoted to the main cluster. We will want to rename the sandbox subcluster to match the original names. However, the statefulset name always included the subcluster name. This new annotation will allow us to rename the subcluster while keeping the statefulset name constant. This ensurse we can do a rename without needing to rebuild the statefulset.