### PR TITLE
Give the vdb verification exactly once semantics for vrpq

### DIFF
--- a/api/v1beta1/helpers.go
+++ b/api/v1beta1/helpers.go
@@ -142,6 +142,10 @@ func (vrpq *VerticaRestorePointsQuery) IsStatusConditionFalse(statusCondition st
 	return meta.IsStatusConditionFalse(vrpq.Status.Conditions, statusCondition)
 }
 
+func (vrpq *VerticaRestorePointsQuery) IsStatusConditionPresent(statusCondition string) bool {
+	return meta.FindStatusCondition(vrpq.Status.Conditions, statusCondition) != nil
+}
+
 func MakeSampleVrpqName() types.NamespacedName {
 	return types.NamespacedName{Name: "vrpq-sample", Namespace: "default"}
 }

--- a/changes/unreleased/Changed-20240430-115516.yaml
+++ b/changes/unreleased/Changed-20240430-115516.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: VerticaRestorePointsQuery will minimize the number of retry attempts
+time: 2024-04-30T11:55:16.622684237-03:00
+custom:
+  Issue: "781"

--- a/pkg/controllers/vrpq/vdbverify_reconciler.go
+++ b/pkg/controllers/vrpq/vdbverify_reconciler.go
@@ -54,9 +54,9 @@ func MakeVDBVerifyReconciler(r *VerticaRestorePointsQueryReconciler, vrpq *v1bet
 // Reconcile will verify the VerticaDB in the Vrpq CR exists, vclusterops is enabled and
 // the vertica version supports vclusterops deployment
 func (q *VDBVerifyReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
-	// no-op if the check has already been done once
-	isSet := q.Vrpq.IsStatusConditionTrue(v1beta1.QueryReady)
-	if isSet {
+	// no-op if QueryReady is present (either true or false)
+	isPresent := q.Vrpq.IsStatusConditionPresent(v1beta1.QueryReady)
+	if isPresent {
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
The VerticaRestorePointsQuery reconciler will keep retrying the query when a previous query has failed. We should check if QueryComplete is present instead of checking if QueryComplete is true to ensure the verification of exactly-once semantics.
The VRep reconciler change will be opened in another PR in vnext branch