### PR TITLE
Give the vdb verification exactly once semantics for vrep

### DIFF
--- a/pkg/controllers/vrep/vdbverify_reconciler.go
+++ b/pkg/controllers/vrep/vdbverify_reconciler.go
@@ -52,9 +52,9 @@ func MakeVdbVerifyReconciler(r *VerticaReplicatorReconciler, vrep *v1beta1.Verti
 // Reconcile will verify the verticaDBs in the vrep CR source and target exist and
 // both vertica versions support the replication feature
 func (r *VdbVerifyReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
-	// no-op if the check has already been done once and was successful
-	isSet := r.Vrep.IsStatusConditionTrue(v1beta1.ReplicationReady)
-	if isSet {
+	// no-op if ReplicationReady is present (either true or false)
+	isPresent := r.Vrep.IsStatusConditionPresent(v1beta1.ReplicationReady)
+	if isPresent {
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
To follow up on #781, we will verify the presence of QueryReady instead of checking if QueryReady is true. This ensures the verification of exactly-once semantics for vrep.