### PR TITLE
Create sandbox config maps in sandbox reconciler

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1308,8 +1308,8 @@ func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox
 		// the data should be immutable since dbName and sandboxName are fixed
 		Immutable: &immutable,
 		Data: map[string]string{
-			"verticaDBName": vdb.Spec.DBName,
-			"sandboxName":   sandbox,
+			vapi.VerticaDBNameKey: vdb.Spec.DBName,
+			vapi.SandboxNameKey:   sandbox,
 		},
 	}
 }

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1290,6 +1290,30 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 	}
 }
 
+// BuildSandboxConfigMap builds a config map for sandbox controller
+func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox string) *corev1.ConfigMap {
+	immutable := true
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            nm.Name,
+			Namespace:       nm.Namespace,
+			Labels:          MakeLabelsForSandboxConfigMap(vdb),
+			Annotations:     MakeAnnotationsForSandboxConfigMap(vdb),
+			OwnerReferences: []metav1.OwnerReference{vdb.GenerateOwnerReference()},
+		},
+		// the data should be immutable since dbName and sandboxName are fixed
+		Immutable: &immutable,
+		Data: map[string]string{
+			"verticaDBName": vdb.Spec.DBName,
+			"sandboxName":   sandbox,
+		},
+	}
+}
+
 // BuildScrutinizePod construct the spec for the scrutinize pod
 func BuildScrutinizePod(vscr *v1beta1.VerticaScrutinize, vdb *vapi.VerticaDB, args []string) *corev1.Pod {
 	return &corev1.Pod{

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -110,6 +110,13 @@ func MakeLabelsForSvcObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, svcType st
 	return labels
 }
 
+// MakeLabelsForSandboxConfigMap constructs the labels of the sandbox config map
+func MakeLabelsForSandboxConfigMap(vdb *vapi.VerticaDB) map[string]string {
+	labels := makeLabelsForObject(vdb, nil, false)
+	labels[vmeta.WatchedBySandboxLabel] = vmeta.WatchedBySandboxTrue
+	return labels
+}
+
 // MakeAnnotationsForObjects builds the list of annotations that are to be
 // included on new objects.
 func MakeAnnotationsForObject(vdb *vapi.VerticaDB) map[string]string {
@@ -131,6 +138,16 @@ func MakeAnnotationsForStsObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[s
 	annotations := MakeAnnotationsForObject(vdb)
 	for k, v := range sc.Annotations {
 		annotations[k] = v
+	}
+	return annotations
+}
+
+// MakeAnnotationsForSandboxConfigMap builds the list of annotations that are included
+// in the sandbox config map.
+func MakeAnnotationsForSandboxConfigMap(vdb *vapi.VerticaDB) map[string]string {
+	annotations := MakeAnnotationsForObject(vdb)
+	if ver, ok := vdb.Annotations[vmeta.VersionAnnotation]; ok {
+		annotations[vmeta.VersionAnnotation] = ver
 	}
 	return annotations
 }

--- a/pkg/controllers/vdb/imageversion_reconciler.go
+++ b/pkg/controllers/vdb/imageversion_reconciler.go
@@ -281,7 +281,7 @@ func (v *ImageVersionReconciler) updateVDBAnnotations(ctx context.Context, versi
 // updateConfigMapAnnotations updates the sandbox's configmap annotations with
 // the version
 func (v *ImageVersionReconciler) updateConfigMapAnnotations(ctx context.Context, versionAnn map[string]string) error {
-	nm := names.GenConfigMapName(v.Vdb, v.PFacts.SandboxName)
+	nm := names.GenSandboxConfigMapName(v.Vdb, v.PFacts.SandboxName)
 
 	chgs := vk8s.MetaChanges{
 		NewAnnotations: map[string]string{

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -392,7 +392,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		// we get the sandbox name from the sts labels if the subcluster
 		// belongs to a sandbox. If the node is up, we will later retrieve
 		// the sandbox state from the catalog
-		pf.sandbox = p.SandboxName
+		pf.sandbox = sts.Labels[vmeta.SandboxNameLabel]
 		setSandboxNodeType(&pf)
 	}
 

--- a/pkg/controllers/vdb/sandbox_configmap.go
+++ b/pkg/controllers/vdb/sandbox_configmap.go
@@ -65,13 +65,13 @@ func (s *SandboxConfigMapManager) triggerSandboxController(ctx context.Context) 
 	chgs := vk8s.MetaChanges{
 		NewAnnotations: anns,
 	}
-	nm := names.GenConfigMapName(s.vdb, s.sandbox)
+	nm := names.GenSandboxConfigMapName(s.vdb, s.sandbox)
 	return vk8s.MetaUpdate(ctx, s.vrec.GetClient(), nm, s.configMap, chgs)
 }
 
 // fetchConfigMap will fetch the sandbox configmap
 func (s *SandboxConfigMapManager) fetchConfigMap(ctx context.Context) error {
-	nm := names.GenConfigMapName(s.vdb, s.sandbox)
+	nm := names.GenSandboxConfigMapName(s.vdb, s.sandbox)
 	err := s.vrec.GetClient().Get(ctx, nm, s.configMap)
 	if err != nil {
 		return err

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
@@ -201,17 +201,29 @@ func (s *SandboxSubclusterReconciler) updateSandboxConfigMapFields(curCM, newCM 
 	// exclude sandbox controller trigger ID from the annotations because
 	// vdb controller will set this in current config map, and the new
 	// config map cannot get it
-	triggerID, ok := curCM.Annotations[vmeta.SandboxControllerTriggerID]
-	if ok {
+	triggerID, hasTriggerID := curCM.Annotations[vmeta.SandboxControllerTriggerID]
+	if hasTriggerID {
 		delete(curCM.Annotations, vmeta.SandboxControllerTriggerID)
 	}
+	delete(newCM.Annotations, vmeta.SandboxControllerTriggerID)
+	// exclude version annotation because vdb controller can set a different
+	// vertica version annotation for a sandbox in current config map
+	version, hasVersion := curCM.Annotations[vmeta.VersionAnnotation]
+	if hasVersion {
+		delete(curCM.Annotations, vmeta.VersionAnnotation)
+	}
+	delete(newCM.Annotations, vmeta.VersionAnnotation)
 	if stringMapDiffer(curCM.ObjectMeta.Annotations, newCM.ObjectMeta.Annotations) {
 		updated = true
 		curCM.ObjectMeta.Annotations = newCM.ObjectMeta.Annotations
 	}
 	// add sandbox controller trigger ID back to the annotations
-	if ok {
+	if hasTriggerID {
 		curCM.Annotations[vmeta.SandboxControllerTriggerID] = triggerID
+	}
+	// add vertica version back to the annotations
+	if hasVersion {
+		curCM.Annotations[vmeta.VersionAnnotation] = version
 	}
 	if stringMapDiffer(curCM.ObjectMeta.Labels, newCM.ObjectMeta.Labels) {
 		updated = true

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,7 +30,7 @@ import (
 )
 
 // initPFacts is a helper function to initialize pod facts with some test information
-func initPFacts(pfacts *PodFacts, vdb *vapi.VerticaDB, sc1, sc2 string) (pfmain, pfsc1, pfsc2 types.NamespacedName) {
+func initPFacts(pfacts *PodFacts, vdb *vapi.VerticaDB, sc1, sc2 string) (pfmain, pfsc1 types.NamespacedName) {
 	pfmain = names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
 	pfacts.Detail[pfmain] = &PodFact{}
 	pfacts.Detail[pfmain].upNode = true
@@ -39,11 +40,11 @@ func initPFacts(pfacts *PodFacts, vdb *vapi.VerticaDB, sc1, sc2 string) (pfmain,
 	pfacts.Detail[pfsc1] = &PodFact{}
 	pfacts.Detail[pfsc1].upNode = true
 	pfacts.Detail[pfsc1].subclusterName = sc1
-	pfsc2 = names.GenPodName(vdb, &vdb.Spec.Subclusters[2], 0)
+	pfsc2 := names.GenPodName(vdb, &vdb.Spec.Subclusters[2], 0)
 	pfacts.Detail[pfsc2] = &PodFact{}
 	pfacts.Detail[pfsc2].upNode = true
 	pfacts.Detail[pfsc2].subclusterName = sc2
-	return pfmain, pfsc1, pfsc2
+	return pfmain, pfsc1
 }
 
 var _ = Describe("sandboxsubcluster_reconcile", func() {
@@ -126,12 +127,13 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		defer test.DeletePods(ctx, k8sClient, vdb)
 
 		fpr := &cmds.FakePodRunner{}
-		pfacts := MakePodFacts(vdbRec, fpr, logger, TestPassword)
-		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
-		_, pfsc1, pfsc2 := initPFacts(&pfacts, vdb, subcluster1, subcluster2)
-		// subcluster1 and subcluster2 are sandboxed
-		pfacts.Detail[pfsc1].sandbox = sandbox1
-		pfacts.Detail[pfsc2].sandbox = sandbox2
+		pfacts := PodFacts{}
+		pfacts.Detail = make(PodFactDetail)
+		pfmain := names.GenPodName(vdb, &vdb.Spec.Subclusters[0], 0)
+		pfacts.Detail[pfmain] = &PodFact{}
+		pfacts.Detail[pfmain].upNode = true
+		pfacts.Detail[pfmain].subclusterName = ""
+		pfacts.Detail[pfmain].isPrimary = true
 		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
 		r := MakeSandboxSubclusterReconciler(vdbRec, logger, vdb, &pfacts, dispatcher, k8sClient)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
@@ -154,7 +156,7 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr, logger, TestPassword)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
-		pfmain, pfsc1, _ := initPFacts(&pfacts, vdb, subcluster1, subcluster2)
+		pfmain, pfsc1 := initPFacts(&pfacts, vdb, subcluster1, subcluster2)
 		// let subcluster1 down
 		// should requeue the iteration without any error
 		pfacts.Detail[pfsc1].upNode = false
@@ -187,7 +189,7 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		fpr := &cmds.FakePodRunner{}
 		pfacts := MakePodFacts(vdbRec, fpr, logger, TestPassword)
 		Expect(pfacts.Collect(ctx, vdb)).Should(Succeed())
-		_, _, _ = initPFacts(&pfacts, vdb, subcluster1, subcluster2)
+		_, _ = initPFacts(&pfacts, vdb, subcluster1, subcluster2)
 		pfsc3 := names.GenPodName(vdb, &vdb.Spec.Subclusters[3], 0)
 		pfacts.Detail[pfsc3] = &PodFact{}
 		pfacts.Detail[pfsc3].upNode = true
@@ -234,5 +236,53 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		newVdb := &vapi.VerticaDB{}
 		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), newVdb)).Should(Succeed())
 		Expect(newVdb.Status.Sandboxes).Should(ConsistOf(targetSandboxStatus))
+	})
+
+	It("should create and update a sandbox config map correctly", func() {
+		vdb := vapi.MakeVDBForVclusterOps()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: maincluster, Size: 3, Type: vapi.PrimarySubcluster},
+			{Name: subcluster1, Size: 1, Type: vapi.SecondarySubcluster},
+		}
+		vdb.Spec.Sandboxes = []vapi.Sandbox{
+			{Name: sandbox1, Subclusters: []vapi.SubclusterName{{Name: subcluster1}}},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := MakePodFacts(vdbRec, fpr, logger, TestPassword)
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
+		rec := MakeSandboxSubclusterReconciler(vdbRec, logger, vdb, &pfacts, dispatcher, k8sClient)
+		r := rec.(*SandboxSubclusterReconciler)
+		// should create config map for sandbox1
+		err := r.checkSandboxConfigMap(ctx, sandbox1)
+		Expect(err).Should(BeNil())
+		nm := names.GenSandboxConfigMapName(r.Vdb, sandbox1)
+		defer deleteConfigMap(ctx, r.Vdb, nm.Name)
+
+		// verify the content of the config map
+		cm, res, err := getConfigMap(ctx, r.VRec, r.Vdb, nm)
+		Expect(err).Should(Succeed())
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(cm.Data["sandboxName"]).Should(Equal(sandbox1))
+		Expect(cm.Data["verticaDBName"]).Should(Equal(r.Vdb.Spec.DBName))
+		Expect(cm.Annotations[vmeta.VersionAnnotation]).Should(Equal(vapi.VcluseropsAsDefaultDeploymentMethodMinVersion))
+
+		newVersion := "v24.3.0"
+		r.Vdb.Annotations[vmeta.VersionAnnotation] = newVersion
+		// should update config map for sandbox1
+		err = r.checkSandboxConfigMap(ctx, sandbox1)
+		Expect(err).Should(BeNil())
+
+		// verify the content of the config map
+		cm, res, err = getConfigMap(ctx, r.VRec, r.Vdb, nm)
+		Expect(err).Should(Succeed())
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(cm.Data["sandboxName"]).Should(Equal(sandbox1))
+		Expect(cm.Data["verticaDBName"]).Should(Equal(r.Vdb.Spec.DBName))
+		Expect(cm.Annotations[vmeta.VersionAnnotation]).Should(Equal(newVersion))
 	})
 })

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
-	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"k8s.io/apimachinery/pkg/types"
@@ -269,10 +268,11 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		Expect(res).Should(Equal(ctrl.Result{}))
 		Expect(cm.Data[vapi.SandboxNameKey]).Should(Equal(sandbox1))
 		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Spec.DBName))
-		Expect(cm.Annotations[vmeta.VersionAnnotation]).Should(Equal(vapi.VcluseropsAsDefaultDeploymentMethodMinVersion))
 
-		newVersion := "v24.3.0"
-		r.Vdb.Annotations[vmeta.VersionAnnotation] = newVersion
+		testAnnotation := "test-annotation"
+		testValue := "test-value"
+		r.Vdb.Spec.Annotations = make(map[string]string)
+		r.Vdb.Spec.Annotations[testAnnotation] = testValue
 		// should update config map for sandbox1
 		err = r.checkSandboxConfigMap(ctx, sandbox1)
 		Expect(err).Should(BeNil())
@@ -283,6 +283,6 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		Expect(res).Should(Equal(ctrl.Result{}))
 		Expect(cm.Data[vapi.SandboxNameKey]).Should(Equal(sandbox1))
 		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Spec.DBName))
-		Expect(cm.Annotations[vmeta.VersionAnnotation]).Should(Equal(newVersion))
+		Expect(cm.Annotations[testAnnotation]).Should(Equal(testValue))
 	})
 })

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
@@ -267,8 +267,8 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		cm, res, err := getConfigMap(ctx, r.VRec, r.Vdb, nm)
 		Expect(err).Should(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
-		Expect(cm.Data["sandboxName"]).Should(Equal(sandbox1))
-		Expect(cm.Data["verticaDBName"]).Should(Equal(r.Vdb.Spec.DBName))
+		Expect(cm.Data[vapi.SandboxNameKey]).Should(Equal(sandbox1))
+		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Spec.DBName))
 		Expect(cm.Annotations[vmeta.VersionAnnotation]).Should(Equal(vapi.VcluseropsAsDefaultDeploymentMethodMinVersion))
 
 		newVersion := "v24.3.0"
@@ -281,8 +281,8 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		cm, res, err = getConfigMap(ctx, r.VRec, r.Vdb, nm)
 		Expect(err).Should(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
-		Expect(cm.Data["sandboxName"]).Should(Equal(sandbox1))
-		Expect(cm.Data["verticaDBName"]).Should(Equal(r.Vdb.Spec.DBName))
+		Expect(cm.Data[vapi.SandboxNameKey]).Should(Equal(sandbox1))
+		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Spec.DBName))
 		Expect(cm.Annotations[vmeta.VersionAnnotation]).Should(Equal(newVersion))
 	})
 })

--- a/pkg/controllers/vdb/sandboxupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/sandboxupgrade_reconciler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("sandboxupgrade_reconciler", func() {
 
 		validateReconcile(ctx, vdb, false)
 		cm := &corev1.ConfigMap{}
-		nm := names.GenConfigMapName(vdb, sandbox1)
+		nm := names.GenSandboxConfigMapName(vdb, sandbox1)
 		Expect(k8sClient.Get(ctx, nm, cm)).Should(Succeed())
 		Expect(cm.Annotations[vmeta.SandboxControllerTriggerID]).ShouldNot(Equal(""))
 		Expect(cm.Annotations[vmeta.SandboxControllerTriggerID]).ShouldNot(Equal(tID))

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -52,9 +52,9 @@ type VerticaDBReconciler struct {
 	EVRec  record.EventRecorder
 }
 
-//+kubebuilder:rbac:groups=vertica.com,resources=verticadbs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=vertica.com,resources=verticadbs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=vertica.com,resources=verticadbs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=vertica.com,resources=verticadbs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=vertica.com,resources=verticadbs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=vertica.com,resources=verticadbs/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create
@@ -66,7 +66,7 @@ type VerticaDBReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=update
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;delete;create
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -113,7 +113,3 @@ func GenPVName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.N
 		Name: fmt.Sprintf("pv-%s-%s-%d", vapi.LocalDataPVC, sc.GetStatefulSetName(vdb), podIndex),
 	}
 }
-
-func GenConfigMapName(vdb *vapi.VerticaDB, sandbox string) types.NamespacedName {
-	return GenNamespacedName(vdb, fmt.Sprintf("%s-%s", vdb.Name, sandbox))
-}

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -60,6 +60,11 @@ func GenStsName(vdb *vapi.VerticaDB, sc *vapi.Subcluster) types.NamespacedName {
 	return GenNamespacedName(vdb, sc.GetStatefulSetName(vdb))
 }
 
+// GenSandboxConfigMapName returns the name of the sandbox config map
+func GenSandboxConfigMapName(vdb *vapi.VerticaDB, sandbox string) types.NamespacedName {
+	return GenNamespacedName(vdb, vdb.Name+"-"+sandbox)
+}
+
 // GenCommunalCredSecretName returns the name of the secret that has the credentials to access s3
 func GenCommunalCredSecretName(vdb *vapi.VerticaDB) types.NamespacedName {
 	return GenNamespacedName(vdb, vdb.Spec.Communal.CredentialSecret)

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -92,7 +92,7 @@ func CreateSts(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sc *va
 }
 
 func CreateConfigMap(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, id, sbName string) {
-	nm := names.GenConfigMapName(vdb, sbName)
+	nm := names.GenSandboxConfigMapName(vdb, sbName)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -210,7 +210,7 @@ func DeleteStorageClass(ctx context.Context, c client.Client) {
 
 func DeleteConfigMap(ctx context.Context, c client.Client, vdb *vapi.VerticaDB, sbName string) {
 	cm := &corev1.ConfigMap{}
-	nm := names.GenConfigMapName(vdb, sbName)
+	nm := names.GenSandboxConfigMapName(vdb, sbName)
 	err := c.Get(ctx, nm, cm)
 	if !kerrors.IsNotFound(err) {
 		Expect(c.Delete(ctx, cm)).Should(Succeed())

--- a/tests/e2e-leg-9/sandbox/35-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/35-assert.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    vertica.com/operator-deployment-method: helm
+    vertica.com/operator-version: 2.1.2
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: v-sandbox
+    app.kubernetes.io/managed-by: verticadb-operator
+    app.kubernetes.io/name: vertica
+    app.kubernetes.io/version: 2.1.2
+    vertica.com/database: sandbox_db
+    vertica.com/watched-by-sandbox-controller: "true"
+  name: v-sandbox-sandbox1
+  ownerReferences:
+  - apiVersion: vertica.com/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: VerticaDB
+    name: v-sandbox
+data:
+  sandboxName: sandbox1
+  verticaDBName: sandbox_db
+immutable: true

--- a/tests/e2e-leg-9/sandbox/35-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/35-assert.yaml
@@ -16,13 +16,11 @@ kind: ConfigMap
 metadata:
   annotations:
     vertica.com/operator-deployment-method: helm
-    vertica.com/operator-version: 2.1.2
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: v-sandbox
     app.kubernetes.io/managed-by: verticadb-operator
     app.kubernetes.io/name: vertica
-    app.kubernetes.io/version: 2.1.2
     vertica.com/database: sandbox_db
     vertica.com/watched-by-sandbox-controller: "true"
   name: v-sandbox-sandbox1

--- a/tests/e2e-leg-9/sandbox/45-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/45-assert.yaml
@@ -16,13 +16,11 @@ kind: ConfigMap
 metadata:
   annotations:
     vertica.com/operator-deployment-method: helm
-    vertica.com/operator-version: 2.1.2
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: v-sandbox
     app.kubernetes.io/managed-by: verticadb-operator
     app.kubernetes.io/name: vertica
-    app.kubernetes.io/version: 2.1.2
     vertica.com/database: sandbox_db
     vertica.com/watched-by-sandbox-controller: "true"
   name: v-sandbox-sandbox2

--- a/tests/e2e-leg-9/sandbox/45-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/45-assert.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    vertica.com/operator-deployment-method: helm
+    vertica.com/operator-version: 2.1.2
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: v-sandbox
+    app.kubernetes.io/managed-by: verticadb-operator
+    app.kubernetes.io/name: vertica
+    app.kubernetes.io/version: 2.1.2
+    vertica.com/database: sandbox_db
+    vertica.com/watched-by-sandbox-controller: "true"
+  name: v-sandbox-sandbox2
+  ownerReferences:
+  - apiVersion: vertica.com/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: VerticaDB
+    name: v-sandbox
+data:
+  sandboxName: sandbox2
+  verticaDBName: sandbox_db
+immutable: true


### PR DESCRIPTION
This will create/update a sandbox config map whenever we create a new sandbox in sandbox reconciler. The config map is watched by sandbox controller for restarting/upgrading the nodes in a sandbox. The config map will be deleted if vdb is deleted or the sandbox is unsandboxed.