### PR TITLE
Vcluster API Refresh

### DIFF
--- a/api/v1beta1/verticarestorepointquery_webhook.go
+++ b/api/v1beta1/verticarestorepointquery_webhook.go
@@ -84,9 +84,9 @@ func (vrpq *VerticaRestorePointsQuery) validateVrpqSpec() field.ErrorList {
 func (vrpq *VerticaRestorePointsQuery) validateTimeStamp(allErrs field.ErrorList) field.ErrorList {
 	if filter := vrpq.Spec.FilterOptions; filter != nil {
 		options := vops.ShowRestorePointFilterOptions{}
-		options.ArchiveName = &filter.ArchiveName
-		options.StartTimestamp = &filter.StartTimestamp
-		options.EndTimestamp = &filter.EndTimestamp
+		options.ArchiveName = filter.ArchiveName
+		options.StartTimestamp = filter.StartTimestamp
+		options.EndTimestamp = filter.EndTimestamp
 		timestampErr := options.ValidateAndStandardizeTimestampsIfAny()
 		if timestampErr != nil {
 			err := field.Invalid(field.NewPath("spec").Child("filterOptions"),

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.2.1-0.20240411151456-29d822a8fa93
+	github.com/vertica/vcluster v1.2.1-0.20240430113909-05f5afab3e7f
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	golang.org/x/text v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.2.1-0.20240411151456-29d822a8fa93 h1:8FnB36cLWSPq0iSQg+w8JkJsdkE7WnTQZ5PV1hXn0sw=
-github.com/vertica/vcluster v1.2.1-0.20240411151456-29d822a8fa93/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
+github.com/vertica/vcluster v1.2.1-0.20240430113909-05f5afab3e7f h1:l+601eyb8JnsFvaiAXuFOnq7mVJW5Skl6aJX+mxl0vg=
+github.com/vertica/vcluster v1.2.1-0.20240430113909-05f5afab3e7f/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/add_node_vc.go
+++ b/pkg/vadmin/add_node_vc.go
@@ -58,29 +58,29 @@ func (v *VClusterOps) genAddNodeOptions(s *addnode.Parms, certs *HTTPSCerts) vop
 
 	// required options
 	opts.NewHosts = s.Hosts
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
-	opts.SCName = &s.Subcluster
-	opts.DataPrefix = &v.VDB.Spec.Local.DataPath
-	*opts.ForceRemoval = true
+	opts.SCName = s.Subcluster
+	opts.DataPrefix = v.VDB.Spec.Local.DataPath
+	opts.ForceRemoval = true
 	*opts.SkipRebalanceShards = true
 	if v.VDB.IsNMASideCarDeploymentEnabled() {
-		*opts.StartUpConf = paths.StartupConfFile
+		opts.StartUpConf = paths.StartupConfFile
 	}
 	opts.ExpectedNodeNames = s.ExpectedNodeNames
 	v.Log.Info("Nodes in request", "ExpectedNodeNames", opts.ExpectedNodeNames, "NewHosts", opts.NewHosts)
 
 	if v.VDB.Spec.Communal.Path != "" {
-		opts.DepotPrefix = &v.VDB.Spec.Local.DepotPath
+		opts.DepotPrefix = v.VDB.Spec.Local.DepotPath
 	}
 
 	// auth options
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/add_node_vc_test.go
+++ b/pkg/vadmin/add_node_vc_test.go
@@ -54,7 +54,7 @@ func (m *MockVClusterOps) VAddNode(options *vops.VAddNodeOptions) (vops.VCoordin
 	if !reflect.DeepEqual(options.NewHosts, TestNewHosts) {
 		return vdb, fmt.Errorf("failed to retrieve hosts to add")
 	}
-	if *options.SCName != TestSCName {
+	if options.SCName != TestSCName {
 		return vdb, fmt.Errorf("failed to retrieve subcluster name")
 	}
 	if !reflect.DeepEqual(options.RawHosts, []string{TestInitiatorPodIP}) {

--- a/pkg/vadmin/add_sc_vc.go
+++ b/pkg/vadmin/add_sc_vc.go
@@ -37,11 +37,11 @@ func (v *VClusterOps) AddSubcluster(_ context.Context, opts ...addsc.Option) err
 	vopts := v.genAddSubclusterOptions(&s)
 	err := v.VAddSubcluster(&vopts)
 	if err != nil {
-		v.Log.Error(err, "failed to add a subcluster", "scName", *vopts.SCName)
+		v.Log.Error(err, "failed to add a subcluster", "scName", vopts.SCName)
 		return err
 	}
 
-	v.Log.Info("Successfully added a subcluster to the database", "scName", *vopts.SCName, "dbName", *vopts.DBName)
+	v.Log.Info("Successfully added a subcluster to the database", "scName", vopts.SCName, "dbName", vopts.DBName)
 	return nil
 }
 
@@ -52,13 +52,13 @@ func (v *VClusterOps) genAddSubclusterOptions(s *addsc.Parms) vops.VAddSubcluste
 	v.Log.Info("Setup add subcluster options", "hosts", opts.RawHosts[0])
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
-	opts.SCName = &s.Subcluster
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.SCName = s.Subcluster
+	opts.DBName = v.VDB.Spec.DBName
 	opts.IsEon = v.VDB.IsEON()
-	opts.IsPrimary = &s.IsPrimary
+	opts.IsPrimary = s.IsPrimary
 
 	// auth options
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/add_sc_vc_test.go
+++ b/pkg/vadmin/add_sc_vc_test.go
@@ -45,10 +45,10 @@ func (m *MockVClusterOps) VAddSubcluster(options *vops.VAddSubclusterOptions) er
 	}
 
 	// verify basic options
-	if *options.SCName != TestSCName {
+	if options.SCName != TestSCName {
 		return fmt.Errorf("failed to retrieve subcluster name")
 	}
-	if *options.IsPrimary != TestIsPrimary {
+	if options.IsPrimary != TestIsPrimary {
 		return fmt.Errorf("failed to retrieve subcluster type")
 	}
 

--- a/pkg/vadmin/create_db_vc.go
+++ b/pkg/vadmin/create_db_vc.go
@@ -79,44 +79,44 @@ func (v *VClusterOps) genCreateDBOptions(s *createdb.Parms, certs *HTTPSCerts) v
 	if len(opts.RawHosts) > 0 {
 		opts.IPv6 = net.IsIPv6(opts.RawHosts[0])
 	}
-	opts.CatalogPrefix = &s.CatalogPath
-	opts.DBName = &s.DBName
-	opts.LicensePathOnNode = &s.LicensePath
-	*opts.ForceRemovalAtCreation = true
-	opts.SkipPackageInstall = &s.SkipPackageInstall
-	opts.DataPrefix = &s.DataPath
+	opts.CatalogPrefix = s.CatalogPath
+	opts.DBName = s.DBName
+	opts.LicensePathOnNode = s.LicensePath
+	opts.ForceRemovalAtCreation = true
+	opts.SkipPackageInstall = s.SkipPackageInstall
+	opts.DataPrefix = s.DataPath
 	if v.VDB.IsNMASideCarDeploymentEnabled() {
-		*opts.StartUpConf = paths.StartupConfFile
+		opts.StartUpConf = paths.StartupConfFile
 	}
 
 	// If a communal path is set, include all of the EON parameters.
 	if s.CommunalPath != "" {
-		opts.DepotPrefix = &s.DepotPath
-		opts.CommunalStorageLocation = &s.CommunalPath
+		opts.DepotPrefix = s.DepotPath
+		opts.CommunalStorageLocation = s.CommunalPath
 	}
 
 	// Additional configuration parameters for create db.
 	opts.ConfigurationParameters = s.ConfigurationParams
 
 	// Flag to generate HTTPS tls conf in vertica bootstrap catalog
-	*opts.GenerateHTTPCerts = true
+	opts.GenerateHTTPCerts = true
 
 	if s.ShardCount > 0 {
-		opts.ShardCount = &s.ShardCount
+		opts.ShardCount = s.ShardCount
 	}
 
 	// auth options
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	if v.Password != "" {
 		opts.Password = &v.Password
 	}
 
 	// Timeout
 	if timeout := v.VDB.GetCreateDBNodeStartTimeout(); timeout != 0 {
-		opts.TimeoutNodeStartupSeconds = &timeout
+		opts.TimeoutNodeStartupSeconds = timeout
 	}
 
 	return opts

--- a/pkg/vadmin/create_db_vc_test.go
+++ b/pkg/vadmin/create_db_vc_test.go
@@ -58,26 +58,26 @@ func (m *MockVClusterOps) VCreateDatabase(options *vops.VCreateDatabaseOptions) 
 	if err != nil {
 		return vdb, err
 	}
-	err = m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.ConfigurationParameters)
+	err = m.VerifyCommunalStorageOptions(options.CommunalStorageLocation, options.ConfigurationParameters)
 	if err != nil {
 		return vdb, err
 	}
-	if *options.CatalogPrefix != TestCatalogPath {
+	if options.CatalogPrefix != TestCatalogPath {
 		return vdb, fmt.Errorf("failed to retrieve catalog path")
 	}
-	if *options.DepotPrefix != TestDepotPath {
+	if options.DepotPrefix != TestDepotPath {
 		return vdb, fmt.Errorf("failed to retrieve depot path")
 	}
-	if *options.DataPrefix != TestDataPath {
+	if options.DataPrefix != TestDataPath {
 		return vdb, fmt.Errorf("failed to retrieve data path")
 	}
-	if *options.LicensePathOnNode != TestLicensePath {
+	if options.LicensePathOnNode != TestLicensePath {
 		return vdb, fmt.Errorf("failed to retrieve license path")
 	}
-	if *options.ShardCount != TestShardCount {
+	if options.ShardCount != TestShardCount {
 		return vdb, fmt.Errorf("failed to retrieve shard count")
 	}
-	if *options.SkipPackageInstall != TestSkipPackageInstall {
+	if options.SkipPackageInstall != TestSkipPackageInstall {
 		return vdb, fmt.Errorf("failed to retrieve SkipPackageInstall")
 	}
 
@@ -95,8 +95,8 @@ func (m *MockVClusterOps) VCreateDatabase(options *vops.VCreateDatabaseOptions) 
 	}
 
 	// verify TimeoutNodeStartupSeconds
-	if m.VerifyTimeoutNodeStartupSeconds && *options.TimeoutNodeStartupSeconds != TestTimeoutNodeStartupSeconds {
-		return vdb, fmt.Errorf("fail to read TimeoutNodeStartupSeconds from annotations: %d", *options.TimeoutNodeStartupSeconds)
+	if m.VerifyTimeoutNodeStartupSeconds && options.TimeoutNodeStartupSeconds != TestTimeoutNodeStartupSeconds {
+		return vdb, fmt.Errorf("fail to read TimeoutNodeStartupSeconds from annotations: %d", options.TimeoutNodeStartupSeconds)
 	}
 
 	return vdb, nil

--- a/pkg/vadmin/fetch_node_details_vc.go
+++ b/pkg/vadmin/fetch_node_details_vc.go
@@ -55,13 +55,13 @@ func (v *VClusterOps) FetchNodeDetails(_ context.Context, opts ...fetchnodedetai
 func (v *VClusterOps) genFetchNodeDetailsOptions(s *fetchnodedetails.Parms) vops.VFetchNodesDetailsOptions {
 	opts := vops.VFetchNodesDetailsOptionsFactory()
 
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
 	// auth options
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/fetch_node_state_vc.go
+++ b/pkg/vadmin/fetch_node_state_vc.go
@@ -55,13 +55,13 @@ func (v *VClusterOps) FetchNodeState(_ context.Context, opts ...fetchnodestate.O
 func (v *VClusterOps) genFetchNodeStateOptions(s *fetchnodestate.Parms) vops.VFetchNodeStateOptions {
 	opts := vops.VFetchNodeStateOptionsFactory()
 
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
 	// auth options
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/install_packages_vc.go
+++ b/pkg/vadmin/install_packages_vc.go
@@ -46,7 +46,7 @@ func (v *VClusterOps) InstallPackages(_ context.Context, opts ...installpackages
 		return status, err
 	}
 
-	v.Log.Info("Packages installation finished", "dbName", *vopts.DBName,
+	v.Log.Info("Packages installation finished", "dbName", vopts.DBName,
 		"installPackageStatus", *status)
 	return status, nil
 }
@@ -58,15 +58,15 @@ func (v *VClusterOps) genInstallPackagesOptions(i *installpackages.Parms) vops.V
 	v.Log.Info("Setup install packages options", "hosts", opts.RawHosts[0])
 	opts.IPv6 = net.IsIPv6(i.InitiatorIP)
 
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 	opts.IsEon = v.VDB.IsEON()
 
 	// auth options
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	// force reinstall option
-	*opts.ForceReinstall = i.ForceReinstall
+	opts.ForceReinstall = i.ForceReinstall
 
 	return opts
 }

--- a/pkg/vadmin/install_packages_vc_test.go
+++ b/pkg/vadmin/install_packages_vc_test.go
@@ -44,7 +44,7 @@ func (m *MockVClusterOps) VInstallPackages(options *vops.VInstallPackagesOptions
 	}
 
 	// verify force reinstall option
-	if !*options.ForceReinstall {
+	if !options.ForceReinstall {
 		return nil, err
 	}
 

--- a/pkg/vadmin/opts/showrestorepoints/opts.go
+++ b/pkg/vadmin/opts/showrestorepoints/opts.go
@@ -60,18 +60,18 @@ func WithConfigurationParams(parms map[string]string) Option {
 
 func WithArchiveNameFilter(archiveName string) Option {
 	return func(s *Parms) {
-		s.FilterOptions.ArchiveName = &archiveName
+		s.FilterOptions.ArchiveName = archiveName
 	}
 }
 
 func WithStartTimestampFilter(startTimestamp string) Option {
 	return func(s *Parms) {
-		s.FilterOptions.StartTimestamp = &startTimestamp
+		s.FilterOptions.StartTimestamp = startTimestamp
 	}
 }
 
 func WithEndTimestampFilter(endTimestamp string) Option {
 	return func(s *Parms) {
-		s.FilterOptions.EndTimestamp = &endTimestamp
+		s.FilterOptions.EndTimestamp = endTimestamp
 	}
 }

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	vops "github.com/vertica/vcluster/vclusterops"
-	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
@@ -70,10 +69,10 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	opts.IPv6 = net.IsIPv6(opts.RawHosts[0])
 
 	// catalog prefix
-	*opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
+	opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
 
 	// database name
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 
 	// re-ip list
 	for _, h := range s.Hosts {
@@ -88,8 +87,7 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	// we do not need to access communal storage in re_ip after create_db.
 	if v.VDB.Spec.InitPolicy == vapi.CommunalInitPolicyRevive {
 		opts.IsEon = v.VDB.IsEON()
-		opts.OldIsEon = vstruct.MakeNullableBool(opts.IsEon)
-		*opts.CommunalStorageLocation = s.CommunalPath
+		opts.CommunalStorageLocation = s.CommunalPath
 		opts.ConfigurationParameters = s.ConfigurationParams
 	}
 
@@ -97,7 +95,7 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	// other options

--- a/pkg/vadmin/re_ip_vc_test.go
+++ b/pkg/vadmin/re_ip_vc_test.go
@@ -37,7 +37,7 @@ func (m *MockVClusterOps) VReIP(options *vops.VReIPOptions) error {
 	}
 
 	// verify catalog path
-	if *options.CatalogPrefix != TestCatalogPrefix {
+	if options.CatalogPrefix != TestCatalogPrefix {
 		return fmt.Errorf("failed to retrieve catalog prefix")
 	}
 
@@ -50,7 +50,7 @@ func (m *MockVClusterOps) VReIP(options *vops.VReIPOptions) error {
 	if options.IsEon != TestIsEon {
 		return fmt.Errorf("failed to retrieve eon mode")
 	}
-	return m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.ConfigurationParameters)
+	return m.VerifyCommunalStorageOptions(options.CommunalStorageLocation, options.ConfigurationParameters)
 }
 
 var _ = Describe("re_ip_vc", func() {

--- a/pkg/vadmin/remove_node_vc.go
+++ b/pkg/vadmin/remove_node_vc.go
@@ -49,22 +49,22 @@ func (v *VClusterOps) genRemoveNodeOptions(s *removenode.Parms, certs *HTTPSCert
 
 	// required options
 	opts.HostsToRemove = s.Hosts
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 
 	opts.RawHosts = []string{s.InitiatorIP}
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
-	opts.DataPrefix = &v.VDB.Spec.Local.DataPath
-	*opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
+	opts.DataPrefix = v.VDB.Spec.Local.DataPath
+	opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
 
 	if v.VDB.Spec.Communal.Path != "" {
-		opts.DepotPrefix = &v.VDB.Spec.Local.DepotPath
+		opts.DepotPrefix = v.VDB.Spec.Local.DepotPath
 	}
 
 	// auth options
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -68,6 +68,7 @@ func (v *VClusterOps) genRemoveSubclusterOptions(s *removesc.Parms, certs *HTTPS
 	v.Log.Info("Setup remove subcluster options", "hosts", opts.RawHosts[0])
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 	opts.DataPrefix = v.VDB.Spec.Local.DataPath
+	opts.IsEon = v.VDB.IsEON()
 	opts.ForceDelete = true
 
 	if v.VDB.Spec.Communal.Path != "" {

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -61,24 +61,24 @@ func (v *VClusterOps) genRemoveSubclusterOptions(s *removesc.Parms, certs *HTTPS
 	opts := vops.VRemoveScOptionsFactory()
 
 	// required options
-	opts.DBName = &v.VDB.Spec.DBName
-	opts.SubclusterToRemove = &s.Subcluster
+	opts.DBName = v.VDB.Spec.DBName
+	opts.SubclusterToRemove = s.Subcluster
 
 	opts.RawHosts = []string{s.InitiatorIP}
 	v.Log.Info("Setup remove subcluster options", "hosts", opts.RawHosts[0])
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
-	opts.DataPrefix = &v.VDB.Spec.Local.DataPath
-	*opts.ForceDelete = true
+	opts.DataPrefix = v.VDB.Spec.Local.DataPath
+	opts.ForceDelete = true
 
 	if v.VDB.Spec.Communal.Path != "" {
-		opts.DepotPrefix = &v.VDB.Spec.Local.DepotPath
+		opts.DepotPrefix = v.VDB.Spec.Local.DepotPath
 	}
 
 	// auth options
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/remove_sc_vc_test.go
+++ b/pkg/vadmin/remove_sc_vc_test.go
@@ -36,7 +36,7 @@ func (m *MockVClusterOps) VRemoveSubcluster(options *vops.VRemoveScOptions) (vop
 	}
 
 	// verify basic options
-	if *options.SubclusterToRemove != TestSCName {
+	if options.SubclusterToRemove != TestSCName {
 		return vdb, fmt.Errorf("failed to retrieve subcluster name")
 	}
 

--- a/pkg/vadmin/replication_start_vc.go
+++ b/pkg/vadmin/replication_start_vc.go
@@ -49,7 +49,7 @@ func (v *VClusterOps) ReplicateDB(ctx context.Context, opts ...replicationstart.
 		return ctrl.Result{}, err
 	}
 
-	v.Log.Info("Successfully replicated a database", "sourceDBName", *vopts.DBName,
+	v.Log.Info("Successfully replicated a database", "sourceDBName", vopts.DBName,
 		"targetDBName", vopts.TargetDB)
 	return ctrl.Result{}, nil
 }
@@ -57,8 +57,8 @@ func (v *VClusterOps) ReplicateDB(ctx context.Context, opts ...replicationstart.
 func (v *VClusterOps) genReplicateDBOptions(s *replicationstart.Parms, certs *HTTPSCerts) *vops.VReplicationDatabaseOptions {
 	opts := vops.VReplicationDatabaseFactory()
 	opts.RawHosts = append(opts.RawHosts, s.SourceIP)
-	opts.DBName = &v.VDB.Spec.DBName
-	opts.UserName = &s.SourceUserName
+	opts.DBName = v.VDB.Spec.DBName
+	opts.UserName = s.SourceUserName
 	opts.Password = &v.Password
 	opts.TargetDB = s.TargetDBName
 	opts.TargetUserName = s.TargetUserName

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -53,18 +53,18 @@ func (v *VClusterOps) RestartNode(ctx context.Context, opts ...restartnode.Optio
 func (v *VClusterOps) genStartNodeOptions(s *restartnode.Parms, certs *HTTPSCerts) *vops.VStartNodesOptions {
 	su := v.VDB.GetVerticaUser()
 	opts := vops.VStartNodesOptionsFactory()
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 	opts.RawHosts = []string{s.InitiatorIP}
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	opts.UserName = &su
+	opts.UserName = su
 	opts.Password = &v.Password
 	opts.Nodes = s.RestartHosts
 	opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
 	if v.VDB.IsNMASideCarDeploymentEnabled() {
-		*opts.StartUpConf = paths.StartupConfFile
+		opts.StartUpConf = paths.StartupConfFile
 	}
 	return &opts
 }

--- a/pkg/vadmin/restore_points_query_vc.go
+++ b/pkg/vadmin/restore_points_query_vc.go
@@ -53,8 +53,8 @@ func (v *VClusterOps) genRestorePointsOptions(s *showrestorepoints.Parms, certs 
 	opts := vops.VShowRestorePointsFactory()
 
 	// required options
-	opts.DBName = &v.VDB.Spec.DBName
-	opts.CommunalStorageLocation = &s.CommunalPath
+	opts.DBName = v.VDB.Spec.DBName
+	opts.CommunalStorageLocation = s.CommunalPath
 
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 	v.Log.Info("Setup restore point options", "rawhosts", opts.RawHosts)
@@ -68,7 +68,7 @@ func (v *VClusterOps) genRestorePointsOptions(s *showrestorepoints.Parms, certs 
 	opts.CaCert = certs.CaCert
 
 	// optional query filter options
-	opts.FilterOptions = &s.FilterOptions
+	opts.FilterOptions = s.FilterOptions
 
 	return &opts
 }

--- a/pkg/vadmin/restore_points_query_vc_test.go
+++ b/pkg/vadmin/restore_points_query_vc_test.go
@@ -43,12 +43,12 @@ func (m *MockVClusterOps) VShowRestorePoints(options *vops.VShowRestorePointsOpt
 		return restorePoints, fmt.Errorf("failed to retrieve hosts")
 	}
 
-	err = m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.ConfigurationParameters)
+	err = m.VerifyCommunalStorageOptions(options.CommunalStorageLocation, options.ConfigurationParameters)
 	if err != nil {
 		return restorePoints, err
 	}
 
-	err = m.VerifyFilterOptions(options.FilterOptions)
+	err = m.VerifyFilterOptions(&options.FilterOptions)
 	if err != nil {
 		return restorePoints, err
 	}

--- a/pkg/vadmin/revive_db_vc.go
+++ b/pkg/vadmin/revive_db_vc.go
@@ -52,11 +52,11 @@ func (v *VClusterOps) ReviveDB(ctx context.Context, opts ...revivedb.Option) (ct
 func (v *VClusterOps) genReviveDBOptions(s *revivedb.Parms, certs *HTTPSCerts) *vops.VReviveDatabaseOptions {
 	opts := vops.VReviveDBOptionsFactory()
 
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 	opts.RawHosts = s.Hosts
 	v.Log.Info("Setup revive database options", "hosts", opts.RawHosts)
 	opts.IPv6 = net.IsIPv6(opts.RawHosts[0])
-	opts.CommunalStorageLocation = &s.CommunalPath
+	opts.CommunalStorageLocation = s.CommunalPath
 	opts.ConfigurationParameters = s.ConfigurationParams
 	opts.IgnoreClusterLease = s.IgnoreClusterLease
 

--- a/pkg/vadmin/revive_db_vc_test.go
+++ b/pkg/vadmin/revive_db_vc_test.go
@@ -51,7 +51,7 @@ func (m *MockVClusterOps) VReviveDatabase(options *vops.VReviveDatabaseOptions) 
 	if err != nil {
 		return "", nil, err
 	}
-	err = m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.ConfigurationParameters)
+	err = m.VerifyCommunalStorageOptions(options.CommunalStorageLocation, options.ConfigurationParameters)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/vadmin/sandbox_sc_vc.go
+++ b/pkg/vadmin/sandbox_sc_vc.go
@@ -37,28 +37,28 @@ func (v *VClusterOps) SandboxSubcluster(_ context.Context, opts ...sandboxsc.Opt
 	vopts := v.genSandboxSubclusterOptions(&s)
 	err := v.VSandbox(&vopts)
 	if err != nil {
-		v.Log.Error(err, "failed to add a subcluster to a sandbox", "subcluster", *vopts.SCName, "sandbox", *vopts.SandboxName)
+		v.Log.Error(err, "failed to add a subcluster to a sandbox", "subcluster", vopts.SCName, "sandbox", vopts.SandboxName)
 		return err
 	}
 
-	v.Log.Info("Successfully added a subcluster to a sandbox", "scName", *vopts.SCName, "sandbox", *vopts.SandboxName)
+	v.Log.Info("Successfully added a subcluster to a sandbox", "scName", vopts.SCName, "sandbox", vopts.SandboxName)
 	return nil
 }
 
 func (v *VClusterOps) genSandboxSubclusterOptions(s *sandboxsc.Params) vops.VSandboxOptions {
 	opts := vops.VSandboxOptionsFactory()
 
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 	opts.IsEon = v.VDB.IsEON()
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 	v.Log.Info("Setup sandbox subcluster options", "hosts", opts.RawHosts[0])
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
-	opts.SandboxName = &s.Sandbox
-	opts.SCName = &s.Subcluster
+	opts.SandboxName = s.Sandbox
+	opts.SCName = s.Subcluster
 
 	// auth options
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/sandbox_sc_vc_test.go
+++ b/pkg/vadmin/sandbox_sc_vc_test.go
@@ -42,10 +42,10 @@ func (m *MockVClusterOps) VSandbox(options *vops.VSandboxOptions) error {
 	}
 
 	// verify basic options
-	if *options.SCName != TestSCName {
+	if options.SCName != TestSCName {
 		return fmt.Errorf("failed to retrieve subcluster name")
 	}
-	if *options.SandboxName != TestSandboxName {
+	if options.SandboxName != TestSandboxName {
 		return fmt.Errorf("failed to retrieve sandbox name")
 	}
 

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	vops "github.com/vertica/vcluster/vclusterops"
-	"github.com/vertica/vcluster/vclusterops/vstruct"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
@@ -58,7 +57,7 @@ func (v *VClusterOps) StartDB(ctx context.Context, opts ...startdb.Option) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	v.Log.Info("Successfully start a database", "dbName", *vopts.DBName)
+	v.Log.Info("Successfully start a database", "dbName", vopts.DBName)
 	return ctrl.Result{}, nil
 }
 
@@ -70,33 +69,32 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 		return vops.VStartDatabaseOptions{}, fmt.Errorf("hosts should not be empty %s", opts.RawHosts)
 	}
 	opts.IPv6 = net.IsIPv6(opts.RawHosts[0])
-	*opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.CatalogPrefix = v.VDB.Spec.Local.GetCatalogPath()
+	opts.DBName = v.VDB.Spec.DBName
 	opts.IsEon = v.VDB.IsEON()
-	opts.OldIsEon = vstruct.MakeNullableBool(opts.IsEon)
 	opts.ConfigurationParameters = s.ConfigurationParams
 	if v.VDB.IsNMASideCarDeploymentEnabled() {
-		*opts.StartUpConf = paths.StartupConfFile
+		opts.StartUpConf = paths.StartupConfFile
 	}
 
 	// Provide communal storage location to vclusterops only after revive_db because
 	// we do not need to access communal storage in start_db after create_db.
 	if v.VDB.Spec.InitPolicy == vapi.CommunalInitPolicyRevive {
-		*opts.CommunalStorageLocation = s.CommunalPath
+		opts.CommunalStorageLocation = s.CommunalPath
 	}
 
 	// auth options
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	// timeout option
-	*opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
+	opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
 
 	// other options
-	*opts.TrimHostList = true
+	opts.TrimHostList = true
 
 	return opts, nil
 }

--- a/pkg/vadmin/start_db_vc_test.go
+++ b/pkg/vadmin/start_db_vc_test.go
@@ -45,18 +45,18 @@ func (m *MockVClusterOps) VStartDatabase(options *vops.VStartDatabaseOptions) (*
 	if err != nil {
 		return nil, err
 	}
-	err = m.VerifyCommunalStorageOptions(*options.CommunalStorageLocation, options.ConfigurationParameters)
+	err = m.VerifyCommunalStorageOptions(options.CommunalStorageLocation, options.ConfigurationParameters)
 	if err != nil {
 		return nil, err
 	}
 
 	// verify catalog prefix
-	if *options.CatalogPrefix != TestCatalogPrefix {
+	if options.CatalogPrefix != TestCatalogPrefix {
 		return nil, fmt.Errorf("failed to retrieve catalog prefix")
 	}
 
 	// verify timeout
-	if *options.StatePollingTimeout != TestTimeout {
+	if options.StatePollingTimeout != TestTimeout {
 		return nil, fmt.Errorf("failed to retrieve timeout")
 	}
 

--- a/pkg/vadmin/stop_db_vc.go
+++ b/pkg/vadmin/stop_db_vc.go
@@ -41,7 +41,7 @@ func (v *VClusterOps) StopDB(_ context.Context, opts ...stopdb.Option) error {
 		return err
 	}
 
-	v.Log.Info("Successfully stopped a database", "dbName", *vopts.DBName)
+	v.Log.Info("Successfully stopped a database", "dbName", vopts.DBName)
 	return nil
 }
 
@@ -52,11 +52,11 @@ func (v *VClusterOps) genStopDBOptions(s *stopdb.Parms) vops.VStopDatabaseOption
 	v.Log.Info("Setup stop db options", "hosts", opts.RawHosts[0])
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
-	opts.DBName = &v.VDB.Spec.DBName
+	opts.DBName = v.VDB.Spec.DBName
 	opts.IsEon = v.VDB.IsEON()
 
 	// auth options
-	*opts.UserName = v.VDB.GetVerticaUser()
+	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
 
 	return opts

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -125,7 +125,7 @@ func (m *MockVClusterOps) VerifyDBNameAndIPv6(options *vops.DatabaseOptions) err
 	if options.IPv6 != TestIPv6 {
 		return fmt.Errorf("failed to retrieve IPv6")
 	}
-	if *options.DBName != TestDBName {
+	if options.DBName != TestDBName {
 		return fmt.Errorf("failed to retrieve database name")
 	}
 
@@ -141,7 +141,7 @@ func (m *MockVClusterOps) VerifyCommonOptions(options *vops.DatabaseOptions) err
 	}
 
 	// verify auth options
-	if *options.UserName != vapi.SuperUser {
+	if options.UserName != vapi.SuperUser {
 		return fmt.Errorf("failed to retrieve Vertica username")
 	}
 	if *options.Password != TestPassword {
@@ -213,13 +213,13 @@ func (m *MockVClusterOps) VerifyFilterOptions(options *vops.ShowRestorePointFilt
 	if options == nil {
 		return fmt.Errorf("failed to retrieve filter options")
 	}
-	if options.ArchiveName == nil || *options.ArchiveName != TestArchiveName {
+	if options.ArchiveName == "" || options.ArchiveName != TestArchiveName {
 		return fmt.Errorf("failed to retrieve archive name filter")
 	}
-	if options.StartTimestamp == nil || *options.StartTimestamp != TestStartTimestamp {
+	if options.StartTimestamp == "" || options.StartTimestamp != TestStartTimestamp {
 		return fmt.Errorf("failed to retrieve start timestamp filter")
 	}
-	if options.EndTimestamp == nil || *options.EndTimestamp != TestEndTimestamp {
+	if options.EndTimestamp == "" || options.EndTimestamp != TestEndTimestamp {
 		return fmt.Errorf("failed to retrieve end timestamp filter")
 	}
 	return nil


### PR DESCRIPTION
I have a GitHub issue , then I moved #789 to this PR
This pulls in the latest vclusterops library changes. Many of the changes that we are incorporating relate to improvements made to the vcluster CLI:

- Replaced pointer types with value types for all database operations.
- Remove oldIPv6 and update the tests
- Add eon option for remove_sc_vc.go to integrate the changes in remove_subcluster CLI