### PR TITLE
Add support for multiple subclusters in a sandbox

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -168,6 +168,16 @@ func (v *VerticaDB) GenSubclusterMap() map[string]*Subcluster {
 	return scMap
 }
 
+// GenSandboxMap will build a map that can find a sandbox by name.
+func (v *VerticaDB) GenSandboxMap() map[string]*Sandbox {
+	sbMap := map[string]*Sandbox{}
+	for i := range v.Spec.Sandboxes {
+		sb := &v.Spec.Sandboxes[i]
+		sbMap[sb.Name] = sb
+	}
+	return sbMap
+}
+
 // GenSubclusterSandboxMap will scan all sandboxes and return a map
 // with subcluster name as the key and sandbox name as the value
 func (v *VerticaDB) GenSubclusterSandboxMap() map[string]string {
@@ -187,6 +197,17 @@ func (v *VerticaDB) GenSubclusterIndexMap() map[string]int {
 	m := make(map[string]int)
 	for i := range v.Spec.Subclusters {
 		m[v.Spec.Subclusters[i].Name] = i
+	}
+	return m
+}
+
+// GenSandboxIndexMap will create a map that allows us to figure out the index
+// in vdb.Spec.Sandboxes for each sandbox. Returns a map of sandbox name to its
+// index position.
+func (v *VerticaDB) GenSandboxIndexMap() map[string]int {
+	m := make(map[string]int)
+	for i := range v.Spec.Sandboxes {
+		m[v.Spec.Sandboxes[i].Name] = i
 	}
 	return m
 }
@@ -704,7 +725,11 @@ func (v *VerticaDB) GetKerberosServiceName() string {
 }
 
 func (s *Subcluster) IsPrimary() bool {
-	return s.Type == PrimarySubcluster
+	return s.Type == PrimarySubcluster || s.Type == SandboxPrimarySubcluster
+}
+
+func (s *Subcluster) IsSandboxPrimary() bool {
+	return s.Type == SandboxPrimarySubcluster
 }
 
 func (s *Subcluster) IsSecondary() bool {

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -902,6 +902,11 @@ const (
 	PrimarySubcluster   = "primary"
 	SecondarySubcluster = "secondary"
 	TransientSubcluster = "transient"
+	// A sandbox primary subcluster is a secondary subcluster that was the first
+	// subcluster in a sandbox. These subclusters are primaries when they are
+	// sandboxed. When unsandboxed, they will go back to being just a secondary
+	// subcluster
+	SandboxPrimarySubcluster = "sandboxprimary"
 )
 
 // SubclusterStatus defines the per-subcluster status that we track

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -104,8 +104,6 @@ func (v *VerticaDB) ValidateCreate() error {
 	verticadblog.Info("validate create", "name", v.Name, "GroupVersion", GroupVersion)
 
 	allErrs := v.validateVerticaDBSpec()
-	// temporary check added here to make testing easier
-	allErrs = v.validateSandboxSize(allErrs)
 	if allErrs == nil {
 		return nil
 	}
@@ -117,8 +115,6 @@ func (v *VerticaDB) ValidateUpdate(old runtime.Object) error {
 	verticadblog.Info("validate update", "name", v.Name, "GroupVersion", GroupVersion)
 
 	allErrs := append(v.validateImmutableFields(old), v.validateVerticaDBSpec()...)
-	// temporary check added here to make testing easier
-	allErrs = v.validateSandboxSize(allErrs)
 	if allErrs == nil {
 		return nil
 	}
@@ -149,6 +145,44 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 	allErrs = v.checkImmutableSubclusterDuringUpgrade(oldObj, allErrs)
 	allErrs = v.checkImmutableSubclusterInSandbox(oldObj, allErrs)
 	allErrs = v.checkImmutableStsName(oldObj, allErrs)
+	allErrs = v.checkValidSubclusterTypeTransition(oldObj, allErrs)
+	return allErrs
+}
+
+func (v *VerticaDB) checkValidSubclusterTypeTransition(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
+	// Create a map of subclusterName -> type using the old object.
+	nameToTypeMap := map[string]string{}
+	for i := range oldObj.Spec.Subclusters {
+		sc := oldObj.Spec.Subclusters[i]
+		nameToTypeMap[sc.Name] = sc.Type
+	}
+	scToSbMap := v.GenSubclusterSandboxMap()
+	// Helper function to log an error
+	invalidStateTransitionErr := func(inx int) {
+		path := field.NewPath("spec").Child("subclusters").Index(inx).Child("type")
+		err := field.Invalid(path,
+			v.Spec.Subclusters[inx].Type,
+			fmt.Sprintf("subcluster %s has invalid type change", v.Spec.Subclusters[inx].Name))
+		allErrs = append(allErrs, err)
+	}
+	// Go through new object to see that existing subclusters have a valid type change.
+	for i := range v.Spec.Subclusters {
+		sc := v.Spec.Subclusters[i]
+		oldType, ok := nameToTypeMap[sc.Name]
+		// Can skip new subclusters
+		if !ok {
+			continue
+		}
+		if (oldType == PrimarySubcluster || oldType == TransientSubcluster) && oldType != sc.Type {
+			invalidStateTransitionErr(i)
+		} else if oldType == SecondarySubcluster && sc.Type != SecondarySubcluster {
+			_, found := scToSbMap[sc.Name]
+			// You can only transition out of a secondary subcluster if its during sandboxing.
+			if sc.Type != SandboxPrimarySubcluster || !found {
+				invalidStateTransitionErr(i)
+			}
+		}
+	}
 	return allErrs
 }
 
@@ -208,15 +242,16 @@ func (v *VerticaDB) hasAtLeastOneSC(allErrs field.ErrorList) field.ErrorList {
 func (v *VerticaDB) hasValidSubclusterTypes(allErrs field.ErrorList) field.ErrorList {
 	for i := range v.Spec.Subclusters {
 		sc := &v.Spec.Subclusters[i]
-		if sc.Type == PrimarySubcluster || sc.Type == SecondarySubcluster || sc.Type == TransientSubcluster {
+		if sc.Type == PrimarySubcluster || sc.Type == SecondarySubcluster ||
+			sc.Type == TransientSubcluster || sc.Type == SandboxPrimarySubcluster {
 			continue
 		}
 		fieldPrefix := field.NewPath("spec").Child("subclusters").Index(i)
 		err := field.Invalid(fieldPrefix.Child("type"),
 			sc.Type,
 			fmt.Sprintf("subcluster type is invalid. A valid case-sensitive type a user can specify is %q or %q. "+
-				"(%q is a valid type that should only be set by the operator during online upgrade)",
-				PrimarySubcluster, SecondarySubcluster, TransientSubcluster))
+				"(%q and %q are valid types that should only be set by the operator)",
+				PrimarySubcluster, SecondarySubcluster, SandboxPrimarySubcluster, TransientSubcluster))
 		allErrs = append(allErrs, err)
 	}
 	return allErrs
@@ -497,28 +532,6 @@ func (v *VerticaDB) hasValidSvcAndScName(allErrs field.ErrorList) field.ErrorLis
 	return allErrs
 }
 
-// validateSandboxSize is a temporary check that makes sure each sandbox
-// contains only one subcluster. This is needed until we figure out how to get
-// a sandboxed subcluster's type and how to set it in the podfacts
-func (v *VerticaDB) validateSandboxSize(allErrs field.ErrorList) field.ErrorList {
-	// if vdb does not have any sandboxes, skip this check
-	if len(v.Spec.Sandboxes) == 0 {
-		return allErrs
-	}
-	for i := range v.Spec.Sandboxes {
-		if len(v.Spec.Sandboxes[i].Subclusters) > 1 {
-			fieldPrefix := field.NewPath("spec").Child("sandboxes").Index(i)
-			err := field.Invalid(
-				fieldPrefix.Child("subclusters"),
-				v.Spec.Sandboxes[i].Subclusters,
-				"there can only be one subcluster in a sandbox",
-			)
-			allErrs = append(allErrs, err)
-		}
-	}
-	return allErrs
-}
-
 func isNodePortNumberInvalid(port int32) bool {
 	return port != 0 && (port < portLowerBound || port > portUpperBound)
 }
@@ -748,25 +761,6 @@ func (v *VerticaDB) hasValidTemporarySubclusterRouting(allErrs field.ErrorList) 
 		allErrs = append(allErrs, err)
 	}
 	return allErrs
-}
-
-func (v *VerticaDB) isSubclusterTypeIsChanging(oldObj *VerticaDB) (ok bool, scInx int) {
-	// Create a map of subclusterName -> type using the old object.
-	nameToPrimaryMap := map[string]string{}
-	for i := range oldObj.Spec.Subclusters {
-		sc := oldObj.Spec.Subclusters[i]
-		nameToPrimaryMap[sc.Name] = sc.Type
-	}
-	// Go through new object to see that type isn't changing for any
-	// existing subcluster
-	for i := range v.Spec.Subclusters {
-		sc := v.Spec.Subclusters[i]
-		oldType, ok := nameToPrimaryMap[sc.Name]
-		if ok && oldType != sc.Type {
-			return true, i
-		}
-	}
-	return false, 0
 }
 
 // matchingServiceNamesAreConsistent ensures that any subclusters that share the
@@ -1170,12 +1164,23 @@ func (v *VerticaDB) validateSubclustersInSandboxes(allErrs field.ErrorList) fiel
 
 	// check if a non-existing subcluster is defined in a sandbox
 	scMap := v.GenSubclusterMap()
+	// Also keep track of the number of sandbox primary in a sandbox. We can
+	// only have at most 1.
+	primarySubclustersInSandboxes := map[string]int{}
 	for sc, i := range seenScWithSbIndex {
 		if scInfo, ok := scMap[sc]; !ok {
 			err := field.Invalid(path.Index(i),
 				sandboxes[i],
 				fmt.Sprintf("subcluster %s does not exist", sc))
 			allErrs = append(allErrs, err)
+		} else if scInfo.IsSandboxPrimary() {
+			primarySubclustersInSandboxes[sandboxes[i].Name]++
+			if primarySubclustersInSandboxes[sandboxes[i].Name] > 1 {
+				err := field.Invalid(path.Index(i),
+					sandboxes[i],
+					"cannot have more than one sandbox primary in a sandbox")
+				allErrs = append(allErrs, err)
+			}
 		} else if scInfo.IsPrimary() {
 			err := field.Invalid(path.Index(i),
 				sandboxes[i],
@@ -1250,14 +1255,6 @@ func (v *VerticaDB) checkImmutableBasic(oldObj *VerticaDB, allErrs field.ErrorLi
 		err := field.Invalid(field.NewPath("spec").Child("subclusters"),
 			v.Spec.Subclusters,
 			"at least one subcluster name should match its old name")
-		allErrs = append(allErrs, err)
-	}
-	// validate that for existing subclusters that we don't change the
-	// primary/secondary type
-	if ok, inx := v.isSubclusterTypeIsChanging(oldObj); ok {
-		err := field.Invalid(field.NewPath("spec").Child("subclusters").Index(inx).Child("type"),
-			v.Spec.Subclusters[inx].Type,
-			fmt.Sprintf("subcluster %s cannot have it's type change", v.Spec.Subclusters[inx].Name))
 		allErrs = append(allErrs, err)
 	}
 	return allErrs
@@ -1599,22 +1596,53 @@ func (v *VerticaDB) checkImmutableSubclusterInSandbox(oldObj *VerticaDB, allErrs
 	}
 
 	// find subclusters that are sandboxed in old vdb but removed in new vdb
-	oldSandboxes := oldObj.Spec.Sandboxes
-	scInSandbox := make(map[string]any)
-	for _, sandbox := range oldSandboxes {
-		for _, sc := range sandbox.Subclusters {
-			scInSandbox[sc.Name] = struct{}{}
-		}
-	}
+	oldScInSandbox := oldObj.GenSubclusterSandboxMap()
 	removedScs := vutil.MapKeyDiff(oldScMap, newScMap)
 	for _, sc := range removedScs {
-		if _, ok := scInSandbox[sc]; ok {
+		if _, ok := oldScInSandbox[sc]; ok {
 			i := oldScIndexMap[sc]
 			err := field.Invalid(path.Index(i),
 				oldObj.Spec.Subclusters[i],
 				fmt.Sprintf("Cannot remove subcluster %q when it is in a sandbox", sc))
 			allErrs = append(allErrs, err)
 			continue
+		}
+	}
+
+	newScInSandbox := v.GenSubclusterSandboxMap()
+	oldSbIndexMap := v.GenSandboxIndexMap()
+	oldSbMap := v.GenSandboxMap()
+
+	// This loop ensures a couple of things:
+	// - a sandbox primary subcluster cannot be moved to another sandbox
+	// - cannot remove the sandbox primary subcluster from a sandbox
+	// The sandbox primary subcluster must stay constant until the sandbox is
+	// removed entirely.
+	for oldScName, oldSbName := range oldScInSandbox {
+		newSbName, newFound := newScInSandbox[oldScName]
+		sc := oldScMap[oldScName]
+
+		if !newFound && sc.Type == SandboxPrimarySubcluster {
+			i := oldScIndexMap[oldScName]
+			err := field.Invalid(path.Index(i),
+				oldObj.Spec.Subclusters[i],
+				fmt.Sprintf("Cannot remove primary subcluster %q from the sandbox", oldScName))
+			allErrs = append(allErrs, err)
+			continue
+		}
+
+		// Remaining check is concerned with subclusters moving between sandboxes.
+		if oldSbName == newSbName {
+			continue
+		}
+		if sc.Type == SandboxPrimarySubcluster {
+			i := oldSbIndexMap[oldSbName]
+			p := field.NewPath("spec").Child("sandboxes")
+			err := field.Invalid(p.Index(i),
+				oldSbMap[oldSbName],
+				fmt.Sprintf("cannot remove the primary subcluster from sandbox %q unless you are removing the sandbox",
+					oldScName))
+			allErrs = append(allErrs, err)
 		}
 	}
 

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -469,7 +469,7 @@ func (v *VerticaDB) getClusterSize() int {
 		// we calculate the cluster size on the primary nodes only
 		for i := range v.Spec.Subclusters {
 			sc := &v.Spec.Subclusters[i]
-			if sc.IsPrimary() {
+			if sc.IsPrimary() && !sc.IsSandboxPrimary() {
 				sizeSum += int(sc.Size)
 			}
 		}

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 var _ = Describe("verticadb_webhook", func() {
@@ -1129,26 +1128,6 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(vdb.validateVerticaDBSpec()).Should(HaveLen(1))
 	})
 
-	It("should validate the number of subclusters in each sandbox", func() {
-		vdb := MakeVDB()
-		// no sandboxes -> should be empty
-		Ω(vdb.validateSandboxSize(field.ErrorList{})).Should(HaveLen(0))
-
-		vdb.Spec.Sandboxes = []Sandbox{
-			{Name: "sandbox1", Subclusters: []SubclusterName{{Name: "sc1"}}},
-			{Name: "sandbox2", Subclusters: []SubclusterName{{Name: "sc2"}}},
-		}
-		// only one subcluster in each sandbox -> should be empty
-		Ω(vdb.validateSandboxSize(field.ErrorList{})).Should(HaveLen(0))
-
-		vdb.Spec.Sandboxes = []Sandbox{
-			{Name: "sandbox1", Subclusters: []SubclusterName{{Name: "sc1"}}},
-			{Name: "sandbox2", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
-		}
-		// cannot have a sandbox with more than one subcluster
-		Ω(vdb.validateSandboxSize(field.ErrorList{})).Should(HaveLen(1))
-	})
-
 	It("should prevent the statefulset name from changing for existing subclusters", func() {
 		newVdb := MakeVDB()
 		oldVdb := newVdb.DeepCopy()
@@ -1165,6 +1144,78 @@ var _ = Describe("verticadb_webhook", func() {
 			},
 		)
 		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+	})
+
+	It("should prevent removing the primary subcluster from a sandbox", func() {
+		oldVdb := MakeVDB()
+		oldVdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1", Type: PrimarySubcluster, Size: 1},
+			{Name: "sc2", Type: SecondarySubcluster, Size: 1},
+			{Name: "sc3", Type: SandboxPrimarySubcluster, Size: 1},
+		}
+		oldVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+		}
+		newVdb := oldVdb.DeepCopy()
+		newVdb.Spec.Sandboxes[0].Subclusters = []SubclusterName{{Name: "sc2"}}
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
+		newVdb.Spec.Sandboxes[0].Subclusters = []SubclusterName{{Name: "sc3"}}
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes = nil
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+	})
+
+	It("should prevent switching the primary subcluster in two sandboxes", func() {
+		oldVdb := MakeVDB()
+		oldVdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1", Type: PrimarySubcluster, Size: 1},
+			{Name: "sc2", Type: SecondarySubcluster, Size: 1},
+			{Name: "sc3", Type: SandboxPrimarySubcluster, Size: 1},
+			{Name: "sc4", Type: SecondarySubcluster, Size: 1},
+			{Name: "sc5", Type: SandboxPrimarySubcluster, Size: 1},
+		}
+		oldVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+			{Name: "sand2", Subclusters: []SubclusterName{{Name: "sc4"}, {Name: "sc5"}}},
+		}
+		newVdb := oldVdb.DeepCopy()
+		newVdb.Spec.Sandboxes[0].Name = "sand2"
+		newVdb.Spec.Sandboxes[1].Name = "sand1"
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(2))
+	})
+
+	It("should not allow a sandbox to have multiple primary subclusters", func() {
+		vdb := MakeVDBForVclusterOps()
+		vdb.ObjectMeta.Annotations[vmeta.VersionAnnotation] = SandboxSupportedMinVersion
+		vdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc2", Type: SandboxPrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc3", Type: SandboxPrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
+		}
+		vdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+		}
+		Ω(vdb.validateVerticaDBSpec()).Should(HaveLen(1))
+		vdb.Spec.Subclusters[1].Type = SecondarySubcluster
+		Ω(vdb.validateVerticaDBSpec()).Should(HaveLen(0))
+	})
+
+	It("should only allow sc type change for secondaries in a sandbox", func() {
+		oldVdb := MakeVDB()
+		oldVdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1", Type: PrimarySubcluster, Size: 3},
+			{Name: "sc2", Type: SecondarySubcluster, Size: 1},
+			{Name: "sc3", Type: SecondarySubcluster, Size: 1},
+		}
+		newVdb := oldVdb.DeepCopy()
+		newVdb.Spec.Subclusters[2].Type = SandboxPrimarySubcluster
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
+		newVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc3"}}},
+		}
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+		newVdb.Spec.Subclusters[1].Type = PrimarySubcluster
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
 	})
 })
 

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -328,6 +328,7 @@ func convertFromSubcluster(src *v1.Subcluster) Subcluster {
 		Size:                src.Size,
 		IsPrimary:           src.IsPrimary(),
 		IsTransient:         src.IsTransient(),
+		IsSandboxPrimary:    src.IsSandboxPrimary(),
 		ImageOverride:       src.ImageOverride,
 		NodeSelector:        src.NodeSelector,
 		Affinity:            Affinity(src.Affinity),
@@ -566,6 +567,9 @@ func convertFromStatusCondition(src *metav1.Condition) VerticaDBCondition {
 // convertToSubclusterType returns the v1 Subcluster type for a given v1beta1
 // Subcluster
 func convertToSubclusterType(src *Subcluster) string {
+	if src.IsSandboxPrimary {
+		return v1.SandboxPrimarySubcluster
+	}
 	if src.IsPrimary {
 		return v1.PrimarySubcluster
 	}

--- a/api/v1beta1/verticadb_conversion_test.go
+++ b/api/v1beta1/verticadb_conversion_test.go
@@ -226,6 +226,31 @@ var _ = Describe("verticadb_conversion", func() {
 		Ω(v1beta1VDB.Spec.Subclusters[0].IsPrimary).Should(BeFalse())
 	})
 
+	It("should convert between sandbox subcluster types", func() {
+		v1beta1VDB := MakeVDB()
+		v1VDB := v1.VerticaDB{}
+
+		// v1beta1 -> v1
+		v1beta1VDB.Spec.Subclusters[0].IsPrimary = true
+		v1beta1VDB.Spec.Subclusters[0].IsSandboxPrimary = true
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Spec.Subclusters[0].Type).Should(Equal(v1.SandboxPrimarySubcluster))
+		v1beta1VDB.Spec.Subclusters[0].IsPrimary = false
+		Ω(v1VDB.Spec.Subclusters[0].Type).Should(Equal(v1.SandboxPrimarySubcluster))
+		v1beta1VDB.Spec.Subclusters[0].IsSandboxPrimary = false
+		Ω(v1beta1VDB.ConvertTo(&v1VDB)).Should(Succeed())
+		Ω(v1VDB.Spec.Subclusters[0].Type).Should(Equal(v1.SecondarySubcluster))
+
+		// v1 -> v1beta1
+		v1VDB.Spec.Subclusters[0].Type = v1.SandboxPrimarySubcluster
+		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
+		Ω(v1beta1VDB.Spec.Subclusters[0].IsPrimary).Should(BeTrue())
+		Ω(v1beta1VDB.Spec.Subclusters[0].IsSandboxPrimary).Should(BeTrue())
+		v1VDB.Spec.Subclusters[0].Type = v1.SecondarySubcluster
+		Ω(v1beta1VDB.ConvertFrom(&v1VDB)).Should(Succeed())
+		Ω(v1beta1VDB.Spec.Subclusters[0].IsSandboxPrimary).Should(BeFalse())
+	})
+
 	It("should convert isTransient", func() {
 		v1beta1VDB := MakeVDB()
 		v1VDB := v1.VerticaDB{}

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -778,6 +778,14 @@ type Subcluster struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// A sandbox primary subcluster is a secondary subcluster that was the first
+	// subcluster in a sandbox. These subclusters are primaries when they are
+	// sandboxed. When unsandboxed, they will go back to being just a secondary
+	// subcluster
+	IsSandboxPrimary bool `json:"isSandboxPrimary"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
 	// This allows a different image to be used for the subcluster than the one
 	// in VerticaDB.  This is intended to be used internally by the online image
 	// change process.

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -393,7 +393,6 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 		// belongs to a sandbox. If the node is up, we will later retrieve
 		// the sandbox state from the catalog
 		pf.sandbox = sts.Labels[vmeta.SandboxNameLabel]
-		setSandboxNodeType(&pf)
 	}
 
 	fns := []CheckerFunc{
@@ -1161,19 +1160,6 @@ func (p *PodFacts) GetClusterExtendedName() string {
 		return "main cluster"
 	}
 	return fmt.Sprintf("sandbox %s", sbName)
-}
-
-// setSandboxNodeType sets the isPrimary state for a sandboxed
-// subcluster's node
-func setSandboxNodeType(pf *PodFact) {
-	// For nodes that belong to a sandboxed subcluster, we cannot rely
-	// on the VDB subcluster state. There is still some work needed in
-	// order to figure out how to get the subcluster type for a sandboxed
-	// node. In the meantime, we are going to limit a sandbox size to
-	// one subcluster and default its type to primary
-	if pf.sandbox != vapi.MainCluster {
-		pf.isPrimary = true
-	}
 }
 
 // checkIfNodeUpCmd builds and returns the command to check

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
@@ -18,18 +18,21 @@ package vdb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/sandboxsc"
 	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
+	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,12 +41,12 @@ import (
 
 // SandboxSubclusterReconciler will add subclusters to sandboxes
 type SandboxSubclusterReconciler struct {
-	VRec        *VerticaDBReconciler
-	Log         logr.Logger
-	Vdb         *vapi.VerticaDB // Vdb is the CRD we are acting on
-	PFacts      *PodFacts
-	InitiatorIP string // The IP of the pod that we run vclusterOps from
-	Dispatcher  vadmin.Dispatcher
+	VRec         *VerticaDBReconciler
+	Log          logr.Logger
+	Vdb          *vapi.VerticaDB // Vdb is the CRD we are acting on
+	PFacts       *PodFacts
+	InitiatorIPs map[string]string // IPs from main cluster and sandboxes that should be passed down to vcluster
+	Dispatcher   vadmin.Dispatcher
 	client.Client
 }
 
@@ -51,12 +54,13 @@ type SandboxSubclusterReconciler struct {
 func MakeSandboxSubclusterReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger, vdb *vapi.VerticaDB,
 	pfacts *PodFacts, dispatcher vadmin.Dispatcher, cli client.Client) controllers.ReconcileActor {
 	return &SandboxSubclusterReconciler{
-		VRec:       vdbrecon,
-		Log:        log.WithName("SandboxSubclusterReconciler"),
-		Vdb:        vdb,
-		PFacts:     pfacts,
-		Dispatcher: dispatcher,
-		Client:     cli,
+		VRec:         vdbrecon,
+		Log:          log.WithName("SandboxSubclusterReconciler"),
+		Vdb:          vdb,
+		InitiatorIPs: make(map[string]string),
+		PFacts:       pfacts,
+		Dispatcher:   dispatcher,
+		Client:       cli,
 	}
 }
 
@@ -131,20 +135,21 @@ func (s *SandboxSubclusterReconciler) sandboxSubclusters(ctx context.Context) (c
 		return ctrl.Result{}, nil
 	}
 
-	// find an initiator to call vclusterOps
+	// find an initiator from the main cluster that we can use to pass down to
+	// vclusterOps.
 	initiator, ok := s.PFacts.findFirstPodSorted(func(v *PodFact) bool {
 		return v.sandbox == vapi.MainCluster && v.isPrimary && v.upNode
 	})
 	if ok {
-		s.InitiatorIP = initiator.podIP
+		s.InitiatorIPs[vapi.MainCluster] = initiator.podIP
 	} else {
 		s.Log.Info("Requeue because there are no UP nodes in main cluster to execute sandbox operation")
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	err := s.executeSandboxCommand(ctx, scSbMap)
-	if err != nil {
-		return ctrl.Result{}, err
+	res, err := s.executeSandboxCommand(ctx, scSbMap)
+	if verrors.IsReconcileAborted(res, err) {
+		return res, err
 	}
 	s.PFacts.Invalidate()
 
@@ -153,27 +158,86 @@ func (s *SandboxSubclusterReconciler) sandboxSubclusters(ctx context.Context) (c
 
 // executeSandboxCommand will call sandbox API in vclusterOps, create/update sandbox config maps,
 // and update sandbox status in vdb
-func (s *SandboxSubclusterReconciler) executeSandboxCommand(ctx context.Context, scSbMap map[string]string) error {
+func (s *SandboxSubclusterReconciler) executeSandboxCommand(ctx context.Context, scSbMap map[string]string) (ctrl.Result, error) {
 	succeedSbScMap := make(map[string][]string)
 	seenSandboxes := make(map[string]any)
-	for sc, sb := range scSbMap {
-		err := s.sandboxSubcluster(ctx, sc, sb)
-		if err != nil {
-			// when one subcluster failed to be sandboxed, update sandbox status and return error
-			return errors.Join(err, s.updateSandboxStatus(ctx, succeedSbScMap))
-		}
-		succeedSbScMap[sb] = append(succeedSbScMap[sb], sc)
-		// create/update a sandbox config map
-		if _, ok := seenSandboxes[sb]; !ok {
-			err = s.checkSandboxConfigMap(ctx, sb)
-			if err != nil {
-				// when creating/updating sandbox config map failed, update sandbox status and return error
-				return errors.Join(err, s.updateSandboxStatus(ctx, succeedSbScMap))
+
+	// We can simply loop over the scSbMap and sandbox each subcluster. However,
+	// we want to sandbox in a determinstic order because the first subcluster
+	// in a sandbox is the primary.
+	for i := range s.Vdb.Spec.Sandboxes {
+		vdbSb := &s.Vdb.Spec.Sandboxes[i]
+		for j := range vdbSb.Subclusters {
+			sc := vdbSb.Subclusters[j].Name
+			sb, found := scSbMap[sc]
+			if !found {
+				// assume it is already sandboxed
+				continue
 			}
+			// The first subcluster in a sandbox turns into a primary. Set
+			// state in the vdb to indicate that.
+			if j == 0 {
+				_, err := vk8s.UpdateVDBWithRetry(ctx, s.VRec, s.Vdb, func() (bool, error) {
+					scMap := s.Vdb.GenSubclusterMap()
+					vdbSc, found := scMap[sc]
+					if !found {
+						return false, fmt.Errorf("subcluster %q missing in vdb %q", sc, s.Vdb.Name)
+					}
+					vdbSc.Type = vapi.SandboxPrimarySubcluster
+					return true, nil
+				})
+				if err != nil {
+					return ctrl.Result{}, errors.Join(err, s.updateSandboxStatus(ctx, succeedSbScMap))
+				}
+			}
+			res, err := s.sandboxSubcluster(ctx, sc, sb)
+			if verrors.IsReconcileAborted(res, err) {
+				// when one subcluster failed to be sandboxed, update sandbox status and return error
+				return res, errors.Join(err, s.updateSandboxStatus(ctx, succeedSbScMap))
+			}
+			succeedSbScMap[sb] = append(succeedSbScMap[sb], sc)
+			// create/update a sandbox config map
+			if _, ok := seenSandboxes[sb]; !ok {
+				err = s.checkSandboxConfigMap(ctx, sb)
+				if err != nil {
+					// when creating/updating sandbox config map failed, update sandbox status and return error
+					return ctrl.Result{}, errors.Join(err, s.updateSandboxStatus(ctx, succeedSbScMap))
+				}
+			}
+			seenSandboxes[sb] = struct{}{}
 		}
-		seenSandboxes[sb] = struct{}{}
 	}
-	return s.updateSandboxStatus(ctx, succeedSbScMap)
+	return ctrl.Result{}, s.updateSandboxStatus(ctx, succeedSbScMap)
+}
+
+// findInitiatorIPs returns the IPs to pass down to vclusterops as the initiator
+// nodes. The number of IPs could be one or two. If two, they are separated with
+// a comma.
+func (s *SandboxSubclusterReconciler) findInitiatorIPs(ctx context.Context, sandbox string) ([]string, ctrl.Result, error) {
+	// We already have an IP of an up pod from the main cluster. If we are
+	// adding to an existing sandbox, then we need to find an IP from a pod in
+	// that sandbox too.
+	_, found := s.InitiatorIPs[sandbox]
+	if !found {
+		pfs := s.PFacts.Copy(sandbox)
+		if err := pfs.Collect(ctx, s.Vdb); err != nil {
+			return nil, ctrl.Result{}, err
+		}
+		// If this is the first pod in the sandbox, then only an API from the
+		// main cluster is needed.
+		if len(pfs.Detail) == 0 {
+			return []string{s.InitiatorIPs[vapi.MainCluster]}, ctrl.Result{}, nil
+		}
+		pf, found := pfs.findFirstPodSorted(func(v *PodFact) bool {
+			return v.upNode
+		})
+		if !found {
+			s.Log.Info("Requeue because there are no UP nodes in the target sandbox", "sandbox", sandbox)
+			return nil, ctrl.Result{Requeue: true}, nil
+		}
+		s.InitiatorIPs[sandbox] = pf.podIP
+	}
+	return []string{s.InitiatorIPs[vapi.MainCluster], s.InitiatorIPs[sandbox]}, ctrl.Result{}, nil
 }
 
 // checkSandboxConfigMap will create or update a sandbox config map if needed
@@ -273,22 +337,27 @@ func (s *SandboxSubclusterReconciler) fetchSubclustersWithSandboxes() (map[strin
 }
 
 // sandboxSubcluster will add a subcluster to a sandbox by calling vclusterOps
-func (s *SandboxSubclusterReconciler) sandboxSubcluster(ctx context.Context, subcluster, sandbox string) error {
+func (s *SandboxSubclusterReconciler) sandboxSubcluster(ctx context.Context, subcluster, sandbox string) (ctrl.Result, error) {
+	initiatorIPs, res, err := s.findInitiatorIPs(ctx, sandbox)
+	if verrors.IsReconcileAborted(res, err) {
+		return res, err
+	}
+
 	s.VRec.Eventf(s.Vdb, corev1.EventTypeNormal, events.SandboxSubclusterStart,
 		"Starting add subcluster %q to sandbox %q", subcluster, sandbox)
-	err := s.Dispatcher.SandboxSubcluster(ctx,
-		sandboxsc.WithInitiator(s.InitiatorIP),
+	err = s.Dispatcher.SandboxSubcluster(ctx,
+		sandboxsc.WithInitiators(initiatorIPs),
 		sandboxsc.WithSubcluster(subcluster),
 		sandboxsc.WithSandbox(sandbox),
 	)
 	if err != nil {
 		s.VRec.Eventf(s.Vdb, corev1.EventTypeWarning, events.SandboxSubclusterFailed,
 			"Failed to add subcluster %q to sandbox %q", subcluster, sandbox)
-		return err
+		return ctrl.Result{}, err
 	}
 	s.VRec.Eventf(s.Vdb, corev1.EventTypeNormal, events.SandboxSubclusterSucceeded,
 		"Successfully added subcluster %q to sandbox %q", subcluster, sandbox)
-	return nil
+	return ctrl.Result{}, nil
 }
 
 // updateSandboxStatus will update sandbox status in vdb

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
@@ -229,7 +229,7 @@ func (s *SandboxSubclusterReconciler) findInitiatorIPs(ctx context.Context, sand
 			return []string{s.InitiatorIPs[vapi.MainCluster]}, ctrl.Result{}, nil
 		}
 		pf, found := pfs.findFirstPodSorted(func(v *PodFact) bool {
-			return v.upNode
+			return v.upNode && v.isPrimary
 		})
 		if !found {
 			s.Log.Info("Requeue because there are no UP nodes in the target sandbox", "sandbox", sandbox)

--- a/pkg/mockvops/mockvops.go
+++ b/pkg/mockvops/mockvops.go
@@ -16,7 +16,14 @@ limitations under the License.
 
 package mockvops
 
-import "github.com/vertica/vcluster/vclusterops"
+import (
+	"github.com/go-logr/logr"
+	"github.com/vertica/vcluster/vclusterops"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/aterrors"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // MockVClusterOps is used to invoke mock vcluster-ops functions;
 // MockVClusterOps implements vadmin.VClusterProvider interface;
@@ -73,4 +80,13 @@ func (*MockVClusterOps) VFetchNodesDetails(_ *vclusterops.VFetchNodesDetailsOpti
 }
 func (*MockVClusterOps) VSandbox(_ *vclusterops.VSandboxOptions) error {
 	return nil
+}
+
+// MakeMockVClusterOpsDispatch will create a mock vcluster dispatcher
+func MakeMockVClusterOpsDispatcher(vdb *vapi.VerticaDB, logger logr.Logger, cl client.Client,
+	setupAPIFunc func(logr.Logger, string) (vadmin.VClusterProvider, logr.Logger)) *vadmin.VClusterOps {
+	evWriter := aterrors.TestEVWriter{}
+	const testPassword = "secret"
+	dispatcher := vadmin.MakeVClusterOps(logger, vdb, cl, testPassword, &evWriter, setupAPIFunc)
+	return dispatcher.(*vadmin.VClusterOps)
 }

--- a/pkg/vadmin/opts/sandboxsc/opts.go
+++ b/pkg/vadmin/opts/sandboxsc/opts.go
@@ -17,9 +17,9 @@ package sandboxsc
 
 // Params holds all of the option for a sandbox subcluster invocation.
 type Params struct {
-	InitiatorIP string
-	Subcluster  string
-	Sandbox     string
+	InitiatorIPs []string
+	Subcluster   string
+	Sandbox      string
 }
 
 type Option func(*Params)
@@ -31,9 +31,9 @@ func (s *Params) Make(opts ...Option) {
 	}
 }
 
-func WithInitiator(initiatorIP string) Option {
+func WithInitiators(initiatorIPs []string) Option {
 	return func(s *Params) {
-		s.InitiatorIP = initiatorIP
+		s.InitiatorIPs = append(s.InitiatorIPs, initiatorIPs...)
 	}
 }
 

--- a/pkg/vadmin/sandbox_sc_vc.go
+++ b/pkg/vadmin/sandbox_sc_vc.go
@@ -50,9 +50,9 @@ func (v *VClusterOps) genSandboxSubclusterOptions(s *sandboxsc.Params) vops.VSan
 
 	opts.DBName = v.VDB.Spec.DBName
 	opts.IsEon = v.VDB.IsEON()
-	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
-	v.Log.Info("Setup sandbox subcluster options", "hosts", opts.RawHosts[0])
-	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
+	opts.RawHosts = append(opts.RawHosts, s.InitiatorIPs...)
+	v.Log.Info("Setup sandbox subcluster options", "hosts", opts.RawHosts)
+	opts.IPv6 = net.IsIPv6(s.InitiatorIPs[0])
 
 	opts.SandboxName = s.Sandbox
 	opts.SCName = s.Subcluster

--- a/pkg/vadmin/sandbox_sc_vc_test.go
+++ b/pkg/vadmin/sandbox_sc_vc_test.go
@@ -59,7 +59,7 @@ var _ = Describe("sandbox_sc_vc", func() {
 		dispatcher := mockVClusterOpsDispatcher()
 		dispatcher.VDB.Spec.DBName = TestDBName
 		Ω(dispatcher.SandboxSubcluster(ctx,
-			sandboxsc.WithInitiator(TestInitiatorIP),
+			sandboxsc.WithInitiators([]string{TestInitiatorIP}),
 			sandboxsc.WithSubcluster(TestSCName),
 			sandboxsc.WithSandbox(TestSandboxName))).Should(Succeed())
 	})

--- a/pkg/vk8s/k8s.go
+++ b/pkg/vk8s/k8s.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -37,4 +38,31 @@ func FetchVDB(ctx context.Context, vrec config.ReconcilerInterface, obj runtime.
 		return ctrl.Result{Requeue: true}, nil
 	}
 	return ctrl.Result{}, err
+}
+
+// UpdateVDBWithRetry will update the VDB by way of a callback. This is done in a retry
+// loop in case there is a write conflict.
+func UpdateVDBWithRetry(ctx context.Context, vrec config.ReconcilerInterface, vdb *v1.VerticaDB,
+	callbackFn func() (bool, error)) (updated bool, err error) {
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := vrec.GetClient().Get(ctx, vdb.ExtractNamespacedName(), vdb)
+		if err != nil {
+			return err
+		}
+
+		needToUpdate, err := callbackFn()
+		if err != nil {
+			return err
+		}
+
+		if !needToUpdate {
+			return nil
+		}
+		err = vrec.GetClient().Update(ctx, vdb)
+		if err == nil {
+			updated = true
+		}
+		return err
+	})
+	return
 }

--- a/pkg/vk8s/k8s_test.go
+++ b/pkg/vk8s/k8s_test.go
@@ -1,0 +1,75 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vk8s
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockVRec struct{}
+
+func (m mockVRec) Event(vdb runtime.Object, eventType, reason, message string) {}
+func (m mockVRec) Eventf(vdb runtime.Object, eventType, reason, messageFmt string, args ...interface{}) {
+}
+func (m mockVRec) GetClient() client.Client { return k8sClient }
+func (m mockVRec) GetEventRecorder() record.EventRecorder {
+	return mgr.GetEventRecorderFor(vmeta.OperatorName)
+}
+func (m mockVRec) GetConfig() *rest.Config { return nil }
+
+var _ = Describe("vk8s/k8s", func() {
+	ctx := context.Background()
+
+	It("should be able to update the vdb with a callback", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		vrec := mockVRec{}
+		updated, err := UpdateVDBWithRetry(ctx, vrec, vdb, func() (bool, error) {
+			vdb.Spec.Subclusters[0].Size = 99
+			return true, nil
+		})
+		Ω(updated).Should(BeTrue())
+		Ω(err).Should(Succeed())
+		Ω(vdb.Spec.Subclusters[0].Size).Should(Equal(int32(99)))
+		fetchVDB := vapi.VerticaDB{}
+		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), &fetchVDB)).Should(Succeed())
+		Ω(fetchVDB.Spec.Subclusters[0].Size).Should(Equal(int32(99)))
+	})
+
+	It("fetch of a non-existent vdb should generate an event", func() {
+		vdb := vapi.MakeVDB()
+		vrec := mockVRec{}
+		Ω(FetchVDB(ctx, vrec, vdb, vdb.ExtractNamespacedName(), vdb)).Should(Equal(ctrl.Result{Requeue: true}))
+
+		vdb = vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		Ω(FetchVDB(ctx, vrec, vdb, vdb.ExtractNamespacedName(), vdb)).Should(Equal(ctrl.Result{}))
+	})
+})

--- a/pkg/vk8s/suite_test.go
+++ b/pkg/vk8s/suite_test.go
@@ -25,16 +25,19 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var logger logr.Logger
 var restCfg *rest.Config
+var mgr manager.Manager
 
 var _ = BeforeSuite(func() {
 	logger = zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
@@ -55,6 +58,12 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(restCfg, client.Options{Scheme: scheme.Scheme})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0", // Disable metrics for the test
+	})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 })
 

--- a/tests/e2e-leg-9/sandbox/30-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/30-assert.yaml
@@ -25,6 +25,16 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-sandbox
+spec:
+  subclusters:
+  - name: pri1
+    type: primary
+  - name: sec1
+    type: sandboxprimary
+  - name: sec2
+    type: secondary
+  - name: sec3
+    type: secondary
 status:
   sandboxes:
     - name: sandbox1

--- a/tests/e2e-leg-9/sandbox/50-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/50-assert.yaml
@@ -11,41 +11,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: v-sandbox-pri1
-status:
-  currentReplicas: 3
-  readyReplicas: 3
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: v-sandbox-sec1
-status:
-  currentReplicas: 3
-  readyReplicas: 3
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: v-sandbox-sec2
-status:
-  currentReplicas: 3
-  readyReplicas: 3
----
 apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-sandbox
-status:
+spec:
   subclusters:
-    - addedToDBCount: 3
-      upNodeCount: 3
-    - addedToDBCount: 3
-      upNodeCount: 3
-    - addedToDBCount: 3
-      upNodeCount: 3
-    - addedToDBCount: 1
-      upNodeCount: 1
+  - name: pri1
+    type: primary
+  - name: sec1
+    type: sandboxprimary
+  - name: sec2
+    type: sandboxprimary
+  - name: sec3
+    type: secondary
+status:
+  sandboxes:
+    - name: sandbox1
+      subclusters:
+        - sec1
+        - sec3
+    - name: sandbox2
+      subclusters:
+        - sec2

--- a/tests/e2e-leg-9/sandbox/50-sandbox-another-sc-to-sec1.yaml
+++ b/tests/e2e-leg-9/sandbox/50-sandbox-another-sc-to-sec1.yaml
@@ -11,41 +11,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: StatefulSet
+apiVersion: vertica.com/v1
+kind: VerticaDB
 metadata:
-  name: v-sandbox-pri1
-status:
-  currentReplicas: 3
-  readyReplicas: 3
+  name: v-sandbox
+spec:
+  sandboxes:
+  - name: sandbox1
+    subclusters:
+      - name: sec1
+      - name: sec3
+  - name: sandbox2
+    subclusters:
+      - name: sec2
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: v-sandbox-sec1
+  labels:
+    vertica.com/sandbox: sandbox1
 status:
-  currentReplicas: 3
   readyReplicas: 3
+  replicas: 3
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: v-sandbox-sec2
+  labels:
+    vertica.com/sandbox: sandbox2
 status:
-  currentReplicas: 3
   readyReplicas: 3
+  replicas: 3
 ---
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
-  name: v-sandbox
+  name: v-sandbox-sec3
+  labels:
+    vertica.com/sandbox: sandbox1
 status:
-  subclusters:
-    - addedToDBCount: 3
-      upNodeCount: 3
-    - addedToDBCount: 3
-      upNodeCount: 3
-    - addedToDBCount: 3
-      upNodeCount: 3
-    - addedToDBCount: 1
-      upNodeCount: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-leg-9/sandbox/55-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-9/sandbox/55-wait-for-steady-state.yaml
@@ -11,25 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-sandbox
-spec:
-  subclusters:
-  - name: pri1
-    type: primary
-  - name: sec1
-    type: sandboxprimary
-  - name: sec2
-    type: sandboxprimary
-  - name: sec3
-    type: secondary
-status:
-  sandboxes:
-    - name: sandbox1
-      subclusters:
-        - sec1
-    - name: sandbox2
-      subclusters:
-        - sec2
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"

--- a/tests/e2e-leg-9/sandbox/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/sandbox/setup-vdb/base/setup-vdb.yaml
@@ -36,6 +36,9 @@ spec:
     - name: sec2
       size: 3
       type: secondary
+    - name: sec3
+      size: 1
+      type: secondary
   certSecrets: []
   imagePullSecrets: []
   volumes: []


### PR DESCRIPTION
This adds support for multiple subclusters in a single sandbox. In order to denote which subclusters are primary in the sandbox, a new subcluster type is added called 'sandboxprimary'. New webhook rules have been added to account for the new subcluster type.

The new type will get added to the first subcluster in a sandbox. We now add subclusters to a sandbox in the order they are defined in the vdb spec. This ensures that we pick a deterministic subcluster as the first one in a sandbox.

When adding a subcluster to an existing sandbox, we need to pass in a host from the main cluster and the sandbox too. This reason this is needed is that we need to replicate the new sandbox state in both the main cluster and in the sandbox. So, the vclusterOps API will update both clusters.

