### PR TITLE
Set VerticaDB name in ConfigMap

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1308,7 +1308,7 @@ func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox
 		// the data should be immutable since dbName and sandboxName are fixed
 		Immutable: &immutable,
 		Data: map[string]string{
-			vapi.VerticaDBNameKey: vdb.Spec.DBName,
+			vapi.VerticaDBNameKey: vdb.Name,
 			vapi.SandboxNameKey:   sandbox,
 		},
 	}

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler_test.go
@@ -267,7 +267,7 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		Expect(err).Should(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
 		Expect(cm.Data[vapi.SandboxNameKey]).Should(Equal(sandbox1))
-		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Spec.DBName))
+		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Name))
 
 		testAnnotation := "test-annotation"
 		testValue := "test-value"
@@ -282,7 +282,7 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		Expect(err).Should(Succeed())
 		Expect(res).Should(Equal(ctrl.Result{}))
 		Expect(cm.Data[vapi.SandboxNameKey]).Should(Equal(sandbox1))
-		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Spec.DBName))
+		Expect(cm.Data[vapi.VerticaDBNameKey]).Should(Equal(r.Vdb.Name))
 		Expect(cm.Annotations[testAnnotation]).Should(Equal(testValue))
 	})
 })

--- a/tests/e2e-leg-9/sandbox/35-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/35-assert.yaml
@@ -32,5 +32,5 @@ metadata:
     name: v-sandbox
 data:
   sandboxName: sandbox1
-  verticaDBName: sandbox_db
+  verticaDBName: v-sandbox
 immutable: true

--- a/tests/e2e-leg-9/sandbox/45-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/45-assert.yaml
@@ -32,5 +32,5 @@ metadata:
     name: v-sandbox
 data:
   sandboxName: sandbox2
-  verticaDBName: sandbox_db
+  verticaDBName: v-sandbox
 immutable: true


### PR DESCRIPTION
The ConfigMap should have the name of the VerticaDB, not the database name. The sandbox controller uses this to figure out the correct VerticaDB to fetch.