### PR TITLE
Use ForceRemoval option with revive

### DIFF
--- a/pkg/vadmin/revive_db_vc.go
+++ b/pkg/vadmin/revive_db_vc.go
@@ -58,6 +58,7 @@ func (v *VClusterOps) genReviveDBOptions(s *revivedb.Parms, certs *HTTPSCerts) *
 	opts.IPv6 = net.IsIPv6(opts.RawHosts[0])
 	opts.CommunalStorageLocation = s.CommunalPath
 	opts.ConfigurationParameters = s.ConfigurationParams
+	opts.ForceRemoval = true
 	opts.IgnoreClusterLease = s.IgnoreClusterLease
 
 	// auth options


### PR DESCRIPTION
This was mistakenly removed in the last VCluster API refresh (#741). Without this, if there is an error during revive, then it will complain that local catalog/data/depot dirs are not empty.