### PR TITLE
Decouple sandbox image from vdb.spec image

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -630,6 +630,7 @@ type Sandbox struct {
 	Name string `json:"name"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default:=""
 	// +kubebuilder:validation:Optional
 	// The name of the image to use for the sandbox. If omitted, the image
 	// is inherited from the spec.image field.

--- a/api/v1beta1/verticadb_types.go
+++ b/api/v1beta1/verticadb_types.go
@@ -717,6 +717,7 @@ type Sandbox struct {
 	Name string `json:"name"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:default:=""
 	// +kubebuilder:validation:Optional
 	// The name of the image to use for the sandbox. If omitted, the image
 	// is inherited from the spec.image field.

--- a/pkg/controllers/vdb/sandboximage_reconciler.go
+++ b/pkg/controllers/vdb/sandboximage_reconciler.go
@@ -1,0 +1,69 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// SandboxImageReconciler will set the image, if missing,
+// for sandboxes
+type SandboxImageReconciler struct {
+	VRec *VerticaDBReconciler
+	Log  logr.Logger
+	Vdb  *vapi.VerticaDB // Vdb is the CRD we are acting on
+}
+
+func MakeSandboxImageReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
+	vdb *vapi.VerticaDB) controllers.ReconcileActor {
+	return &SandboxImageReconciler{
+		VRec: vdbrecon,
+		Log:  log.WithName("SandboxImageReconciler"),
+		Vdb:  vdb,
+	}
+}
+
+func (s *SandboxImageReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
+	if len(s.Vdb.Spec.Sandboxes) == 0 {
+		return ctrl.Result{}, nil
+	}
+	_, err := vk8s.UpdateVDBWithRetry(ctx, s.VRec, s.Vdb, s.setSandboxImagesInVdb)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed trying to update sandbox images in VDB: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// setSandboxImagesInVdb is a callback function for updateVDBWithRetry
+// that will set sandbox images(if empty) in vdb.
+func (s *SandboxImageReconciler) setSandboxImagesInVdb() (bool, error) {
+	updated := false
+	for i := range s.Vdb.Spec.Sandboxes {
+		sb := &s.Vdb.Spec.Sandboxes[i]
+		if sb.Image == "" {
+			updated = true
+			sb.Image = s.Vdb.Spec.Image
+		}
+	}
+	return updated, nil
+}

--- a/pkg/controllers/vdb/sandboximage_reconciler_test.go
+++ b/pkg/controllers/vdb/sandboximage_reconciler_test.go
@@ -1,0 +1,69 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("sandboximage_reconciler", func() {
+	ctx := context.Background()
+
+	It("should set sandbox images in vdb", func() {
+		vdb := vapi.MakeVDB()
+		const (
+			sb1 = "sb1"
+			sb2 = "sb2"
+			sb3 = "sb3"
+			img = "vertica:test"
+		)
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: "default", Size: 1, Type: vapi.PrimarySubcluster},
+			{Name: "sc1", Size: 1, Type: vapi.SecondarySubcluster},
+			{Name: "sc2", Size: 1, Type: vapi.SecondarySubcluster},
+			{Name: "sc3", Size: 1, Type: vapi.SecondarySubcluster},
+		}
+		vdb.Spec.Sandboxes = []vapi.Sandbox{
+			{Name: sb1, Image: img, Subclusters: []vapi.SubclusterName{{Name: vdb.Spec.Subclusters[1].Name}}},
+			{Name: sb2, Subclusters: []vapi.SubclusterName{{Name: vdb.Spec.Subclusters[2].Name}}},
+			{Name: sb3, Subclusters: []vapi.SubclusterName{{Name: vdb.Spec.Subclusters[3].Name}}},
+		}
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		fetchVdb := &vapi.VerticaDB{}
+		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
+		Expect(vdb.Spec.Image).ShouldNot(Equal(""))
+		Expect(fetchVdb.Spec.Sandboxes[0].Image).Should(Equal(img))
+		Expect(fetchVdb.Spec.Sandboxes[1].Image).Should(Equal(""))
+		Expect(fetchVdb.Spec.Sandboxes[2].Image).Should(Equal(""))
+
+		r := MakeSandboxImageReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		// After reconcile, all sandboxes with empty image name should have the same
+		// image set as spec.image
+		Expect(k8sClient.Get(ctx, vapi.MakeVDBName(), fetchVdb)).Should(Succeed())
+		Expect(fetchVdb.Spec.Sandboxes[0].Image).Should(Equal(img))
+		Expect(fetchVdb.Spec.Sandboxes[1].Image).Should(Equal(vdb.Spec.Image))
+		Expect(fetchVdb.Spec.Sandboxes[2].Image).Should(Equal(vdb.Spec.Image))
+	})
+})

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -590,10 +590,10 @@ func (i *UpgradeManager) getTargetImage(sandbox string) (string, error) {
 	}
 	// if the target cluster is a sandbox, the target image
 	// is the one set for that specific sandbox
-	if sb.Image != "" {
-		return sb.Image, nil
+	if sb.Image == "" {
+		return "", fmt.Errorf("could not find image for sandbox %q", sandbox)
 	}
-	return i.Vdb.Spec.Image, nil
+	return sb.Image, nil
 }
 
 // isPrimary returns true if the subcluster is primary

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -195,6 +195,9 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 			ObjReconcileModePreserveScaling|ObjReconcileModePreserveUpdateStrategy),
 		// Add annotations/labels to each pod about the host running them
 		MakeAnnotateAndLabelPodReconciler(r, log, vdb, pfacts),
+		// For any sandboxes with an empty image, set the image to be equal
+		// to the one in spec.image field.
+		MakeSandboxImageReconciler(r, log, vdb),
 		// Handles vertica server upgrade (i.e., when spec.image changes)
 		MakeOfflineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeOnlineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),


### PR DESCRIPTION
When setting a sandbox, if the image is omitted, the operator will internally assume spec.image as the sandbox's image. The issue is that changing spec.image could trigger sandbox upgrade too. Now if the image is omitted, there is a new reconciler that will explicitly set the sandbox image in vdb to spec.image value. 