### PR TITLE
Fix for many subclusters sandboxed at the same time

### DIFF
--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
@@ -229,7 +229,7 @@ func (s *SandboxSubclusterReconciler) findInitiatorIPs(ctx context.Context, sand
 		if err := pfs.Collect(ctx, s.Vdb); err != nil {
 			return nil, ctrl.Result{}, err
 		}
-		// If this is the first pod in the sandbox, then only an API from the
+		// If this is the first pod in the sandbox, then only an ip from the
 		// main cluster is needed.
 		if len(pfs.Detail) == 0 {
 			ips := []string{s.InitiatorIPs[vapi.MainCluster]}

--- a/tests/e2e-leg-9/sandbox-on-create/05-create-secrets.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/05-create-secrets.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/vertica-license/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-9/sandbox-on-create/10-assert.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/10-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-9/sandbox-on-create/10-verify-operator.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/10-verify-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-9/sandbox-on-create/15-assert.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/15-assert.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-sandbox-on-create-pri1
+status:
+  currentReplicas: 3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-sandbox-on-create-sec1
+status:
+  currentReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-sandbox-on-create-sec2
+status:
+  currentReplicas: 1
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-sandbox-on-create

--- a/tests/e2e-leg-9/sandbox-on-create/15-setup-vdb.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/sandbox-on-create/20-assert.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/20-assert.yaml
@@ -1,0 +1,67 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 900 # 15 minutes since this step can be quite long
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-sandbox-on-create-pri1
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-sandbox-on-create-sec1
+status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-sandbox-on-create-sec2
+status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: v-sandbox-on-create-sand1
+data:
+  sandboxName: sand1
+  verticaDBName: v-sandbox-on-create
+immutable: true
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-sandbox-on-create
+status:
+  sandboxes:
+  - name: sand1
+    subclusters:
+    - sec1
+    - sec2
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+    - addedToDBCount: 1
+      upNodeCount: 1
+    - addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-9/sandbox-on-create/20-wait-for-createdb.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/20-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/sandbox-on-create/25-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/25-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"

--- a/tests/e2e-leg-9/sandbox-on-create/95-delete-cr.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-9/sandbox-on-create/95-errors.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-9/sandbox-on-create/96-assert.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-9/sandbox-on-create/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/sandbox-on-create/96-errors.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-9/sandbox-on-create/99-delete-ns.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-9/sandbox-on-create/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-9/sandbox-on-create/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/sandbox-on-create/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,45 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-sandbox-on-create
+  annotations:
+    vertica.com/include-uid-in-path: true
+spec:
+  image: kustomize-vertica-image
+  dbName: sandbox_db
+  initPolicy: CreateSkipPackageInstall
+  communal: {}
+  local:
+    requestSize: 250Mi
+  subclusters:
+    - name: pri1
+      size: 3
+      type: primary
+    - name: sec1
+      size: 1
+      type: secondary
+    - name: sec2
+      size: 1
+      type: secondary
+  sandboxes:
+  - name: sand1
+    subclusters:
+    - name: sec1
+    - name: sec2
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-leg-9/verify-vrep/09-create-data-users-tlsconfig.yaml
+++ b/tests/e2e-leg-9/verify-vrep/09-create-data-users-tlsconfig.yaml
@@ -61,7 +61,7 @@ data:
       echo "Assertion failed: expected 99, got $result"
       exit 1
     fi
-    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables;\"")
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
     echo "$result" | grep -Pzo "^1\n$" > /dev/null
     if [ $? -ne 0 ]; then
       echo "Assertion failed: expected 1, got $result"
@@ -73,7 +73,7 @@ data:
     for POD_NAME in "${POD_NAMES[@]}"; do
       kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"CREATE USER custom_user_with_password IDENTIFIED BY 'topsecret'; GRANT PSEUDOSUPERUSER TO custom_user_with_password; ALTER USER custom_user_with_password DEFAULT ROLE PSEUDOSUPERUSER;\""
       kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"CREATE USER custom_user; GRANT PSEUDOSUPERUSER TO custom_user; ALTER USER custom_user DEFAULT ROLE PSEUDOSUPERUSER;\""
-      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables;\"")
+      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
       echo "$result" | grep -Pzo "^0\n$" > /dev/null
       if [ $? -ne 0 ]; then
         echo "Assertion failed: expected 0, got $result"

--- a/tests/e2e-leg-9/verify-vrep/20-verify-target-data.yaml
+++ b/tests/e2e-leg-9/verify-vrep/20-verify-target-data.yaml
@@ -24,7 +24,7 @@ data:
     POD_NAMES=("v-target-sc5-0" "v-target-sc4-0" "v-target-sc3-0" "v-target-sc2-0")
 
     for POD_NAME in "${POD_NAMES[@]}"; do
-      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables;\"")
+      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
       echo "$result" | grep -Pzo "^0\n$" > /dev/null
       if [ $? -ne 0 ]; then
         echo "Assertion failed: expected 0, got $result"
@@ -41,7 +41,7 @@ data:
         echo "Assertion failed: expected 99, got $result"
         exit 1
       fi
-      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables;\"")
+      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
       echo "$result" | grep -Pzo "^1\n$" > /dev/null
       if [ $? -ne 0 ]; then
         echo "Assertion failed: expected 1, got $result"

--- a/tests/e2e-leg-9/verify-vrep/35-verify-target-sandbox-data.yaml
+++ b/tests/e2e-leg-9/verify-vrep/35-verify-target-sandbox-data.yaml
@@ -24,7 +24,7 @@ data:
     POD_NAMES=("v-target-sc5-0" "v-target-sc4-0" "v-target-sc3-0")
 
     for POD_NAME in "${POD_NAMES[@]}"; do
-      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables;\"")
+      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
       echo "$result" | grep -Pzo "^0\n$" > /dev/null
       if [ $? -ne 0 ]; then
         echo "Assertion failed: expected 0, got $result"
@@ -41,7 +41,7 @@ data:
         echo "Assertion failed: expected 99, got $result"
         exit 1
       fi
-      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables;\"")
+      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
       echo "$result" | grep -Pzo "^1\n$" > /dev/null
       if [ $? -ne 0 ]; then
         echo "Assertion failed: expected 1, got $result"

--- a/tests/e2e-leg-9/verify-vrep/50-verify-target-sandbox-data-custom-username.yaml
+++ b/tests/e2e-leg-9/verify-vrep/50-verify-target-sandbox-data-custom-username.yaml
@@ -24,7 +24,7 @@ data:
     POD_NAMES=("v-target-sc5-0")
 
     for POD_NAME in "${POD_NAMES[@]}"; do
-      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables;\"")
+      result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
       echo "$result" | grep -Pzo "^0\n$" > /dev/null
       if [ $? -ne 0 ]; then
         echo "Assertion failed: expected 0, got $result"
@@ -41,7 +41,7 @@ data:
           echo "Assertion failed: expected 99, got $result"
           exit 1
         fi
-        result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables;\"")
+        result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
         echo "$result" | grep -Pzo "^1\n$" > /dev/null
         if [ $? -ne 0 ]; then
           echo "Assertion failed: expected 1, got $result"

--- a/tests/e2e-leg-9/verify-vrep/65-verify-target-sandbox-data-tls-config.yaml
+++ b/tests/e2e-leg-9/verify-vrep/65-verify-target-sandbox-data-tls-config.yaml
@@ -30,7 +30,7 @@ data:
           echo "Assertion failed: expected 99, got $result"
           exit 1
         fi
-        result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables;\"")
+        result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
         echo "$result" | grep -Pzo "^1\n$" > /dev/null
         if [ $? -ne 0 ]; then
           echo "Assertion failed: expected 1, got $result"

--- a/tests/e2e-leg-9/verify-vrep/70-create-target-sandbox-data.yaml
+++ b/tests/e2e-leg-9/verify-vrep/70-create-target-sandbox-data.yaml
@@ -28,7 +28,7 @@ data:
       echo "Assertion failed: expected lines containing 99 and 100"
       exit 1
     fi
-    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables;\"")
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
     echo "$result" | grep -Pzo "^1\n$" > /dev/null
     if [ $? -ne 0 ]; then
       echo "Assertion failed: expected 1, got $result"
@@ -41,7 +41,7 @@ data:
       echo "Assertion failed: expected 99, got $result"
       exit 1
     fi
-    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables;\"")
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
     echo "$result" | grep -Pzo "^1\n$" > /dev/null
     if [ $? -ne 0 ]; then
       echo "Assertion failed: expected 1, got $result"

--- a/tests/e2e-leg-9/verify-vrep/85-verify-target-sandbox-data.yaml
+++ b/tests/e2e-leg-9/verify-vrep/85-verify-target-sandbox-data.yaml
@@ -27,7 +27,7 @@ data:
       echo "Assertion failed: expected lines containing 99 and 100"
       exit 1
     fi
-    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables;\"")
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
     echo "$result" | grep -Pzo "^1\n$" > /dev/null
     if [ $? -ne 0 ]; then
       echo "Assertion failed: expected 1, got $result"


### PR DESCRIPTION
This update addresses an issue that occurs when multiple subclusters are added to a new sandbox during the same reconciliation iteration. The problem arose after sandboxing the first subcluster; the second subcluster failed to sandbox.

The failure was due to the need to provide both a host from the main cluster and a host from the sandbox to the vcluster API. To obtain the sandbox host, the system relies on the `vdb.status.sandbox` being updated. Since this update wasn't happening, the process of finding the sandbox host by checking pod facts didn't locate any sandboxed pods.

The solution is to update `vdb.status.sandboxes` as each subcluster is sandboxed. This update allows subsequent sandboxes to find the correct pod facts, ensuring the process completes successfully for all subclusters.