### PR TITLE
Added a vertica image reconciler in sandbox controller

### DIFF
--- a/pkg/controllers/sandbox/sandbox_controller.go
+++ b/pkg/controllers/sandbox/sandbox_controller.go
@@ -158,6 +158,8 @@ func (r *SandboxConfigMapReconciler) constructActors(vdb *v1.VerticaDB, log logr
 		MakeVerifyDeploymentReconciler(r, vdb, log),
 		// Move the subclusters from a sandbox to the main cluster
 		MakeUnsandboxSubclusterReconciler(r, vdb, log, r.Client, pfacts, dispatcher, configMap),
+		// Update the vertica image for unsandboxed subclusters
+		MakeVerticaImageReconciler(r, vdb, log, pfacts),
 		// Update the vdb status for the sandbox nodes/pods
 		vdbcontroller.MakeStatusReconciler(r.Client, r.Scheme, log, vdb, pfacts),
 		// Upgrade the sandbox using the offline method

--- a/pkg/controllers/sandbox/verticaimage_reconciler.go
+++ b/pkg/controllers/sandbox/verticaimage_reconciler.go
@@ -1,0 +1,111 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package sandbox
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	vdbcontroller "github.com/vertica/vertica-kubernetes/pkg/controllers/vdb"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	appsv1 "k8s.io/api/apps/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// VerticaImageReconciler will recreate the secondary subclusters' StatefulSets
+// in main cluster if those subclusters have a different vertica image than
+// the one in primary subclusters
+type VerticaImageReconciler struct {
+	SRec   *SandboxConfigMapReconciler
+	Vdb    *vapi.VerticaDB
+	Log    logr.Logger
+	PFacts *vdbcontroller.PodFacts
+}
+
+func MakeVerticaImageReconciler(r *SandboxConfigMapReconciler, vdb *vapi.VerticaDB,
+	log logr.Logger, pfacts *vdbcontroller.PodFacts) controllers.ReconcileActor {
+	pfactsForMainCluster := pfacts.Copy(vapi.MainCluster)
+	return &VerticaImageReconciler{
+		SRec:   r,
+		Log:    log.WithName("VerticaImageReconciler"),
+		Vdb:    vdb,
+		PFacts: &pfactsForMainCluster,
+	}
+}
+
+// Reconcile will fix the image of unsandboxed subclusters by recreating their StatefulSets
+func (r *VerticaImageReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
+	// no-op for ScheduleOnly init policy or enterprise db
+	if r.Vdb.Spec.InitPolicy == vapi.CommunalInitPolicyScheduleOnly || !r.Vdb.IsEON() {
+		return ctrl.Result{}, nil
+	}
+
+	// collect pod facts for main cluster
+	if err := r.PFacts.Collect(ctx, r.Vdb); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return r.reconcileVerticaImage(ctx)
+}
+
+// reconcileVerticaImage recreates the StatefulSet of the secondary subclusters that
+// have the wrong vertica image
+func (r *VerticaImageReconciler) reconcileVerticaImage(ctx context.Context) (ctrl.Result, error) {
+	scsWithWrongImage := r.PFacts.FindSecondarySubclustersWithDifferentImage()
+	scMap := r.Vdb.GenSubclusterMap()
+	for _, sc := range scsWithWrongImage {
+		scInVdb, ok := scMap[sc]
+		if !ok {
+			r.Log.Info("Pods' subcluster name cannot be found in vdb", "subclusterName", sc)
+			continue
+		}
+		nm := names.GenStsName(r.Vdb, scInVdb)
+		curSts := &appsv1.StatefulSet{}
+		expSts := builder.BuildStsSpec(nm, r.Vdb, scInVdb)
+		err := r.SRec.Client.Get(ctx, nm, curSts)
+		if err != nil && kerrors.IsNotFound(err) {
+			r.Log.Info("Creating statefulset", "Name", nm, "Size", expSts.Spec.Replicas, "Image", expSts.Spec.Template.Spec.Containers[0].Image)
+			return ctrl.Result{}, r.createSts(ctx, expSts)
+		}
+		err = r.recreateSts(ctx, curSts, expSts)
+		if err != nil {
+			r.Log.Error(err, "failed to recreate statefulset", "Name", nm)
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// recreateSts will drop then create the statefulset
+func (r *VerticaImageReconciler) recreateSts(ctx context.Context, curSts, expSts *appsv1.StatefulSet) error {
+	if err := r.SRec.Client.Delete(ctx, curSts); err != nil {
+		return err
+	}
+	return r.createSts(ctx, expSts)
+}
+
+// createSts will create a new sts. It assumes the statefulset doesn't already exist.
+func (r *VerticaImageReconciler) createSts(ctx context.Context, expSts *appsv1.StatefulSet) error {
+	err := ctrl.SetControllerReference(r.Vdb, expSts, r.SRec.Client.Scheme())
+	if err != nil {
+		return err
+	}
+	return r.SRec.GetClient().Create(ctx, expSts)
+}

--- a/pkg/controllers/sandbox/verticaimage_reconciler_test.go
+++ b/pkg/controllers/sandbox/verticaimage_reconciler_test.go
@@ -1,0 +1,71 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package sandbox
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/cmds"
+	vdbcontroller "github.com/vertica/vertica-kubernetes/pkg/controllers/vdb"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	appsv1 "k8s.io/api/apps/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("verticaimage_reconciler", func() {
+	ctx := context.Background()
+	maincluster := "main"
+	subcluster1 := "sc1"
+	mainClusterImage := "vertica-k8s:20240404"
+	sandboxImage := "vertica-k8s:20250505"
+
+	It("should recreate the statefulset when a secondary subcluster has a different image", func() {
+		vdb := vapi.MakeVDBForVclusterOps()
+		vdb.Spec.Subclusters = []vapi.Subcluster{
+			{Name: maincluster, Size: 1, Type: vapi.PrimarySubcluster},
+			{Name: subcluster1, Size: 1, Type: vapi.SecondarySubcluster},
+		}
+		vdb.Spec.Image = mainClusterImage
+		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
+		defer test.DeletePods(ctx, k8sClient, vdb)
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+		Expect(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
+
+		fpr := &cmds.FakePodRunner{}
+		pfacts := vdbcontroller.MakePodFacts(sbRec, fpr, logger, TestPassword)
+		rec := MakeVerticaImageReconciler(sbRec, vdb, logger, &pfacts)
+		r := rec.(*VerticaImageReconciler)
+		Expect(r.PFacts.Collect(ctx, vdb)).Should(Succeed())
+		pn := names.GenPodName(vdb, &vdb.Spec.Subclusters[1], 0)
+		sc1Pf := r.PFacts.Detail[pn]
+		// let subcluster1 have a different image, its statefulset
+		// should be recreated
+		sc1Pf.SetImage(sandboxImage)
+		Expect(r.reconcileVerticaImage(ctx)).Should(Equal(ctrl.Result{}))
+
+		sc1 := &vdb.Spec.Subclusters[0]
+		sc1StsName := names.GenStsName(vdb, sc1)
+		sts := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, sc1StsName, sts)).Should(Succeed())
+		// the new statefulset should have the same image as primary subclusters in main cluster
+		Expect(sts.Spec.Template.Spec.Containers[0].Image).Should(Equal(mainClusterImage))
+	})
+})


### PR DESCRIPTION
This PR added a vertica image reconciler in sandbox controller. It could sync the vertica image across the main cluster. After we unsandboxed a subcluster, the subcluster could have different vertica image than the other subclusters in main cluster. This new reconciler will recreate the statefulset of that subcluster for fixing its vertica image.