### PR TITLE
Fixed polling timeout issue of start_db and start_node

### DIFF
--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -62,7 +62,10 @@ func (v *VClusterOps) genStartNodeOptions(s *restartnode.Parms, certs *HTTPSCert
 	opts.UserName = su
 	opts.Password = &v.Password
 	opts.Nodes = s.RestartHosts
-	opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
+	vdbTimeout := v.VDB.GetRestartTimeout()
+	if vdbTimeout != 0 {
+		opts.StatePollingTimeout = vdbTimeout
+	}
 	if v.VDB.IsNMASideCarDeploymentEnabled() {
 		opts.StartUpConf = paths.StartupConfFile
 	}

--- a/pkg/vadmin/start_db_vc.go
+++ b/pkg/vadmin/start_db_vc.go
@@ -91,7 +91,10 @@ func (v *VClusterOps) genStartDBOptions(s *startdb.Parms, certs *HTTPSCerts) (vo
 	opts.Password = &v.Password
 
 	// timeout option
-	opts.StatePollingTimeout = v.VDB.GetRestartTimeout()
+	vdbTimeout := v.VDB.GetRestartTimeout()
+	if vdbTimeout != 0 {
+		opts.StatePollingTimeout = vdbTimeout
+	}
 
 	// other options
 	opts.TrimHostList = true

--- a/tests/e2e-leg-9/sandbox/60-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/60-assert.yaml
@@ -21,6 +21,16 @@ involvedObject:
   kind: VerticaDB
   name: v-sandbox
 ---
+apiVersion: v1
+kind: Event
+reason: ClusterRestartSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-sandbox
+---
 apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:

--- a/tests/e2e-leg-9/sandbox/60-assert.yaml
+++ b/tests/e2e-leg-9/sandbox/60-assert.yaml
@@ -23,7 +23,7 @@ involvedObject:
 ---
 apiVersion: v1
 kind: Event
-reason: ClusterRestartSucceeded
+reason: NodeRestartSucceeded
 source:
   component: verticadb-operator
 involvedObject:
@@ -37,14 +37,14 @@ metadata:
   name: v-sandbox
 spec:
   subclusters:
-  - name: pri1
-    type: primary
-  - name: sec1
-    type: sandboxprimary
-  - name: sec2
-    type: secondary
-  - name: sec3
-    type: secondary
+    - name: pri1
+      type: primary
+    - name: sec1
+      type: sandboxprimary
+    - name: sec2
+      type: secondary
+    - name: sec3
+      type: secondary
 status:
   sandboxes:
     - name: sandbox1


### PR DESCRIPTION
In k8s, the node state polling timeout is controlled by the annotation "vertica.com/restart-timeout". If it's not set, the polling timeout is set to 0 which will fail vclusterOps start_db and start_node. Then we will have many cluster/node restart failure events. This PR simply used vclusterOps default polling timeout if the annotation "vertica.com/restart-timeout" is not set.