### PR TITLE
Added e2e test for verifying replication in upgrade

### DIFF
--- a/tests/e2e-leg-9/replicated-upgrade-sanity/02-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/02-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/02-rbac.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/02-rbac.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
@@ -47,6 +47,16 @@ status:
   currentReplicas: 3
   readyReplicas: 3
 ---
+apiVersion: v1
+kind: Event
+reason: SandboxSubclusterSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-base-upgrade
+---
 apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
@@ -65,3 +75,8 @@ spec:
   - name: sec1-sb
     type: secondary
     size: 3
+status:
+  sandboxes:
+    - name: replica-group-b
+      subclusters:
+        - pri1-sb

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
@@ -80,3 +80,6 @@ status:
     - name: replica-group-b
       subclusters:
         - pri1-sb
+        - pri2-sb
+        - sec1-sb
+          

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/37-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/37-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-create-source-data
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0 

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/37-create-data-in-main-cluster.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/37-create-data-in-main-cluster.yaml
@@ -1,0 +1,64 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-create-source-data
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    POD_NAME=v-base-upgrade-pri1-0
+
+    kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"ALTER DATABASE DEFAULT SET EnableConnectCredentialForwarding = 1;\""
+    kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"CREATE TABLE public.test_table (val INTEGER);\""
+    kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"INSERT INTO public.test_table VALUES (99); COMMIT;\""
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT * FROM public.test_table ORDER BY val;\"")
+    echo "$result" | grep -Pzo "^99\n$" > /dev/null
+    if [ $? -ne 0 ]; then
+      echo "Assertion failed: expected 99, got $result"
+      exit 1
+    fi
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -w superuser -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
+    echo "$result" | grep -Pzo "^1\n$" > /dev/null
+    if [ $? -ne 0 ]; then
+      echo "Assertion failed: expected 1, got $result"
+      exit 1
+    fi
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-create-source-data
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-create-source-data

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/38-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/38-assert.yaml
@@ -1,0 +1,26 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: ReplicationSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1beta1
+  kind: VerticaReplicator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaReplicator
+status:
+  state: "Replication successful"

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/38-wait-for-replication-finish.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/38-wait-for-replication-finish.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/39-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/39-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-data-in-sandbox
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0 

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/39-verify-data-in-sandbox.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/39-verify-data-in-sandbox.yaml
@@ -1,0 +1,60 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-data-in-sandbox
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    POD_NAME=v-base-upgrade-pri1-sb-0
+
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT * FROM public.test_table ORDER BY val;\"")
+    echo "$result" | grep -Pzo "^99\n$" > /dev/null
+    if [ $? -ne 0 ]; then
+      echo "Assertion failed: expected 99, got $result"
+      exit 1
+    fi
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM tables WHERE table_name = 'test_table';\"")
+    echo "$result" | grep -Pzo "^1\n$" > /dev/null
+    if [ $? -ne 0 ]; then
+      echo "Assertion failed: expected 1, got $result"
+      exit 1
+    fi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-data-in-sandbox
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-data-in-sandbox


### PR DESCRIPTION
In the replicated upgrade, the operator should trigger the replication reconciler after the sandbox is upgraded. The replication reconciler will create a replication CR and copy the data from the main cluster to the sandbox. This PR added an e2e test to verify that replication process.