### PR TITLE
Fixed intermittent failure in online-upgrade-kill-transient test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.2.1-0.20240529223132-804280c033ce
+	github.com/vertica/vcluster v1.2.1-0.20240603210230-c66c9e948022
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	golang.org/x/text v0.14.0
@@ -100,5 +100,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/vertica/vcluster => github.com/cchen-vertica/vcluster v0.4.8

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.2.1-0.20240603210230-c66c9e948022
+	github.com/vertica/vcluster v1.2.1-0.20240606170242-fcf68fdd7612
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	golang.org/x/text v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -100,3 +100,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/vertica/vcluster => github.com/cchen-vertica/vcluster v0.4.8

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead h1:UhYWAphNveMty305skySR5ST/hbYDexgsgkhcy0MDhM=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead/go.mod h1:RI5D4DqbDX0Kb0SvKTuAKMYlkSBND3zLQZI/wiS5Ij0=
-github.com/cchen-vertica/vcluster v0.4.8 h1:S9pf8rP/IwZJryhF0wCbwlapcygzU6aX5XL4bSPSu5Y=
-github.com/cchen-vertica/vcluster v0.4.8/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -324,6 +322,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
+github.com/vertica/vcluster v1.2.1-0.20240603210230-c66c9e948022 h1:VV4GfRYOURY2TK3xOdvA1uga+UMzQn+c3YAmpcLeWU4=
+github.com/vertica/vcluster v1.2.1-0.20240603210230-c66c9e948022/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead h1:UhYWAphNveMty305skySR5ST/hbYDexgsgkhcy0MDhM=
 github.com/bigkevmcd/go-configparser v0.0.0-20210106142102-909504547ead/go.mod h1:RI5D4DqbDX0Kb0SvKTuAKMYlkSBND3zLQZI/wiS5Ij0=
+github.com/cchen-vertica/vcluster v0.4.8 h1:S9pf8rP/IwZJryhF0wCbwlapcygzU6aX5XL4bSPSu5Y=
+github.com/cchen-vertica/vcluster v0.4.8/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -322,8 +324,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.2.1-0.20240529223132-804280c033ce h1:ky7TiAUyR95UR6h6k8VTqahAcTYlq3Zqk5P8qPD5DSQ=
-github.com/vertica/vcluster v1.2.1-0.20240529223132-804280c033ce/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.2.1-0.20240603210230-c66c9e948022 h1:VV4GfRYOURY2TK3xOdvA1uga+UMzQn+c3YAmpcLeWU4=
-github.com/vertica/vcluster v1.2.1-0.20240603210230-c66c9e948022/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
+github.com/vertica/vcluster v1.2.1-0.20240606170242-fcf68fdd7612 h1:xs3RCLtcz6iZf02b1Mfs5XzTFzKJSHzJPJ7ZcEjSPEg=
+github.com/vertica/vcluster v1.2.1-0.20240606170242-fcf68fdd7612/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/opts/removesc/opts.go
+++ b/pkg/vadmin/opts/removesc/opts.go
@@ -21,9 +21,10 @@ import (
 
 // Parms holds all of the option for a revive DB invocation.
 type Parms struct {
-	InitiatorName types.NamespacedName
-	InitiatorIP   string
-	Subcluster    string
+	InitiatorName      types.NamespacedName
+	InitiatorIP        string
+	Subcluster         string
+	NodeNameAddressMap map[string]string
 }
 
 type Option func(*Parms)
@@ -45,5 +46,11 @@ func WithInitiator(nm types.NamespacedName, ip string) Option {
 func WithSubcluster(scName string) Option {
 	return func(s *Parms) {
 		s.Subcluster = scName
+	}
+}
+
+func WithNodeNameAddressMap(nodeNameAddressMap map[string]string) Option {
+	return func(s *Parms) {
+		s.NodeNameAddressMap = nodeNameAddressMap
 	}
 }

--- a/pkg/vadmin/remove_sc_vc.go
+++ b/pkg/vadmin/remove_sc_vc.go
@@ -70,6 +70,8 @@ func (v *VClusterOps) genRemoveSubclusterOptions(s *removesc.Parms, certs *HTTPS
 	opts.DataPrefix = v.VDB.Spec.Local.DataPath
 	opts.IsEon = v.VDB.IsEON()
 	opts.ForceDelete = true
+	opts.PrimaryUpHost = s.InitiatorIP
+	opts.NodeNameAddressMap = s.NodeNameAddressMap
 
 	if v.VDB.Spec.Communal.Path != "" {
 		opts.DepotPrefix = v.VDB.Spec.Local.DepotPath

--- a/pkg/vadmin/remove_sc_vc_test.go
+++ b/pkg/vadmin/remove_sc_vc_test.go
@@ -40,6 +40,12 @@ func (m *MockVClusterOps) VRemoveSubcluster(options *vops.VRemoveScOptions) (vop
 		return vdb, fmt.Errorf("failed to retrieve subcluster name")
 	}
 
+	// verify re-ip options
+	err = m.VerifyNodeNameAddressMap(options.NodeNameAddressMap)
+	if err != nil {
+		return vdb, err
+	}
+
 	return vdb, nil
 }
 
@@ -54,6 +60,7 @@ var _ = Describe("remove_sc_vc", func() {
 		defer test.DeleteSecret(ctx, dispatcher.Client, dispatcher.VDB.Spec.NMATLSSecret)
 		Ω(dispatcher.RemoveSubcluster(ctx,
 			removesc.WithInitiator(TestInitiatorPodName, TestInitiatorIP),
-			removesc.WithSubcluster(TestSCName))).Should(Succeed())
+			removesc.WithSubcluster(TestSCName),
+			removesc.WithNodeNameAddressMap(TestNodeNameAddressMap))).Should(Succeed())
 	})
 })


### PR DESCRIPTION
This PR applied new vclusterOps library to fix intermittent failure in online-upgrade-kill-transient test. That intermittent failure is caused by IP inconsistency between the transient node and the catalog. In the new vclusterOps library, we won't check the version of the transient node in start_node, and we will do re-ip before removing the transient node.