### PR TITLE
Downgrade Vertica Image for Temporary Fix of e2e-leg-9-vcluster

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -257,7 +257,7 @@ jobs:
       uses: spilchen/switch-case-action@v2
       id: minimal_vertica_image
       with:
-        default: docker.io/opentext/vertica-k8s-private:20240606-minimal
+        default: docker.io/opentext/vertica-k8s-private:latest-minimal-master
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -257,7 +257,7 @@ jobs:
       uses: spilchen/switch-case-action@v2
       id: minimal_vertica_image
       with:
-        default: docker.io/opentext/vertica-k8s-private:latest-minimal-master
+        default: docker.io/opentext/vertica-k8s-private:20240606-minimal
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -452,7 +452,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           vlogger-image: ${{ needs.build.outputs.vlogger-image }}
           operator-image: ${{ needs.build.outputs.operator-image }}
-          vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+          vertica-image: docker.io/opentext/vertica-k8s-private:20240606-minimal
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           minimum-vertica-image: '24.3.0'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -452,7 +452,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           vlogger-image: ${{ needs.build.outputs.vlogger-image }}
           operator-image: ${{ needs.build.outputs.operator-image }}
-          vertica-image: opentext/vertica-k8s:24.3.0-20240606
+          vertica-image: opentext/vertica-k8s-private:20240606-minimal
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           minimum-vertica-image: '24.3.0'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -452,7 +452,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           vlogger-image: ${{ needs.build.outputs.vlogger-image }}
           operator-image: ${{ needs.build.outputs.operator-image }}
-          vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+          vertica-image: opentext/vertica-k8s:24.3.0-20240606
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           minimum-vertica-image: '24.3.0'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -452,7 +452,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           vlogger-image: ${{ needs.build.outputs.vlogger-image }}
           operator-image: ${{ needs.build.outputs.operator-image }}
-          vertica-image: opentext/vertica-k8s-private:20240606-minimal
+          vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           minimum-vertica-image: '24.3.0'


### PR DESCRIPTION
This PR updates the Vertica image to `20240606` to avoid replication errors from the server side. This is a temporary fix, and we will revert this change after fixing the issue on the server side