### PR TITLE
Revert Latest Vertica Image for E2E Leg9 vCluster

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -452,7 +452,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           vlogger-image: ${{ needs.build.outputs.vlogger-image }}
           operator-image: ${{ needs.build.outputs.operator-image }}
-          vertica-image: docker.io/opentext/vertica-k8s-private:20240606-minimal
+          vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           minimum-vertica-image: '24.3.0'


### PR DESCRIPTION
With the change on the server side, we have already fixed the issue in https://github.com/vertica/vertica-kubernetes/pull/832. We can revert to the latest Vertica image to fix the replication issue