### PR TITLE
Applied the latest vclusterOps library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.2.1-0.20240624163103-d83e09f30972
+	github.com/vertica/vcluster v1.2.1-0.20240625153548-76b66d006109
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	golang.org/x/text v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.2.1-0.20240617234347-bf13430bb165
+	github.com/vertica/vcluster v1.2.1-0.20240624163103-d83e09f30972
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	golang.org/x/text v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.2.1-0.20240617234347-bf13430bb165 h1:5lQI7Upv9aOxvNUHB75Z30ZF4OyrElc6K/P7YvebKZM=
-github.com/vertica/vcluster v1.2.1-0.20240617234347-bf13430bb165/go.mod h1:zkTLy1hF6LzTeWmXiGYLFzihbi397WTQhPZ9xX4B+FY=
+github.com/vertica/vcluster v1.2.1-0.20240624163103-d83e09f30972 h1:UwHiq2st0oE197wiwmWZJ75B033/L1DWRVITaAeJS7k=
+github.com/vertica/vcluster v1.2.1-0.20240624163103-d83e09f30972/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.2.1-0.20240624163103-d83e09f30972 h1:UwHiq2st0oE197wiwmWZJ75B033/L1DWRVITaAeJS7k=
-github.com/vertica/vcluster v1.2.1-0.20240624163103-d83e09f30972/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
+github.com/vertica/vcluster v1.2.1-0.20240625153548-76b66d006109 h1:VT08SpbW1uyG88RB3JRLXDFQk8NLvab0A5gHh4INY6s=
+github.com/vertica/vcluster v1.2.1-0.20240625153548-76b66d006109/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/vadmin/promote_sandbox_to_main_vc.go
+++ b/pkg/vadmin/promote_sandbox_to_main_vc.go
@@ -30,10 +30,16 @@ func (v *VClusterOps) PromoteSandboxToMain(ctx context.Context, opts ...promotes
 	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster PromoteSandboxToMain")
 
+	// get the certs
+	certs, err := v.retrieveNMACerts(ctx)
+	if err != nil {
+		return err
+	}
+
 	s := promotesandboxtomain.Params{}
 	s.Make(opts...)
 
-	vcOpts := v.genPromoteSandboxToMainOptions(&s)
+	vcOpts := v.genPromoteSandboxToMainOptions(&s, certs)
 	err = v.VPromoteSandboxToMain(vcOpts)
 	if err != nil {
 		return fmt.Errorf("failed to promote sandbox to main: %w", err)
@@ -42,7 +48,7 @@ func (v *VClusterOps) PromoteSandboxToMain(ctx context.Context, opts ...promotes
 	return nil
 }
 
-func (v *VClusterOps) genPromoteSandboxToMainOptions(s *promotesandboxtomain.Params) *vops.VPromoteSandboxToMainOptions {
+func (v *VClusterOps) genPromoteSandboxToMainOptions(s *promotesandboxtomain.Params, certs *HTTPSCerts) *vops.VPromoteSandboxToMainOptions {
 	opts := vops.VPromoteSandboxToMainFactory()
 
 	// required options
@@ -57,6 +63,9 @@ func (v *VClusterOps) genPromoteSandboxToMainOptions(s *promotesandboxtomain.Par
 	// auth options
 	opts.UserName = v.VDB.GetVerticaUser()
 	opts.Password = &v.Password
+	opts.Key = certs.Key
+	opts.Cert = certs.Cert
+	opts.CaCert = certs.CaCert
 
 	return &opts
 }

--- a/pkg/vadmin/promote_sandbox_to_main_vc_test.go
+++ b/pkg/vadmin/promote_sandbox_to_main_vc_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	vops "github.com/vertica/vcluster/vclusterops"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin/opts/promotesandboxtomain"
 )
 
@@ -44,7 +45,7 @@ func (m *MockVClusterOps) VPromoteSandboxToMain(options *vops.VPromoteSandboxToM
 		return fmt.Errorf("failed to verify sandbox name")
 	}
 
-	return nil
+	return m.VerifyCerts(&options.DatabaseOptions)
 }
 
 var _ = Describe("promote_sandbox_to_main_vc", func() {
@@ -53,6 +54,9 @@ var _ = Describe("promote_sandbox_to_main_vc", func() {
 	It("should call vclusterOps library with promote_sandbox_to_main task", func() {
 		dispatcher := mockVClusterOpsDispatcher()
 		dispatcher.VDB.Spec.DBName = TestDBName
+		dispatcher.VDB.Spec.NMATLSSecret = TestNMATLSSecret
+		test.CreateFakeTLSSecret(ctx, dispatcher.VDB, dispatcher.Client, dispatcher.VDB.Spec.NMATLSSecret)
+		defer test.DeleteSecret(ctx, dispatcher.Client, dispatcher.VDB.Spec.NMATLSSecret)
 		Ω(dispatcher.PromoteSandboxToMain(ctx,
 			promotesandboxtomain.WithInitiator(TestInitiatorIP),
 			promotesandboxtomain.WithSandbox(TestSandboxName),


### PR DESCRIPTION
The latest vclusterOps improves the promote_sandbox API to clean communal storage after sandbox promotion. This PR simply updates vclusterOps library to clean communal storage in the online upgrade.