### PR TITLE
Remove sandbox configmap after promotion

### DIFF
--- a/pkg/controllers/vdb/replicatedupgrade_reconciler.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler.go
@@ -157,6 +157,7 @@ func (r *ReplicatedUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Req
 		// old main.
 		r.postPromoteSandboxMsg,
 		r.promoteSandboxToMainCluster,
+		r.deleteSandboxConfigMap,
 		// Remove original main cluster. We will remove replica group A since
 		// replica group B is promoted to main cluster now.
 		r.postRemoveOriginalClusterMsg,
@@ -677,6 +678,27 @@ func (r *ReplicatedUpgradeReconciler) promoteSandboxToMainCluster(ctx context.Co
 	r.PFacts[vapi.MainCluster].Invalidate()
 	r.Log.Info("sandbox has been promoted to main", "sandboxName", r.sandboxName)
 	return ctrl.Result{}, r.updateAnnotationForReplicatedUpgrade(ctx, vmeta.ReplicatedUpgradeSandboxPromotedAnnotation)
+}
+
+// deleteSandboxConfigMap deletes the sandbox(which is now the new main) configmap after
+// the sandbox promotion.
+func (r *ReplicatedUpgradeReconciler) deleteSandboxConfigMap(ctx context.Context) (ctrl.Result, error) {
+	sb := r.VDB.GetSandboxStatus(r.sandboxName)
+	if sb != nil {
+		// We requeue if the sandbox still exists in the status
+		return ctrl.Result{Requeue: true}, nil
+	}
+	sbMan := MakeSandboxConfigMapManager(r.VRec, r.VDB, r.sandboxName, "" /*no uuid*/)
+	calledDelete, err := sbMan.deleteConfigMap(ctx)
+	if !calledDelete {
+		return ctrl.Result{}, err
+	}
+	if err != nil {
+		r.Log.Error(err, "failed to delete sandbox config map", "configMapName", sbMan.configMap.Name)
+		return ctrl.Result{}, err
+	}
+	r.Log.Info("deleted sandbox config map", "configMapName", sbMan.configMap.Name)
+	return ctrl.Result{}, nil
 }
 
 // postRemoveOriginalClusterMsg will update the status message to indicate that

--- a/pkg/controllers/vdb/replicatedupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/replicatedupgrade_reconciler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/test"
 	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
 	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -316,6 +317,34 @@ var _ = Describe("replicatedupgrade_reconciler", func() {
 		Ω(rr.finishUpgrade(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
 		Ω(vmeta.GetReplicatedUpgradeReplicator(vdb.Annotations)).Should(Equal(""))
+	})
+
+	It("should delete sandbox config map", func() {
+		const sbName = "sb1"
+		vdb := vapi.MakeVDBForVclusterOps()
+		vdb.Status = vapi.VerticaDBStatus{
+			Sandboxes: []vapi.SandboxStatus{
+				{Name: sbName},
+			},
+		}
+
+		test.CreateConfigMap(ctx, k8sClient, vdb, "", sbName)
+		defer test.DeleteConfigMap(ctx, k8sClient, vdb, sbName)
+		rr := &ReplicatedUpgradeReconciler{
+			sandboxName: sbName,
+			VDB:         vdb,
+			VRec:        vdbRec,
+		}
+		// requeue because sandbox still exists in the status
+		Ω(rr.deleteSandboxConfigMap(ctx)).Should(Equal(ctrl.Result{Requeue: true}))
+
+		nm := names.GenSandboxConfigMapName(rr.VDB, rr.sandboxName)
+		cm := &v1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, nm, cm)).Should(BeNil())
+		rr.VDB.Status.Sandboxes = []vapi.SandboxStatus{}
+		Ω(rr.deleteSandboxConfigMap(ctx)).Should(Equal(ctrl.Result{}))
+		err := k8sClient.Get(ctx, nm, cm)
+		Expect(kerrors.IsNotFound(err)).Should(BeTrue())
 	})
 
 	It("should remove the client routing label on replica group A subclusters for the pause", func() {

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/35-assert.yaml
@@ -57,6 +57,15 @@ involvedObject:
   kind: VerticaDB
   name: v-base-upgrade
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: v-base-upgrade-replica-group-b
+data:
+  sandboxName: replica-group-b
+  verticaDBName: v-base-upgrade
+immutable: true
+---
 apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:

--- a/tests/e2e-leg-9/replicated-upgrade-sanity/40-errors.yaml
+++ b/tests/e2e-leg-9/replicated-upgrade-sanity/40-errors.yaml
@@ -25,3 +25,12 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: v-base-upgrade-sec1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: v-base-upgrade-replica-group-b
+data:
+  sandboxName: replica-group-b
+  verticaDBName: v-base-upgrade
+immutable: true


### PR DESCRIPTION
After promoting sandbox to main, we need to delete sandbox config map to avoid any kind of conflicts as the sandbox does not exist anymore.