### PR TITLE
Update vcluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.2.1-0.20240625153548-76b66d006109
+	github.com/vertica/vcluster v1.2.1-0.20240701150554-6951dc4e4c1e
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	golang.org/x/text v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/vertica/vcluster v1.2.1-0.20240625153548-76b66d006109 h1:VT08SpbW1uyG88RB3JRLXDFQk8NLvab0A5gHh4INY6s=
-github.com/vertica/vcluster v1.2.1-0.20240625153548-76b66d006109/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
+github.com/vertica/vcluster v1.2.1-0.20240701150554-6951dc4e4c1e h1:yjWGjynMvt2AcPu+C+BUio1nRKXsVBIC4AZVgvaSY60=
+github.com/vertica/vcluster v1.2.1-0.20240701150554-6951dc4e4c1e/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Latest vclusterops fix a bug that would incorrectly trim nodes from sandbox clusters if not included in --node-names, when --node-names is specified