### PR TITLE
Use different sandbox name for each online upgrade

### DIFF
--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -923,10 +923,11 @@ func (r *OnlineUpgradeReconciler) getNewSandboxName(preferredName string) (strin
 		sbNames[r.VDB.Spec.Sandboxes[i].Name] = true
 	}
 
-	// To make this easier to test, we will favor the preferredName as the
+	// To make this easier to test, we will favor the annotation's value as the
 	// sandbox name. If that's available that's our name.
-	if _, found := sbNames[preferredName]; !found {
-		return preferredName, nil
+	sbName := vmeta.GetOnlineUpgradeSandboxName(r.VDB.Annotations)
+	if _, found := sbNames[sbName]; sbName != "" && !found {
+		return sbName, nil
 	}
 
 	// Add a uuid suffix to the preferred name.

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -146,6 +146,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 
 	It("should sandbox subclusters in replica group B", func() {
 		vdb := vapi.MakeVDBForVclusterOps()
+		vdb.Annotations[vmeta.OnlineUpgradeSandboxNameAnnotation] = preferredSandboxName
 		vdb.Spec.Subclusters = []vapi.Subcluster{
 			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
 			{Name: "pri2", Type: vapi.PrimarySubcluster, Size: 2},
@@ -184,6 +185,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 
 	It("should handle collisions with the sandbox name", func() {
 		vdb := vapi.MakeVDBForVclusterOps()
+		vdb.Annotations[vmeta.OnlineUpgradeSandboxNameAnnotation] = preferredSandboxName
 		vdb.Spec.Subclusters = []vapi.Subcluster{
 			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
 			{Name: "sec1", Type: vapi.SecondarySubcluster, Size: 2},

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -278,6 +278,10 @@ const (
 	ReplicaARemovedTrue                    = "true"
 	ReplicaARemovedFalse                   = "false"
 
+	// The sandbox name used for online upgrade contains a uuid. This annotation
+	// will allow to set a fixed name for testing purposes
+	OnlineUpgradeSandboxNameAnnotation = "vertica.com/online-upgrade-sandbox"
+
 	// This will be set in a sandbox configMap by the vdb controller to wake up the sandbox
 	// controller for upgrading the sandboxes
 	SandboxControllerUpgradeTriggerID = "vertica.com/sandbox-controller-upgrade-trigger-id"
@@ -536,6 +540,11 @@ func GetOnlineUpgradeReplicaARemoved(annotations map[string]string) string {
 // object used during online upgrade.
 func GetOnlineUpgradeReplicator(annotations map[string]string) string {
 	return lookupStringAnnotation(annotations, OnlineUpgradeReplicatorAnnotation, "")
+}
+
+// GetOnlineUpgradeSandboxName returns the sandbox name to use for online upgrade.
+func GetOnlineUpgradeSandboxName(annotations map[string]string) string {
+	return lookupStringAnnotation(annotations, OnlineUpgradeSandboxNameAnnotation, "")
 }
 
 // GetStsNameOverride returns the override for the statefulset name. If one is

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/setup-vdb/base/setup-vdb.yaml
@@ -17,6 +17,7 @@ metadata:
   name: v-base-upgrade
   annotations:
     vertica.com/include-uid-in-path: true
+    vertica.com/online-upgrade-sandbox: "replica-group-b"
 spec:
   image: kustomize-vertica-image
   dbName: repUP


### PR DESCRIPTION
Because we cannot reuse a sandbox name after promotion, a uuid is appended for each online upgrade run. The operator will first try to get the sandbox name from an annotation(useful for testing). If the annotation is not set, it will build a name that contains a uid.