### PR TITLE
Fixed re-ip error when restart the cluster

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -957,3 +957,8 @@ func (v *VerticaDB) GetSubclustersForReplicaGroup(groupName string) []string {
 	}
 	return scNames
 }
+
+// IsOnlineUpgradeSandboxPromoted will check if replica-group-b has been promoted to main cluster
+func (v *VerticaDB) IsOnlineUpgradeSandboxPromoted() bool {
+	return vmeta.GetOnlineUpgradeSandboxPromoted(v.Annotations) == vmeta.SandboxPromotedTrue
+}

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -233,7 +233,7 @@ func (r *OnlineUpgradeReconciler) assignSubclustersToReplicaGroupA(ctx context.C
 // necessary objects the upgrade depends on.
 func (r *OnlineUpgradeReconciler) runObjReconcilerForMainCluster(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to check objects in old main cluster
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -247,7 +247,7 @@ func (r *OnlineUpgradeReconciler) runObjReconcilerForMainCluster(ctx context.Con
 // runAddSubclusterReconcilerForMainCluster will run the reconciler to create any necessary subclusters
 func (r *OnlineUpgradeReconciler) runAddSubclusterReconcilerForMainCluster(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to touch old main cluster
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -261,7 +261,7 @@ func (r *OnlineUpgradeReconciler) runAddSubclusterReconcilerForMainCluster(ctx c
 // runAddNodesReconcilerForMainCluster will run the reconciler to scale out any subclusters.
 func (r *OnlineUpgradeReconciler) runAddNodesReconcilerForMainCluster(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to touch old main cluster
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -276,7 +276,7 @@ func (r *OnlineUpgradeReconciler) runAddNodesReconcilerForMainCluster(ctx contex
 // runRebalanceSandboxSubcluster will run a rebalance against the subclusters that will be sandboxed.
 func (r *OnlineUpgradeReconciler) runRebalanceSandboxSubcluster(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to touch old main cluster
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -298,7 +298,7 @@ func (r *OnlineUpgradeReconciler) postCreateNewSubclustersMsg(ctx context.Contex
 // eventually exist in its own sandbox.
 func (r *OnlineUpgradeReconciler) assignSubclustersToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -332,7 +332,7 @@ func (r *OnlineUpgradeReconciler) sandboxReplicaGroupB(ctx context.Context) (ctr
 	}
 
 	// If we have already promoted sandbox to main, we don't need to sandbox replica B again
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -386,7 +386,7 @@ func (r *OnlineUpgradeReconciler) postPromoteSubclustersInSandboxMsg(ctx context
 // parent subcluster is primary
 func (r *OnlineUpgradeReconciler) promoteReplicaBSubclusters(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to promote subclusters in sandbox
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -416,7 +416,7 @@ func (r *OnlineUpgradeReconciler) postUpgradeSandboxMsg(ctx context.Context) (ct
 // upgradeSandbox will upgrade the nodes in replica group B (sandbox) to the new version.
 func (r *OnlineUpgradeReconciler) upgradeSandbox(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to upgrade the sandbox again
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -455,7 +455,7 @@ func (r *OnlineUpgradeReconciler) upgradeSandbox(ctx context.Context) (ctrl.Resu
 // continually check if the pods in the sandbox are up.
 func (r *OnlineUpgradeReconciler) waitForSandboxUpgrade(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to wait for sandbox upgrade
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -486,7 +486,7 @@ func (r *OnlineUpgradeReconciler) postPauseConnectionsMsg(ctx context.Context) (
 // (momentarily) so that the two replica groups have the same data.
 func (r *OnlineUpgradeReconciler) pauseConnectionsAtReplicaGroupA(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to pause connections
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -540,7 +540,7 @@ func (r *OnlineUpgradeReconciler) postStartReplicationMsg(ctx context.Context) (
 // the sandbox from replica group A to replica group B.
 func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -594,7 +594,7 @@ func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Co
 // waitForReplicateToReplicaGroupB will poll the VerticaReplicator waiting for the replication to finish.
 func (r *OnlineUpgradeReconciler) waitForReplicateToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -645,7 +645,7 @@ func (r *OnlineUpgradeReconciler) postRedirectToSandboxMsg(ctx context.Context) 
 // established at replica group A to go to replica group B.
 func (r *OnlineUpgradeReconciler) redirectConnectionsToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to redirect connections
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 
@@ -696,7 +696,7 @@ func (r *OnlineUpgradeReconciler) postPromoteSandboxMsg(ctx context.Context) (ct
 // discard the pods for the old main.
 func (r *OnlineUpgradeReconciler) promoteSandboxToMainCluster(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeSandboxPromoted(r.VDB.Annotations) == vmeta.SandboxPromotedTrue {
+	if r.VDB.IsOnlineUpgradeSandboxPromoted() {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -1256,3 +1256,21 @@ func (p *PodFacts) findNodeNamesInSubclusters(scNames []string) []string {
 
 	return nodeNames
 }
+
+// quorumCheckForRestartCluster checks if restartable pods have enough primary nodes to do re-ip
+func (p *PodFacts) quorumCheckForRestartCluster(restartOnly bool) bool {
+	pfacts := p.findRestartablePods(restartOnly, false /* restartTransient */, true /* restartPendingDelete */)
+	restartablePrimaryNodeCount := 0
+	for _, v := range pfacts {
+		if v.isPrimary {
+			restartablePrimaryNodeCount++
+		}
+	}
+	primaryNodeCount := p.countPods(func(v *PodFact) int {
+		if v.isPrimary {
+			return 1
+		}
+		return 0
+	})
+	return restartablePrimaryNodeCount >= (primaryNodeCount+1)/2
+}

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -936,14 +936,14 @@ func (p *PodFacts) findInstalledPods() []*PodFact {
 
 // findReIPPods returns a list of pod facts that may need their IPs to be refreshed with re-ip.
 // An empty list implies there are no pods that match the criteria.
-func (p *PodFacts) findReIPPods(chk dBCheckType, useVClusterOps bool) []*PodFact {
+func (p *PodFacts) findReIPPods(chk dBCheckType, nmaAsSideCar bool) []*PodFact {
 	return p.filterPods(func(pod *PodFact) bool {
 		// Only consider running pods that exist and have an installation
 		if !pod.exists || !pod.isPodRunning || !pod.isInstalled {
 			return false
 		}
 		// NMA needs to be running before re-ip
-		if useVClusterOps && !pod.isNMAContainerReady {
+		if nmaAsSideCar && !pod.isNMAContainerReady {
 			return false
 		}
 		switch chk {

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -936,14 +936,14 @@ func (p *PodFacts) findInstalledPods() []*PodFact {
 
 // findReIPPods returns a list of pod facts that may need their IPs to be refreshed with re-ip.
 // An empty list implies there are no pods that match the criteria.
-func (p *PodFacts) findReIPPods(chk dBCheckType, nmaAsSideCar bool) []*PodFact {
+func (p *PodFacts) findReIPPods(chk dBCheckType) []*PodFact {
 	return p.filterPods(func(pod *PodFact) bool {
 		// Only consider running pods that exist and have an installation
 		if !pod.exists || !pod.isPodRunning || !pod.isInstalled {
 			return false
 		}
 		// NMA needs to be running before re-ip
-		if nmaAsSideCar && !pod.isNMAContainerReady {
+		if pod.hasNMASidecar && !pod.isNMAContainerReady {
 			return false
 		}
 		switch chk {

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -332,7 +332,7 @@ var _ = Describe("podfacts", func() {
 	It("should correctly return re-ip pods", func() {
 		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger, TestPassword)
 		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
-			dnsName: "p1", vnodeName: "node1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true,
+			dnsName: "p1", vnodeName: "node1", dbExists: true, exists: true, isPodRunning: true, isInstalled: true, isNMAContainerReady: true,
 		}
 		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
 			dnsName: "p2", vnodeName: "node2", dbExists: false, exists: true, isPodRunning: true, isInstalled: true,
@@ -363,18 +363,23 @@ var _ = Describe("podfacts", func() {
 
 func verifyReIP(pf *PodFacts) {
 	By("finding any installed pod")
-	pods := pf.findReIPPods(dBCheckAny)
+	pods := pf.findReIPPods(dBCheckAny, false)
 	Ω(pods).Should(HaveLen(2))
 	Ω(pods[0].dnsName).Should(Equal("p1"))
 	Ω(pods[1].dnsName).Should(Equal("p2"))
 
 	By("finding pods with a db")
-	pods = pf.findReIPPods(dBCheckOnlyWithDBs)
+	pods = pf.findReIPPods(dBCheckOnlyWithDBs, false)
 	Ω(pods).Should(HaveLen(1))
 	Ω(pods[0].dnsName).Should(Equal("p1"))
 
 	By("finding pods without a db")
-	pods = pf.findReIPPods(dBCheckOnlyWithoutDBs)
+	pods = pf.findReIPPods(dBCheckOnlyWithoutDBs, false)
 	Ω(pods).Should(HaveLen(1))
 	Ω(pods[0].dnsName).Should(Equal("p2"))
+
+	By("finding any installed pod that uses vclusterOps")
+	pods = pf.findReIPPods(dBCheckAny, true)
+	Ω(pods).Should(HaveLen(1))
+	Ω(pods[0].dnsName).Should(Equal("p1"))
 }

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -342,7 +342,7 @@ var _ = Describe("podfacts", func() {
 			dnsName: "p3", vnodeName: "node3", dbExists: false, exists: true, isPodRunning: true, isInstalled: false,
 		}
 		pf.Detail[types.NamespacedName{Name: "p4"}] = &PodFact{
-			dnsName: "p3", vnodeName: "node3", dbExists: true, exists: true, isPodRunning: true, isInstalled: false,
+			dnsName: "p4", vnodeName: "node4", dbExists: true, exists: true, isPodRunning: true, isInstalled: false,
 			hasNMASidecar: true, isNMAContainerReady: false,
 		}
 		verifyReIP(&pf)
@@ -363,6 +363,37 @@ var _ = Describe("podfacts", func() {
 		vdb.Annotations["foo"] = "bar"
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 		Ω(pf.HasVerticaDBChangedSinceCollection(ctx, vdb)).Should(BeTrue())
+	})
+
+	It("should do quorum check correctly", func() {
+		pf := MakePodFacts(vdbRec, &cmds.FakePodRunner{}, logger, TestPassword)
+		pf.Detail[types.NamespacedName{Name: "p1"}] = &PodFact{
+			isPrimary: true, dbExists: true, hasDCTableAnnotations: true, isPodRunning: true, upNode: false,
+		}
+		pf.Detail[types.NamespacedName{Name: "p2"}] = &PodFact{
+			isPrimary: true, dbExists: true, hasDCTableAnnotations: true, isPodRunning: true, upNode: false,
+		}
+		pf.Detail[types.NamespacedName{Name: "p3"}] = &PodFact{
+			isPrimary: false, dbExists: true, hasDCTableAnnotations: true, isPodRunning: true, upNode: false,
+		}
+		pf.Detail[types.NamespacedName{Name: "p4"}] = &PodFact{
+			isPrimary: true, dbExists: false, hasDCTableAnnotations: true, isPodRunning: true, upNode: false,
+		}
+		pf.Detail[types.NamespacedName{Name: "p5"}] = &PodFact{
+			isPrimary: true, dbExists: false, hasDCTableAnnotations: true, isPodRunning: true, upNode: false,
+		}
+
+		// 4 primary nodes, 2 restartable primary nodes
+		result := pf.quorumCheckForRestartCluster(true)
+		Expect(result).Should(BeTrue())
+		// 5 primary nodes, 3 restartable primary nodes
+		pf.Detail[types.NamespacedName{Name: "p3"}].isPrimary = true
+		result = pf.quorumCheckForRestartCluster(true)
+		Expect(result).Should(BeTrue())
+		// 5 primary nodes, 2 restartable primary nodes
+		pf.Detail[types.NamespacedName{Name: "p3"}].dbExists = false
+		result = pf.quorumCheckForRestartCluster(true)
+		Expect(result).Should(BeFalse())
 	})
 })
 

--- a/pkg/controllers/vdb/podfacts_test.go
+++ b/pkg/controllers/vdb/podfacts_test.go
@@ -378,7 +378,7 @@ func verifyReIP(pf *PodFacts) {
 	Ω(pods).Should(HaveLen(1))
 	Ω(pods[0].dnsName).Should(Equal("p2"))
 
-	By("finding any installed pod that uses vclusterOps")
+	By("finding any installed pod that use NMA as a sidecar")
 	pods = pf.findReIPPods(dBCheckAny, true)
 	Ω(pods).Should(HaveLen(1))
 	Ω(pods[0].dnsName).Should(Equal("p1"))

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -212,8 +212,8 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 	// re_ip nodes. This is done ahead of the db check in case we need to update
 	// the IP of nodes that have been installed but not yet added to the db.
 	reIPPods := r.getReIPPods(false)
-	if len(reIPPods) != len(r.PFacts.Detail) {
-		r.Log.Info("Not all pods are running. Need to requeue restart reconciler")
+	if len(reIPPods) != len(downPods) {
+		r.Log.Info("Not all restartable pods are running. Need to requeue restart reconciler")
 		return ctrl.Result{Requeue: true}, nil
 	}
 	if res, err := r.reipNodes(ctx, reIPPods); verrors.IsReconcileAborted(res, err) {
@@ -713,13 +713,13 @@ func (r *RestartReconciler) getReIPPods(isRestartNode bool) []*PodFact {
 		if vmeta.UseVClusterOps(r.Vdb.Annotations) {
 			return nil
 		}
-		return r.PFacts.findReIPPods(dBCheckOnlyWithoutDBs, false)
+		return r.PFacts.findReIPPods(dBCheckOnlyWithoutDBs)
 	}
 	// For cluster restart, we re-ip all nodes that have been added to the DB.
 	// And if using admintools, we also need to re-ip installed pods that
 	// haven't been added to the db to keep admintools.conf in-sync.
 	if vmeta.UseVClusterOps(r.Vdb.Annotations) {
-		return r.PFacts.findReIPPods(dBCheckOnlyWithDBs, r.Vdb.IsNMASideCarDeploymentEnabled())
+		return r.PFacts.findReIPPods(dBCheckOnlyWithDBs)
 	}
-	return r.PFacts.findReIPPods(dBCheckAny, false)
+	return r.PFacts.findReIPPods(dBCheckAny)
 }

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -719,7 +719,7 @@ func (r *RestartReconciler) getReIPPods(isRestartNode bool) []*PodFact {
 	// And if using admintools, we also need to re-ip installed pods that
 	// haven't been added to the db to keep admintools.conf in-sync.
 	if vmeta.UseVClusterOps(r.Vdb.Annotations) {
-		return r.PFacts.findReIPPods(dBCheckOnlyWithDBs, true)
+		return r.PFacts.findReIPPods(dBCheckOnlyWithDBs, r.Vdb.IsNMASideCarDeploymentEnabled())
 	}
 	return r.PFacts.findReIPPods(dBCheckAny, false)
 }


### PR DESCRIPTION
This PR fixed re-ip error when restart the cluster by checking all pods are up and NMA is running in all pods. Without the check, vclusterOps re-ip could fail when NMA is not running or half of the primary nodes are not up.