### PR TITLE
Added a test to verify we can restart secondary nodes after online upgrade

### DIFF
--- a/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
@@ -27,7 +27,7 @@ spec:
     dataPath: /data
     depotPath: /depot
     requestSize: 100Mi
-  dbName: Vert_DB
+  dbName: vert_db
   subclusters:
     - name: main
       isPrimary: true

--- a/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
@@ -35,7 +35,7 @@ spec:
     dataPath: /data
     depotPath: /depot
     requestSize: 100Mi
-  dbName: Vert_DB
+  dbName: vert_db
   subclusters:
     - name: main
       isPrimary: true

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/55-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/55-assert.yaml
@@ -11,12 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: v-base-upgrade-sec1-sb
 status:
-  subclusters:
-    - addedToDBCount: 3
-      name: sec1
-      upNodeCount: 2
+  currentReplicas: 3
+  readyReplicas: 2

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/55-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/55-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade-sec1-sb
+status:
+  subclusters:
+    - addedToDBCount: 3
+      name: sec1
+      upNodeCount: 2

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/55-kill-one-pod.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/55-kill-one-pod.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete pod v-base-upgrade-sec1-sb-0
+    namespaced: true

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/56-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/56-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade-sec1-sb
+status:
+  subclusters:
+    - addedToDBCount: 3
+      name: sec1
+      upNodeCount: 3

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/56-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/56-assert.yaml
@@ -11,12 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: v-base-upgrade-sec1-sb
 status:
-  subclusters:
-    - addedToDBCount: 3
-      name: sec1
-      upNodeCount: 3
+  currentReplicas: 3
+  readyReplicas: 3

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/56-wait-for-restart.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/56-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl


### PR DESCRIPTION
The server side has fixed the bug that the catalog in secondary nodes cannot be refreshed. This PR adds a test to verify that fix.