### PR TITLE
Improve failure recovery during online upgrade

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -957,8 +957,3 @@ func (v *VerticaDB) GetSubclustersForReplicaGroup(groupName string) []string {
 	}
 	return scNames
 }
-
-// IsOnlineUpgradeSandboxPromoted will check if replica-group-b has been promoted to main cluster
-func (v *VerticaDB) IsOnlineUpgradeSandboxPromoted() bool {
-	return vmeta.GetOnlineUpgradeSandboxPromoted(v.Annotations) == vmeta.SandboxPromotedTrue
-}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/vertica/vcluster v1.2.1-0.20240701150554-6951dc4e4c1e
+	github.com/vertica/vcluster v1.2.1-0.20240722164320-d70d186a3ae6
 	github.com/vertica/vertica-sql-go v1.1.1
 	go.uber.org/zap v1.25.0
 	golang.org/x/text v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,7 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
+github.com/tonglil/buflogr v1.0.1/go.mod h1:yYWwvSpn/3uAaqjf6mJg/XMiAciaR0QcRJH2gJGDxNE=
 github.com/vertica/vcluster v1.2.1-0.20240722164320-d70d186a3ae6 h1:vjm2DjnUpNYpg4i3XfY89HgAUEIqoQLkU+DawRqoDWI=
 github.com/vertica/vcluster v1.2.1-0.20240722164320-d70d186a3ae6/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=

--- a/go.sum
+++ b/go.sum
@@ -329,9 +329,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/theckman/yacspin v0.13.12 h1:CdZ57+n0U6JMuh2xqjnjRq5Haj6v1ner2djtLQRzJr4=
 github.com/theckman/yacspin v0.13.12/go.mod h1:Rd2+oG2LmQi5f3zC3yeZAOl245z8QOvrH4OPOJNZxLg=
 github.com/tonglil/buflogr v1.0.1 h1:WXFZLKxLfqcVSmckwiMCF8jJwjIgmStJmg63YKRF1p0=
-github.com/tonglil/buflogr v1.0.1/go.mod h1:yYWwvSpn/3uAaqjf6mJg/XMiAciaR0QcRJH2gJGDxNE=
-github.com/vertica/vcluster v1.2.1-0.20240701150554-6951dc4e4c1e h1:yjWGjynMvt2AcPu+C+BUio1nRKXsVBIC4AZVgvaSY60=
-github.com/vertica/vcluster v1.2.1-0.20240701150554-6951dc4e4c1e/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
+github.com/vertica/vcluster v1.2.1-0.20240722164320-d70d186a3ae6 h1:vjm2DjnUpNYpg4i3XfY89HgAUEIqoQLkU+DawRqoDWI=
+github.com/vertica/vcluster v1.2.1-0.20240722164320-d70d186a3ae6/go.mod h1:MUCZD+YrTyI0/Ei7yjImqaKruUE65Rm8pynBmi+VdJU=
 github.com/vertica/vertica-sql-go v1.1.1 h1:sZYijzBbvdAbJcl4cYlKjR+Eh/X1hGKzukWuhh8PjvI=
 github.com/vertica/vertica-sql-go v1.1.1/go.mod h1:fGr44VWdEvL+f+Qt5LkKLOT7GoxaWdoUCnPBU9h6t04=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -80,7 +80,6 @@ const (
 	addNodeInx
 	promoteSandbox
 	removeReplicaGroupA
-	lastStep
 )
 
 // OnlineUpgradeReconciler will coordinate an online upgrade that allows

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -148,6 +148,7 @@ func (r *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 		// Copy any new data that was added since the sandbox from replica group
 		// A to replica group B.
 		r.postStartReplicationMsg,
+		r.prepareReplication,
 		r.startReplicationToReplicaGroupB,
 		r.waitForReplicateToReplicaGroupB,
 		// Redirect all of the connections to replica group A to replica group B.
@@ -283,7 +284,9 @@ func (r *OnlineUpgradeReconciler) runRebalanceSandboxSubcluster(ctx context.Cont
 	pf := r.PFacts[vapi.MainCluster]
 	actor := MakeRebalanceShardsReconciler(r.VRec, r.Log, r.VDB, pf.PRunner, pf, "" /*all subclusters*/)
 	r.Manager.traceActorReconcile(actor)
-	return actor.Reconcile(ctx, &ctrl.Request{})
+	res, err := actor.Reconcile(ctx, &ctrl.Request{})
+	r.PFacts[vapi.MainCluster].Invalidate()
+	return res, err
 }
 
 // postCreateNewSubclustersMsg will update the status message to indicate that
@@ -327,8 +330,12 @@ func (r *OnlineUpgradeReconciler) postSandboxSubclustersMsg(ctx context.Context)
 func (r *OnlineUpgradeReconciler) sandboxReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// We can skip this step if the replica sandbox is already created and fully
 	// sandboxed (according to status).
-	if r.sandboxName != "" && r.VDB.GetSandboxStatus(r.sandboxName) != nil {
-		return ctrl.Result{}, nil
+	if r.sandboxName != "" {
+		sb := r.VDB.GetSandboxStatus(r.sandboxName)
+		rgbSize := r.countSubclustersForReplicaGroup(vmeta.ReplicaGroupBValue)
+		if sb != nil && rgbSize == len(sb.Subclusters) {
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// If we have already promoted sandbox to main, we don't need to sandbox replica B again
@@ -355,17 +362,13 @@ func (r *OnlineUpgradeReconciler) sandboxReplicaGroupB(ctx context.Context) (ctr
 	// The nodes in the subcluster to sandbox must be running in order for
 	// sandboxing to work. For this reason, we need to use the restart
 	// reconciler to restart any down nodes.
-	pf := r.PFacts[vapi.MainCluster]
-	const DoNotRestartReadOnly = false
-	actor := MakeRestartReconciler(r.VRec, r.Log, r.VDB, pf.PRunner, pf, DoNotRestartReadOnly, r.Dispatcher)
-	r.Manager.traceActorReconcile(actor)
-	res, err := actor.Reconcile(ctx, &ctrl.Request{})
+	res, err := r.restartMainCluster(ctx)
 	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 
 	// Drive the actual sandbox command. When this returns we know the sandbox is complete.
-	actor = MakeSandboxSubclusterReconciler(r.VRec, r.Log, r.VDB, r.PFacts[vapi.MainCluster], r.Dispatcher, r.VRec.Client)
+	actor := MakeSandboxSubclusterReconciler(r.VRec, r.Log, r.VDB, r.PFacts[vapi.MainCluster], r.Dispatcher, r.VRec.Client)
 	r.Manager.traceActorReconcile(actor)
 	res, err = actor.Reconcile(ctx, &ctrl.Request{})
 	if verrors.IsReconcileAborted(res, err) {
@@ -390,12 +393,6 @@ func (r *OnlineUpgradeReconciler) promoteReplicaBSubclusters(ctx context.Context
 		return ctrl.Result{}, nil
 	}
 
-	sb := r.VDB.GetSandboxStatus(r.sandboxName)
-	rgbSize := r.countSubclustersForReplicaGroup(vmeta.ReplicaGroupBValue)
-	if sb == nil || rgbSize != len(sb.Subclusters) {
-		r.Log.Info("sandboxing replica group b is not complete")
-		return ctrl.Result{Requeue: true}, nil
-	}
 	// Get the sandbox podfacts only to invalidate the cache
 	sbPFacts, err := r.getSandboxPodFacts(ctx, false)
 	if err != nil {
@@ -534,6 +531,42 @@ func (r *OnlineUpgradeReconciler) pauseConnectionsAtReplicaGroupA(ctx context.Co
 // replication from the main to the sandbox is starting.
 func (r *OnlineUpgradeReconciler) postStartReplicationMsg(ctx context.Context) (ctrl.Result, error) {
 	return r.postNextStatusMsg(ctx, startReplicationMsgInx)
+}
+
+// prepareReplication makes sure there is at least an Up node in the main cluster
+// and the sandbox, to perform replication.
+// Once we start using services for replication, we will check only the scs served by the services.
+func (r *OnlineUpgradeReconciler) prepareReplication(ctx context.Context) (ctrl.Result, error) {
+	// Skip if the VerticaReplicator has already been created.
+	if vmeta.GetOnlineUpgradeReplicator(r.VDB.Annotations) != "" {
+		return ctrl.Result{}, nil
+	}
+	// we need fresh podfacts just in case some pods went down while
+	// sandbox upgrade was in progress.
+	r.PFacts[vapi.MainCluster].Invalidate()
+	err := r.PFacts[vapi.MainCluster].Collect(ctx, r.VDB)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to collect podfacts for main cluster: %w", err)
+	}
+	_, ok := r.PFacts[vapi.MainCluster].FindFirstUpPodIP(true, "")
+	if !ok {
+		r.Log.Info("Cannot find any up hosts in main cluster. Restarting main cluster.")
+		var res ctrl.Result
+		res, err = r.restartMainCluster(ctx)
+		if verrors.IsReconcileAborted(res, err) {
+			return res, err
+		}
+	}
+	sbPFacts, err := r.getSandboxPodFacts(ctx, true)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	_, ok = sbPFacts.FindFirstUpPodIP(false, "")
+	if !ok {
+		r.Log.Info("Cannot find any up hosts in sandbox. Requeue.", "sandboxName", r.sandboxName)
+		return ctrl.Result{Requeue: true}, nil
+	}
+	return ctrl.Result{}, nil
 }
 
 // startReplicationToReplicaGroupB will copy any new data that was added since
@@ -704,9 +737,14 @@ func (r *OnlineUpgradeReconciler) promoteSandboxToMainCluster(ctx context.Contex
 	if sb == nil {
 		return ctrl.Result{}, nil
 	}
-	sbPFacts, err := r.getSandboxPodFacts(ctx, false)
+	sbPFacts, err := r.getSandboxPodFacts(ctx, true)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	// All nodes in the sandbox must be up before sandbox promotion
+	if sbPFacts.getUpNodeCount() != len(sbPFacts.Detail) {
+		r.Log.Info("Waiting for all pods in sandbox to be up for promotion.", "sandboxName", r.sandboxName)
+		return ctrl.Result{Requeue: true}, nil
 	}
 	actor := MakePromoteSandboxToMainReconciler(r.VRec, r.Log, r.VDB, sbPFacts, r.Dispatcher, r.VRec.Client)
 	r.Manager.traceActorReconcile(actor)
@@ -1081,6 +1119,7 @@ func (r *OnlineUpgradeReconciler) getSandboxPodFacts(ctx context.Context, doColl
 		r.PFacts[r.sandboxName] = &sbPfacts
 	}
 	if doCollection {
+		r.PFacts[r.sandboxName].Invalidate()
 		err := r.PFacts[r.sandboxName].Collect(ctx, r.VDB)
 		if err != nil {
 			return nil, fmt.Errorf("failed to collect podfacts for sandbox: %w", err)
@@ -1165,7 +1204,9 @@ func (r *OnlineUpgradeReconciler) deleteReplicaGroupASts(ctx context.Context) (c
 
 	actor := MakeObjReconciler(r.VRec, r.Log, r.VDB, r.PFacts[vapi.MainCluster], ObjReconcileModeAll)
 	r.Manager.traceActorReconcile(actor)
-	return actor.Reconcile(ctx, &ctrl.Request{})
+	res, err := actor.Reconcile(ctx, &ctrl.Request{})
+	r.PFacts[vapi.MainCluster].Invalidate()
+	return res, err
 }
 
 // renameReplicaGroupBFromVdb will rename the subclusters in promoted-sandbox/new-main-cluster to
@@ -1291,4 +1332,14 @@ func (r *OnlineUpgradeReconciler) updateAnnotationForOnlineUpgrade(ctx context.C
 		r.Log.Info("updated annotation in VerticaDB", "annotation", annotation)
 	}
 	return nil
+}
+
+// restartMainCluster calls restart reconciler on the main cluster
+func (r *OnlineUpgradeReconciler) restartMainCluster(ctx context.Context) (ctrl.Result, error) {
+	// reconciler to restart any down nodes.
+	pf := r.PFacts[vapi.MainCluster]
+	const DoNotRestartReadOnly = false
+	actor := MakeRestartReconciler(r.VRec, r.Log, r.VDB, pf.PRunner, pf, DoNotRestartReadOnly, r.Dispatcher)
+	r.Manager.traceActorReconcile(actor)
+	return actor.Reconcile(ctx, &ctrl.Request{})
 }

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -79,9 +79,9 @@ const (
 	runObjRecForMainInx = iota
 	addSubclustersInx
 	addNodeInx
-	promoteSandbox
-	removeReplicaGroupA
-	deleteReplicaGroupASts
+	promoteSandboxInx
+	removeReplicaGroupAInx
+	deleteReplicaGroupAStsInx
 )
 
 // OnlineUpgradeReconciler will coordinate an online upgrade that allows
@@ -228,7 +228,7 @@ func (r *OnlineUpgradeReconciler) loadUpgradeState(ctx context.Context) (ctrl.Re
 // saved in the status.upgradeState.replicaGroups field.
 func (r *OnlineUpgradeReconciler) assignSubclustersToReplicaGroupA(ctx context.Context) (ctrl.Result, error) {
 	// Early out if we have already promoted and removed replica group A, or we have already created replica group A.
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > removeReplicaGroupA ||
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > removeReplicaGroupAInx ||
 		r.countSubclustersForReplicaGroup(vmeta.ReplicaGroupAValue) != 0 {
 		return ctrl.Result{}, nil
 	}
@@ -297,7 +297,7 @@ func (r *OnlineUpgradeReconciler) runAddNodesReconcilerForMainCluster(ctx contex
 // runRebalanceSandboxSubcluster will run a rebalance against the subclusters that will be sandboxed.
 func (r *OnlineUpgradeReconciler) runRebalanceSandboxSubcluster(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to touch old main cluster
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -321,7 +321,7 @@ func (r *OnlineUpgradeReconciler) postCreateNewSubclustersMsg(ctx context.Contex
 // eventually exist in its own sandbox.
 func (r *OnlineUpgradeReconciler) assignSubclustersToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -359,7 +359,7 @@ func (r *OnlineUpgradeReconciler) sandboxReplicaGroupB(ctx context.Context) (ctr
 	}
 
 	// If we have already promoted sandbox to main, we don't need to sandbox replica B again
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -409,7 +409,7 @@ func (r *OnlineUpgradeReconciler) postPromoteSubclustersInSandboxMsg(ctx context
 // parent subcluster is primary
 func (r *OnlineUpgradeReconciler) promoteReplicaBSubclusters(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to promote subclusters in sandbox
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -433,7 +433,7 @@ func (r *OnlineUpgradeReconciler) postUpgradeSandboxMsg(ctx context.Context) (ct
 // upgradeSandbox will upgrade the nodes in replica group B (sandbox) to the new version.
 func (r *OnlineUpgradeReconciler) upgradeSandbox(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to upgrade the sandbox again
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -472,7 +472,7 @@ func (r *OnlineUpgradeReconciler) upgradeSandbox(ctx context.Context) (ctrl.Resu
 // continually check if the pods in the sandbox are up.
 func (r *OnlineUpgradeReconciler) waitForSandboxUpgrade(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to wait for sandbox upgrade
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -503,7 +503,7 @@ func (r *OnlineUpgradeReconciler) postPauseConnectionsMsg(ctx context.Context) (
 // (momentarily) so that the two replica groups have the same data.
 func (r *OnlineUpgradeReconciler) pauseConnectionsAtReplicaGroupA(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to pause connections
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -559,7 +559,7 @@ func (r *OnlineUpgradeReconciler) postStartReplicationMsg(ctx context.Context) (
 func (r *OnlineUpgradeReconciler) prepareReplication(ctx context.Context) (ctrl.Result, error) {
 	// Skip if the VerticaReplicator has already been created or
 	// if we have already promoted sandbox to main
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox ||
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx ||
 		vmeta.GetOnlineUpgradeReplicator(r.VDB.Annotations) != "" {
 		return ctrl.Result{}, nil
 	}
@@ -595,7 +595,7 @@ func (r *OnlineUpgradeReconciler) prepareReplication(ctx context.Context) (ctrl.
 // the sandbox from replica group A to replica group B.
 func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -649,7 +649,7 @@ func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Co
 // waitForReplicateToReplicaGroupB will poll the VerticaReplicator waiting for the replication to finish.
 func (r *OnlineUpgradeReconciler) waitForReplicateToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -700,7 +700,7 @@ func (r *OnlineUpgradeReconciler) postRedirectToSandboxMsg(ctx context.Context) 
 // established at replica group A to go to replica group B.
 func (r *OnlineUpgradeReconciler) redirectConnectionsToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to redirect connections
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -751,7 +751,7 @@ func (r *OnlineUpgradeReconciler) postPromoteSandboxMsg(ctx context.Context) (ct
 // discard the pods for the old main.
 func (r *OnlineUpgradeReconciler) promoteSandboxToMainCluster(ctx context.Context) (ctrl.Result, error) {
 	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandbox {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -1173,7 +1173,7 @@ func (r *OnlineUpgradeReconciler) removeReplicaGroupAFromVdb(ctx context.Context
 // removeReplicaGroupA will remove the old main cluster
 func (r *OnlineUpgradeReconciler) removeReplicaGroupA(ctx context.Context) (ctrl.Result, error) {
 	// if replica group A has already been removed, we skip removing the old main cluster
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > removeReplicaGroupA {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > removeReplicaGroupAInx {
 		return ctrl.Result{}, nil
 	}
 	// if the sandbox is still there, we wait for promote_sandbox to be done
@@ -1193,7 +1193,7 @@ func (r *OnlineUpgradeReconciler) removeReplicaGroupA(ctx context.Context) (ctrl
 
 // deleteReplicaGroupASts will delete the statefulSet of replicate group A.
 func (r *OnlineUpgradeReconciler) deleteReplicaGroupASts(ctx context.Context) (ctrl.Result, error) {
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > deleteReplicaGroupASts {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > deleteReplicaGroupAStsInx {
 		return ctrl.Result{}, nil
 	}
 	// if the sandbox is still there, we wait for promote_sandbox to be done

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -274,8 +274,7 @@ func (i *UpgradeManager) clearOnlineUpgradeAnnotationCallback() (updated bool, e
 
 	// Clear annotations set in the VerticaDB's metadata.annotations.
 	for _, a := range []string{vmeta.OnlineUpgradeReplicatorAnnotation, vmeta.OnlineUpgradeSandboxAnnotation,
-		vmeta.OnlineUpgradeSandboxPromotedAnnotation, vmeta.OnlineUpgradeReplicaARemovedAnnotation,
-		vmeta.OnlineUpgradePreferredSandboxAnnotation} {
+		vmeta.OnlineUpgradeStepInxAnnotation, vmeta.OnlineUpgradePreferredSandboxAnnotation} {
 		if _, annotationFound := i.Vdb.Annotations[a]; annotationFound {
 			delete(i.Vdb.Annotations, a)
 			updated = true

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -266,12 +266,6 @@ const (
 	// This is the name of the VerticaReplicator that is generated during a online upgrade
 	OnlineUpgradeReplicatorAnnotation = "vertica.com/online-upgrade-replicator-name"
 
-	// During online upgrade, we store an annotation in the VerticaDB to indicate
-	// that we have done sandbox promotion.
-	OnlineUpgradeSandboxPromotedAnnotation = "vertica.com/online-upgrade-sandbox-promoted"
-	SandboxPromotedTrue                    = "true"
-	SandboxPromotedFalse                   = "false"
-
 	// During online upgrade, this annotation store some steps that we have
 	// already passed. This will allow us to skip them.
 	OnlineUpgradeStepInxAnnotation = "vertica.com/online-upgrade-step-index"
@@ -528,11 +522,6 @@ func GenScrutinizeMainContainerResourcesAnnotationName(resourceName corev1.Resou
 // GetOnlineUpgradeSandbox returns the name of the sandbox used for online upgrade.
 func GetOnlineUpgradeSandbox(annotations map[string]string) string {
 	return lookupStringAnnotation(annotations, OnlineUpgradeSandboxAnnotation, "")
-}
-
-// GetOnlineUpgradeSandboxPromoted returns if sandbox has been promoted in online upgrade.
-func GetOnlineUpgradeSandboxPromoted(annotations map[string]string) string {
-	return lookupStringAnnotation(annotations, OnlineUpgradeSandboxPromotedAnnotation, SandboxPromotedFalse)
 }
 
 // GetOnlineUpgradeStepInx returns the online upgrade step we are in.

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -272,6 +272,10 @@ const (
 	SandboxPromotedTrue                    = "true"
 	SandboxPromotedFalse                   = "false"
 
+	// During online upgrade, this annotation store some steps that we have
+	// already passed. This will allow us to skip them.
+	OnlineUpgradeStepInxAnnotation = "vertica.com/online-upgrade-step-index"
+
 	// During online upgrade, we store an annotation in the VerticaDB to indicate
 	// that we have removed old-main-cluster/replica-group-A.
 	OnlineUpgradeReplicaARemovedAnnotation = "vertica.com/online-upgrade-replica-A-removed"
@@ -531,6 +535,11 @@ func GetOnlineUpgradeSandboxPromoted(annotations map[string]string) string {
 	return lookupStringAnnotation(annotations, OnlineUpgradeSandboxPromotedAnnotation, SandboxPromotedFalse)
 }
 
+// GetOnlineUpgradeStepInx returns the online upgrade step we are in.
+func GetOnlineUpgradeStepInx(annotations map[string]string) int {
+	return lookupIntAnnotation(annotations, OnlineUpgradeStepInxAnnotation, 0)
+}
+
 // GetOnlineUpgradeReplicaARemoved returns if replica A has been removed in online upgrade.
 func GetOnlineUpgradeReplicaARemoved(annotations map[string]string) string {
 	return lookupStringAnnotation(annotations, OnlineUpgradeReplicaARemovedAnnotation, ReplicaARemovedFalse)
@@ -593,7 +602,7 @@ func genResourcesAnnotationName(prefix string, resourceName corev1.ResourceName)
 	// resource name like "limits.cpu" or "requests.memory". We don't want the
 	// period in the annotation name since it doesn't fit the style, so we
 	// replace that with a dash.
-	return fmt.Sprintf("%s-%s", prefix, strings.Replace(string(resourceName), ".", "-", 1))
+	return genAnnotationName(prefix, strings.Replace(string(resourceName), ".", "-", 1))
 }
 
 // getResource retrieves a specific resource given the annotation.
@@ -612,4 +621,8 @@ func getResource(annotations map[string]string, annotationName, defValStr string
 		return defVal
 	}
 	return quantity
+}
+
+func genAnnotationName(prefix, name string) string {
+	return fmt.Sprintf("%s-%s", prefix, name)
 }

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/02-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/02-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/02-rbac.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/02-rbac.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/05-create-secrets.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/05-create-secrets.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/vertica-license/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/10-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/10-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/10-verify-operator.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/10-verify-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/15-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/15-assert.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-main
+status:
+  currentReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/15-setup-vdb.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/20-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/20-assert.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-main
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+status:
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/20-wait-for-createdb.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/20-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/25-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/25-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/30-initiate-upgrade.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/30-initiate-upgrade.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade opentext/vertica-k8s-private:20240626-minimal

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/30-initiate-upgrade.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/30-initiate-upgrade.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade opentext/vertica-k8s-private:20240626-minimal
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/32-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/32-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: SandboxSubclusterStart
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-base-upgrade

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/32-wait-sandbox-start.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/32-wait-sandbox-start.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/35-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/35-assert.yaml
@@ -1,0 +1,48 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-main-sb
+  annotations:
+    vertica.com/statefulset-name-override: "v-base-upgrade-main-sb"
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: v1
+kind: Event
+reason: SandboxSubclusterSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-base-upgrade
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+spec:
+  subclusters:
+  - name: main
+  - name: main-sb
+    type: sandboxprimary
+    size: 3
+status:
+  sandboxes:
+    - subclusters:
+        - main-sb
+          

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/35-wait-for-sandbox.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/35-wait-for-sandbox.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/36-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/36-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-main
+status:
+  currentReplicas: 3
+  readyReplicas: 3

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/36-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/36-assert.yaml
@@ -17,4 +17,3 @@ metadata:
   name: v-base-upgrade-main
 status:
   currentReplicas: 3
-  readyReplicas: 3

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/36-kill-pods-in-main.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/36-kill-pods-in-main.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete pod v-base-upgrade-main-0 v-base-upgrade-main-1 v-base-upgrade-main-2
+    namespaced: true

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/37-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/37-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-main
+status:
+  currentReplicas: 3
+  readyReplicas: 3

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/37-wait-for-up-nodes.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/37-wait-for-up-nodes.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/40-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/40-assert.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-main-sb
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+spec:
+  subclusters:
+  - name: main
+    type: primary    
+    size: 3

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/40-errors.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/40-errors.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-base-upgrade-main

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/40-wait-for-new-main-cluster-to-be-ready.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/40-wait-for-new-main-cluster-to-be-ready.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/95-delete-cr.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/95-errors.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/96-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/96-errors.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/99-delete-ns.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,37 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-base-upgrade
+  annotations:
+    vertica.com/include-uid-in-path: true
+spec:
+  image: kustomize-vertica-image
+  dbName: repUP
+  initPolicy: CreateSkipPackageInstall
+  upgradePolicy: Online
+  communal: {}
+  local:
+    requestSize: 250Mi
+  # We pick a cluster size that is too big for the CE license. This relies on
+  # having a license, which will be added by kustomize.
+  subclusters:
+    - name: main
+      size: 3
+      type: primary
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
With this:
- The operator waits until all replica subcluater are sandboxed
- Makes sure there is an initiator in both main cluster and sandbox before replication
- Waits for all the nodes in sandbox to be up before promotion



Conversion happened in https://github.com/vertica/vertica-kubernetes/pull/857