### PR TITLE
Handle existing sandbox before online upgrade

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -588,13 +588,17 @@ func (v *VerticaDB) GetUpgradePolicyToUse() UpgradePolicyType {
 // containsSandboxNotForUpgrade returns true if there is already a sandbox in the database, except
 // from the one created for online upgrade.
 func (v *VerticaDB) containsSandboxNotForUpgrade() bool {
-	if len(v.Status.Sandboxes) > 1 {
+	if len(v.Status.Sandboxes) > 1 || len(v.Spec.Sandboxes) > 1 {
 		return true
 	}
+	upgradeSandbox := vmeta.GetOnlineUpgradeSandbox(v.Annotations)
 	if len(v.Status.Sandboxes) == 1 {
-		sbName := v.Status.Sandboxes[0].Name
-		upgradeSandbox := vmeta.GetOnlineUpgradeSandbox(v.Annotations)
-		return sbName != "" && upgradeSandbox != sbName
+		if upgradeSandbox != v.Status.Sandboxes[0].Name {
+			return true
+		}
+	}
+	if len(v.Spec.Sandboxes) == 1 {
+		return upgradeSandbox != v.Spec.Sandboxes[0].Name
 	}
 	return false
 }

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -567,7 +567,10 @@ func (v *VerticaDB) GetUpgradePolicyToUse() UpgradePolicyType {
 		const ceLicenseLimit = 3
 		if vinf.IsEqualOrNewer(OnlineUpgradeVersion) &&
 			!v.IsKSafety0() &&
-			(v.getNumberOfNodes() > ceLicenseLimit || v.Spec.LicenseSecret != "") {
+			(v.getNumberOfNodes() > ceLicenseLimit || v.Spec.LicenseSecret != "") &&
+			// online upgrade is not allowed if a there is already a sandbox
+			// in vertica
+			len(v.Status.Sandboxes) == 0 {
 			return OnlineUpgrade
 		} else if vinf.IsEqualOrNewer(ReadOnlyOnlineUpgradeVersion) {
 			return ReadOnlyOnlineUpgrade

--- a/api/v1/verticadb_types_test.go
+++ b/api/v1/verticadb_types_test.go
@@ -123,6 +123,11 @@ var _ = Describe("verticadb_types", func() {
 		}
 		vdb.Spec.LicenseSecret = "v-license"
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OnlineUpgrade))
+		// Ensure we don't pick online if there is already a sandbox in the status
+		vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, SandboxStatus{})
+		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(ReadOnlyOnlineUpgrade))
+		vdb.Status.Sandboxes = nil
+		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OnlineUpgrade))
 
 		// If older version than what we support for online. We should revert to read-only online upgrade.
 		vdb.Spec.UpgradePolicy = OnlineUpgrade

--- a/api/v1/verticadb_types_test.go
+++ b/api/v1/verticadb_types_test.go
@@ -124,9 +124,15 @@ var _ = Describe("verticadb_types", func() {
 		vdb.Spec.LicenseSecret = "v-license"
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OnlineUpgrade))
 		// Ensure we don't pick online if there is already a sandbox in the status
-		vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, SandboxStatus{})
+		const sbName = "sb1"
+		vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, SandboxStatus{Name: sbName})
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(ReadOnlyOnlineUpgrade))
 		vdb.Status.Sandboxes = nil
+		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OnlineUpgrade))
+		// We should pick online upgrade if the only existing sandbox is the one used
+		// by online upgrade
+		vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, SandboxStatus{Name: sbName})
+		vdb.Annotations[vmeta.OnlineUpgradeSandboxAnnotation] = sbName
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OnlineUpgrade))
 
 		// If older version than what we support for online. We should revert to read-only online upgrade.

--- a/api/v1/verticadb_types_test.go
+++ b/api/v1/verticadb_types_test.go
@@ -123,8 +123,11 @@ var _ = Describe("verticadb_types", func() {
 		}
 		vdb.Spec.LicenseSecret = "v-license"
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OnlineUpgrade))
-		// Ensure we don't pick online if there is already a sandbox in the status
+		// Ensure we don't pick online if there is already a sandbox
 		const sbName = "sb1"
+		vdb.Spec.Sandboxes = append(vdb.Spec.Sandboxes, Sandbox{Name: sbName})
+		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(ReadOnlyOnlineUpgrade))
+		vdb.Spec.Sandboxes = nil
 		vdb.Status.Sandboxes = append(vdb.Status.Sandboxes, SandboxStatus{Name: sbName})
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(ReadOnlyOnlineUpgrade))
 		vdb.Status.Sandboxes = nil

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1307,8 +1307,9 @@ func (v *VerticaDB) checkSandboxesDuringUpgrade(oldObj *VerticaDB, allErrs field
 		return allErrs
 	}
 	upgradeSbName := vmeta.GetOnlineUpgradeSandbox(v.Annotations)
-	// No error if the sandbox added is used by online upgrade.
-	if len(v.Spec.Sandboxes) == 1 && v.Spec.Sandboxes[0].Name == upgradeSbName {
+	// No error if the sandbox changed is used by online upgrade.
+	if (len(v.Spec.Sandboxes) == 1 && v.Spec.Sandboxes[0].Name == upgradeSbName) ||
+		(len(v.Spec.Sandboxes) == 0 && oldObj.Spec.Sandboxes[0].Name == upgradeSbName) {
 		return allErrs
 	}
 	err := field.Invalid(field.NewPath("spec").Child("sandboxes"),

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -147,6 +147,7 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 	allErrs = v.checkImmutableSubclusterInSandbox(oldObj, allErrs)
 	allErrs = v.checkImmutableStsName(oldObj, allErrs)
 	allErrs = v.checkValidSubclusterTypeTransition(oldObj, allErrs)
+	allErrs = v.checkSandboxesDuringUpgrade(oldObj, allErrs)
 	return allErrs
 }
 
@@ -1293,6 +1294,27 @@ func (v *VerticaDB) checkImmutableDeploymentMethod(oldObj *VerticaDB, allErrs fi
 		allErrs = append(allErrs, err)
 	}
 	return allErrs
+}
+
+// checkSandboxesDuringUpgrade will check if sandboxes size has changed during an upgrade.
+func (v *VerticaDB) checkSandboxesDuringUpgrade(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
+	// No error if upgrade is not in progress
+	if !oldObj.isUpgradeInProgress() {
+		return allErrs
+	}
+	// No error if sandboxes size did not change
+	if len(v.Spec.Sandboxes) == len(oldObj.Spec.Sandboxes) {
+		return allErrs
+	}
+	upgradeSbName := vmeta.GetOnlineUpgradeSandbox(v.Annotations)
+	// No error if the sandbox added is used by online upgrade.
+	if len(v.Spec.Sandboxes) == 1 && v.Spec.Sandboxes[0].Name == upgradeSbName {
+		return allErrs
+	}
+	err := field.Invalid(field.NewPath("spec").Child("sandboxes"),
+		v.Spec.Sandboxes,
+		"cannot add or remove sandboxes during an upgrade")
+	return append(allErrs, err)
 }
 
 // checkImmutableTemporarySubclusterRouting will check if

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1263,6 +1263,11 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
 		newVdb.Annotations[vmeta.OnlineUpgradeSandboxAnnotation] = sbName
 		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes = nil
+		oldVdb.Spec.Sandboxes = []Sandbox{
+			{Name: sbName, Subclusters: []SubclusterName{{Name: "sc3"}}},
+		}
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
 	})
 })
 

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1243,6 +1243,27 @@ var _ = Describe("verticadb_webhook", func() {
 		newVdb.Spec.Subclusters[1].Type = PrimarySubcluster
 		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
 	})
+
+	It("should disallow sandboxes size change during upgrade", func() {
+		oldVdb := MakeVDB()
+		oldVdb.Status.Conditions = []metav1.Condition{
+			{Type: UpgradeInProgress, Status: metav1.ConditionTrue},
+		}
+		const sbName = "sb1"
+		oldVdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1", Type: PrimarySubcluster, Size: 3},
+			{Name: "sc2", Type: SecondarySubcluster, Size: 1},
+			{Name: "sc3", Type: SecondarySubcluster, Size: 1},
+		}
+		newVdb := oldVdb.DeepCopy()
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes = []Sandbox{
+			{Name: sbName, Subclusters: []SubclusterName{{Name: "sc3"}}},
+		}
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
+		newVdb.Annotations[vmeta.OnlineUpgradeSandboxAnnotation] = sbName
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
+	})
 })
 
 func createVDBHelper() *VerticaDB {

--- a/api/v1beta1/helpers.go
+++ b/api/v1beta1/helpers.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	ReasonSucceeded = "Succeeded"
+)
+
 // Affinity is used instead of corev1.Affinity and behaves the same.
 // This structure is used in some CRs fields to define the "Affinity".
 // corev1.Affinity is composed of 3 fields and for each of them,
@@ -146,6 +150,11 @@ func (vrpq *VerticaRestorePointsQuery) IsStatusConditionFalse(statusCondition st
 
 func (vrpq *VerticaRestorePointsQuery) IsStatusConditionPresent(statusCondition string) bool {
 	return meta.FindStatusCondition(vrpq.Status.Conditions, statusCondition) != nil
+}
+
+// FindStatusCondition finds the conditionType in conditions.
+func (vrep *VerticaReplicator) FindStatusCondition(conditionType string) *metav1.Condition {
+	return meta.FindStatusCondition(vrep.Status.Conditions, conditionType)
 }
 
 func (vrep *VerticaReplicator) IsStatusConditionTrue(statusCondition string) bool {

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -128,6 +128,7 @@ func (r *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 	funcs := []func(context.Context) (ctrl.Result, error){
 		// Initiate an upgrade by setting condition and event recording
 		r.startUpgrade,
+		r.logEventIfThisUpgradeWasNotChosen,
 		r.postStartOnlineUpgradeMsg,
 		// Load up state that is used for the subsequent steps
 		r.loadUpgradeState,
@@ -198,6 +199,13 @@ func (r *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 
 func (r *OnlineUpgradeReconciler) startUpgrade(ctx context.Context) (ctrl.Result, error) {
 	return r.Manager.startUpgrade(ctx, vapi.MainCluster)
+}
+
+// logEventIfThisUpgradeWasNotChosen will write an event log if we are doing this
+// upgrade method as a fall back from a requested policy.
+func (r *OnlineUpgradeReconciler) logEventIfThisUpgradeWasNotChosen(_ context.Context) (ctrl.Result, error) {
+	r.Manager.logEventIfRequestedUpgradeIsDifferent(vapi.OnlineUpgrade)
+	return ctrl.Result{}, nil
 }
 
 func (r *OnlineUpgradeReconciler) finishUpgrade(ctx context.Context) (ctrl.Result, error) {

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -626,7 +626,7 @@ func (r *OnlineUpgradeReconciler) waitForReplicateToReplicaGroupB(ctx context.Co
 	}
 
 	cond := vrep.FindStatusCondition(v1beta1.ReplicationComplete)
-	if cond == nil || (cond != nil && cond.Status != metav1.ConditionTrue) {
+	if cond == nil || cond.Status != metav1.ConditionTrue {
 		r.Log.Info("Requeue replication is not finished", "vrepName", vrepName)
 		return ctrl.Result{Requeue: true}, nil
 	}

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -1085,7 +1085,6 @@ func (r *OnlineUpgradeReconciler) duplicateSubclusterForReplicaGroupB(
 	if baseSc.Annotations == nil {
 		baseSc.Annotations = make(map[string]string)
 	}
-	baseSc.Annotations[vmeta.ChildSubclusterAnnotation] = newSc.Name
 	return newSc
 }
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -98,7 +98,6 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(sc3.Size).Should(Equal(int32(6)))
 		Ω(sc3.Annotations).Should(HaveKeyWithValue(vmeta.ReplicaGroupAnnotation, vmeta.ReplicaGroupBValue))
 		Ω(sc3.Annotations).Should(HaveKeyWithValue(vmeta.ParentSubclusterAnnotation, sc1.Name))
-		Ω(sc1.Annotations).Should(HaveKeyWithValue(vmeta.ChildSubclusterAnnotation, sc3.Name))
 		Ω(sc3.Annotations).Should(HaveKeyWithValue(vmeta.ParentSubclusterTypeAnnotation, vapi.PrimarySubcluster))
 
 		sc5 := vdb.Spec.Subclusters[4]
@@ -169,16 +168,6 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(vdb.Spec.Subclusters).Should(HaveLen(4))
 		sbName := vmeta.GetOnlineUpgradeSandbox(vdb.Annotations)
 		Ω(sbName).Should(Equal(preferredSandboxName))
-		pri1 := vdb.Spec.Subclusters[0]
-		pri2 := vdb.Spec.Subclusters[1]
-		Ω(pri1.Annotations).Should(HaveKey(vmeta.ChildSubclusterAnnotation))
-		Ω(pri2.Annotations).Should(HaveKey(vmeta.ChildSubclusterAnnotation))
-
-		sbMap := genSandboxMap(vdb)
-		sbScs, found := sbMap[sbName]
-		Ω(found).Should(BeTrue())
-		Ω(sbScs).Should(HaveKey(pri1.Annotations[vmeta.ChildSubclusterAnnotation]))
-		Ω(sbScs).Should(HaveKey(pri2.Annotations[vmeta.ChildSubclusterAnnotation]))
 
 		// Should clear annotation at end of upgrade
 		Ω(rr.finishUpgrade(ctx)).Should(Equal(ctrl.Result{}))
@@ -219,10 +208,6 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(sbMap).Should(HaveKey(sbName))
 		Ω(sbMap).Should(HaveKey(preferredSandboxName))
 
-		pri1 := vdb.Spec.Subclusters[0]
-		Ω(pri1.Annotations).Should(HaveKey(vmeta.ChildSubclusterAnnotation))
-		repSb := sbMap[sbName]
-		Ω(repSb).Should(HaveKey(pri1.Annotations[vmeta.ChildSubclusterAnnotation]))
 		firstSb := sbMap[preferredSandboxName]
 		Ω(firstSb).Should(HaveKey("sec1"))
 	})

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -83,6 +83,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		rr := createOnlineUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 
 		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
@@ -130,6 +131,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		rr := createOnlineUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 
 		Ω(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), vdb)).Should(Succeed())
@@ -159,6 +161,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		rr := createOnlineUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 
@@ -204,6 +207,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		rr := createOnlineUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 
@@ -237,6 +241,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		rr := createOnlineUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 
@@ -259,6 +264,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		rr := createOnlineUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		mockCompletionOfSandbox(ctx, vdb)
@@ -302,6 +308,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 		Ω(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
 		rr := createOnlineUpgradeReconciler(ctx, vdb)
+		Ω(rr.assignSubclustersToReplicaGroupA(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.assignSubclustersToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.sandboxReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))
 		Ω(rr.startReplicationToReplicaGroupB(ctx)).Should(Equal(ctrl.Result{}))

--- a/pkg/controllers/vdb/readonlyonlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/readonlyonlineupgrade_reconciler.go
@@ -140,8 +140,8 @@ func (o *ReadOnlyOnlineUpgradeReconciler) finishUpgrade(ctx context.Context) (ct
 
 // logEventIfThisUpgradeWasNotChosen will write an event log if we are doing this
 // upgrade method as a fall back from a requested policy.
-func (o *ReadOnlyOnlineUpgradeReconciler) logEventIfThisUpgradeWasNotChosen(ctx context.Context) (ctrl.Result, error) {
-	o.Manager.logEventIfRequestedUpgradeIsDifferent(vapi.OnlineUpgrade)
+func (o *ReadOnlyOnlineUpgradeReconciler) logEventIfThisUpgradeWasNotChosen(_ context.Context) (ctrl.Result, error) {
+	o.Manager.logEventIfRequestedUpgradeIsDifferent(vapi.ReadOnlyOnlineUpgrade)
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -529,7 +529,8 @@ func offlineUpgradeAllowed(vdb *vapi.VerticaDB) bool {
 	return vdb.GetUpgradePolicyToUse() == vapi.OfflineUpgrade
 }
 
-// onlineUpgradeAllowed returns true if upgrade must be done online
+// readOnlyOnlineUpgradeAllowed returns true if upgrade must be done online
+// in read-only mode
 func readOnlyOnlineUpgradeAllowed(vdb *vapi.VerticaDB) bool {
 	return vdb.GetUpgradePolicyToUse() == vapi.ReadOnlyOnlineUpgrade
 }

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -263,7 +263,7 @@ func (i *UpgradeManager) clearOnlineUpgradeAnnotations(ctx context.Context) erro
 func (i *UpgradeManager) clearOnlineUpgradeAnnotationCallback() (updated bool, err error) {
 	for inx := range i.Vdb.Spec.Subclusters {
 		sc := &i.Vdb.Spec.Subclusters[inx]
-		for _, a := range []string{vmeta.ReplicaGroupAnnotation, vmeta.ChildSubclusterAnnotation,
+		for _, a := range []string{vmeta.ReplicaGroupAnnotation,
 			vmeta.ParentSubclusterAnnotation, vmeta.ParentSubclusterTypeAnnotation} {
 			if _, annotationFound := sc.Annotations[a]; annotationFound {
 				delete(sc.Annotations, a)

--- a/pkg/controllers/vdb/upgrade_test.go
+++ b/pkg/controllers/vdb/upgrade_test.go
@@ -295,7 +295,6 @@ var _ = Describe("upgrade", func() {
 		vdb.Spec.Subclusters[0].Annotations = map[string]string{
 			vmeta.ReplicaGroupAnnotation:     vmeta.ReplicaGroupAValue,
 			vmeta.ParentSubclusterAnnotation: "main",
-			vmeta.ChildSubclusterAnnotation:  "child",
 		}
 		Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
 
@@ -303,12 +302,10 @@ var _ = Describe("upgrade", func() {
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
 		Expect(fetchedVdb.Spec.Subclusters[0].Annotations).Should(HaveKey(vmeta.ReplicaGroupAnnotation))
 		Expect(fetchedVdb.Spec.Subclusters[0].Annotations).Should(HaveKey(vmeta.ParentSubclusterAnnotation))
-		Expect(fetchedVdb.Spec.Subclusters[0].Annotations).Should(HaveKey(vmeta.ChildSubclusterAnnotation))
 
 		Expect(mgr.finishUpgrade(ctx, vapi.MainCluster)).Should(Equal(ctrl.Result{}))
 		Expect(k8sClient.Get(ctx, vdb.ExtractNamespacedName(), fetchedVdb)).Should(Succeed())
 		Expect(fetchedVdb.Spec.Subclusters[0].Annotations).ShouldNot(HaveKey(vmeta.ReplicaGroupAnnotation))
 		Expect(fetchedVdb.Spec.Subclusters[0].Annotations).ShouldNot(HaveKey(vmeta.ParentSubclusterAnnotation))
-		Expect(fetchedVdb.Spec.Subclusters[0].Annotations).ShouldNot(HaveKey(vmeta.ChildSubclusterAnnotation))
 	})
 })

--- a/pkg/controllers/vrep/replication_reconciler.go
+++ b/pkg/controllers/vrep/replication_reconciler.go
@@ -318,6 +318,6 @@ func (r *ReplicationReconciler) runReplicateDB(ctx context.Context, dispatcher v
 
 	// clear Replicating status condition and set the ReplicationComplete status condition
 	return vrepstatus.Update(ctx, r.VRec.Client, r.VRec.Log, r.Vrep,
-		[]*metav1.Condition{vapi.MakeCondition(v1beta1.Replicating, metav1.ConditionFalse, "Succeeded"),
-			vapi.MakeCondition(v1beta1.ReplicationComplete, metav1.ConditionTrue, "Succeeded")}, stateSucceededReplication)
+		[]*metav1.Condition{vapi.MakeCondition(v1beta1.Replicating, metav1.ConditionFalse, v1beta1.ReasonSucceeded),
+			vapi.MakeCondition(v1beta1.ReplicationComplete, metav1.ConditionTrue, v1beta1.ReasonSucceeded)}, stateSucceededReplication)
 }

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -254,7 +254,6 @@ const (
 	// subcluster in the other replica group. This annotation is used to
 	// establish the relationship.
 	ParentSubclusterAnnotation = "vertica.com/parent-subcluster"
-	ChildSubclusterAnnotation  = "vertica.com/child-subcluster"
 	// For each subcluster in replica group b, this is type of the associated
 	// subcluster in replica group a.
 	ParentSubclusterTypeAnnotation = "vertica.com/parent-subcluster-type"

--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -227,6 +227,7 @@ replacements:
         reject:
         - name: v-upgrade-vertica
         - name: v-base-upgrade
+        - name: v-fallback
   - source:
       kind: ConfigMap
       name: e2e
@@ -235,6 +236,11 @@ replacements:
       - select:
           kind: VerticaDB
           name: v-base-upgrade
+        fieldPaths:
+          - spec.image
+      - select:
+          kind: VerticaDB
+          name: v-fallback
         fieldPaths:
           - spec.image
   - source:

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/02-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/02-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/02-rbac.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/02-rbac.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/05-create-secrets.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/05-create-secrets.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/vertica-license/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/10-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/10-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/10-verify-operator.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/10-verify-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/15-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/15-assert.yaml
@@ -1,0 +1,26 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-fallback-pri1
+status:
+  currentReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-fallback-sec1
+status:
+  currentReplicas: 2

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/15-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/15-assert.yaml
@@ -16,11 +16,11 @@ kind: StatefulSet
 metadata:
   name: v-fallback-pri1
 status:
-  currentReplicas: 1
+  currentReplicas: 3
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: v-fallback-sec1
 status:
-  currentReplicas: 2
+  currentReplicas: 1

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/15-setup-vdb.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/20-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/20-assert.yaml
@@ -1,0 +1,39 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-fallback-pri1
+status:
+  currentReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-fallback-sec1
+status:
+  currentReplicas: 2
+  readyReplicas: 2
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-fallback
+status:
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1
+    - addedToDBCount: 2
+      upNodeCount: 2

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/20-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/20-assert.yaml
@@ -16,16 +16,16 @@ kind: StatefulSet
 metadata:
   name: v-fallback-pri1
 status:
-  currentReplicas: 1
-  readyReplicas: 1
+  currentReplicas: 3
+  readyReplicas: 3
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: v-fallback-sec1
 status:
-  currentReplicas: 2
-  readyReplicas: 2
+  currentReplicas: 1
+  readyReplicas: 1
 ---
 apiVersion: vertica.com/v1
 kind: VerticaDB
@@ -33,7 +33,7 @@ metadata:
   name: v-fallback
 status:
   subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
     - addedToDBCount: 1
       upNodeCount: 1
-    - addedToDBCount: 2
-      upNodeCount: 2

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/20-wait-for-createdb.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/20-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/25-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/25-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/30-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/30-assert.yaml
@@ -1,0 +1,43 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: SandboxSubclusterSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-fallback
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-fallback
+spec:
+  subclusters:
+  - name: pri1
+    type: primary
+  - name: sec1
+    type: sandboxprimary
+status:
+  sandboxes:
+    - name: sandbox1
+      subclusters:
+        - sec1
+  subclusters:
+    - addedToDBCount: 1
+      name: pri1
+    - addedToDBCount: 2
+      name: sec1

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/30-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/30-assert.yaml
@@ -37,7 +37,7 @@ status:
       subclusters:
         - sec1
   subclusters:
-    - addedToDBCount: 1
+    - addedToDBCount: 3
       name: pri1
-    - addedToDBCount: 2
+    - addedToDBCount: 1
       name: sec1

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/30-sandbox-sec1.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/30-sandbox-sec1.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-fallback
+spec:
+  sandboxes:
+  - name: sandbox1
+    subclusters:
+      - name: sec1

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/35-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/35-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: v-fallback-sandbox1
+data:
+  sandboxName: sandbox1
+  verticaDBName: v-fallback
+immutable: true

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/35-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/35-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/40-initiate-upgrade.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/40-initiate-upgrade.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-fallback

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/45-wait-for-read-only-upgrade.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/45-wait-for-read-only-upgrade.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl wait --for=condition=ReadOnlyOnlineUpgradeInProgress=True vdb/v-fallback --timeout=600s
+    namespaced: true

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/95-delete-cr.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/95-errors.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/96-assert.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/96-errors.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/99-delete-ns.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/setup-vdb/base/setup-vdb.yaml
@@ -17,20 +17,20 @@ metadata:
   name: v-fallback
   annotations:
     vertica.com/include-uid-in-path: true
-    vertica.com/k-safety: "0"
 spec:
   image: kustomize-vertica-image
-  dbName: sandbox_db
+  dbName: mydb
   initPolicy: CreateSkipPackageInstall
+  upgradePolicy: Online
   communal: {}
   local:
     requestSize: 100Mi
   subclusters:
     - name: pri1
-      size: 1
+      size: 3
       type: primary
     - name: sec1
-      size: 2
+      size: 1
       type: secondary
   certSecrets: []
   imagePullSecrets: []

--- a/tests/e2e-leg-9/fallback-to-read-only-upgrade/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/fallback-to-read-only-upgrade/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-fallback
+  annotations:
+    vertica.com/include-uid-in-path: true
+    vertica.com/k-safety: "0"
+spec:
+  image: kustomize-vertica-image
+  dbName: sandbox_db
+  initPolicy: CreateSkipPackageInstall
+  communal: {}
+  local:
+    requestSize: 100Mi
+  subclusters:
+    - name: pri1
+      size: 1
+      type: primary
+    - name: sec1
+      size: 2
+      type: secondary
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
If online upgrade is done when there is already a sandbox, unsandboxing that sandbox after upgrade will fail. To prevent that, online upgrade will not be allowed if a sandbox exists. The operator will pick readonlyonlineupgrade.



The conversation happened  in https://github.com/vertica/vertica-kubernetes/pull/861