### PR TITLE
Create restore point before replication

### DIFF
--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -57,6 +57,7 @@ var onlineUpgradeStatusMsgs = []string{
 	"Preparing replication",
 	"Back up database before replication",
 	"Replicate new data from main cluster to sandbox",
+	"Back up database after replication",
 	"Redirect connections to sandbox",
 	"Promote sandbox to main cluster",
 	"Remove original main cluster",

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -43,6 +43,8 @@ import (
 // When we generate a sandbox for the upgrade, this is preferred name of that sandbox.
 const preferredSandboxName = "replica-group-b"
 
+const archiveBaseName = "upgrade_backup"
+
 // List of status messages for online upgrade. When adding a new entry here,
 // be sure to add a *StatusMsgInx const below.
 var onlineUpgradeStatusMsgs = []string{
@@ -52,6 +54,8 @@ var onlineUpgradeStatusMsgs = []string{
 	"Promote secondaries whose base subcluster is primary",
 	"Upgrade sandbox to new version",
 	"Pause connections to main cluster",
+	"Preparing replication",
+	"Back up database before replication",
 	"Replicate new data from main cluster to sandbox",
 	"Redirect connections to sandbox",
 	"Promote sandbox to main cluster",
@@ -67,6 +71,8 @@ const (
 	promoteSubclustersInSandboxMsgInx
 	upgradeSandboxMsgInx
 	pauseConnectionsMsgInx
+	prepareReplicationInx
+	backupDBBeforeReplicationInx
 	startReplicationMsgInx
 	redirectToSandboxMsgInx
 	promoteSandboxMsgInx
@@ -79,6 +85,9 @@ const (
 	runObjRecForMainInx = iota
 	addSubclustersInx
 	addNodeInx
+	upgradeSandboxInx
+	createRestorePointInx
+	replicationInx
 	promoteSandboxInx
 	removeReplicaGroupAInx
 	deleteReplicaGroupAStsInx
@@ -156,11 +165,15 @@ func (r *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 		// replication below.
 		r.postPauseConnectionsMsg,
 		r.pauseConnectionsAtReplicaGroupA,
+		// Prepare replication by ensuring nodes are up
+		r.postPrepareReplicationMsg,
+		r.prepareReplication,
+		// Back up database before replication
+		r.postBackupDBMsg,
 		r.createRestorePoint,
 		// Copy any new data that was added since the sandbox from replica group
 		// A to replica group B.
 		r.postStartReplicationMsg,
-		r.prepareReplication,
 		r.startReplicationToReplicaGroupB,
 		r.waitForReplicateToReplicaGroupB,
 		// Redirect all of the connections to replica group A to replica group B.
@@ -433,8 +446,8 @@ func (r *OnlineUpgradeReconciler) postUpgradeSandboxMsg(ctx context.Context) (ct
 
 // upgradeSandbox will upgrade the nodes in replica group B (sandbox) to the new version.
 func (r *OnlineUpgradeReconciler) upgradeSandbox(ctx context.Context) (ctrl.Result, error) {
-	// If we have already promoted sandbox to main, we don't need to upgrade the sandbox again
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
+	// We skip this if sandbox upgrade already happened
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > upgradeSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -472,8 +485,8 @@ func (r *OnlineUpgradeReconciler) upgradeSandbox(ctx context.Context) (ctrl.Resu
 // waitForSandboxUpgrade will wait for the sandbox upgrade to finish. It will
 // continually check if the pods in the sandbox are up.
 func (r *OnlineUpgradeReconciler) waitForSandboxUpgrade(ctx context.Context) (ctrl.Result, error) {
-	// If we have already promoted sandbox to main, we don't need to wait for sandbox upgrade
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
+	// We skip this if sandbox upgrade already happened
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > upgradeSandboxInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -490,7 +503,7 @@ func (r *OnlineUpgradeReconciler) waitForSandboxUpgrade(ctx context.Context) (ct
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, r.updateOnlineUpgradeStepAnnotation(ctx, r.getNextStep())
 }
 
 // postPauseConnectionsMsg will update the status message to indicate that
@@ -548,23 +561,19 @@ func (r *OnlineUpgradeReconciler) pauseConnectionsAtReplicaGroupA(ctx context.Co
 	return ctrl.Result{}, nil
 }
 
-func (r *OnlineUpgradeReconciler) createRestorePoint(ctx context.Context) (ctrl.Result, error) {
-	return r.Manager.createRestorePoint(ctx, r.PFacts[vapi.MainCluster], r.sandboxName)
-}
-
-// postStartReplicationMsg will update the status message to indicate that
-// replication from the main to the sandbox is starting.
-func (r *OnlineUpgradeReconciler) postStartReplicationMsg(ctx context.Context) (ctrl.Result, error) {
-	return r.postNextStatusMsg(ctx, startReplicationMsgInx)
+// postPrepareReplicationMsg will update the status message to indicate that
+// we are doing some preparation work before replication
+func (r *OnlineUpgradeReconciler) postPrepareReplicationMsg(ctx context.Context) (ctrl.Result, error) {
+	return r.postNextStatusMsg(ctx, prepareReplicationInx)
 }
 
 // prepareReplication makes sure there is at least an Up node in the main cluster
 // and the sandbox, to perform replication.
 // Once we start using services for replication, we will check only the scs served by the services.
 func (r *OnlineUpgradeReconciler) prepareReplication(ctx context.Context) (ctrl.Result, error) {
-	// Skip if the VerticaReplicator has already been created or
-	// if we have already promoted sandbox to main
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx ||
+	// Skip if the replication has already completed successfully or VerticaReplicator
+	// already exists
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > replicationInx ||
 		vmeta.GetOnlineUpgradeReplicator(r.VDB.Annotations) != "" {
 		return ctrl.Result{}, nil
 	}
@@ -596,11 +605,35 @@ func (r *OnlineUpgradeReconciler) prepareReplication(ctx context.Context) (ctrl.
 	return ctrl.Result{}, nil
 }
 
+// backupDBBeforeReplicationInx will update the status message to indicate that
+// we backing up the db before replication.
+func (r *OnlineUpgradeReconciler) postBackupDBMsg(ctx context.Context) (ctrl.Result, error) {
+	return r.postNextStatusMsg(ctx, backupDBBeforeReplicationInx)
+}
+
+func (r *OnlineUpgradeReconciler) createRestorePoint(ctx context.Context) (ctrl.Result, error) {
+	// Skip if the db has already been backed up
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > createRestorePointInx {
+		return ctrl.Result{}, nil
+	}
+	res, err := r.Manager.createRestorePoint(ctx, r.PFacts[vapi.MainCluster], genBaseNameWithUUID(archiveBaseName, "_"))
+	if verrors.IsReconcileAborted(res, err) {
+		return res, err
+	}
+	return ctrl.Result{}, r.updateOnlineUpgradeStepAnnotation(ctx, r.getNextStep())
+}
+
+// postStartReplicationMsg will update the status message to indicate that
+// replication from the main to the sandbox is starting.
+func (r *OnlineUpgradeReconciler) postStartReplicationMsg(ctx context.Context) (ctrl.Result, error) {
+	return r.postNextStatusMsg(ctx, startReplicationMsgInx)
+}
+
 // startReplicationToReplicaGroupB will copy any new data that was added since
 // the sandbox from replica group A to replica group B.
 func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
-	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
+	// Skip if the replication has already completed successfully
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > replicationInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -653,8 +686,8 @@ func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Co
 
 // waitForReplicateToReplicaGroupB will poll the VerticaReplicator waiting for the replication to finish.
 func (r *OnlineUpgradeReconciler) waitForReplicateToReplicaGroupB(ctx context.Context) (ctrl.Result, error) {
-	// If we have already promoted sandbox to main, we don't need to do this step
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
+	// Skip if the replication has already completed successfully
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > replicationInx {
 		return ctrl.Result{}, nil
 	}
 
@@ -692,7 +725,7 @@ func (r *OnlineUpgradeReconciler) waitForReplicateToReplicaGroupB(ctx context.Co
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to delete the VerticaReplicator %s: %w", vrepName, err)
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, r.updateOnlineUpgradeStepAnnotation(ctx, r.getNextStep())
 }
 
 // postRedirectToSandboxMsg will update the status message to indicate that
@@ -1026,8 +1059,7 @@ func (r *OnlineUpgradeReconciler) genNameWithUUID(baseName string, lookupFunc fu
 	// Add a uuid suffix.
 	const maxAttempts = 100
 	for i := 0; i < maxAttempts; i++ {
-		u := uuid.NewString()
-		nm := fmt.Sprintf("%s-%s", baseName, u[0:5])
+		nm := genBaseNameWithUUID(baseName, "-")
 		if !lookupFunc(nm) {
 			return nm, nil
 		}
@@ -1339,4 +1371,9 @@ func (r *OnlineUpgradeReconciler) restartMainCluster(ctx context.Context) (ctrl.
 
 func (r *OnlineUpgradeReconciler) getNextStep() int {
 	return vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) + 1
+}
+
+func genBaseNameWithUUID(baseName, sep string) string {
+	u := uuid.NewString()
+	return fmt.Sprintf("%s%s%s", baseName, sep, u[0:5])
 }

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -145,6 +145,7 @@ func (r *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 		// replication below.
 		r.postPauseConnectionsMsg,
 		r.pauseConnectionsAtReplicaGroupA,
+		r.createRestorePoint,
 		// Copy any new data that was added since the sandbox from replica group
 		// A to replica group B.
 		r.postStartReplicationMsg,
@@ -528,6 +529,10 @@ func (r *OnlineUpgradeReconciler) pauseConnectionsAtReplicaGroupA(ctx context.Co
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *OnlineUpgradeReconciler) createRestorePoint(ctx context.Context) (ctrl.Result, error) {
+	return r.Manager.createRestorePoint(ctx, r.PFacts[vapi.MainCluster], r.sandboxName)
 }
 
 // postStartReplicationMsg will update the status message to indicate that

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -689,7 +689,7 @@ func (i *UpgradeManager) createRestorePoint(ctx context.Context, pfacts *PodFact
 	if arch == 0 {
 		sql = fmt.Sprintf("create archive %s;", archive)
 		cmd = []string{"-tAc", sql}
-		_, _, err := pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
+		_, _, err = pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -664,7 +664,7 @@ func (i *UpgradeManager) closeAllSessions(ctx context.Context, pfacts *PodFacts)
 	return nil
 }
 
-// closeAllSessions will run a query to close all active user sessions.
+// createRestorePoint creates a restore point to backup the db in case upgrade does not go well.
 func (i *UpgradeManager) createRestorePoint(ctx context.Context, pfacts *PodFacts, archive string) (ctrl.Result, error) {
 	pf, ok := pfacts.findFirstPodSorted(func(v *PodFact) bool {
 		return v.isPrimary && v.upNode

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -18,6 +18,7 @@ package vdb
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"errors"
@@ -662,6 +663,42 @@ func (i *UpgradeManager) closeAllSessions(ctx context.Context, pfacts *PodFacts)
 	}
 
 	return nil
+}
+
+// closeAllSessions will run a query to close all active user sessions.
+func (i *UpgradeManager) createRestorePoint(ctx context.Context, pfacts *PodFacts, archive string) (ctrl.Result, error) {
+	pf, ok := pfacts.findFirstPodSorted(func(v *PodFact) bool {
+		return v.isPrimary && v.upNode
+	})
+	if !ok {
+		i.Log.Info("No pod found to run vsql. Requeueing")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	sql := fmt.Sprintf("select count(*) from archives where name = '%s';", archive)
+	cmd := []string{"-tAc", sql}
+	stdout, _, err := pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	lines := strings.Split(stdout, "\n")
+	arch, err := strconv.Atoi(lines[0])
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// Create the archive only if it does not already exist
+	if arch == 0 {
+		sql = fmt.Sprintf("create archive %s;", archive)
+		cmd = []string{"-tAc", sql}
+		_, _, err := pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	sql = fmt.Sprintf("save restore point to archive %s;", archive)
+	cmd = []string{"-tAc", sql}
+	_, _, err = pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
+	return ctrl.Result{}, err
 }
 
 // routeClientTraffic will update service objects for the source subcluster to

--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -227,6 +227,7 @@ replacements:
         reject:
         - name: v-upgrade-vertica
         - name: v-base-upgrade
+        - name: v-upgrade-bad-image
   - source:
       kind: ConfigMap
       name: e2e
@@ -235,6 +236,16 @@ replacements:
       - select:
           kind: VerticaDB
           name: v-base-upgrade
+        fieldPaths:
+          - spec.image
+  - source:
+      kind: ConfigMap
+      name: e2e
+      fieldPath: data.baseVerticaImage
+    targets:
+      - select:
+          kind: VerticaDB
+          name: v-upgrade-bad-image
         fieldPaths:
           - spec.image
   - source:

--- a/scripts/setup-kustomize.sh
+++ b/scripts/setup-kustomize.sh
@@ -238,11 +238,6 @@ replacements:
           name: v-base-upgrade
         fieldPaths:
           - spec.image
-  - source:
-      kind: ConfigMap
-      name: e2e
-      fieldPath: data.baseVerticaImage
-    targets:
       - select:
           kind: VerticaDB
           name: v-upgrade-bad-image

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/02-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/02-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/02-rbac.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/02-rbac.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/05-create-secrets.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/05-create-secrets.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/vertica-license/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/10-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/10-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/10-verify-operator.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/10-verify-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/15-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/15-assert.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-upgrade-bad-image-main
+status:
+  currentReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-upgrade-bad-image

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/15-setup-vdb.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/20-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/20-assert.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-upgrade-bad-image-main
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-upgrade-bad-image
+status:
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/20-wait-for-createdb.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/20-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/25-wait-for-steady-state.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/25-wait-for-steady-state.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "../../../scripts/wait-for-verticadb-steady-state.sh -n verticadb-operator -t 360 $NAMESPACE"

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/30-setup-vdb-with-bad-image.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/30-setup-vdb-with-bad-image.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Start another upgrade but with a bogus image that doesn't exist.  The purpose
+# of this is abort an upgrade that is improgress and get it back to a good
+# state.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-upgrade-bad-image
+spec:
+  image: wrong-image

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/31-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/31-assert.yaml
@@ -19,4 +19,4 @@ source:
 involvedObject:
   apiVersion: vertica.com/v1
   kind: VerticaDB
-  name: v-base-upgrade
+  name: v-upgrade-bad-image

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/31-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/31-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: SandboxSubclusterStart
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-base-upgrade

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/31-wait-sandbox-start.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/31-wait-sandbox-start.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/32-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/32-assert.yaml
@@ -1,0 +1,48 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-upgrade-bad-image-main-sb
+  annotations:
+    vertica.com/statefulset-name-override: "v-upgrade-bad-image-main-sb"
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: v1
+kind: Event
+reason: SandboxSubclusterSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-upgrade-bad-image
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-upgrade-bad-image
+spec:
+  subclusters:
+  - name: main
+  - name: main-sb
+    type: sandboxprimary
+    size: 3
+status:
+  sandboxes:
+    - subclusters:
+        - main-sb
+          

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/32-wait-for-sandbox.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/32-wait-for-sandbox.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/33-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/33-assert.yaml
@@ -1,0 +1,31 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: v-upgrade-bad-image-main-sb-0
+status:
+  phase: Pending
+  containerStatuses:
+    - name: nma
+      state:
+        waiting:
+          reason: ImagePullBackOff
+      started: false
+    - name: server
+      state:
+        waiting:
+          reason: ImagePullBackOff
+      started: false
+  

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/33-wait-for-sandbox-upgrade-failure.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/33-wait-for-sandbox-upgrade-failure.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/35-set-right-image.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/35-set-right-image.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-upgrade-bad-image

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/50-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/50-assert.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-upgrade-bad-image-main-sb
+status:
+  currentReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-upgrade-bad-image
+spec:
+  subclusters:
+  - name: main
+    type: primary    
+    size: 3

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/50-errors.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/50-errors.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-upgrade-bad-image-main

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/50-wait-for-new-main-cluster-to-be-ready.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/50-wait-for-new-main-cluster-to-be-ready.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/95-delete-cr.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/95-errors.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/95-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/96-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/96-errors.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/99-delete-ns.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-9/new-online-upgrade-bad-image/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-bad-image/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,37 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-upgrade-bad-image
+  annotations:
+    vertica.com/include-uid-in-path: true
+spec:
+  image: kustomize-vertica-image
+  dbName: repUP
+  initPolicy: CreateSkipPackageInstall
+  upgradePolicy: Online
+  communal: {}
+  local:
+    requestSize: 250Mi
+  # We pick a cluster size that is too big for the CE license. This relies on
+  # having a license, which will be added by kustomize.
+  subclusters:
+    - name: main
+      size: 3
+      type: primary
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/60-assert.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/60-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-restore-point
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0 

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/60-verify-restore-point.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/60-verify-restore-point.yaml
@@ -23,7 +23,7 @@ data:
 
     POD_NAME=v-base-upgrade-pri1-sb-0
 
-    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM archive_restore_points WHERE name LIKE 'upgrade_backup%';\"")
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM archive_restore_points WHERE archive LIKE 'upgrade_backup%';\"")
     echo "$result" | grep -Pzo "^1\n$" > /dev/null
     if [ $? -ne 0 ]; then
       echo "Assertion failed: expected 1, got $result"

--- a/tests/e2e-leg-9/new-online-upgrade-sanity/60-verify-restore-point.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-sanity/60-verify-restore-point.yaml
@@ -1,0 +1,54 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-restore-point
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    POD_NAME=v-base-upgrade-pri1-sb-0
+
+    result=$(kubectl exec $POD_NAME -i -c server -- bash -c "vsql -U dbadmin -tAc \"SELECT COUNT(*) FROM archive_restore_points WHERE name LIKE 'upgrade_backup%';\"")
+    echo "$result" | grep -Pzo "^1\n$" > /dev/null
+    if [ $? -ne 0 ]; then
+      echo "Assertion failed: expected 1, got $result"
+      exit 1
+    fi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-restore-point
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-restore-point


### PR DESCRIPTION
Before starting replication, we back up the db. This will allow users to recover in case online upgrade fails.


Moreover an e2e test was added to make sure we con recover from a wrong image.