### PR TITLE
Deny online upgrade on version 24.3.0-0

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -565,7 +565,7 @@ func (v *VerticaDB) GetUpgradePolicyToUse() UpgradePolicyType {
 		// there is evidence that we have already scaled past 3 nodes (CE
 		// license limit), or we have a license defined.
 		const ceLicenseLimit = 3
-		if vinf.IsEqualOrNewer(OnlineUpgradeVersion) &&
+		if v.isOnlineUpgradeSupported(vinf) &&
 			!v.IsKSafety0() &&
 			(v.getNumberOfNodes() > ceLicenseLimit || v.Spec.LicenseSecret != "") &&
 			// online upgrade is not allowed if there is already a sandbox

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -157,10 +157,11 @@ func (v *VerticaDB) IsUpgradePathSupported(newAnnotations map[string]string) (ok
 // isOnlineUpgradeSupported returns true if the version in the Vdb is is equal or newer than
 // 24.3.0-0.
 func (v *VerticaDB) isOnlineUpgradeSupported(vinf *version.Info) bool {
-	const ver = "v24.3.0-0"
+	const ver1 = "v24.3.0-0"
+	const ver2 = "v24.3.0-1"
 	vdbVer, _ := v.GetVerticaVersionStr()
-	if vdbVer == ver {
-		// All v24.3.0-* supports online upgrade except v24.3.0-0
+	if vdbVer == ver1 || vdbVer == ver2 {
+		// All v24.3.0-* supports online upgrade except v24.3.0-0 and v24.3.0-1
 		return false
 	}
 	return vinf.IsEqualOrNewer(OnlineUpgradeVersion)

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -153,3 +153,15 @@ func (v *VerticaDB) IsUpgradePathSupported(newAnnotations map[string]string) (ok
 	ok, failureReason = vinf.IsValidUpgradePath(newAnnotations[vmeta.VersionAnnotation])
 	return
 }
+
+// isOnlineUpgradeSupported returns true if the version in the Vdb is is equal or newer than
+// 24.3.0-0.
+func (v *VerticaDB) isOnlineUpgradeSupported(vinf *version.Info) bool {
+	const ver = "v24.3.0-0"
+	vdbVer, _ := v.GetVerticaVersionStr()
+	if vdbVer == ver {
+		// All v24.3.0-* supports online upgrade except v24.3.0-0
+		return false
+	}
+	return vinf.IsEqualOrNewer(OnlineUpgradeVersion)
+}

--- a/api/v1/verticadb_types_test.go
+++ b/api/v1/verticadb_types_test.go
@@ -138,6 +138,11 @@ var _ = Describe("verticadb_types", func() {
 		vdb.Annotations[vmeta.OnlineUpgradeSandboxAnnotation] = sbName
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OnlineUpgrade))
 
+		// If version 24.3.0-0. We should revert to read-only online upgrade.
+		vdb.Spec.UpgradePolicy = OnlineUpgrade
+		vdb.Annotations[vmeta.VersionAnnotation] = "v24.3.0-0"
+		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(ReadOnlyOnlineUpgrade))
+
 		// If older version than what we support for online. We should revert to read-only online upgrade.
 		vdb.Spec.UpgradePolicy = OnlineUpgrade
 		vdb.Annotations[vmeta.VersionAnnotation] = ReadOnlyOnlineUpgradeVersion

--- a/pkg/controllers/vdb/imageversion_reconciler.go
+++ b/pkg/controllers/vdb/imageversion_reconciler.go
@@ -298,6 +298,12 @@ func (v *ImageVersionReconciler) updateConfigMapAnnotations(ctx context.Context,
 func (v *ImageVersionReconciler) isUpgradePathSupported(ctx context.Context, versionAnn map[string]string,
 ) (ok bool, failureReason string, err error) {
 	if v.PFacts.GetSandboxName() == vapi.MainCluster {
+		if v.Vdb.IsOnlineUpgradeInProgress() {
+			vdbVer, _ := v.Vdb.GetVerticaVersionStr()
+			if vdbVer == versionAnn[vmeta.VersionAnnotation] {
+				return false, "Versions are the same and can cause issues during online upgrade", nil
+			}
+		}
 		ok, failureReason = v.Vdb.IsUpgradePathSupported(versionAnn)
 		return ok, failureReason, nil
 	}


### PR DESCRIPTION
This disallow online upgrade for version 24.3.0-0 because an hotfix has been released recently with updeates needed for online upgrade. This is simple on purpose as it is for the target release "2.2.0".