### PR TITLE
Fixed Online Upgrade Error

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -407,6 +407,11 @@ func (v *VerticaDB) IsOnlineUpgradeInProgress() bool {
 	return v.IsStatusConditionTrue(OnlineUpgradeInProgress)
 }
 
+// IsOnlineUpgradeInProgress returns true if an upgrade is in progress
+func (v *VerticaDB) IsUpgradeInProgress() bool {
+	return v.IsStatusConditionTrue(UpgradeInProgress)
+}
+
 // IsStatusConditionTrue returns true when the conditionType is present and set to
 // `metav1.ConditionTrue`
 func (v *VerticaDB) IsStatusConditionTrue(statusCondition string) bool {

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -90,12 +90,29 @@ func (v *VerticaDB) GetVerticaVersionStr() (string, bool) {
 	return ver, ok
 }
 
+// GetVerticaVersionStr returns vertica version prior to the upgrade
+func (v *VerticaDB) GetPreviousVerticaVersionStr() (string, bool) {
+	ver, ok := v.ObjectMeta.Annotations[vmeta.PreviousVersionAnnotation]
+	return ver, ok
+}
+
 // MakeVersionInfo will construct an Info struct by extracting the version from the
 // given vdb.  This returns false if it was unable to get the version from the
 // vdb.
 func (v *VerticaDB) MakeVersionInfo() (*version.Info, bool) {
 	vdbVer, ok := v.GetVerticaVersionStr()
 	// If the version annotation isn't present, we abort creation of Info
+	if !ok {
+		return nil, false
+	}
+	return version.MakeInfoFromStr(vdbVer)
+}
+
+// MakePerviousVersionInfo will construct an Info struct by extracting the previous version
+// from the given vdb. This returns false if it was unable to get the version from the vdb.
+func (v *VerticaDB) MakePreviousVersionInfo() (*version.Info, bool) {
+	vdbVer, ok := v.GetPreviousVerticaVersionStr()
+	// If the annotation isn't present, we abort creation of Info
 	if !ok {
 		return nil, false
 	}

--- a/pkg/controllers/vdb/imageversion_reconciler.go
+++ b/pkg/controllers/vdb/imageversion_reconciler.go
@@ -234,6 +234,10 @@ func (v *ImageVersionReconciler) getVersion(ctx context.Context, pod *PodFact) (
 // fail if it detects an invalid upgrade path.
 func (v *ImageVersionReconciler) updateVDBVersion(ctx context.Context, newVersion string) (ctrl.Result, error) {
 	versionAnnotations := vapi.ParseVersionOutput(newVersion)
+	// if we found vertica version is changed, we save previous vertica version to vdb
+	if versionAnnotations[vmeta.VersionAnnotation] != v.Vdb.ObjectMeta.Annotations[vmeta.VersionAnnotation] {
+		versionAnnotations[vmeta.PreviousVersionAnnotation] = v.Vdb.ObjectMeta.Annotations[vmeta.VersionAnnotation]
+	}
 
 	if v.EnforceUpgradePath && !v.Vdb.GetIgnoreUpgradePath() {
 		ok, failureReason, err := v.isUpgradePathSupported(ctx, versionAnnotations)

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -132,6 +132,8 @@ const (
 	VersionAnnotation   = "vertica.com/version"
 	BuildDateAnnotation = "vertica.com/buildDate"
 	BuildRefAnnotation  = "vertica.com/buildRef"
+	// Annotation that records the vertica version prior to the upgrade
+	PreviousVersionAnnotation = "vertica.com/previous-version"
 	// Annotation for the database's revive_instance_id
 	ReviveInstanceIDAnnotation = "vertica.com/revive-instance-id"
 


### PR DESCRIPTION
When we run an online upgrade from Version 24.2.x to 24.3.x, the operator will fail due to pod facts collection error. The reason is that secondary subclusters still use the old Vertica Version 24.2.x when primary subclusters finished the upgrade. As a result, the operator will call vclusterOps API to collect node details on secondary subclusters, but secondary subclusters doesn't have that API due to a low Vertica version.

This PR saved the old Vertica version prior to the upgrade, and used that version to decide if the operator should call vclusterOps API to collect node details during the upgrade. 