### PR TITLE
Fixed online upgrade halting issue

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -407,9 +407,9 @@ func (v *VerticaDB) IsOnlineUpgradeInProgress() bool {
 	return v.IsStatusConditionTrue(OnlineUpgradeInProgress)
 }
 
-// IsOnlineUpgradeInProgress returns true if an upgrade is in progress
-func (v *VerticaDB) IsUpgradeInProgress() bool {
-	return v.IsStatusConditionTrue(UpgradeInProgress)
+// IsROOnlineUpgradeInProgress returns true if an read-only online upgrade is in progress
+func (v *VerticaDB) IsROUpgradeInProgress() bool {
+	return v.IsStatusConditionTrue(ReadOnlyOnlineUpgradeInProgress)
 }
 
 // IsStatusConditionTrue returns true when the conditionType is present and set to

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -104,6 +104,7 @@ const (
 	rebalanceShardsInx
 	waitForActiveSubsInx
 	setConfigParamInx
+	clearConfigParamInx
 	upgradeSandboxInx
 	backupBeforeReplicationInx
 	replicationInx
@@ -472,7 +473,7 @@ func (r *OnlineUpgradeReconciler) postClearConfigParamDisableNonReplicatableQuer
 // clearConfigParamDisableNonReplicatableQueries clears the config parameter
 // DisableNonReplicatableQueries from the sandbox
 func (r *OnlineUpgradeReconciler) clearConfigParamDisableNonReplicatableQueries(ctx context.Context) (ctrl.Result, error) {
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > promoteSandboxInx {
+	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > clearConfigParamInx {
 		return ctrl.Result{}, nil
 	}
 	// update podfacts for sandbox
@@ -484,7 +485,7 @@ func (r *OnlineUpgradeReconciler) clearConfigParamDisableNonReplicatableQueries(
 		return res, err
 	}
 	r.Log.Info(fmt.Sprintf("cleared DisableNonReplicatableQueries in sandbox %s", r.sandboxName))
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, r.updateOnlineUpgradeStepAnnotation(ctx, r.getNextStep())
 }
 
 // setConfigParamDisableNonReplicatableQueriesImpl sets the config parameter

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -455,7 +455,8 @@ func (r *OnlineUpgradeReconciler) setConfigParamDisableNonReplicatableQueries(ct
 	if r.originalConfigParamDisableNonReplicatableQueriesValue == "1" {
 		return ctrl.Result{}, r.updateOnlineUpgradeStepAnnotation(ctx, r.getNextStep())
 	}
-	if res, err := r.setConfigParamDisableNonReplicatableQueriesImpl(ctx, ConfigParamBoolTrue, r.sandboxName); err != nil {
+	res, err := r.setConfigParamDisableNonReplicatableQueriesImpl(ctx, ConfigParamBoolTrue, r.sandboxName)
+	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 	r.Log.Info("set DisableNonReplicatableQueries in main cluster before sandboxing")
@@ -478,7 +479,8 @@ func (r *OnlineUpgradeReconciler) clearConfigParamDisableNonReplicatableQueries(
 	if _, err := r.getSandboxPodFacts(ctx, true); err != nil {
 		return ctrl.Result{}, err
 	}
-	if res, err := r.setConfigParamDisableNonReplicatableQueriesImpl(ctx, ConfigParamBoolFalse, r.sandboxName); err != nil {
+	res, err := r.setConfigParamDisableNonReplicatableQueriesImpl(ctx, ConfigParamBoolFalse, r.sandboxName)
+	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 	r.Log.Info(fmt.Sprintf("cleared DisableNonReplicatableQueries in sandbox %s", r.sandboxName))

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -771,11 +771,11 @@ func (p *PodFacts) makeNodeInfoFetcher(vdb *vapi.VerticaDB, pf *PodFact) catalog
 	var ok bool
 	oldVerInfo, ok1 := vdb.MakePreviousVersionInfo()
 	newVerInfo, ok2 := vdb.MakeVersionInfo()
-	// During the upgrade, we should use the old version to determine if we will call
+	// During read-only online upgrade, we should use the old version to determine if we will call
 	// vclusterOps API to collect node info. The reason is some subclusters might uses
 	// a low version that does not contain vcluster API in the midst of the upgrade.
 	// Apart from the upgrade, we should check current version to make the decision.
-	if vdb.IsUpgradeInProgress() {
+	if vdb.IsROUpgradeInProgress() {
 		verInfo = oldVerInfo
 		ok = ok1
 	} else {


### PR DESCRIPTION
This PR fixed online upgrade halting issue after sandbox restart. We use vclusterOps to collect node details in online upgrade rather than vsql. This change will remove active connections on the subclusters so subclusters doesn't need to wait for user connections to be paused. As a result, it will fix the halting issue.