### PR TITLE
Install more packages for e2e tests in dockerfile

### DIFF
--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -74,6 +74,7 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION} as initial
 # packages can be queried through dnf. For instance, "dnf search openjdk"
 ARG JRE_PKG=java-1.8.0-openjdk-headless
 ARG MINIMAL
+ARG FOR_GITHUB_CI
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
@@ -89,6 +90,12 @@ RUN set -x \
   procps \
   sysstat \
   which \
+  # Install packages for e2e tests
+  && if [[ $FOR_GITHUB_CI == "true" ]] ; then \
+    yum install -y diffutils gcc-c++ boost-devel libcurl-devel bzip2-devel bzip2 perl java-1.8.0-openjdk-devel zlib-devel \
+    && ln -s /opt/vertica/oss/python3/bin/python3 /usr/bin/python \
+    && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0; \
+  fi \
   && if [[ $(rpm -E '%{rhel}') == "9" ]] ; then \
     yum install -y libxcrypt-compat; \
   fi \

--- a/docker-vertica-v2/Makefile
+++ b/docker-vertica-v2/Makefile
@@ -3,6 +3,7 @@ BUILDER_OS_NAME?=almalinux
 BUILDER_OS_VERSION?=8
 BASE_OS_NAME?=rockylinux
 BASE_OS_VERSION?=9
+FOR_GITHUB_CI?=false
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
@@ -25,5 +26,6 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_NAME=${BUILDER_OS_NAME} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
+		--build-arg FOR_GITHUB_CI=${FOR_GITHUB_CI} \
 		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \
 		-t ${VERTICA_IMG} .

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -101,6 +101,7 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION} as initial
 # packages can be queried through dnf. For instance, "dnf search openjdk"
 ARG JRE_PKG=java-1.8.0-openjdk-headless
 ARG MINIMAL
+ARG FOR_GITHUB_CI
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
@@ -122,6 +123,12 @@ RUN set -x \
   sysstat \
   sudo \
   which \
+  # Install packages for e2e tests
+  && if [[ $FOR_GITHUB_CI == "true" ]] ; then \
+    yum install -y diffutils gcc-c++ boost-devel libcurl-devel bzip2-devel bzip2 perl java-1.8.0-openjdk-devel zlib-devel \
+    && ln -s /opt/vertica/oss/python3/bin/python3 /usr/bin/python \
+    && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0; \
+  fi \
   && if [[ $(rpm -E '%{rhel}') == "9" ]] ; then \
     yum install -y libxcrypt-compat; \
   fi \

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -3,6 +3,7 @@ BUILDER_OS_NAME?=almalinux
 BUILDER_OS_VERSION?=8
 BASE_OS_NAME?=rockylinux
 BASE_OS_VERSION?=9
+FOR_GITHUB_CI?=false
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
@@ -25,5 +26,6 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_NAME=${BUILDER_OS_NAME} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
+		--build-arg FOR_GITHUB_CI=${FOR_GITHUB_CI} \
 		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \
 		-t ${VERTICA_IMG} .


### PR DESCRIPTION
This PR adds a new building argument to dockerfile of Vertica images. Devops will build the new daily Vertica images using the new dockerfile. Then our e2e tests don't need to access Vertica VPN any more.