### PR TITLE
Removed FOR_GITHUB_CI from legacy and minimal images

### DIFF
--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -90,8 +90,8 @@ RUN set -x \
   procps \
   sysstat \
   which \
-  # Install packages for e2e tests
-  && if [[ $FOR_GITHUB_CI == "true" ]] ; then \
+  # Install packages in full vertica image for e2e tests
+  && if [[ $FOR_GITHUB_CI == "true" ]] && [[ ${MINIMAL^^} != "YES" ]] ; then \
     yum install -y diffutils gcc-c++ boost-devel libcurl-devel bzip2-devel bzip2 perl java-1.8.0-openjdk-devel zlib-devel \
     && ln -s /opt/vertica/oss/python3/bin/python3 /usr/bin/python \
     && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0; \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -101,7 +101,6 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION} as initial
 # packages can be queried through dnf. For instance, "dnf search openjdk"
 ARG JRE_PKG=java-1.8.0-openjdk-headless
 ARG MINIMAL
-ARG FOR_GITHUB_CI
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
@@ -123,12 +122,6 @@ RUN set -x \
   sysstat \
   sudo \
   which \
-  # Install packages for e2e tests
-  && if [[ $FOR_GITHUB_CI == "true" ]] ; then \
-    yum install -y diffutils gcc-c++ boost-devel libcurl-devel bzip2-devel bzip2 perl java-1.8.0-openjdk-devel zlib-devel \
-    && ln -s /opt/vertica/oss/python3/bin/python3 /usr/bin/python \
-    && ln -s /usr/lib64/libbz2.so /usr/lib64/libbz2.so.1.0; \
-  fi \
   && if [[ $(rpm -E '%{rhel}') == "9" ]] ; then \
     yum install -y libxcrypt-compat; \
   fi \

--- a/docker-vertica/Makefile
+++ b/docker-vertica/Makefile
@@ -3,7 +3,6 @@ BUILDER_OS_NAME?=almalinux
 BUILDER_OS_VERSION?=8
 BASE_OS_NAME?=rockylinux
 BASE_OS_VERSION?=9
-FOR_GITHUB_CI?=false
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
 VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
@@ -26,6 +25,5 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_NAME=${BUILDER_OS_NAME} \
 		--build-arg BUILDER_OS_VERSION=${BUILDER_OS_VERSION} \
-		--build-arg FOR_GITHUB_CI=${FOR_GITHUB_CI} \
 		${VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS} \
 		-t ${VERTICA_IMG} .


### PR DESCRIPTION
Legacy and minimal images aren't using ot-harden images as the base images so I removed the option added in #902 