### PR TITLE
Processed hotfix number in vertica version

### DIFF
--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -33,7 +33,7 @@ const (
 	// The minimum version that allows for read-only online upgrade.
 	ReadOnlyOnlineUpgradeVersion = "v11.1.0"
 	// The minimum version that allows for online upgrade.
-	OnlineUpgradeVersion = "v24.3.0"
+	OnlineUpgradeVersion = "v24.3.0-2"
 	// The version that added the --force option to reip to handle up nodes
 	ReIPAllowedWithUpNodesVersion = "v11.1.0"
 	// The version of the server that doesn't support cgroup v2
@@ -172,14 +172,7 @@ func (v *VerticaDB) IsUpgradePathSupported(newAnnotations map[string]string) (ok
 }
 
 // isOnlineUpgradeSupported returns true if the version in the Vdb is is equal or newer than
-// 24.3.0-0.
+// 24.3.0-2.
 func (v *VerticaDB) isOnlineUpgradeSupported(vinf *version.Info) bool {
-	const ver1 = "v24.3.0-0"
-	const ver2 = "v24.3.0-1"
-	vdbVer, _ := v.GetVerticaVersionStr()
-	if vdbVer == ver1 || vdbVer == ver2 {
-		// All v24.3.0-* supports online upgrade except v24.3.0-0 and v24.3.0-1
-		return false
-	}
-	return vinf.IsEqualOrNewer(OnlineUpgradeVersion)
+	return vinf.HasEqualOrNewerHotfix(OnlineUpgradeVersion)
 }

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -174,5 +174,5 @@ func (v *VerticaDB) IsUpgradePathSupported(newAnnotations map[string]string) (ok
 // isOnlineUpgradeSupported returns true if the version in the Vdb is is equal or newer than
 // 24.3.0-2.
 func (v *VerticaDB) isOnlineUpgradeSupported(vinf *version.Info) bool {
-	return vinf.HasEqualOrNewerHotfix(OnlineUpgradeVersion)
+	return vinf.IsEqualOrNewerWithHotfix(OnlineUpgradeVersion)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -62,6 +62,19 @@ func (i *Info) compareVersion(comp Components) ComparisonResult {
 	return compareEqual
 }
 
+func (i *Info) compareVersionWithHotfix(comp Components) ComparisonResult {
+	if i.compareVersion(comp) == compareEqual {
+		if i.VdbHotfix > comp.VdbHotfix {
+			return compareLarger
+		}
+		if i.VdbHotfix < comp.VdbHotfix {
+			return compareSmaller
+		}
+		return compareEqual
+	}
+	return i.compareVersion(comp)
+}
+
 // MakeInfoFromStrCheck is like MakeInfoFromStr but returns an error
 // if the version Info cannot be constructed from the version string
 func MakeInfoFromStrCheck(curVer string) (*Info, error) {
@@ -83,15 +96,16 @@ func (i *Info) IsEqualOrNewer(inVer string) bool {
 	return res != compareSmaller
 }
 
-// HasEqualOrNewerHotfix checks if both versions have the same major, minor, patch numbers, and
-// if hotfix number in source version is equal or newer than the one in target version
-func (i *Info) HasEqualOrNewerHotfix(inVer string) bool {
+// IsEqualOrNewerWithHotfix checks if the version in the Vdb is is equal or newer
+// than the given version. It will compare hotfix number if all other numbers are
+// the same.
+func (i *Info) IsEqualOrNewerWithHotfix(inVer string) bool {
 	comp, ok := parseVersion(inVer)
 	if !ok {
 		panic(fmt.Sprintf("could not parse input version: %s", inVer))
 	}
-	res := i.compareVersion(comp)
-	return res == compareEqual && i.VdbHotfix >= comp.VdbHotfix
+	res := i.compareVersionWithHotfix(comp)
+	return res != compareSmaller
 }
 
 // IsOlder returns true if the version in info is older than the given version

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -95,10 +95,16 @@ var _ = Describe("version", func() {
 		Expect(cur.VdbPatch).Should(Equal(5))
 		Expect(cur.VdbHotfix).Should(Equal(6))
 		ver2 := "v24.3.5-4"
-		Expect(cur.HasEqualOrNewerHotfix(ver2)).Should(BeTrue())
+		Expect(cur.IsEqualOrNewerWithHotfix(ver2)).Should(BeTrue())
 		ver3 := "v24.3.5-6"
-		Expect(cur.HasEqualOrNewerHotfix(ver3)).Should(BeTrue())
+		Expect(cur.IsEqualOrNewerWithHotfix(ver3)).Should(BeTrue())
 		ver4 := "v24.3.5-8"
-		Expect(cur.HasEqualOrNewerHotfix(ver4)).Should(BeFalse())
+		Expect(cur.IsEqualOrNewerWithHotfix(ver4)).Should(BeFalse())
+		ver5 := "v24.2.5-8"
+		Expect(cur.IsEqualOrNewerWithHotfix(ver5)).Should(BeTrue())
+		ver6 := "v24.4.0-0"
+		Expect(cur.IsEqualOrNewerWithHotfix(ver6)).Should(BeFalse())
+		ver7 := "v23.4.0-0"
+		Expect(cur.IsEqualOrNewerWithHotfix(ver7)).Should(BeTrue())
 	})
 })

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -85,4 +85,20 @@ var _ = Describe("version", func() {
 			Expect(ok).Should(BeTrue())
 		}
 	})
+
+	It("should compare the versions with hotfix correctly", func() {
+		ver1 := "v24.3.5-6"
+		cur, ok := MakeInfoFromStr(ver1)
+		Expect(ok).Should(BeTrue())
+		Expect(cur.VdbMajor).Should(Equal(24))
+		Expect(cur.VdbMinor).Should(Equal(3))
+		Expect(cur.VdbPatch).Should(Equal(5))
+		Expect(cur.VdbHotfix).Should(Equal(6))
+		ver2 := "v24.3.5-4"
+		Expect(cur.HasEqualOrNewerHotfix(ver2)).Should(BeTrue())
+		ver3 := "v24.3.5-6"
+		Expect(cur.HasEqualOrNewerHotfix(ver3)).Should(BeTrue())
+		ver4 := "v24.3.5-8"
+		Expect(cur.HasEqualOrNewerHotfix(ver4)).Should(BeFalse())
+	})
 })


### PR DESCRIPTION
This is an improvement of Vertica version process. Sometimes we support a feature from a specific hotfix of a version. For the low hotfix number, we don't support the feature. This PR allows us to process and compare hotfix numbers in the version.