### PR TITLE
Tighten the check for expired sandbox config map

### DIFF
--- a/pkg/controllers/sandbox/unsandboxsubcluster_reconciler.go
+++ b/pkg/controllers/sandbox/unsandboxsubcluster_reconciler.go
@@ -134,7 +134,7 @@ func (r *UnsandboxSubclusterReconciler) reconcileSandboxConfigMap(ctx context.Co
 	cmName := r.ConfigMap.Name
 	sb := r.Vdb.GetSandboxStatus(sbName)
 	// if the sandbox doesn't have any subclusters, we delete the config map
-	if r.OriginalPFacts.IfNoPodsInSandbox(sbName) && (sb == nil || len(sb.Subclusters) == 0) {
+	if r.OriginalPFacts.IsSandboxEmpty(sbName) && (sb == nil || len(sb.Subclusters) == 0) {
 		err := r.Client.Delete(ctx, r.ConfigMap)
 		if err != nil {
 			r.Log.Error(err, "failed to delete expired sandbox config map", "configMapName", cmName)

--- a/pkg/controllers/sandbox/unsandboxsubcluster_reconciler.go
+++ b/pkg/controllers/sandbox/unsandboxsubcluster_reconciler.go
@@ -126,11 +126,15 @@ func (r *UnsandboxSubclusterReconciler) reconcileSandboxInfoInVdb(ctx context.Co
 // reconcileSandboxConfigMap will update/delete sandbox config map if it expires, this function will return
 // an error and a boolean to indicate if sandbox config map is deleted
 func (r *UnsandboxSubclusterReconciler) reconcileSandboxConfigMap(ctx context.Context) (error, bool) {
+	if err := r.OriginalPFacts.Collect(ctx, r.Vdb); err != nil {
+		return err, false
+	}
+
 	sbName := r.ConfigMap.Data[vapi.SandboxNameKey]
 	cmName := r.ConfigMap.Name
 	sb := r.Vdb.GetSandboxStatus(sbName)
 	// if the sandbox doesn't have any subclusters, we delete the config map
-	if sb == nil || len(sb.Subclusters) == 0 {
+	if r.OriginalPFacts.IfNoPodsInSandbox(sbName) && (sb == nil || len(sb.Subclusters) == 0) {
 		err := r.Client.Delete(ctx, r.ConfigMap)
 		if err != nil {
 			r.Log.Error(err, "failed to delete expired sandbox config map", "configMapName", cmName)

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -1290,3 +1290,11 @@ func (p *PodFacts) quorumCheckForRestartCluster(restartOnly bool) bool {
 	})
 	return restartablePrimaryNodeCount >= (primaryNodeCount+1)/2
 }
+
+// IfNoPodsInSandbox returns true if we cannot find any pods in the target sandbox
+func (p *PodFacts) IfNoPodsInSandbox(sandbox string) bool {
+	pods := p.filterPods(func(v *PodFact) bool {
+		return v.sandbox == sandbox
+	})
+	return len(pods) == 0
+}

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -1291,8 +1291,8 @@ func (p *PodFacts) quorumCheckForRestartCluster(restartOnly bool) bool {
 	return restartablePrimaryNodeCount >= (primaryNodeCount+1)/2
 }
 
-// IfNoPodsInSandbox returns true if we cannot find any pods in the target sandbox
-func (p *PodFacts) IfNoPodsInSandbox(sandbox string) bool {
+// IsSandboxEmpty returns true if we cannot find any pods in the target sandbox
+func (p *PodFacts) IsSandboxEmpty(sandbox string) bool {
 	pods := p.filterPods(func(v *PodFact) bool {
 		return v.sandbox == sandbox
 	})


### PR DESCRIPTION
There is an ND error during the online upgrade. After a successful sandboxing, the config map is deleted by the sandbox controller which is not desired. There is a delay for sandbox controller to get the latest sandbox status. I made the expired sandbox check more strict in this PR. You can download the error logs from Jira VER-96105.