### PR TITLE
Adds support for Multi-Arch image builds

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -359,6 +359,7 @@ jobs:
         # pushing it up to an external repository.
         if [ $GITHUB_EVENT_NAME != 'pull_request' ]
         then
+          # Will be removed once we merge this and make the multiarch builds as the default
           make docker-build-crossplatform-operator
         else
           make docker-build-operator

--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -16,12 +16,13 @@ ARG BASE_OS_VERSION
 ARG BUILDER_OS_NAME
 ARG BUILDER_OS_VERSION
 ARG MINIMAL=""
-FROM ${BUILDER_OS_NAME}:${BUILDER_OS_VERSION} as builder
+FROM ${BUILDER_OS_NAME}:${BUILDER_OS_VERSION} AS builder
 
-ARG VERTICA_RPM
+ARG VERTICA_X86_RPM
+ARG VERTICA_ARM64_RPM
 ARG MINIMAL
 
-COPY ./packages/${VERTICA_RPM} /tmp/
+COPY ./packages/*.rpm /tmp/
 # this is a script which removes unnecessary stuff from the
 # container image
 COPY ./packages/cleanup.sh /tmp/
@@ -29,13 +30,21 @@ COPY ./packages/package-checksum-patcher.py /tmp/
 COPY ./packages/httpstls.json /tmp/
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# Update is needed to be confident that we're picking up
+# fixed libraries.
+# Using --nobest to make it easier yum install to work. This stage isn't used
+# for the final image, so any package is good enough. We just need to install
+# the vertica rpm and copy that over.
+
+# It can be challenging to identify the exact architecture that the build file is targetting when doing a multi-platform build
+# The pain is described in https://github.com/BretFisher/multi-platform-docker-build quite well
+# We only need to do this because we have separate vertica RPMs for ARM and x86. 
+# There is no need for us to differentiate between the vriants of ARM. So we consider those as equivalent for our RPM install.
+
+# Don't move the ARG from here. The ARG is only read by the build system if its declared after the SHELL
+ARG TARGETARCH
 RUN set -x \
-  # Update is needed to be confident that we're picking up
-  # fixed libraries.
   && yum -y update \
-  # Using --nobest to make it easier yum install to work. This stage isn't used
-  # for the final image, so any package is good enough. We just need to install
-  # the vertica rpm and copy that over.
   && yum install -y --nobest \
   dialog \
   glibc \
@@ -44,10 +53,17 @@ RUN set -x \
   openssl \
   && /usr/sbin/groupadd -r verticadba \
   && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba dbadmin \
-  && yum localinstall -y /tmp/${VERTICA_RPM} \
+  && ls /tmp/ \
+  && if [[ "$TARGETARCH" == "arm64" ]] ; then \
+      uname -m && \
+      yum localinstall -y /tmp/${VERTICA_ARM64_RPM} ; \
+    elif [[ "$TARGETARCH" == "amd64" ]] ; then \
+      yum localinstall -y /tmp/${VERTICA_X86_RPM} ; \
+    else \
+      exit 1; \
+    fi \
   && mkdir -p /opt/vertica/config/https_certs \
   && cp /tmp/httpstls.json /opt/vertica/config/https_certs/ \
-  # Run install_vertica script to prepare environment
   && /opt/vertica/sbin/install_vertica \
   --accept-eula \
   --debug \
@@ -68,7 +84,7 @@ RUN set -x \
   && sh /tmp/cleanup.sh
 
 ##############################################################################################
-FROM ${BASE_OS_NAME}:${BASE_OS_VERSION} as initial
+FROM ${BASE_OS_NAME}:${BASE_OS_VERSION} AS initial
 
 # Controls the version of jre to be installed. The list of all available jre
 # packages can be queried through dnf. For instance, "dnf search openjdk"

--- a/docker-vertica-v2/Makefile
+++ b/docker-vertica-v2/Makefile
@@ -1,4 +1,5 @@
-VERTICA_RPM?=$(notdir $(wildcard packages/vertica*.rpm))
+VERTICA_X86_RPM?=$(notdir $(wildcard packages/vertica*.x86_64.rpm))
+VERTICA_ARM64_RPM?=$(notdir $(wildcard packages/vertica*.aarch64.rpm))
 BUILDER_OS_NAME?=almalinux
 BUILDER_OS_VERSION?=8
 BASE_OS_NAME?=rockylinux
@@ -6,8 +7,11 @@ BASE_OS_VERSION?=9
 FOR_GITHUB_CI?=false
 VERTICA_IMG?=vertica-k8s
 MINIMAL_VERTICA_IMG?=
-VERTICA_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_RPM))
+TARGET_ARCH?=linux/amd64
 VERTICA_ADDITIONAL_DOCKER_BUILD_OPTIONS?=
+
+VERTICA_X86_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_X86_RPM))
+VERTICA_ARM_VERSION?=$(shell rpm --nosignature -qp --queryformat '%{VERSION}-%{RELEASE}' packages/$(VERTICA_ARM64_RPM))
 
 all: docker-build-vertica
 
@@ -17,11 +21,13 @@ docker-build-vertica: Dockerfile packages/package-checksum-patcher.py
 	docker buildx build \
 		--load \
 		-f Dockerfile \
+		--platform ${TARGET_ARCH} \
 		--label minimal=${MINIMAL_VERTICA_IMG} \
 		--label os-version=${BASE_OS_VERSION} \
 		--label vertica-version=${VERTICA_VERSION} \
 		--build-arg MINIMAL=${MINIMAL_VERTICA_IMG} \
-		--build-arg VERTICA_RPM=${VERTICA_RPM} \
+		--build-arg VERTICA_X86_RPM=${VERTICA_X86_RPM} \
+		--build-arg VERTICA_ARM64_RPM=${VERTICA_ARM64_RPM} \
 		--build-arg BASE_OS_NAME=${BASE_OS_NAME} \
 		--build-arg BASE_OS_VERSION=${BASE_OS_VERSION} \
 		--build-arg BUILDER_OS_NAME=${BUILDER_OS_NAME} \

--- a/docker-vlogger/Dockerfile
+++ b/docker-vlogger/Dockerfile
@@ -16,6 +16,7 @@
 
 ARG ALPINE_VERSION
 ARG BASE_IMG
+ARG TARGETARCH
 FROM ${BASE_IMG}:${ALPINE_VERSION}
 
 # Tini - A tiny but valid init for containers


### PR DESCRIPTION
This PR updates the Make targets and Dockerfiles to allow passing a TARGET_ARCH argument that allows creating a Multi-architecture image, specifically intended towards ARM64 support. This does not yet create or test the multi-arch images. That will be handled in a following PR once we verify the Dev builds. This creates one image (each with a list of manifest)e and the container runtime picks the one architecture that it matches at runtime.

We leverage the buildx support by docker (something that we already use for the operator), where passing the TARGET_ARCH into the Dockerfile can be used to generate different layers based on the architecture. 
https://docs.docker.com/build/building/multi-platform/, https://forums.docker.com/t/build-multi-arch-images-with-different-commands-per-architecture-in-docker-file/134795
Note that for the operator cross platform builds, we can afford to do a cross compilation based build, but for vertica-k8s we would need to use emulation based build because we already have the vertica RPM that we want to install.

Some highlights are:

- The Makefile is updated such that it can read both x86 and aarch64 vertica RPMs and pass it on to the Dockerfile.
- Update the Dockerfile to check what RPMs are passed and accordingly make conditional installation of the respective architecture RPM in the image layer.
- This also updates some artifact download links to support future multi-arch builds and e2e tests: OPERATOR_SDK, CHANGIE_VERSION, ISTIO and OPM.
- We should eventually have one target for operator build as well when we are ready to use multiarch builds as default. Added a comment as a reminder for us to revisit, as changing that now might break other devops pipelines.
