### PR TITLE
Fix autoscaler bug

### DIFF
--- a/api/v1beta1/helpers.go
+++ b/api/v1beta1/helpers.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"regexp"
 
+	v1 "github.com/vertica/vertica-kubernetes/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -231,4 +232,26 @@ func MakeVrep() *VerticaReplicator {
 func GenCompatibleFQDNHelper(scName string) string {
 	m := regexp.MustCompile(`_`)
 	return m.ReplaceAllString(scName, "-")
+}
+
+func GetV1SubclusterFromV1beta1(src *Subcluster) v1.Subcluster {
+	return v1.Subcluster{
+		Name:                src.Name,
+		Size:                src.Size,
+		Type:                convertToSubclusterType(src),
+		ImageOverride:       src.ImageOverride,
+		NodeSelector:        src.NodeSelector,
+		Affinity:            v1.Affinity(src.Affinity),
+		PriorityClassName:   src.PriorityClassName,
+		Tolerations:         src.Tolerations,
+		Resources:           src.Resources,
+		ServiceType:         src.ServiceType,
+		ServiceName:         src.ServiceName,
+		ClientNodePort:      src.NodePort,
+		VerticaHTTPNodePort: src.VerticaHTTPNodePort,
+		ExternalIPs:         src.ExternalIPs,
+		LoadBalancerIP:      src.LoadBalancerIP,
+		ServiceAnnotations:  src.ServiceAnnotations,
+		Annotations:         src.Annotations,
+	}
 }

--- a/api/v1beta1/verticadb_conversion.go
+++ b/api/v1beta1/verticadb_conversion.go
@@ -300,25 +300,7 @@ func convertFromStatus(src *v1.VerticaDBStatus) VerticaDBStatus {
 
 // convertToSubcluster will take a v1beta1 Subcluster and convert it to a v1 version
 func convertToSubcluster(src *Subcluster) v1.Subcluster {
-	return v1.Subcluster{
-		Name:                src.Name,
-		Size:                src.Size,
-		Type:                convertToSubclusterType(src),
-		ImageOverride:       src.ImageOverride,
-		NodeSelector:        src.NodeSelector,
-		Affinity:            v1.Affinity(src.Affinity),
-		PriorityClassName:   src.PriorityClassName,
-		Tolerations:         src.Tolerations,
-		Resources:           src.Resources,
-		ServiceType:         src.ServiceType,
-		ServiceName:         src.ServiceName,
-		ClientNodePort:      src.NodePort,
-		VerticaHTTPNodePort: src.VerticaHTTPNodePort,
-		ExternalIPs:         src.ExternalIPs,
-		LoadBalancerIP:      src.LoadBalancerIP,
-		ServiceAnnotations:  src.ServiceAnnotations,
-		Annotations:         src.Annotations,
-	}
+	return GetV1SubclusterFromV1beta1(src)
 }
 
 // convertFromSubcluster will take a v1 Subcluster and convert it to a v1beta1 version

--- a/changes/unreleased/Fixed-20240902-223100.yaml
+++ b/changes/unreleased/Fixed-20240902-223100.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: CreateContainerError occurs when trying to use VerticaAutoscaler.
+time: 2024-09-02T22:31:00.0323243+02:00
+custom:
+    Issue: "913"

--- a/pkg/controllers/vas/k8s.go
+++ b/pkg/controllers/vas/k8s.go
@@ -18,7 +18,8 @@ package vas
 import (
 	"context"
 
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +30,7 @@ import (
 // fetchVDB will fetch the VerticaDB that is referenced in a VerticaAutoscaler.
 // This will log an event if the VerticaDB is not found.
 func fetchVDB(ctx context.Context, vrec *VerticaAutoscalerReconciler,
-	vas *vapi.VerticaAutoscaler, vdb *vapi.VerticaDB) (ctrl.Result, error) {
+	vas *v1beta1.VerticaAutoscaler, vdb *vapi.VerticaDB) (ctrl.Result, error) {
 	nm := types.NamespacedName{
 		Namespace: vas.Namespace,
 		Name:      vas.Spec.VerticaDBName,

--- a/pkg/controllers/vas/refreshcurrentsize_reconciler.go
+++ b/pkg/controllers/vas/refreshcurrentsize_reconciler.go
@@ -18,7 +18,8 @@ package vas
 import (
 	"context"
 
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/vasstatus"
@@ -28,10 +29,10 @@ import (
 // RefreshCurrentSizeReconciler will refresh the currentSize status field in the CR.
 type RefreshCurrentSizeReconciler struct {
 	VRec *VerticaAutoscalerReconciler
-	Vas  *vapi.VerticaAutoscaler
+	Vas  *v1beta1.VerticaAutoscaler
 }
 
-func MakeRefreshCurrentSizeReconciler(v *VerticaAutoscalerReconciler, vas *vapi.VerticaAutoscaler) controllers.ReconcileActor {
+func MakeRefreshCurrentSizeReconciler(v *VerticaAutoscalerReconciler, vas *v1beta1.VerticaAutoscaler) controllers.ReconcileActor {
 	return &RefreshCurrentSizeReconciler{VRec: v, Vas: vas}
 }
 

--- a/pkg/controllers/vas/subclusterresize_reconciler.go
+++ b/pkg/controllers/vas/subclusterresize_reconciler.go
@@ -18,7 +18,8 @@ package vas
 import (
 	"context"
 
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
@@ -32,17 +33,17 @@ import (
 // target pod count in the CR.
 type SubclusterResizeReconciler struct {
 	VRec *VerticaAutoscalerReconciler
-	Vas  *vapi.VerticaAutoscaler
+	Vas  *v1beta1.VerticaAutoscaler
 	Vdb  *vapi.VerticaDB
 }
 
-func MakeSubclusterResizeReconciler(r *VerticaAutoscalerReconciler, vas *vapi.VerticaAutoscaler) controllers.ReconcileActor {
+func MakeSubclusterResizeReconciler(r *VerticaAutoscalerReconciler, vas *v1beta1.VerticaAutoscaler) controllers.ReconcileActor {
 	return &SubclusterResizeReconciler{VRec: r, Vas: vas, Vdb: &vapi.VerticaDB{}}
 }
 
 // Reconcile will grow/shrink an existing subcluste based on the target pod count
 func (s *SubclusterResizeReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
-	if s.Vas.Spec.ScalingGranularity != vapi.PodScalingGranularity {
+	if s.Vas.Spec.ScalingGranularity != v1beta1.PodScalingGranularity {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/vas/subclusterresize_reconciler_test.go
+++ b/pkg/controllers/vas/subclusterresize_reconciler_test.go
@@ -20,8 +20,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	test "github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	test "github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -29,11 +31,11 @@ var _ = Describe("subclusterresize_reconcile", func() {
 	ctx := context.Background()
 
 	It("should requeue if VerticaDB doesn't exist", func() {
-		vas := vapi.MakeVAS()
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		vas := v1beta1.MakeVAS()
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{Requeue: true}))
 	})
 
@@ -42,13 +44,13 @@ var _ = Describe("subclusterresize_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
+		vas := v1beta1.MakeVAS()
 		vas.Spec.ServiceName = "not-there"
 		vas.Spec.TargetSize = 5
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{Requeue: true}))
 	})
 
@@ -62,17 +64,17 @@ var _ = Describe("subclusterresize_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
+		vas := v1beta1.MakeVAS()
 		vas.Spec.TargetSize = TargetSize
 		vas.Spec.ServiceName = ScName
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
-		fetchVdb := &vapi.VerticaDB{}
-		nm := vapi.MakeVDBName()
+		fetchVdb := &v1beta1.VerticaDB{}
+		nm := v1beta1.MakeVDBName()
 		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
 		Expect(fetchVdb.Spec.Subclusters[0].Size).Should(Equal(TargetSize))
 	})
@@ -82,17 +84,17 @@ var _ = Describe("subclusterresize_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
+		vas := v1beta1.MakeVAS()
 		vas.Spec.TargetSize = 0
 		vas.Spec.ServiceName = vdb.Spec.Subclusters[0].GetServiceName()
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
-		fetchVdb := &vapi.VerticaDB{}
-		nm := vapi.MakeVDBName()
+		fetchVdb := &v1beta1.VerticaDB{}
+		nm := v1beta1.MakeVDBName()
 		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
 		Expect(fetchVdb.Spec.Subclusters[0].Size).Should(Equal(vdb.Spec.Subclusters[0].Size))
 	})
@@ -102,17 +104,17 @@ var _ = Describe("subclusterresize_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
+		vas := v1beta1.MakeVAS()
 		vas.Spec.TargetSize = vdb.Spec.Subclusters[0].Size
 		vas.Spec.ServiceName = vdb.Spec.Subclusters[0].GetServiceName()
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
-		fetchVdb := &vapi.VerticaDB{}
-		nm := vapi.MakeVDBName()
+		fetchVdb := &v1beta1.VerticaDB{}
+		nm := v1beta1.MakeVDBName()
 		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
 		Expect(fetchVdb.Spec.Subclusters[0].Size).Should(Equal(vdb.Spec.Subclusters[0].Size))
 	})
@@ -128,18 +130,18 @@ var _ = Describe("subclusterresize_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
+		vas := v1beta1.MakeVAS()
 		const NumPodsToAdd = 5
 		vas.Spec.TargetSize = vdb.Spec.Subclusters[0].Size + vdb.Spec.Subclusters[1].Size + NumPodsToAdd
 		vas.Spec.ServiceName = TargetSvcName
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
-		fetchVdb := &vapi.VerticaDB{}
-		nm := vapi.MakeVDBName()
+		fetchVdb := &v1beta1.VerticaDB{}
+		nm := v1beta1.MakeVDBName()
 		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
 		Expect(fetchVdb.Spec.Subclusters[0].Size).Should(Equal(vdb.Spec.Subclusters[0].Size))
 		Expect(fetchVdb.Spec.Subclusters[1].Size).Should(Equal(vas.Spec.TargetSize - vdb.Spec.Subclusters[0].Size))
@@ -157,18 +159,18 @@ var _ = Describe("subclusterresize_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
+		vas := v1beta1.MakeVAS()
 		const NumPodsToRemove = 3
 		vas.Spec.TargetSize = vdb.Spec.Subclusters[0].Size + vdb.Spec.Subclusters[2].Size - NumPodsToRemove
 		vas.Spec.ServiceName = TargetSvcName
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
-		fetchVdb := &vapi.VerticaDB{}
-		nm := vapi.MakeVDBName()
+		fetchVdb := &v1beta1.VerticaDB{}
+		nm := v1beta1.MakeVDBName()
 		Expect(k8sClient.Get(ctx, nm, fetchVdb)).Should(Succeed())
 		Expect(fetchVdb.Spec.Subclusters[0].Size).Should(Equal(vdb.Spec.Subclusters[0].Size + vdb.Spec.Subclusters[2].Size - NumPodsToRemove))
 		Expect(fetchVdb.Spec.Subclusters[1].Size).Should(Equal(vdb.Spec.Subclusters[1].Size))

--- a/pkg/controllers/vas/subclusterscale_reconciler.go
+++ b/pkg/controllers/vas/subclusterscale_reconciler.go
@@ -19,7 +19,8 @@ import (
 	"context"
 	"fmt"
 
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
@@ -32,17 +33,17 @@ import (
 // SubclusterScaleReconciler will scale a VerticaDB by adding or removing subclusters.
 type SubclusterScaleReconciler struct {
 	VRec *VerticaAutoscalerReconciler
-	Vas  *vapi.VerticaAutoscaler
+	Vas  *v1beta1.VerticaAutoscaler
 	Vdb  *vapi.VerticaDB
 }
 
-func MakeSubclusterScaleReconciler(r *VerticaAutoscalerReconciler, vas *vapi.VerticaAutoscaler) controllers.ReconcileActor {
+func MakeSubclusterScaleReconciler(r *VerticaAutoscalerReconciler, vas *v1beta1.VerticaAutoscaler) controllers.ReconcileActor {
 	return &SubclusterScaleReconciler{VRec: r, Vas: vas, Vdb: &vapi.VerticaDB{}}
 }
 
 // Reconcile will grow/shrink the VerticaDB passed on the target pod count.
 func (s *SubclusterScaleReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
-	if s.Vas.Spec.ScalingGranularity != vapi.SubclusterScalingGranularity {
+	if s.Vas.Spec.ScalingGranularity != v1beta1.SubclusterScalingGranularity {
 		return ctrl.Result{}, nil
 	}
 
@@ -166,9 +167,9 @@ func (s *SubclusterScaleReconciler) calcNextSubcluster(scMap map[string]*vapi.Su
 	// If the template is set, we will use that.  Otherwise, we try to use an
 	// existing subcluster (last one added) as a base.
 	if s.Vas.CanUseTemplate() {
-		sc := s.Vas.Spec.Template.DeepCopy()
+		sc := v1beta1.GetV1SubclusterFromV1beta1(s.Vas.Spec.Template.DeepCopy())
 		sc.Name = s.genNextSubclusterName(scMap)
-		return sc, true
+		return &sc, true
 	}
 	scs, _ := s.Vdb.FindSubclusterForServiceName(s.Vas.Spec.ServiceName)
 	if len(scs) == 0 {

--- a/pkg/controllers/vas/subclusterscale_reconciler_test.go
+++ b/pkg/controllers/vas/subclusterscale_reconciler_test.go
@@ -21,8 +21,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	test "github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	test "github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -34,18 +36,18 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
-		vas.Spec.ScalingGranularity = vapi.SubclusterScalingGranularity
-		vas.Spec.Template = vapi.Subcluster{
+		vas := v1beta1.MakeVAS()
+		vas.Spec.ScalingGranularity = v1beta1.SubclusterScalingGranularity
+		vas.Spec.Template = v1beta1.Subcluster{
 			Name:        "blah",
 			ServiceName: "my-ut",
 			Size:        8,
 		}
 		vas.Spec.TargetSize = vas.Spec.Template.Size * 2
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -73,19 +75,19 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
-		vas.Spec.ScalingGranularity = vapi.SubclusterScalingGranularity
+		vas := v1beta1.MakeVAS()
+		vas.Spec.ScalingGranularity = v1beta1.SubclusterScalingGranularity
 		vas.Spec.ServiceName = ServiceName
-		vas.Spec.Template = vapi.Subcluster{
+		vas.Spec.Template = v1beta1.Subcluster{
 			Name:        "blah",
 			ServiceName: ServiceName,
 			Size:        5,
 		}
 		vas.Spec.TargetSize = 8
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -98,7 +100,7 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		Expect(fetchVdb.Spec.Subclusters[3].Size).Should(Equal(vdb.Spec.Subclusters[3].Size))
 		Expect(fetchVdb.Spec.Subclusters[4].Size).Should(Equal(vdb.Spec.Subclusters[4].Size))
 
-		vasName := vapi.MakeVASName()
+		vasName := v1beta1.MakeVASName()
 		Expect(k8sClient.Get(ctx, vasName, vas)).Should(Succeed())
 		vas.Spec.TargetSize = 3
 		Expect(k8sClient.Update(ctx, vas)).Should(Succeed())
@@ -124,19 +126,19 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
-		vas.Spec.ScalingGranularity = vapi.SubclusterScalingGranularity
+		vas := v1beta1.MakeVAS()
+		vas.Spec.ScalingGranularity = v1beta1.SubclusterScalingGranularity
 		vas.Spec.ServiceName = ServiceName
-		vas.Spec.Template = vapi.Subcluster{
+		vas.Spec.Template = v1beta1.Subcluster{
 			Name:        "blah",
 			ServiceName: ServiceName,
 			Size:        5,
 		}
 		vas.Spec.TargetSize = 0
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -145,7 +147,7 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		// Expect no change since targetSize is zero without allowScaleToZero
 		Expect(len(fetchVdb.Spec.Subclusters)).Should(Equal(5))
 
-		vasName := vapi.MakeVASName()
+		vasName := v1beta1.MakeVASName()
 		Expect(k8sClient.Get(ctx, vasName, vas)).Should(Succeed())
 		vas.Spec.TargetSize = 0
 		Expect(k8sClient.Update(ctx, vas)).Should(Succeed())
@@ -167,15 +169,15 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
-		vas.Spec.ScalingGranularity = vapi.SubclusterScalingGranularity
+		vas := v1beta1.MakeVAS()
+		vas.Spec.ScalingGranularity = v1beta1.SubclusterScalingGranularity
 		vas.Spec.ServiceName = ServiceName
 		vas.Spec.Template.Size = 0
 		vas.Spec.TargetSize = 8
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}
@@ -183,7 +185,7 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		Expect(k8sClient.Get(ctx, vdbName, fetchVdb)).Should(Succeed())
 		Expect(len(fetchVdb.Spec.Subclusters)).Should(Equal(1))
 
-		vasName := vapi.MakeVASName()
+		vasName := v1beta1.MakeVASName()
 		Expect(k8sClient.Get(ctx, vasName, vas)).Should(Succeed())
 		vas.Spec.TargetSize = 13
 		Expect(k8sClient.Update(ctx, vas)).Should(Succeed())
@@ -202,15 +204,15 @@ var _ = Describe("subclusterscale_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
-		vas.Spec.ScalingGranularity = vapi.SubclusterScalingGranularity
+		vas := v1beta1.MakeVAS()
+		vas.Spec.ScalingGranularity = v1beta1.SubclusterScalingGranularity
 		vas.Spec.ServiceName = "BrandNewServiceName"
 		vas.Spec.Template.Size = 0
 		vas.Spec.TargetSize = 50
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
 		fetchVdb := &vapi.VerticaDB{}

--- a/pkg/controllers/vas/suite_test.go
+++ b/pkg/controllers/vas/suite_test.go
@@ -22,7 +22,8 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -54,6 +55,8 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, cfg).NotTo(BeNil())
 	restCfg = cfg
 
+	err = v1beta1.AddToScheme(scheme.Scheme)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	err = vapi.AddToScheme(scheme.Scheme)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 

--- a/pkg/controllers/vas/targetsizeinitializer_reconciler.go
+++ b/pkg/controllers/vas/targetsizeinitializer_reconciler.go
@@ -18,7 +18,8 @@ package vas
 import (
 	"context"
 
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/vasstatus"
@@ -29,17 +30,17 @@ import (
 
 type TargetSizeInitializerReconciler struct {
 	VRec *VerticaAutoscalerReconciler
-	Vas  *vapi.VerticaAutoscaler
+	Vas  *v1beta1.VerticaAutoscaler
 }
 
-func MakeTargetSizeInitializerReconciler(v *VerticaAutoscalerReconciler, vas *vapi.VerticaAutoscaler) controllers.ReconcileActor {
+func MakeTargetSizeInitializerReconciler(v *VerticaAutoscalerReconciler, vas *v1beta1.VerticaAutoscaler) controllers.ReconcileActor {
 	return &TargetSizeInitializerReconciler{VRec: v, Vas: vas}
 }
 
 // Reconcile will update the targetSize in a Vas if not already initialized
 func (v *TargetSizeInitializerReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
-	if len(v.Vas.Status.Conditions) > vapi.TargetSizeInitializedIndex &&
-		v.Vas.Status.Conditions[vapi.TargetSizeInitializedIndex].Status == corev1.ConditionTrue {
+	if len(v.Vas.Status.Conditions) > v1beta1.TargetSizeInitializedIndex &&
+		v.Vas.Status.Conditions[v1beta1.TargetSizeInitializedIndex].Status == corev1.ConditionTrue {
 		// Already initialized
 		return ctrl.Result{}, nil
 	}
@@ -76,8 +77,8 @@ func (v *TargetSizeInitializerReconciler) initTargetSize(ctx context.Context) (c
 
 // setTargetSizeInitializedCondition will seth the targetSizeInitialized condition to true
 func (v *TargetSizeInitializerReconciler) setTargetSizeInitializedCondition(ctx context.Context, req *ctrl.Request) error {
-	cond := vapi.VerticaAutoscalerCondition{
-		Type:   vapi.TargetSizeInitialized,
+	cond := v1beta1.VerticaAutoscalerCondition{
+		Type:   v1beta1.TargetSizeInitialized,
 		Status: corev1.ConditionTrue,
 	}
 	return vasstatus.UpdateCondition(ctx, v.VRec.Client, v.VRec.Log, req, cond)

--- a/pkg/controllers/vas/targetsizeinitializer_reconciler_test.go
+++ b/pkg/controllers/vas/targetsizeinitializer_reconciler_test.go
@@ -20,8 +20,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
-	test "github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	test "github.com/vertica/vertica-kubernetes/pkg/test"
+	"github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -39,20 +41,20 @@ var _ = Describe("targetsizeinitializer_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
-		vas := vapi.MakeVAS()
+		vas := v1beta1.MakeVAS()
 		vas.Spec.ServiceName = ServiceName
 		vas.Spec.TargetSize = 0
-		test.CreateVAS(ctx, k8sClient, vas)
-		defer test.DeleteVAS(ctx, k8sClient, vas)
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
 
-		req := ctrl.Request{NamespacedName: vapi.MakeVASName()}
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
 		Expect(vasRec.Reconcile(ctx, req)).Should(Equal(ctrl.Result{}))
 
-		fetchVas := &vapi.VerticaAutoscaler{}
-		nm := vapi.MakeVASName()
+		fetchVas := &v1beta1.VerticaAutoscaler{}
+		nm := v1beta1.MakeVASName()
 		Expect(k8sClient.Get(ctx, nm, fetchVas)).Should(Succeed())
 		Expect(fetchVas.Spec.TargetSize).Should(Equal(int32(25)))
 		Expect(len(fetchVas.Status.Conditions)).Should(Equal(1))
-		Expect(fetchVas.Status.Conditions[vapi.TargetSizeInitializedIndex].Status).Should(Equal(corev1.ConditionTrue))
+		Expect(fetchVas.Status.Conditions[v1beta1.TargetSizeInitializedIndex].Status).Should(Equal(corev1.ConditionTrue))
 	})
 })

--- a/pkg/controllers/vas/vdbverify_reconciler.go
+++ b/pkg/controllers/vas/vdbverify_reconciler.go
@@ -18,7 +18,8 @@ package vas
 import (
 	"context"
 
-	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -26,11 +27,11 @@ import (
 // VDBVerifyReconciler will verify the VerticaDB in the VAS CR exists
 type VDBVerifyReconciler struct {
 	VRec *VerticaAutoscalerReconciler
-	Vas  *vapi.VerticaAutoscaler
+	Vas  *v1beta1.VerticaAutoscaler
 	Vdb  *vapi.VerticaDB
 }
 
-func MakeVDBVerifyReconciler(r *VerticaAutoscalerReconciler, vas *vapi.VerticaAutoscaler) controllers.ReconcileActor {
+func MakeVDBVerifyReconciler(r *VerticaAutoscalerReconciler, vas *v1beta1.VerticaAutoscaler) controllers.ReconcileActor {
 	return &VDBVerifyReconciler{VRec: r, Vas: vas, Vdb: &vapi.VerticaDB{}}
 }
 


### PR DESCRIPTION
When running a VerticaAutoscaler on a VerticaDB where `vcluster-ops` was not explicitly set to `true` we hit a `CreateContainerError` error. This happens because the autoscaler was still internally  using a v1beta1 VerticaDB which led to the conversion webhook wrongfully setting that annotation to `false`.
This fixes the issue by using a v1 VerticaDB instead.

Closes #908 