### PR TITLE
Remove workarounds for online upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ endif
 docker-push-extra-vertica: # Push a hard-coded image used in multi-online-upgrade test
 ifeq ($(LEG9), yes)
 ifeq ($(shell $(KIND_CHECK)), 1)
-	scripts/push-to-kind.sh -i opentext/vertica-k8s-private:20240729-minimal
+	scripts/push-to-kind.sh -i opentext/vertica-k8s-private:20240923-minimal
 endif
 endif
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -108,7 +108,6 @@ const (
 	addSubclustersInx
 	addNodeInx
 	rebalanceShardsInx
-	waitForActiveSubsInx
 	setConfigParamInx
 	sandboxInx
 	clearConfigParamInx
@@ -182,7 +181,6 @@ func (r *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 		r.runAddSubclusterReconcilerForMainCluster,
 		r.runAddNodesReconcilerForMainCluster,
 		r.runRebalanceSandboxSubcluster,
-		r.validateSubscriptionsActive,
 		// Get the original value of config parameter DisableNonReplicatableQueries at database level
 		r.postQueryOriginalConfigParamDisableNonReplicatableQueriesMsg,
 		r.queryOriginalConfigParamDisableNonReplicatableQueries,
@@ -204,14 +202,14 @@ func (r *OnlineUpgradeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request
 		r.postUpgradeSandboxMsg,
 		r.upgradeSandbox,
 		r.waitForSandboxUpgrade,
+		// Prepare replication by ensuring nodes are up
+		r.postPrepareReplicationMsg,
+		r.prepareReplication,
 		// Pause all connections to replica A. This is to prepare for the
 		// replication below.
 		r.postPauseConnectionsMsg,
 		r.pauseConnectionsAtReplicaGroupA,
 		r.waitForConnectionsPaused,
-		// Prepare replication by ensuring nodes are up
-		// r.postPrepareReplicationMsg,
-		// r.prepareReplication,
 		// Back up database before replication
 		r.postBackupDBBeforeReplicationMsg,
 		r.createRestorePointBeforeReplication,
@@ -375,18 +373,6 @@ func (r *OnlineUpgradeReconciler) runRebalanceSandboxSubcluster(ctx context.Cont
 	r.Manager.traceActorReconcile(actor)
 	res, err := actor.Reconcile(ctx, &ctrl.Request{})
 	r.PFacts[vapi.MainCluster].Invalidate()
-	if verrors.IsReconcileAborted(res, err) {
-		return res, err
-	}
-	return ctrl.Result{}, r.updateOnlineUpgradeStepAnnotation(ctx, r.getNextStep())
-}
-
-func (r *OnlineUpgradeReconciler) validateSubscriptionsActive(ctx context.Context) (ctrl.Result, error) {
-	// If we have already promoted sandbox to main, we don't need to touch old main cluster
-	if vmeta.GetOnlineUpgradeStepInx(r.VDB.Annotations) > waitForActiveSubsInx {
-		return ctrl.Result{}, nil
-	}
-	res, err := r.Manager.checkAllSubscriptionsActive(ctx, r.PFacts[vapi.MainCluster])
 	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
@@ -731,9 +717,6 @@ func (r *OnlineUpgradeReconciler) waitForConnectionsPaused(ctx context.Context) 
 
 // postPrepareReplicationMsg will update the status message to indicate that
 // we are doing some preparation work before replication
-// Remove nolint below when we figure out how to restart node/cluster when non-replication-action know is on
-//
-//nolint:unused
 func (r *OnlineUpgradeReconciler) postPrepareReplicationMsg(ctx context.Context) (ctrl.Result, error) {
 	return r.postNextStatusMsg(ctx, prepareReplicationInx)
 }
@@ -741,9 +724,6 @@ func (r *OnlineUpgradeReconciler) postPrepareReplicationMsg(ctx context.Context)
 // prepareReplication makes sure there is at least an Up node in the main cluster
 // and the sandbox, to perform replication.
 // Once we start using services for replication, we will check only the scs served by the services.
-// Remove nolint below when we figure out how to restart node/cluster when non-replication-action know is on
-//
-//nolint:unused
 func (r *OnlineUpgradeReconciler) prepareReplication(ctx context.Context) (ctrl.Result, error) {
 	// Skip if the replication has already completed successfully or VerticaReplicator
 	// already exists

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -811,27 +811,3 @@ func (i *UpgradeManager) getSubclusterNameFromSts(ctx context.Context, stsName s
 	}
 	return scNameFromLabel, nil
 }
-
-func (i *UpgradeManager) checkAllSubscriptionsActive(ctx context.Context, pfacts *PodFacts) (ctrl.Result, error) {
-	pf, ok := pfacts.findFirstPodSorted(func(v *PodFact) bool {
-		return v.isPrimary && v.upNode
-	})
-	if !ok {
-		i.Log.Info("No pod found to run vsql. Requeueing for retrying checking subscription status")
-		return ctrl.Result{Requeue: true}, nil
-	}
-
-	cmd := []string{"-tAc", "SELECT count(*) FROM node_subscriptions WHERE subscription_state != 'ACTIVE';"}
-	stdout, _, err := pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, cmd...)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	lines := strings.Split(stdout, "\n")
-	inactive, err := strconv.Atoi(lines[0])
-	if err != nil || inactive == 0 {
-		return ctrl.Result{}, err
-	}
-
-	i.Log.Info("One or more node subscriptions is not active, requeueing")
-	return ctrl.Result{Requeue: true}, nil
-}

--- a/scripts/guess-server-upgrade-base-image.sh
+++ b/scripts/guess-server-upgrade-base-image.sh
@@ -72,8 +72,8 @@ then
         # upgrade from. We will pick a random 24.2.0 image.
         print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "1f759615f0f723080b398edcf096a0bc8bc03aef-minimal"
     else
-        # For all newer versions, we pick a random 24.3.0 image.
-        print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20240724-minimal"
+        # For all newer versions, we pick a random 24.4.0 image.
+        print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20240921-minimal"
     fi
 else
     print_vertica_k8s_img $PUBLIC_REPO $PUBLIC_IMAGE 12 0 2

--- a/tests/e2e-leg-9/multi-online-upgrade/30-initiate-upgrade.yaml
+++ b/tests/e2e-leg-9/multi-online-upgrade/30-initiate-upgrade.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade opentext/vertica-k8s-private:20240729-minimal
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade opentext/vertica-k8s-private:20240923-minimal

--- a/tests/e2e-leg-9/new-online-upgrade-pods-down/36-kill-pods-in-main.yaml
+++ b/tests/e2e-leg-9/new-online-upgrade-pods-down/36-kill-pods-in-main.yaml
@@ -14,5 +14,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl delete pod v-base-upgrade-main-0
+  - command: kubectl delete pod v-base-upgrade-main-0 v-base-upgrade-main-1 v-base-upgrade-main-2
     namespaced: true


### PR DESCRIPTION
the server can now reshard even with DisableNonReplicatableQueries set
sandboxing now properly clears DisableNonReplicatableQueries during sandbox setup, plus cat editor ignores it