### PR TITLE
Installed strip in build image

### DIFF
--- a/docker-vertica-v2/Dockerfile
+++ b/docker-vertica-v2/Dockerfile
@@ -42,6 +42,7 @@ RUN set -x \
   glibc-langpack-en \
   iproute \
   openssl \
+  binutils \
   && /usr/sbin/groupadd -r verticadba \
   && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba dbadmin \
   && yum localinstall -y /tmp/${VERTICA_RPM} \

--- a/docker-vertica/Dockerfile
+++ b/docker-vertica/Dockerfile
@@ -49,6 +49,7 @@ RUN set -x \
   openssh-server \
   openssh-clients \
   openssl \
+  binutils \
   && /usr/sbin/groupadd -r verticadba --gid ${DBADMIN_GID} \
   && /usr/sbin/useradd -r -m -s /bin/bash -g verticadba --uid ${DBADMIN_UID} dbadmin \
   && yum localinstall -q -y /tmp/${VERTICA_RPM} \


### PR DESCRIPTION
This PR simply installed "strip" command in the build image for stripping /opt/vertica. It should restore the size of Vertica minimal images.