### PR TITLE
Used daily minimal image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -257,7 +257,7 @@ jobs:
       uses: spilchen/switch-case-action@v2
       id: minimal_vertica_image
       with:
-        default: docker.io/opentext/vertica-k8s-private:20240906-minimal
+        default: docker.io/opentext/vertica-k8s-private:latest-minimal-master
         conditionals-with-values: |
           ${{ inputs.minimal_vertica_image != '' }} => ${{ inputs.minimal_vertica_image }}
 


### PR DESCRIPTION
Since now the minimal image's size is normal and we don't create the restore point in the sandbox, we should be good to use daily vertica images.