### PR TITLE
update log age time default message if not set

### DIFF
--- a/api/v1beta1/verticascrutinize_webhook.go
+++ b/api/v1beta1/verticascrutinize_webhook.go
@@ -156,24 +156,21 @@ func (vscr *VerticaScrutinize) ValidateLogAgeTimes(allErrs field.ErrorList) fiel
 	}
 
 	if logAgeOldestTime.After(logAgeNewestTime) {
-		oldAfterNewMsg := ""
+		// if log-age-oldest-time is not set, default as 24 hours ago
+		logAgeOldestTimeStr := "log-age-oldest-time is: \"" + logAgeOldestTime.Format("2006-01-02 15 MST") + "\""
+		if scrutinizeLogAgeOldestTime == "" {
+			logAgeOldestTimeStr = "log-age-oldest-time default as 24 hours ago: \"" + logAgeOldestTime.Format("2006-01-02 15 MST") + "\""
+		}
 
 		// if log-age-newest-time is not set, default as the current time
-		logAgeNewestTimeStr := logAgeNewestTime.Format("2006-01-02 15 MST")
+		logAgeNewestTimeStr := "log-age-newest-time is: \"" + logAgeNewestTime.Format("2006-01-02 15 MST") + "\""
 		if scrutinizeLogAgeNewestTime == "" {
-			oldAfterNewMsg += "log-age-newest-time default as current time: \"" + logAgeNewestTimeStr + "\"."
+			logAgeNewestTimeStr = "log-age-newest-time default as current time: \"" + logAgeNewestTime.Format("2006-01-02 15 MST") + "\""
 		}
-
-		// if log-age-oldest-time is not set, default as 24 hours ago
-		logAgeOldestTimeStr := logAgeOldestTime.Format("2006-01-02 15 MST")
-		if scrutinizeLogAgeOldestTime == "" {
-			oldAfterNewMsg += "log-age-oldest-time default as 24 hours ago: \"" + logAgeOldestTimeStr + "\"."
-		}
-
-		oldAfterNewMsg += " log-age-oldest-time cannot be set after log-age-newest-time."
 
 		err := field.Invalid(prefix.Key(vmeta.ScrutinizeLogAgeNewestTime),
-			scrutinizeLogAgeNewestTime, oldAfterNewMsg)
+			scrutinizeLogAgeNewestTime,
+			fmt.Sprintf("log-age-oldest-time cannot be set after log-age-newest-time. %s, %s.", logAgeOldestTimeStr, logAgeNewestTimeStr))
 		allErrs = append(allErrs, err)
 	}
 

--- a/api/v1beta1/verticascrutinize_webhook.go
+++ b/api/v1beta1/verticascrutinize_webhook.go
@@ -158,16 +158,16 @@ func (vscr *VerticaScrutinize) ValidateLogAgeTimes(allErrs field.ErrorList) fiel
 	if logAgeOldestTime.After(logAgeNewestTime) {
 		oldAfterNewMsg := ""
 
-		// if log-age-newest-time not set, default as current time ()
+		// if log-age-newest-time is not set, default as the current time
 		logAgeNewestTimeStr := logAgeNewestTime.Format("2006-01-02 15 MST")
 		if scrutinizeLogAgeNewestTime == "" {
-			oldAfterNewMsg += "log-age-newest-time default as current time: " + logAgeNewestTimeStr + "."
+			oldAfterNewMsg += "log-age-newest-time default as current time: \"" + logAgeNewestTimeStr + "\"."
 		}
 
-		// if log-age-oldest-time not set, default as 24 hours ago
+		// if log-age-oldest-time is not set, default as 24 hours ago
 		logAgeOldestTimeStr := logAgeOldestTime.Format("2006-01-02 15 MST")
 		if scrutinizeLogAgeOldestTime == "" {
-			oldAfterNewMsg += "log-age-oldest-time default as 24 hours ago: " + logAgeOldestTimeStr + "."
+			oldAfterNewMsg += "log-age-oldest-time default as 24 hours ago: \"" + logAgeOldestTimeStr + "\"."
 		}
 
 		oldAfterNewMsg += " log-age-oldest-time cannot be set after log-age-newest-time."


### PR DESCRIPTION
Print the log age time default values if they are not set. 
1. log-age-oldest-time default as 24 hours ago if not set
2. log-age-newest-time default as the current time if not set


The example error message would look like:
1. set log-age-oldest-time after the current time, and leave log-age-newest-time not set
* metadata.annotations[vertica.com/scrutinize-log-age-oldest-time]: Invalid value: "2024-09-24 08 +08": log-age-oldest-time cannot be set after current time
* metadata.annotations[vertica.com/scrutinize-log-age-newest-time]: Invalid value: "": log-age-oldest-time cannot be set after log-age-newest-time. log-age-oldest-time is: "2024-09-24 00 UTC", log-age-newest-time default as current time: "2024-09-23 20 UTC".
2. set log-age-newest-time before 24 hours ago, and leave log-age-oldest-time not set:
* metadata.annotations[vertica.com/scrutinize-log-age-newest-time]: Invalid value: "2024-09-20 8": log-age-oldest-time cannot be set after log-age-newest-time. log-age-oldest-time default as 24 hours ago: "2024-09-22 20 UTC", log-age-newest-time is: "2024-09-20 00 UTC".
3. both are set:
* metadata.annotations[vertica.com/scrutinize-log-age-newest-time]: Invalid value: "2024-09-20 8": log-age-oldest-time cannot be set after log-age-newest-time. log-age-oldest-time is: "2024-09-22 00 UTC", log-age-newest-time is: "2024-09-20 00 UTC".