### PR TITLE
Update webhook for status condition

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -914,6 +914,9 @@ const (
 const (
 	// list of reasons for conditions' transitions
 	UnknownReason = "UnKnown"
+	// the default condition reason in case that field was left unset
+	DefaultReason = "Init"
+	DefaultMsg    = "Init"
 )
 
 const (

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	vutil "github.com/vertica/vcluster/vclusterops/util"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
@@ -27,6 +28,7 @@ import (
 	vversion "github.com/vertica/vertica-kubernetes/pkg/version"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -93,6 +95,19 @@ func (v *VerticaDB) Default() {
 	}
 	if v.Spec.TemporarySubclusterRouting != nil {
 		v.Spec.TemporarySubclusterRouting.Template.Type = SecondarySubcluster
+	}
+	// Set required status conditions fields if they are unset
+	for i := range v.Status.Conditions {
+		cond := &v.Status.Conditions[i]
+		if cond.LastTransitionTime.IsZero() {
+			cond.LastTransitionTime = metav1.NewTime(time.Now())
+		}
+		if cond.Reason == "" {
+			cond.Reason = DefaultReason
+		}
+		if cond.Message == "" {
+			cond.Message = DefaultMsg
+		}
 	}
 	v.setDefaultServiceName()
 	v.setDefaultSandboxImages()

--- a/tests/e2e-leg-6/save-restore-point/05-create-restore-point.yaml
+++ b/tests/e2e-leg-6/save-restore-point/05-create-restore-point.yaml
@@ -18,7 +18,7 @@ commands:
       kubectl patch vdb v-restore-point --type='json' -p='[{
       "op": "add", 
       "path": "/status/conditions/-", 
-      "value": {"type": "SaveRestorePointNeeded", "status": "True", "message": "test", "reason": "test", "lastTransitionTime": "2024-09-16T21:38:27Z"}
+      "value": {"type": "SaveRestorePointNeeded", "status": "True"}
       }]' --subresource='status'
     namespaced: true
   - command: kubectl wait --for=condition=SaveRestorePointNeeded=True vdb/v-restore-point --timeout=600s


### PR DESCRIPTION
To trigger save_restore_point, you have to set the `SaveRestorePointNeeded` status condition. A status condition has many required fields. With this PR, the user will only have to set the type and condition, there is a webhook that will set the other requirered fields.
As an example, before the user would need this: `{"type": "SaveRestorePointNeeded", "status": "True", "message": "test", "reason": "test", "lastTransitionTime": "2024-09-16T21:38:27Z"}`
Now they only have to set 2 fields: `{"type": "SaveRestorePointNeeded", "status": "True"}`

NB: If the webhook is disabled, you will need to explicitly set all the required fields.