### PR TITLE
Support multiple local pathes in revive_db

### DIFF
--- a/changes/unreleased/Added-20240930-144400.yaml
+++ b/changes/unreleased/Added-20240930-144400.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Support reviving a database with multiple local data paths, local depot paths, and other types of local storage locations
+time: 2024-09-30T14:44:00.863246977-04:00
+custom:
+    Issue: "938"

--- a/changes/unreleased/Added-20240930-144400.yaml
+++ b/changes/unreleased/Added-20240930-144400.yaml
@@ -2,4 +2,4 @@ kind: Added
 body: Support reviving a database with multiple local data paths, local depot paths, and other types of local storage locations
 time: 2024-09-30T14:44:00.863246977-04:00
 custom:
-    Issue: "938"
+    Issue: "940"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -244,6 +244,17 @@ func buildVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 	volMnts = append(volMnts, buildCertSecretVolumeMounts(vdb)...)
 	volMnts = append(volMnts, vdb.Spec.VolumeMounts...)
 
+	extraPathsStr := vmeta.GetExtraLocalPaths(vdb.Annotations)
+	if extraPathsStr != "" {
+		extraPaths := strings.Split(extraPathsStr, ",")
+		for _, path := range extraPaths {
+			volMnts = append(volMnts, corev1.VolumeMount{
+				Name:      vapi.LocalDataPVC,
+				SubPath:   filepath.Clean(vdb.GetPVSubPath(path)),
+				MountPath: path,
+			})
+		}
+	}
 	return volMnts
 }
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -313,6 +313,11 @@ const (
 	// omitted, then the name of the subclusters' statefulset will be
 	// `<vdb-name>-<subcluster-name>'
 	StsNameOverrideAnnotation = "vertica.com/statefulset-name-override"
+
+	// Use this to store extra local paths that we need to create before revive_db.
+	// Those paths include local paths not in loca.catalogPath, loca.dataPath,
+	// and loca.depotPath. For example, the user-created temp paths.
+	ExtraLocalPathsAnnotation = "vertica.com/extra-local-paths"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -600,6 +605,11 @@ func GetSaveRestorePoint(annotations map[string]string) bool {
 // not provided, an empty string is returned.
 func GetStsNameOverride(annotations map[string]string) string {
 	return lookupStringAnnotation(annotations, StsNameOverrideAnnotation, "")
+}
+
+// GetExtraLocalPaths returns the comma separated list of extra local paths
+func GetExtraLocalPaths(annotations map[string]string) string {
+	return lookupStringAnnotation(annotations, ExtraLocalPathsAnnotation, "")
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -315,8 +315,8 @@ const (
 	StsNameOverrideAnnotation = "vertica.com/statefulset-name-override"
 
 	// Use this to store extra local paths that we need to create before revive_db.
-	// Those paths include local paths not in loca.catalogPath, loca.dataPath,
-	// and loca.depotPath. For example, the user-created temp paths.
+	// Those paths include local paths not in local.catalogPath, local.dataPath,
+	// and local.depotPath. For example, the user-created temp paths.
 	ExtraLocalPathsAnnotation = "vertica.com/extra-local-paths"
 )
 

--- a/pkg/reviveplanner/atparser/at_parser.go
+++ b/pkg/reviveplanner/atparser/at_parser.go
@@ -44,6 +44,15 @@ func (a *Parser) GetDataPaths() []string {
 	return paths
 }
 
+// GetOtherPaths will return the user and temp paths for each node
+func (a *Parser) GetOtherPaths() []string {
+	paths := []string{}
+	for i := range a.Database.Nodes {
+		paths = append(paths, a.Database.Nodes[i].GetOtherPaths()...)
+	}
+	return paths
+}
+
 // GetDepotPaths will return the depot paths for each node
 func (a *Parser) GetDepotPaths() []string {
 	paths := []string{}
@@ -168,7 +177,12 @@ func MakeATParserFromVDB(vdb *vapi.VerticaDB, logger logr.Logger) Parser {
 
 // GetDataPaths returns the data paths for the node
 func (n *Node) GetDataPaths() []string {
-	return n.getPathsByUsage(util.UsageIsDataTemp)
+	return append(n.getPathsByUsage(util.UsageIsData), n.getPathsByUsage(util.UsageIsDataTemp)...)
+}
+
+// GetOtherPaths will return the user and temp paths for the node
+func (n *Node) GetOtherPaths() []string {
+	return append(n.getPathsByUsage(util.UsageIsTemp), n.getPathsByUsage(util.UsageIsUser)...)
 }
 
 // GetDepotPath returns the depot paths for the node

--- a/pkg/reviveplanner/interface.go
+++ b/pkg/reviveplanner/interface.go
@@ -33,6 +33,7 @@ type ClusterConfigParser interface {
 	GetDataPaths() []string
 	GetDepotPaths() []string
 	GetCatalogPaths() []string
+	GetOtherPaths() []string
 	GetNumShards() (int, error)
 	GetDatabaseName() string
 }

--- a/pkg/reviveplanner/util/const.go
+++ b/pkg/reviveplanner/util/const.go
@@ -16,8 +16,14 @@
 package util
 
 const (
+	// The usage number for DATA. Set internally by Vertica.
+	UsageIsData = 1
+	// The usage number for TEMP. Set internally by Vertica.
+	UsageIsTemp = 2
 	// The usage number for DATA,TEMP. Set internally by Vertica.
 	UsageIsDataTemp = 3
+	// The usage number for USER. Set internally by Vertica.
+	UsageIsUser = 4
 	// The usage number for DEPOT. Set internally by Vertica.
 	UsageIsDepot = 5
 )

--- a/tests/e2e-leg-3/revive-with-different-local-paths/35-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/35-assert.yaml
@@ -22,6 +22,8 @@ status:
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
+  annotations:
+    vertica.com/extra-local-paths: /tmp/test,/vertica/data/storage,/vertica/data/user
   name: v-revive-1
 spec:
   local:

--- a/tests/e2e-leg-3/revive-with-different-local-paths/37-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/37-assert.yaml
@@ -11,9 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/vertica/data/storage' ALL NODES USAGE 'DATA';"
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/tmp/test' NODE 'v_entdb_node0001' USAGE 'TEMP';"
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/vertica/data/user' ALL NODES USAGE 'USER'; select sync_catalog();"
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-1-main
+status:
+  replicas: 2
+  readyReplicas: 1

--- a/tests/e2e-leg-3/revive-with-different-local-paths/37-verify-storage-location-exists.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/37-verify-storage-location-exists.yaml
@@ -1,0 +1,39 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # verify the storage location is still in database
+  - script: |
+      val=$(kubectl exec -n $NAMESPACE v-revive-1-main-0 -c server -- vsql -tAc "select count(*) from storage_locations where location_path = '/vertica/data/storage' and location_usage = 'DATA'"); \
+      if [ $val == 0 ]; then \
+        exit 1; \
+      fi
+  - script: |
+      val=$(kubectl exec -n $NAMESPACE v-revive-1-main-0 -c server -- vsql -tAc "select count(*) from storage_locations where location_path = '/tmp/test' and location_usage = 'TEMP'"); \
+      if [ $val == 0 ]; then \
+        exit 1; \
+      fi
+  - script: |
+      val=$(kubectl exec -n $NAMESPACE v-revive-1-main-0 -c server -- vsql -tAc "select count(*) from storage_locations where location_path = '/vertica/data/user' and location_usage = 'USER'"); \
+      if [ $val == 0 ]; then \
+        exit 1; \
+      fi
+  # verify the directory is created in the pod
+  - command: kubectl exec -n $NAMESPACE v-revive-1-main-0 -c server -- test -d /vertica/data/storage
+  - command: kubectl exec -n $NAMESPACE v-revive-1-main-0 -c server -- test -d /tmp/test
+  - command: kubectl exec -n $NAMESPACE v-revive-1-main-0 -c server -- test -d /vertica/data/user
+  # delete the pod to ensure the directory is presistent
+  - command: kubectl delete pod v-revive-1-main-0
+    namespaced: true

--- a/tests/e2e-leg-3/revive-with-different-local-paths/38-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/38-assert.yaml
@@ -11,9 +11,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/vertica/data/storage' ALL NODES USAGE 'DATA';"
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/tmp/test' NODE 'v_entdb_node0001' USAGE 'TEMP';"
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/vertica/data/user' ALL NODES USAGE 'USER'; select sync_catalog();"
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-1-main
+status:
+  replicas: 2
+  readyReplicas: 2
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+metadata:
+  name: v-revive-1
+status:
+  subclusters:
+    - installCount: 2
+      addedToDBCount: 2
+      upNodeCount: 2

--- a/tests/e2e-leg-3/revive-with-different-local-paths/38-wait-for-restart.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/38-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-3/revive-with-different-local-paths/39-verify-storage-locations-is-persistent.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/39-verify-storage-locations-is-persistent.yaml
@@ -14,6 +14,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/vertica/data/storage' ALL NODES USAGE 'DATA';"
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/tmp/test' NODE 'v_entdb_node0001' USAGE 'TEMP';"
-  - command: kubectl exec --namespace $NAMESPACE v-create-main-0 -c server -- vsql -c "create location '/vertica/data/user' ALL NODES USAGE 'USER'; select sync_catalog();"
+  # verify the directory is recreated in the pod
+  - command: kubectl exec -n $NAMESPACE v-revive-1-main-1 -c server -- test -d /vertica/data/storage
+  - command: kubectl exec -n $NAMESPACE v-revive-1-main-1 -c server -- test -d /tmp/test
+  - command: kubectl exec -n $NAMESPACE v-revive-1-main-1 -c server -- test -d /vertica/data/user

--- a/tests/e2e-leg-3/revive-with-different-local-paths/55-assert.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/55-assert.yaml
@@ -22,6 +22,8 @@ status:
 apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
+  annotations:
+    vertica.com/extra-local-paths: /tmp/test,/vertica/data/storage,/vertica/data/user
   name: v-revive-2
 spec:
   local:

--- a/tests/e2e-leg-3/revive-with-different-local-paths/57-verify-storage-location-exists.yaml
+++ b/tests/e2e-leg-3/revive-with-different-local-paths/57-verify-storage-location-exists.yaml
@@ -1,0 +1,36 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # verify the storage location is still in database
+  - script: |
+      val=$(kubectl exec -n $NAMESPACE v-revive-2-main-2 -c server -- vsql -tAc "select count(*) from storage_locations where location_path = '/vertica/data/storage' and location_usage = 'DATA'"); \
+      if [ $val == 0 ]; then \
+        exit 1; \
+      fi
+  - script: |
+      val=$(kubectl exec -n $NAMESPACE v-revive-2-main-2 -c server -- vsql -tAc "select count(*) from storage_locations where location_path = '/tmp/test' and location_usage = 'TEMP'"); \
+      if [ $val == 0 ]; then \
+        exit 1; \
+      fi
+  - script: |
+      val=$(kubectl exec -n $NAMESPACE v-revive-2-main-2 -c server -- vsql -tAc "select count(*) from storage_locations where location_path = '/vertica/data/user' and location_usage = 'USER'"); \
+      if [ $val == 0 ]; then \
+        exit 1; \
+      fi
+  # verify the directory is created in the pod
+  - command: kubectl exec -n $NAMESPACE v-revive-2-main-2 -c server -- test -d /vertica/data/storage
+  - command: kubectl exec -n $NAMESPACE v-revive-2-main-2 -c server -- test -d /tmp/test
+  - command: kubectl exec -n $NAMESPACE v-revive-2-main-2 -c server -- test -d /vertica/data/user


### PR DESCRIPTION
This PR supports reviving a database with multiple data paths, temp paths, user paths, and depot paths.