### PR TITLE
fix online upgrade pause timeout logic

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -249,7 +249,7 @@ The operator pod contains a webhook, which requires TLS certificates. The TLS se
 Deploy the operator with Helm and all its prerequisites:
 First make sure DEPLOY_WITH is set up properly in Makefile:
 ```shell
-DEPLOY_WITH=helm 
+DEPLOY_WITH=helm
 ```
 Next run the following command
 ```shell
@@ -505,7 +505,7 @@ You might need to inspect the contents of the `vertica.log` to diagnose a proble
 
 ### Exec into a container
 
-Drop into the container and navigate to the directory where is is stored:
+Drop into the container and navigate to the directory where it is stored:
 
 ```shell
 docker exec -it <container-name> /bin/bash

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -178,7 +178,7 @@ func (v *VerticaDB) IsUpgradePathSupported(newAnnotations map[string]string) (ok
 	return
 }
 
-// isOnlineUpgradeSupported returns true if the version in the Vdb is is equal or newer than
+// isOnlineUpgradeSupported returns true if the version in the Vdb is equal or newer than
 // 24.3.0-2.
 func (v *VerticaDB) isOnlineUpgradeSupported(vinf *version.Info) bool {
 	return vinf.IsEqualOrNewerWithHotfix(OnlineUpgradeVersion)
@@ -190,8 +190,9 @@ func (v *VerticaDB) IsPausedSessionsSupported() bool {
 	if !ok {
 		return false
 	}
-	if vinf.IsEqualOrNewer(MinPauseSessionsVersion243) {
-		return vinf.IsEqualOrNewerWithHotfix(MinPauseSessionsVersion243)
+	if vinf.IsEqualOrNewer(MinPauseSessionsVersion244) {
+		return true
 	}
-	return vinf.IsEqualOrNewerWithHotfix(MinPauseSessionsVersion243)
+	// the only tricky one: ver needs to be at least 24.3-4, but can't be 24.4 (>= 24.4-1 is handled by the above if)
+	return vinf.IsEqualOrNewerWithHotfix(MinPauseSessionsVersion243) && vinf.IsEqualOrNewer(MinPauseSessionsVersion243)
 }

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -32,9 +32,8 @@ const (
 	NodesHaveReadOnlyStateVersion = "v11.0.2"
 	// The minimum version that allows for read-only online upgrade.
 	ReadOnlyOnlineUpgradeVersion = "v11.1.0"
-	// The minimum versions that allow for online upgrade.
-	OnlineUpgradeVersion243 = "v24.3.0-4"
-	OnlineUpgradeVersion244 = "v24.4.0-1"
+	// The minimum version that allows for online upgrade.
+	OnlineUpgradeVersion = "v24.3.0-2"
 	// The version that added the --force option to reip to handle up nodes
 	ReIPAllowedWithUpNodesVersion = "v11.1.0"
 	// The version of the server that doesn't support cgroup v2
@@ -86,6 +85,9 @@ const (
 	FetchNodeDetailsWithVclusterOpsMinVersion = "v24.3.0"
 	// Starting in v24.4.0, saving a restore point to an existing archive is supported
 	SaveRestorePointNMAOpsMinVersion = "v24.4.0"
+	// starting in v24.3-4, v24.4-1, and v25.0-0 pausing sessions works a little differently
+	MinPauseSessionsVersion243 = "v24.3.0-4"
+	MinPauseSessionsVersion244 = "v24.4.0-1"
 )
 
 // GetVerticaVersionStr returns the vertica version, in string form, that is stored
@@ -176,11 +178,20 @@ func (v *VerticaDB) IsUpgradePathSupported(newAnnotations map[string]string) (ok
 	return
 }
 
-// isOnlineUpgradeSupported returns true if the version in the Vdb is for a version that supports online upgrade
-// 24.3.0-4 and 24.4.0-1 are the oldest version that support online upgrade, anything newer is fine
+// isOnlineUpgradeSupported returns true if the version in the Vdb is is equal or newer than
+// 24.3.0-2.
 func (v *VerticaDB) isOnlineUpgradeSupported(vinf *version.Info) bool {
-	if vinf.IsEqualOrNewer(OnlineUpgradeVersion244) {
-		return vinf.IsEqualOrNewerWithHotfix(OnlineUpgradeVersion244)
+	return vinf.IsEqualOrNewerWithHotfix(OnlineUpgradeVersion)
+}
+
+// IsPausedSessionsSupported returns true if the vertica version supports the expected pause sessions semantics
+func (v *VerticaDB) IsPausedSessionsSupported() bool {
+	vinf, ok := v.MakeVersionInfo()
+	if !ok {
+		return false
 	}
-	return vinf.IsEqualOrNewerWithHotfix(OnlineUpgradeVersion243)
+	if vinf.IsEqualOrNewer(MinPauseSessionsVersion243) {
+		return vinf.IsEqualOrNewerWithHotfix(MinPauseSessionsVersion243)
+	}
+	return vinf.IsEqualOrNewerWithHotfix(MinPauseSessionsVersion243)
 }

--- a/api/v1/verticadb_types_test.go
+++ b/api/v1/verticadb_types_test.go
@@ -107,7 +107,7 @@ var _ = Describe("verticadb_types", func() {
 
 		// Ensure we don't pick online, if there is no evidence we can scale
 		// past 3 nodes.
-		vdb.Annotations[vmeta.VersionAnnotation] = OnlineUpgradeVersion243
+		vdb.Annotations[vmeta.VersionAnnotation] = OnlineUpgradeVersion
 		vdb.Spec.UpgradePolicy = OnlineUpgrade
 		vdb.Spec.LicenseSecret = ""
 		vdb.Spec.Subclusters = []Subcluster{
@@ -153,7 +153,7 @@ var _ = Describe("verticadb_types", func() {
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(OfflineUpgrade))
 
 		// Online selection on latest version should pick read-only online
-		vdb.Annotations[vmeta.VersionAnnotation] = OnlineUpgradeVersion243
+		vdb.Annotations[vmeta.VersionAnnotation] = OnlineUpgradeVersion
 		vdb.Spec.UpgradePolicy = ReadOnlyOnlineUpgrade
 		Ω(vdb.GetUpgradePolicyToUse()).Should(Equal(ReadOnlyOnlineUpgrade))
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler_test.go
@@ -460,7 +460,7 @@ var _ = Describe("onlineupgrade_reconciler", func() {
 	It("should maintain upgrade status messages", func() {
 		vdb := vapi.MakeVDBForVclusterOps()
 		vdb.Spec.UpgradePolicy = vapi.OnlineUpgrade
-		vdb.ObjectMeta.Annotations[vmeta.VersionAnnotation] = vapi.OnlineUpgradeVersion243
+		vdb.ObjectMeta.Annotations[vmeta.VersionAnnotation] = vapi.OnlineUpgradeVersion
 		vdb.Spec.Subclusters = []vapi.Subcluster{
 			{Name: "pri1", Type: vapi.PrimarySubcluster, Size: 2},
 			{Name: "sec1", Type: vapi.SecondarySubcluster, Size: 2},

--- a/pkg/controllers/vdb/upgrade_test.go
+++ b/pkg/controllers/vdb/upgrade_test.go
@@ -40,7 +40,7 @@ var _ = Describe("upgrade", func() {
 		vdb.Spec.Subclusters = append(vdb.Spec.Subclusters, vapi.Subcluster{
 			Name: "sc1", Type: vapi.SecondarySubcluster, Size: 3,
 		})
-		vdb.Annotations[vmeta.VersionAnnotation] = vapi.OnlineUpgradeVersion243
+		vdb.Annotations[vmeta.VersionAnnotation] = vapi.OnlineUpgradeVersion
 
 		vdb.Spec.UpgradePolicy = vapi.OfflineUpgrade
 		Expect(offlineUpgradeAllowed(vdb)).Should(BeTrue())

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -85,7 +85,7 @@ func MakeInfoFromStrCheck(curVer string) (*Info, error) {
 	return verInfo, nil
 }
 
-// IsEqualOrNewer returns true if the version in the Vdb is is equal or newer
+// IsEqualOrNewer returns true if the version in the Vdb is equal or newer
 // than the given version
 func (i *Info) IsEqualOrNewer(inVer string) bool {
 	comp, ok := parseVersion(inVer)
@@ -96,7 +96,7 @@ func (i *Info) IsEqualOrNewer(inVer string) bool {
 	return res != compareSmaller
 }
 
-// IsEqualOrNewerWithHotfix checks if the version in the Vdb is is equal or newer
+// IsEqualOrNewerWithHotfix checks if the version in the Vdb is equal or newer
 // than the given version. It will compare hotfix number if all other numbers are
 // the same.
 func (i *Info) IsEqualOrNewerWithHotfix(inVer string) bool {


### PR DESCRIPTION
kill all sessions during online upgrade when hitting pause timeout when the vertica version is too old to tell us which sessions are paused