### PR TITLE
Fix admintools read-only upgrade bug from a version < v12.0.4 to a version > v12.0.4

### DIFF
--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -124,6 +124,16 @@ func (v *VerticaDB) MakePreviousVersionInfo() (*version.Info, bool) {
 	return version.MakeInfoFromStr(vdbVer)
 }
 
+// MakeVersionInfoDuringROUpgrade will construct an Info struct by extracting
+// the previous version is read-only online upgrade is in progress, from the
+// current version otherwise.
+func (v *VerticaDB) MakeVersionInfoDuringROUpgrade() (*version.Info, bool) {
+	if v.IsROUpgradeInProgress() {
+		return v.MakePreviousVersionInfo()
+	}
+	return v.MakeVersionInfo()
+}
+
 // MakeVersionInfoCheck is like MakeVersionInfo but returns an error if the
 // version is missing. Use this in places where it is a failure if the version
 // is missing.

--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -129,7 +129,14 @@ func (v *VerticaDB) MakePreviousVersionInfo() (*version.Info, bool) {
 // current version otherwise.
 func (v *VerticaDB) MakeVersionInfoDuringROUpgrade() (*version.Info, bool) {
 	if v.IsROUpgradeInProgress() {
-		return v.MakePreviousVersionInfo()
+		vinf, ok := v.MakePreviousVersionInfo()
+		// During a downgrade attempt, the operator does not set
+		// the previous-version annotation, so if it cannot be parsed
+		// we will construct the Info from the version annotation even
+		// if read-only online upgrade is in progress
+		if ok {
+			return vinf, ok
+		}
 	}
 	return v.MakeVersionInfo()
 }

--- a/pkg/catalog/fetch_node_details_vsql.go
+++ b/pkg/catalog/fetch_node_details_vsql.go
@@ -72,10 +72,14 @@ func (v *VSQL) buildFetchNodeStateQuery() string {
 	} else {
 		cols = fmt.Sprintf("%s, ''", cols)
 	}
+	// During read-only online upgrade, we should use the old version to determine if we
+	// will append the sandbox state to the query.
+	// The reason is some subclusters might use a low version that does not contain
+	// the sandbox state.
+	vinf, ok := v.VDB.MakeVersionInfoDuringROUpgrade()
 	// The read-only state is a new state added in 11.0.2.  So we can only query
 	// for it on levels 11.0.2+.  Otherwise, we always treat read-only as being
 	// disabled.
-	vinf, ok := v.VDB.MakeVersionInfo()
 	if ok && vinf.IsEqualOrNewer(vapi.NodesHaveReadOnlyStateVersion) {
 		cols = fmt.Sprintf("%s, is_readonly", cols)
 	}

--- a/pkg/controllers/vdb/podfacts.go
+++ b/pkg/controllers/vdb/podfacts.go
@@ -36,7 +36,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	config "github.com/vertica/vertica-kubernetes/pkg/vdbconfig"
-	"github.com/vertica/vertica-kubernetes/pkg/version"
 	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -767,21 +766,11 @@ func (p *PodFacts) checkIsDBCreated(_ context.Context, vdb *vapi.VerticaDB, pf *
 // the operator will call vclusterOps API to collect the node info. Otherwise, the operator will
 // execute vsql inside the pod to collect the node info.
 func (p *PodFacts) makeNodeInfoFetcher(vdb *vapi.VerticaDB, pf *PodFact) catalog.Fetcher {
-	var verInfo *version.Info
-	var ok bool
-	oldVerInfo, ok1 := vdb.MakePreviousVersionInfo()
-	newVerInfo, ok2 := vdb.MakeVersionInfo()
 	// During read-only online upgrade, we should use the old version to determine if we will call
 	// vclusterOps API to collect node info. The reason is some subclusters might uses
 	// a low version that does not contain vcluster API in the midst of the upgrade.
 	// Apart from the upgrade, we should check current version to make the decision.
-	if vdb.IsROUpgradeInProgress() {
-		verInfo = oldVerInfo
-		ok = ok1
-	} else {
-		verInfo = newVerInfo
-		ok = ok2
-	}
+	verInfo, ok := vdb.MakeVersionInfoDuringROUpgrade()
 	if verInfo != nil && ok {
 		if !verInfo.IsOlder(vapi.FetchNodeDetailsWithVclusterOpsMinVersion) && vmeta.UseVClusterOps(vdb.Annotations) {
 			return catalog.MakeVCluster(vdb, p.VerticaSUPassword, pf.podIP, p.Log, p.VRec.GetClient(), p.VRec.GetEventRecorder())


### PR DESCRIPTION
During podfact collection, we add the sandbox state to the query to get node details only for version >= v12.0.4. The issue is that we get the version from the `version` annotation and in the middle of read-only online upgrade it will contain the new version. Therefore, The `select ... from nodes;` will fail for subclusters that still run the old image, if that image is < v12.0.4, because it contains the sandbox state which is not supported. That is why the daily run fails(base_image<v12.0.4 and target_image>v12.0.4).
To fix it, the operator will get the version from the `previous-version` annotation if read-only online upgrade is in progress.