### PR TITLE
pause timeout

### DIFF
--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -201,7 +201,7 @@ func (v *VerticaDB) isOnlineUpgradeSupported(vinf *version.Info) bool {
 	return vinf.IsEqualOrNewerWithHotfix(OnlineUpgradeVersion)
 }
 
-// IsPausedSessionsSupported returns true if the vertica version supports the expected pause sessions semantics
+// IsPausedSessionsSupported returns true if the vertica version has the is_paused column in vs_sessions
 func (v *VerticaDB) IsPausedSessionsSupported() bool {
 	vinf, ok := v.MakeVersionInfo()
 	if !ok {
@@ -216,4 +216,10 @@ func (v *VerticaDB) IsPausedSessionsSupported() bool {
 		panic(fmt.Sprintf("could not parse input version: %s", MinPauseSessionsVersion243))
 	}
 	return vinf.IsEqualOrNewerWithHotfix(MinPauseSessionsVersion243) && vinf.IsEqual(vinf243)
+}
+
+// as of this commit the jdbc driver doesn't fully support pause/redirect. once we support the client proxy and/or
+// the jdbc driver gets updated we can perform a similar version check as above
+func (v *VerticaDB) IsPauseRedirectFullySupported() bool {
+	return false
 }

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -736,6 +736,10 @@ func (i *UpgradeManager) closeAllUnpausedSessions(ctx context.Context, pfacts *P
 		sql = "select s.session_id from " +
 			"v_internal.vs_sessions s join v_catalog.users u using (user_name) " +
 			"where not " + isSuperuser
+	} else if !i.Vdb.IsPauseRedirectFullySupported() {
+		sql = "select s.session_id from " +
+			"v_internal.vs_sessions s join v_catalog.users u using (user_name) " +
+			"where not s.is_paused and not " + isSuperuser
 	}
 	sessionIds, stderr, err := pfacts.PRunner.ExecVSQL(ctx, pf.name, names.ServerContainer, "-tAc", sql)
 	if err != nil {


### PR DESCRIPTION
i was too optimistic about the server change going in in time for the various hotfixes. this makes the pause timeout both less aggressive than without is_paused, but a little more aggressive than is strictly necessary once the server change goes in. 