### PR TITLE
Prevent skipping some tests

### DIFF
--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	vutil "github.com/vertica/vcluster/vclusterops/util"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
@@ -28,7 +27,6 @@ import (
 	vversion "github.com/vertica/vertica-kubernetes/pkg/version"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -95,19 +93,6 @@ func (v *VerticaDB) Default() {
 	}
 	if v.Spec.TemporarySubclusterRouting != nil {
 		v.Spec.TemporarySubclusterRouting.Template.Type = SecondarySubcluster
-	}
-	// Set required status conditions fields if they are unset
-	for i := range v.Status.Conditions {
-		cond := &v.Status.Conditions[i]
-		if cond.LastTransitionTime.IsZero() {
-			cond.LastTransitionTime = metav1.NewTime(time.Now())
-		}
-		if cond.Reason == "" {
-			cond.Reason = DefaultReason
-		}
-		if cond.Message == "" {
-			cond.Message = DefaultMsg
-		}
 	}
 	v.setDefaultServiceName()
 	v.setDefaultSandboxImages()

--- a/scripts/is-image.sh
+++ b/scripts/is-image.sh
@@ -60,6 +60,14 @@ then
 fi
 
 logAndRunCommand docker pull $IMG
+# Normally we would rely on the vertica-version label of the image but it is empty
+# for the latest-test-master image. Until we figure out why, we are adding
+# this work around to not skip some tests.
+if [[ "$IMG" == "docker.io/opentext/vertica-k8s-private:latest-test-master" ]]
+then
+    logInfo "$IMG is newer"
+    exit 1
+fi
 IMG_VER=$(determine_image_version $IMG)
 logInfo "Image $IMG has version $IMG_VER"
 logInfo "Checking if $IMG_VER is $COMPARE_TYPE than $COMPARE_VERSION"

--- a/tests/e2e-leg-6/save-restore-point/05-create-restore-point.yaml
+++ b/tests/e2e-leg-6/save-restore-point/05-create-restore-point.yaml
@@ -18,7 +18,7 @@ commands:
       kubectl patch vdb v-restore-point --type='json' -p='[{
       "op": "add", 
       "path": "/status/conditions/-", 
-      "value": {"type": "SaveRestorePointNeeded", "status": "True"}
+      "value": {"type": "SaveRestorePointNeeded", "status": "True", "message": "test", "reason": "test", "lastTransitionTime": "2024-09-16T21:38:27Z"}
       }]' --subresource='status'
     namespaced: true
   - command: kubectl wait --for=condition=SaveRestorePointNeeded=True vdb/v-restore-point --timeout=600s


### PR DESCRIPTION
The reason why normal ci tests were oddly more stable than daily build tests was because we were skipping a lot of them.
We rely on the vertica-version label in the image to skip some tests in case the vertica version is lower than the min required version by the test. The issue is that label is empty for `latest-test-master` which leads to all the tests using that image to be skipped. We need to set that label properly for that image too but in the meantime, we are adding this work-around to not skip some tests.