### PR TITLE
fix value in integration test

### DIFF
--- a/tests/e2e-leg-6/save-restore-point/05-create-restore-point.yaml
+++ b/tests/e2e-leg-6/save-restore-point/05-create-restore-point.yaml
@@ -18,7 +18,7 @@ commands:
       kubectl patch vdb v-restore-point --type='json' -p='[{
       "op": "add", 
       "path": "/status/conditions/-", 
-      "value": {"type": "SaveRestorePointNeeded", "status": "True"}
+      "value": {"type": "SaveRestorePointNeeded", "status": "True", "lastTransitionTime": "2024-09-10T07:07:12Z", "message": "", "reason": "test"}
       }]' --subresource='status'
     namespaced: true
   - command: kubectl wait --for=condition=SaveRestorePointNeeded=True vdb/v-restore-point --timeout=600s


### PR DESCRIPTION
The value is not setup correctly so we see error in the integration test:
 kubectl patch vdb vertica-db --type='json' -p='[{
> "op": "add",
> "path": "/status/conditions/-",
> "value": {"type": "SaveRestorePointNeeded", "status": "True"}
> }]' --subresource='status'
The VerticaDB "vertica-db" is invalid:
* conditions[3].lastTransitionTime: Required value
* conditions[3].message: Required value
* conditions[3].reason: Required value

We need to add value for the missing attribute.