### PR TITLE
trivy scan setup backup url for downloading db artifacts

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -120,15 +120,18 @@ jobs:
     # We never run the sarif scanner in PRs because PRs don't have permission
     # to upload the results to github.
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan == 'all' && github.event_name != 'pull_request' }}
       with:
-        image-ref: ${{ steps.full_vertica_image.outputs.value }}
-        ignore-unfixed: true
-        security-checks: vuln
-        timeout: '20m0s'
-        format: 'sarif'
-        output: 'trivy-results-vertica-image.sarif'
+        action: aquasecurity/trivy-action@0.24.0
+        retry_condition: steps._this.outputs.code == 0
+        with:
+          image-ref: ${{ steps.full_vertica_image.outputs.value }}
+          ignore-unfixed: true
+          security-checks: vuln
+          timeout: '20m0s'
+          format: 'sarif'
+          output: 'trivy-results-vertica-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -137,15 +140,18 @@ jobs:
         sarif_file: 'trivy-results-vertica-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan == 'all' }}
       with:
-        image-ref: ${{ steps.full_vertica_image.outputs.value }}
-        ignore-unfixed: true
-        security-checks: vuln
-        timeout: '20m0s'
-        format: 'table'
-        output: 'trivy-results-vertica-image.out'
+        action: aquasecurity/trivy-action@0.24.0
+        retry_condition: steps._this.outputs.code == 0
+        with:
+          image-ref: ${{ steps.full_vertica_image.outputs.value }}
+          ignore-unfixed: true
+          security-checks: vuln
+          timeout: '20m0s'
+          format: 'table'
+          output: 'trivy-results-vertica-image.out'
         
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-image.out') != '' }}
@@ -402,13 +408,16 @@ jobs:
         docker pull ${{ inputs.operator_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
-        image-ref: ${{ steps.operator_image.outputs.value }}
-        ignore-unfixed: true
-        format: 'sarif'
-        output: 'trivy-results-verticadb-operator-image.sarif'
+        action: aquasecurity/trivy-action@0.24.0
+        retry_condition: steps._this.outputs.code == 0
+        with:
+          image-ref: ${{ steps.operator_image.outputs.value }}
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -417,13 +426,16 @@ jobs:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
-        image-ref: ${{ steps.operator_image.outputs.value }}
-        ignore-unfixed: true
-        format: 'table'
-        output: 'trivy-results-verticadb-operator-image.out'
+        action: aquasecurity/trivy-action@0.24.0
+        retry_condition: steps._this.outputs.code == 0
+        with:
+          image-ref: ${{ steps.operator_image.outputs.value }}
+          ignore-unfixed: true
+          format: 'table'
+          output: 'trivy-results-verticadb-operator-image.out'
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -408,14 +408,12 @@ jobs:
         docker pull ${{ inputs.operator_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      shell: bash
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
-          image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
           format: sarif
           output: trivy-results-verticadb-operator-image.sarif
@@ -427,14 +425,12 @@ jobs:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      shell: bash
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
-          image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
           format: table
           output: trivy-results-verticadb-operator-image.out
@@ -527,14 +523,12 @@ jobs:
         docker pull ${{ inputs.vlogger_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      shell: bash
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
-          image-ref: ${{ steps.vlogger_image.outputs.value }}
           ignore-unfixed: true
           format: sarif
           output: trivy-results-vertica-logger-image.sarif
@@ -546,7 +540,6 @@ jobs:
         sarif_file: 'trivy-results-vertica-logger-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      shell: bash
       id: trivy_scan
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' }}
@@ -554,7 +547,6 @@ jobs:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
-          image-ref: ${{ steps.vlogger_image.outputs.value }}
           ignore-unfixed: true
           format: table
           output: trivy-results-vertica-logger-image.out

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -65,6 +65,10 @@ permissions:
   packages: write
   security-events: write
 
+env:
+  TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
+  TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+
 jobs:
   build-server-full:
     runs-on: ubuntu-latest
@@ -130,8 +134,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-vertica-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -150,8 +154,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-image.out'
       env:
-        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
         
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-image.out') != '' }}
@@ -416,8 +420,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-verticadb-operator-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -434,8 +438,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-verticadb-operator-image.out'
       env:
-        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}
@@ -533,8 +537,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-vertica-logger-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -552,8 +556,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-logger-image.out'
       env:
-        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
 
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-logger-image.out') != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -120,7 +120,7 @@ jobs:
     # We never run the sarif scanner in PRs because PRs don't have permission
     # to upload the results to github.
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: aquasecurity/trivy-action@0.56.2
       if: ${{ inputs.run_security_scan == 'all' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.full_vertica_image.outputs.value }}
@@ -140,7 +140,7 @@ jobs:
         sarif_file: 'trivy-results-vertica-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: aquasecurity/trivy-action@0.56.2
       if: ${{ inputs.run_security_scan == 'all' }}
       with:
         image-ref: ${{ steps.full_vertica_image.outputs.value }}
@@ -408,7 +408,7 @@ jobs:
         docker pull ${{ inputs.operator_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: aquasecurity/trivy-action@0.56.2
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.operator_image.outputs.value }}
@@ -426,7 +426,7 @@ jobs:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: aquasecurity/trivy-action@0.56.2
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
         image-ref: ${{ steps.operator_image.outputs.value }}
@@ -525,7 +525,7 @@ jobs:
         docker pull ${{ inputs.vlogger_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: aquasecurity/trivy-action@0.56.2
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.vlogger_image.outputs.value }}
@@ -544,7 +544,7 @@ jobs:
 
     - name: Run the Trivy vulnerability scanner (pretty print)
       id: trivy_scan
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: aquasecurity/trivy-action@0.56.2
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
         image-ref: ${{ steps.vlogger_image.outputs.value }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -66,8 +66,8 @@ permissions:
   security-events: write
 
 env:
-  TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
-  TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+  TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+  TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
 jobs:
   build-server-full:
@@ -134,8 +134,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-vertica-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
-        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY }}
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY }}
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -154,8 +154,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-image.out'
       env:
-        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
-        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY }}
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY }}
         
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-image.out') != '' }}
@@ -420,8 +420,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-verticadb-operator-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
-        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY }}
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY }}
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -438,8 +438,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-verticadb-operator-image.out'
       env:
-        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
-        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY }}
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY }}
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}
@@ -537,8 +537,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-vertica-logger-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
-        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY }}
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY }}
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -556,8 +556,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-logger-image.out'
       env:
-        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY}}"
-        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY}}"
+        TRIVY_DB_REPOSITORY: ${{ env.TRIVY_DB_REPOSITORY }}
+        TRIVY_JAVA_DB_REPOSITORY: ${{ env.TRIVY_JAVA_DB_REPOSITORY }}
 
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-logger-image.out') != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -120,7 +120,7 @@ jobs:
     # We never run the sarif scanner in PRs because PRs don't have permission
     # to upload the results to github.
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.56.2
+      uses: aquasecurity/trivy-action@0.27.0
       if: ${{ inputs.run_security_scan == 'all' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.full_vertica_image.outputs.value }}
@@ -140,7 +140,7 @@ jobs:
         sarif_file: 'trivy-results-vertica-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: aquasecurity/trivy-action@0.56.2
+      uses: aquasecurity/trivy-action@0.27.0
       if: ${{ inputs.run_security_scan == 'all' }}
       with:
         image-ref: ${{ steps.full_vertica_image.outputs.value }}
@@ -408,7 +408,7 @@ jobs:
         docker pull ${{ inputs.operator_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.56.2
+      uses: aquasecurity/trivy-action@0.27.0
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.operator_image.outputs.value }}
@@ -426,7 +426,7 @@ jobs:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: aquasecurity/trivy-action@0.56.2
+      uses: aquasecurity/trivy-action@0.27.0
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
         image-ref: ${{ steps.operator_image.outputs.value }}
@@ -525,7 +525,7 @@ jobs:
         docker pull ${{ inputs.vlogger_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.56.2
+      uses: aquasecurity/trivy-action@0.27.0
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
         image-ref: ${{ steps.vlogger_image.outputs.value }}
@@ -544,7 +544,7 @@ jobs:
 
     - name: Run the Trivy vulnerability scanner (pretty print)
       id: trivy_scan
-      uses: aquasecurity/trivy-action@0.56.2
+      uses: aquasecurity/trivy-action@0.27.0
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
         image-ref: ${{ steps.vlogger_image.outputs.value }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -414,6 +414,7 @@ jobs:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
+          image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
           format: sarif
           output: trivy-results-verticadb-operator-image.sarif
@@ -431,9 +432,10 @@ jobs:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
+          image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
           format: table
-          output: trivy-results-verticadb-operator-image.out
+          output: trivy-results-verticadb-operator-image.out'
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}
@@ -529,6 +531,7 @@ jobs:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
+          image-ref: ${{ steps.vlogger_image.outputs.value }}
           ignore-unfixed: true
           format: sarif
           output: trivy-results-vertica-logger-image.sarif
@@ -547,6 +550,7 @@ jobs:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
         with: |
+          image-ref: ${{ steps.vlogger_image.outputs.value }}
           ignore-unfixed: true
           format: table
           output: trivy-results-vertica-logger-image.out

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -125,7 +125,7 @@ jobs:
       with:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
-        with:
+        with: |
           image-ref: ${{ steps.full_vertica_image.outputs.value }}
           ignore-unfixed: true
           security-checks: vuln
@@ -145,7 +145,7 @@ jobs:
       with:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
-        with:
+        with: |
           image-ref: ${{ steps.full_vertica_image.outputs.value }}
           ignore-unfixed: true
           security-checks: vuln
@@ -413,7 +413,7 @@ jobs:
       with:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
-        with:
+        with: |
           image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
           format: 'sarif'
@@ -431,7 +431,7 @@ jobs:
       with:
         action: aquasecurity/trivy-action@0.24.0
         retry_condition: steps._this.outputs.code == 0
-        with:
+        with: |
           image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
           format: 'table'

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -129,9 +129,9 @@ jobs:
           image-ref: ${{ steps.full_vertica_image.outputs.value }}
           ignore-unfixed: true
           security-checks: vuln
-          timeout: '20m0s'
-          format: 'sarif'
-          output: 'trivy-results-vertica-image.sarif'
+          timeout: 20m0s
+          format: sarif
+          output: trivy-results-vertica-image.sarif
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -149,9 +149,9 @@ jobs:
           image-ref: ${{ steps.full_vertica_image.outputs.value }}
           ignore-unfixed: true
           security-checks: vuln
-          timeout: '20m0s'
-          format: 'table'
-          output: 'trivy-results-vertica-image.out'
+          timeout: 20m0s
+          format: table
+          output: trivy-results-vertica-image.out
         
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-image.out') != '' }}
@@ -416,8 +416,8 @@ jobs:
         with: |
           image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results-verticadb-operator-image.sarif'
+          format: sarif
+          output: trivy-results-verticadb-operator-image.sarif
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -434,8 +434,8 @@ jobs:
         with: |
           image-ref: ${{ steps.operator_image.outputs.value }}
           ignore-unfixed: true
-          format: 'table'
-          output: 'trivy-results-verticadb-operator-image.out'
+          format: table
+          output: trivy-results-verticadb-operator-image.out
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}
@@ -533,8 +533,8 @@ jobs:
         with: |
           image-ref: ${{ steps.vlogger_image.outputs.value }}
           ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results-vertica-logger-image.sarif'
+          format: sarif
+          output: trivy-results-vertica-logger-image.sarif
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -552,8 +552,8 @@ jobs:
         with: |
           image-ref: ${{ steps.vlogger_image.outputs.value }}
           ignore-unfixed: true
-          format: 'table'
-          output: 'trivy-results-vertica-logger-image.out'
+          format: table
+          output: trivy-results-vertica-logger-image.out
 
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-logger-image.out') != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -130,8 +130,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-vertica-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -150,8 +150,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-image.out'
       env:
-        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-image.out') != '' }}
@@ -416,8 +416,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-verticadb-operator-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -434,8 +434,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-verticadb-operator-image.out'
       env:
-        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}
@@ -533,8 +533,8 @@ jobs:
         format: 'sarif'
         output: 'trivy-results-vertica-logger-image.sarif'
       env:
-        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -552,8 +552,8 @@ jobs:
         format: 'table'
         output: 'trivy-results-vertica-logger-image.out'
       env:
-        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
-        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-logger-image.out') != '' }}
@@ -583,13 +583,3 @@ jobs:
         echo "Size: **$(docker inspect --format '{{.Size}}' ${{ steps.vlogger_image.outputs.value }} | numfmt --to=iec)**" >> $GITHUB_STEP_SUMMARY
         echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.vlogger_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
-
-  rerun-failed-jobs:
-    runs-on: ubuntu-latest
-    needs: [ build-server-full, build-server-legacy, build-server-minimal, build-operator, build-vlogger]
-    if: failure()
-    steps:
-      - name: Rerun failed jobs in the current workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh run rerun ${{ github.run_id }} --failed

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -408,6 +408,7 @@ jobs:
         docker pull ${{ inputs.operator_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
+      shell: bash
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
@@ -426,6 +427,7 @@ jobs:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
+      shell: bash
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
@@ -525,6 +527,7 @@ jobs:
         docker pull ${{ inputs.vlogger_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
+      shell: bash
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
@@ -543,6 +546,7 @@ jobs:
         sarif_file: 'trivy-results-vertica-logger-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
+      shell: bash
       id: trivy_scan
       uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -129,6 +129,9 @@ jobs:
         timeout: '20m0s'
         format: 'sarif'
         output: 'trivy-results-vertica-image.sarif'
+      env:
+        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -146,6 +149,9 @@ jobs:
         timeout: '20m0s'
         format: 'table'
         output: 'trivy-results-vertica-image.out'
+      env:
+        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
         
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-image.out') != '' }}
@@ -409,6 +415,9 @@ jobs:
         ignore-unfixed: true
         format: 'sarif'
         output: 'trivy-results-verticadb-operator-image.sarif'
+      env:
+        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -424,6 +433,9 @@ jobs:
         ignore-unfixed: true
         format: 'table'
         output: 'trivy-results-verticadb-operator-image.out'
+      env:
+        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}
@@ -520,6 +532,9 @@ jobs:
         ignore-unfixed: true
         format: 'sarif'
         output: 'trivy-results-vertica-logger-image.sarif'
+      env:
+        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -536,6 +551,9 @@ jobs:
         ignore-unfixed: true
         format: 'table'
         output: 'trivy-results-vertica-logger-image.out'
+      env:
+        TRIVY_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+        TRIVY_JAVA_DB_REPOSITORY=ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db
 
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-logger-image.out') != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -525,13 +525,16 @@ jobs:
         docker pull ${{ inputs.vlogger_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
-        image-ref: ${{ steps.vlogger_image.outputs.value }}
-        ignore-unfixed: true
-        format: 'sarif'
-        output: 'trivy-results-vertica-logger-image.sarif'
+        action: aquasecurity/trivy-action@0.24.0
+        retry_condition: steps._this.outputs.code == 0
+        with: |
+          image-ref: ${{ steps.vlogger_image.outputs.value }}
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results-vertica-logger-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -541,13 +544,16 @@ jobs:
 
     - name: Run the Trivy vulnerability scanner (pretty print)
       id: trivy_scan
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: Wandalen/wretry.action@master
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
-        image-ref: ${{ steps.vlogger_image.outputs.value }}
-        ignore-unfixed: true
-        format: 'table'
-        output: 'trivy-results-vertica-logger-image.out'
+        action: aquasecurity/trivy-action@0.24.0
+        retry_condition: steps._this.outputs.code == 0
+        with: |
+          image-ref: ${{ steps.vlogger_image.outputs.value }}
+          ignore-unfixed: true
+          format: 'table'
+          output: 'trivy-results-vertica-logger-image.out'
 
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-logger-image.out') != '' }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -120,18 +120,15 @@ jobs:
     # We never run the sarif scanner in PRs because PRs don't have permission
     # to upload the results to github.
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: Wandalen/wretry.action@master
+      uses: aquasecurity/trivy-action@0.24.0
       if: ${{ inputs.run_security_scan == 'all' && github.event_name != 'pull_request' }}
       with:
-        action: aquasecurity/trivy-action@0.24.0
-        retry_condition: steps._this.outputs.code == 0
-        with: |
-          image-ref: ${{ steps.full_vertica_image.outputs.value }}
-          ignore-unfixed: true
-          security-checks: vuln
-          timeout: 20m0s
-          format: sarif
-          output: trivy-results-vertica-image.sarif
+        image-ref: ${{ steps.full_vertica_image.outputs.value }}
+        ignore-unfixed: true
+        security-checks: vuln
+        timeout: '20m0s'
+        format: 'sarif'
+        output: 'trivy-results-vertica-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -140,18 +137,15 @@ jobs:
         sarif_file: 'trivy-results-vertica-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: Wandalen/wretry.action@master
+      uses: aquasecurity/trivy-action@0.24.0
       if: ${{ inputs.run_security_scan == 'all' }}
       with:
-        action: aquasecurity/trivy-action@0.24.0
-        retry_condition: steps._this.outputs.code == 0
-        with: |
-          image-ref: ${{ steps.full_vertica_image.outputs.value }}
-          ignore-unfixed: true
-          security-checks: vuln
-          timeout: 20m0s
-          format: table
-          output: trivy-results-vertica-image.out
+        image-ref: ${{ steps.full_vertica_image.outputs.value }}
+        ignore-unfixed: true
+        security-checks: vuln
+        timeout: '20m0s'
+        format: 'table'
+        output: 'trivy-results-vertica-image.out'
         
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-image.out') != '' }}
@@ -408,16 +402,13 @@ jobs:
         docker pull ${{ inputs.operator_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: Wandalen/wretry.action@master
+      uses: aquasecurity/trivy-action@0.24.0
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
-        action: aquasecurity/trivy-action@0.24.0
-        retry_condition: steps._this.outputs.code == 0
-        with: |
-          image-ref: ${{ steps.operator_image.outputs.value }}
-          ignore-unfixed: true
-          format: sarif
-          output: trivy-results-verticadb-operator-image.sarif
+        image-ref: ${{ steps.operator_image.outputs.value }}
+        ignore-unfixed: true
+        format: 'sarif'
+        output: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -426,16 +417,13 @@ jobs:
         sarif_file: 'trivy-results-verticadb-operator-image.sarif'
 
     - name: Run the Trivy vulnerability scanner (pretty print)
-      uses: Wandalen/wretry.action@master
+      uses: aquasecurity/trivy-action@0.24.0
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
-        action: aquasecurity/trivy-action@0.24.0
-        retry_condition: steps._this.outputs.code == 0
-        with: |
-          image-ref: ${{ steps.operator_image.outputs.value }}
-          ignore-unfixed: true
-          format: table
-          output: trivy-results-verticadb-operator-image.out'
+        image-ref: ${{ steps.operator_image.outputs.value }}
+        ignore-unfixed: true
+        format: 'table'
+        output: 'trivy-results-verticadb-operator-image.out'
     
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-verticadb-operator-image.out') != '' }}
@@ -525,16 +513,13 @@ jobs:
         docker pull ${{ inputs.vlogger_image }}
 
     - name: Run the Trivy vulnerability scanner (sarif)
-      uses: Wandalen/wretry.action@master
+      uses: aquasecurity/trivy-action@0.24.0
       if: ${{ inputs.run_security_scan != 'none' && github.event_name != 'pull_request' }}
       with:
-        action: aquasecurity/trivy-action@0.24.0
-        retry_condition: steps._this.outputs.code == 0
-        with: |
-          image-ref: ${{ steps.vlogger_image.outputs.value }}
-          ignore-unfixed: true
-          format: sarif
-          output: trivy-results-vertica-logger-image.sarif
+        image-ref: ${{ steps.vlogger_image.outputs.value }}
+        ignore-unfixed: true
+        format: 'sarif'
+        output: 'trivy-results-vertica-logger-image.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -544,16 +529,13 @@ jobs:
 
     - name: Run the Trivy vulnerability scanner (pretty print)
       id: trivy_scan
-      uses: Wandalen/wretry.action@master
+      uses: aquasecurity/trivy-action@0.24.0
       if: ${{ inputs.run_security_scan != 'none' }}
       with:
-        action: aquasecurity/trivy-action@0.24.0
-        retry_condition: steps._this.outputs.code == 0
-        with: |
-          image-ref: ${{ steps.vlogger_image.outputs.value }}
-          ignore-unfixed: true
-          format: table
-          output: trivy-results-vertica-logger-image.out
+        image-ref: ${{ steps.vlogger_image.outputs.value }}
+        ignore-unfixed: true
+        format: 'table'
+        output: 'trivy-results-vertica-logger-image.out'
 
     - name: Generate Warning Annotations
       if: ${{ hashFiles('trivy-results-vertica-logger-image.out') != '' }}
@@ -584,3 +566,12 @@ jobs:
         echo "Image ID: **$(docker inspect --format '{{.ID}}' ${{ steps.vlogger_image.outputs.value }})**" >> $GITHUB_STEP_SUMMARY
         echo "Digest: **$(IFS=":" read image tag <<< $(echo ${{ steps.vlogger_image.outputs.value }} | sed -e 's/^docker.io\///'); docker inspect --format='{{.RepoDigests}}' $image:$tag | sed 's:^.\(.*\).$:\1:' | tr " " "\n" | grep $image | cut -d'@' -f2 || echo "<none>")**" >> $GITHUB_STEP_SUMMARY
 
+  rerun-failed-jobs:
+    runs-on: ubuntu-latest
+    needs: [ build-server-full, build-server-legacy, build-server-minimal, build-operator, build-vlogger]
+    if: failure()
+    steps:
+      - name: Rerun failed jobs in the current workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run rerun ${{ github.run_id }} --failed


### PR DESCRIPTION
We have seen trivy scan failure multiple times due to network issues. To make it more robust, maybe add retry to those steps, so we don't have to re-trigger it manually every time. 
First option, using https://github.com/Wandalen/wretry.action. This one doesn't apply good enough in docker run, get docker os issue when trying

Second solution, add a retry step after the build: https://stackoverflow.com/questions/71574593/how-to-automatically-retry-github-action-jobs-on-failure. 

Third option, wrap the trivy script and then call with run script, that way we can use other github actions like: https://github.com/marketplace/actions/retry-step This requires more efforts and need to download the trivy binary to the repo and run as script.

Fourth option, use backup URL to download if failed, as suggested in: https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-10884984

Let's give the last option a shoot, and see if that makes the run more stable.