### PR TITLE
webhook rules for sandbox shutdown

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -226,6 +226,16 @@ func (v *VerticaDB) GenStatusSubclusterMap() map[string]*SubclusterStatus {
 	return statusSclusterMap
 }
 
+// GenStatusSClusterIndexMap will organize all of the subclusters into a map so we
+// can quickly find its index in the status.subclusters[] array.
+func (v *VerticaDB) GenStatusSClusterIndexMap() map[string]int {
+	m := make(map[string]int)
+	for i := range v.Status.Subclusters {
+		m[v.Status.Subclusters[i].Name] = i
+	}
+	return m
+}
+
 // GenSandboxSubclusterMapForUnsandbox will compare sandbox status and spec
 // for finding subclusters that need to be unsandboxed, this function returns a map
 // with sandbox name as the key and its subclusters (need to be unsandboxed) as the value

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -216,7 +216,7 @@ func (v *VerticaDB) GenStatusSandboxMap() map[string]*SandboxStatus {
 	return statusSboxMap
 }
 
-// GenStatusSandboxMap() returns a map from status. The key is subcluster name and value is the subcluster pointer
+// GenStatusSubclusterMap() returns a map from status. The key is subcluster name and value is the subcluster pointer
 func (v *VerticaDB) GenStatusSubclusterMap() map[string]*SubclusterStatus {
 	statusSclusterMap := make(map[string]*SubclusterStatus)
 	for i := range v.Status.Subclusters {

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -206,6 +206,26 @@ func (v *VerticaDB) GenSubclusterSandboxStatusMap() map[string]string {
 	return scSbMap
 }
 
+// GenStatusSandboxMap() returns a map from status. The key is sandbox name and value is the sandbox pointer
+func (v *VerticaDB) GenStatusSandboxMap() map[string]*SandboxStatus {
+	statusSboxMap := make(map[string]*SandboxStatus)
+	for i := range v.Status.Sandboxes {
+		sBox := &v.Status.Sandboxes[i]
+		statusSboxMap[sBox.Name] = sBox
+	}
+	return statusSboxMap
+}
+
+// GenStatusSandboxMap() returns a map from status. The key is subcluster name and value is the subcluster pointer
+func (v *VerticaDB) GenStatusSubclusterMap() map[string]*SubclusterStatus {
+	statusSclusterMap := make(map[string]*SubclusterStatus)
+	for i := range v.Status.Subclusters {
+		sCluster := &v.Status.Subclusters[i]
+		statusSclusterMap[sCluster.Name] = sCluster
+	}
+	return statusSclusterMap
+}
+
 // GenSandboxSubclusterMapForUnsandbox will compare sandbox status and spec
 // for finding subclusters that need to be unsandboxed, this function returns a map
 // with sandbox name as the key and its subclusters (need to be unsandboxed) as the value

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1788,6 +1788,7 @@ func (v *VerticaDB) checkUnsandboxShutdownConditions(oldObj *VerticaDB, allErrs 
 	statusSClusterIndexMap := v.GenStatusSClusterIndexMap()
 	subclustersToUnsandbox := v.findSclustersToUnsandbox(oldObj)
 	subclusterIndexMap := v.GenSubclusterIndexMap()
+	sandboxIndexMap := v.GenSandboxIndexMap()
 	sandboxesWithError := map[string]bool{}
 	for oldSubcluster, oldSandbox := range subclustersToUnsandbox {
 		oldSubclusterIndex, found := statusSClusterIndexMap[oldSubcluster.Name]
@@ -1802,6 +1803,7 @@ func (v *VerticaDB) checkUnsandboxShutdownConditions(oldObj *VerticaDB, allErrs 
 			continue
 		}
 		if oldSandbox.Shutdown {
+			i := sandboxIndexMap[oldSandbox.Name]
 			_, found := sandboxesWithError[oldSandbox.Name]
 			if !found { // this is to avoid duplicate error messages
 				sandboxesWithError[oldSandbox.Name] = true

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1764,19 +1764,15 @@ func (v *VerticaDB) findSclustersToUnsandbox(oldObj *VerticaDB) map[*Subcluster]
 	newSuclusterInSandbox := v.GenSubclusterSandboxMap()
 	oldSubclusterMap := oldObj.GenSubclusterMap()
 	oldSandboxMap := oldObj.GenSandboxMap()
-	newSubclusterMap := v.GenSubclusterMap()
 	sclusterSboxMap := make(map[*Subcluster]*Sandbox)
 	for oldSubclusterName, oldSandboxName := range oldSubclusterInSandbox {
 		newSandboxName, oldSubclusterInNewSandboxes := newSuclusterInSandbox[oldSubclusterName]
-		_, oldSubclusterInPersist := newSubclusterMap[oldSubclusterName]
 		oldSandbox := oldSandboxMap[oldSandboxName]
 		// for unsandboxing, check shutdown field of the subcluster and sandbox
-		if oldSubclusterInPersist {
-			if !oldSubclusterInNewSandboxes || (oldSubclusterInNewSandboxes && oldSandbox.Name != newSandboxName) {
-				// either subcluster is not in any sbox or is moved to a different sbox in new vdb
-				oldSubcluster := oldSubclusterMap[oldSubclusterName]
-				sclusterSboxMap[oldSubcluster] = oldSandbox
-			}
+		if !oldSubclusterInNewSandboxes || (oldSubclusterInNewSandboxes && oldSandbox.Name != newSandboxName) {
+			// either subcluster is not in any sbox or is moved to a different sbox in new vdb
+			oldSubcluster := oldSubclusterMap[oldSubclusterName]
+			sclusterSboxMap[oldSubcluster] = oldSandbox
 		}
 	}
 	return sclusterSboxMap

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1744,7 +1744,7 @@ func (v *VerticaDB) validateNewSBoxOrSClusterShutdownUnset(allErrs field.ErrorLi
 		}
 	}
 	for i := range v.Spec.Subclusters {
-		newSCluster := v.Spec.Subclusters[i]
+		newSCluster := &v.Spec.Subclusters[i]
 		if _, foundInStatus := statusSClusterMap[newSCluster.Name]; !foundInStatus && newSCluster.Shutdown {
 			p := field.NewPath("spec").Child("subclusters").Index(i)
 			err := field.Invalid(p,

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1816,8 +1816,8 @@ func (v *VerticaDB) checkUnsandboxShutdownConditions(oldObj *VerticaDB, allErrs 
 	return allErrs
 }
 
-// checkAnnotatedSubclustersInShutdownSandbox ensures: when a sandbox is to be shutdown, if a subcluster in it has annotation
-// vertica.com/shutdown-driven-by-sandbox set to true, the subcluster's shutdown field should not be updated
+// checkSubclustersInShutdownSandbox ensures: when a sandbox is marked to be shutdown,
+// the subcluster's shutdown field should not to set to false by a user
 func (v *VerticaDB) checkSubclustersInShutdownSandbox(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
 	persistSandboxes := v.findPersistSandboxes(oldObj)
 	newSandboxMap := v.GenSandboxMap()

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1828,7 +1828,7 @@ func (v *VerticaDB) checkSubclustersInShutdownSandbox(oldObj *VerticaDB, allErrs
 	for sandboxName := range persistSandboxes {
 		newSandbox := newSandboxMap[sandboxName]
 		oldSandbox := oldSandboxMap[sandboxName]
-		if newSandbox.Shutdown { // !oldSandbox.Shutdown &&
+		if newSandbox.Shutdown {
 			for _, subclusterName := range oldSandbox.Subclusters {
 				oldSubcluster := oldSubclusterMap[subclusterName.Name]
 				newSubcluster, oldSclusterPersist := newSubclusterMap[subclusterName.Name]

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1735,7 +1735,7 @@ func (v *VerticaDB) validateNewSBoxOrSClusterShutdownUnset(allErrs field.ErrorLi
 	for i := range v.Spec.Sandboxes {
 		newSBox := v.Spec.Sandboxes[i]
 		if _, foundInStatus := statusSBoxMap[newSBox.Name]; !foundInStatus && newSBox.Shutdown {
-			p := field.NewPath("spec").Child("sandboxes").Index(i).Shutdown
+			p := field.NewPath("spec").Child("sandboxes").Index(i)
 			err := field.Invalid(p,
 				newSBox.Shutdown,
 				fmt.Sprintf("shutdown must be false when adding sandbox %q",
@@ -1746,7 +1746,7 @@ func (v *VerticaDB) validateNewSBoxOrSClusterShutdownUnset(allErrs field.ErrorLi
 	for i := range v.Spec.Subclusters {
 		newSCluster := v.Spec.Subclusters[i]
 		if _, foundInStatus := statusSClusterMap[newSCluster.Name]; !foundInStatus && newSCluster.Shutdown {
-			p := field.NewPath("spec").Child("subclusters").Index(i).Shutdown
+			p := field.NewPath("spec").Child("subclusters").Index(i)
 			err := field.Invalid(p,
 				newSCluster.Shutdown,
 				fmt.Sprintf("shutdown must be false when adding subcluster %q",

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -121,7 +121,7 @@ func (v *VerticaDB) ValidateUpdate(old runtime.Object) error {
 	allErrs := append(v.validateImmutableFields(old), v.validateVerticaDBSpec()...)
 	v.validateSandboxImage(old, allErrs)
 	v.validateTerminatingSandbox(old, allErrs)
-	v.validateSubclustersInSandboxToBeShutdown(old, allErrs)
+	v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
 	v.checkUnsandboxShutdownConditions(old, allErrs)
 	if allErrs == nil {
 		return nil
@@ -1637,7 +1637,7 @@ func (v *VerticaDB) findPersistSandboxes(oldObj *VerticaDB) []string {
 	for _, oldSandbox := range oldSandboxes {
 		sandboxMap[oldSandbox.Name] = 1
 	}
-	persistSandboxes := make([]string, len(newSandboxes))
+	persistSandboxes := make([]string, 0)
 	for _, newSandbox := range newSandboxes {
 		if _, ok := sandboxMap[newSandbox.Name]; ok {
 			persistSandboxes = append(persistSandboxes, newSandbox.Name)
@@ -1804,7 +1804,7 @@ func (v *VerticaDB) checkUnsandboxShutdownConditions(old runtime.Object, allErrs
 
 // ensure: when a sandbox is to be shutdown, if a subcluster in it has annotation vertica.com/shutdown-driven-by-sandbox set to true, the
 // subcluster's shutdown field should not be updated
-func (v *VerticaDB) validateSubclustersInSandboxToBeShutdown(old runtime.Object, allErrs field.ErrorList) field.ErrorList {
+func (v *VerticaDB) validateAnnotatedSubclustersInShutdownSandbox(old runtime.Object, allErrs field.ErrorList) field.ErrorList {
 	oldObj := old.(*VerticaDB)
 	persistSandboxes := v.findPersistSandboxes(oldObj)
 	oldSandboxMap := oldObj.GenSandboxMap()

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1771,17 +1771,9 @@ func (v *VerticaDB) checkUnsandboxShutdownConditions(oldObj *VerticaDB, allErrs 
 
 	for oldSubclusterName, oldSandboxName := range oldSubclusterInSandbox {
 		_, oldSubclusterInNewSandboxes := newSuclusterInSandbox[oldSubclusterName]
-		i, oldSubclusterFound := newSubclusterIndexMap[oldSubclusterName]
-		// this duplicates a check in checkImmutableSubclusterInSandbox().
-		// it is necessary to avoid panic. no guarantee which one runs first
-		if !oldSubclusterFound {
-			path := field.NewPath("spec").Child("subclusters")
-			err := field.Invalid(path,
-				oldSubclusterName,
-				fmt.Sprintf("Cannot remove subcluster %q when it is in a sandbox", oldSubclusterName))
-			allErrs = append(allErrs, err)
-			continue
-		}
+		i := newSubclusterIndexMap[oldSubclusterName]
+		// an error will be reported in checkImmutableSubclusterInSandbox() when oldSubclusterName is not found
+
 		// for unsandboxing, check shutdown field of the subcluster and sandbox
 		if !oldSubclusterInNewSandboxes {
 			oldSubcluster := oldSubclusterMap[oldSubclusterName]
@@ -1876,7 +1868,7 @@ func (v *VerticaDB) validateTerminatingSandbox(old runtime.Object, allErrs field
 	sandboxesToBeRemoved := vutil.MapKeyDiff(oldSandboxMap, newSandboxMap)
 	newSubclusterMap := v.GenSubclusterMap()
 	for _, sandboxToBeRemoved := range sandboxesToBeRemoved {
-		var toToRemoved bool = true
+		var toToRemoved = true
 		for _, subcluster := range oldSandboxMap[sandboxToBeRemoved].Subclusters {
 			if _, ok := newSubclusterMap[subcluster.Name]; ok {
 				toToRemoved = false

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1850,7 +1850,7 @@ func (v *VerticaDB) validateSandboxImage(old runtime.Object, allErrs field.Error
 		newSandbox := newSandboxMap[sandboxName]
 		if oldSandbox.Image != newSandbox.Image {
 			newSandboxIndex := newSandboxIndexMap[sandboxName]
-			msg := v.checkIfSandboxShutdown(newSandbox, newSubclusterMap, oldSubclusterIndexMap)
+			msg := v.checkIfSboxOrSclusterShutdown(newSandbox, newSubclusterMap, oldSubclusterIndexMap)
 			if msg != "" {
 				p := field.NewPath("spec").Child("sandboxes").Index(newSandboxIndex)
 				err := field.Invalid(p.Child("image"),
@@ -1900,7 +1900,7 @@ func (v *VerticaDB) validateTerminatingSandboxes(old runtime.Object, allErrs fie
 	return allErrs
 }
 
-func (v *VerticaDB) checkIfSandboxShutdown(sandbox *Sandbox, subclusterMap map[string]*Subcluster, subclusterIndexMap map[string]int) string {
+func (v *VerticaDB) checkIfSboxOrSclusterShutdown(sandbox *Sandbox, subclusterMap map[string]*Subcluster, subclusterIndexMap map[string]int) string {
 	if sandbox.Shutdown {
 		return fmt.Sprintf("shutdown field for sandbox %q is set to true", sandbox.Name)
 	}

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1735,10 +1735,10 @@ func (v *VerticaDB) validateNewSBoxOrSClusterShutdownUnset(allErrs field.ErrorLi
 	for i := range v.Spec.Sandboxes {
 		newSBox := v.Spec.Sandboxes[i]
 		if _, foundInStatus := statusSBoxMap[newSBox.Name]; !foundInStatus && newSBox.Shutdown {
-			p := field.NewPath("spec").Child("sandboxes")
-			err := field.Invalid(p.Index(i),
-				newSBox.Name,
-				fmt.Sprintf("cannot add sandbox %q that has Shutdown field set to true",
+			p := field.NewPath("spec").Child("sandboxes").Index(i).Shutdown
+			err := field.Invalid(p,
+				newSBox.Shutdown,
+				fmt.Sprintf("shutdown must be false when adding sandbox %q",
 					newSBox.Name))
 			allErrs = append(allErrs, err)
 		}

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1880,9 +1880,7 @@ func (v *VerticaDB) checkShutdownForSandboxesToBeRemoved(oldObj *VerticaDB, allE
 	newSandboxMap := v.GenSandboxMap()
 	sandboxesToBeRemoved := vutil.MapKeyDiff(oldSandboxMap, newSandboxMap)
 	for _, sandboxToBeRemoved := range sandboxesToBeRemoved {
-		if !oldSandboxMap[sandboxToBeRemoved].Shutdown {
-			continue
-		} else {
+		if oldSandboxMap[sandboxToBeRemoved].Shutdown {
 			p := field.NewPath("spec").Child("sandboxes")
 			err := field.Invalid(p,
 				sandboxToBeRemoved,

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1889,14 +1889,7 @@ func (v *VerticaDB) validateTerminatingSandboxes(old runtime.Object, allErrs fie
 						sandboxToBeRemoved))
 				allErrs = append(allErrs, err)
 			} // else looks good
-		} else if sclustersToTerminate != 0 {
-			p := field.NewPath("spec").Child("sandboxes")
-			err := field.Invalid(p,
-				sandboxToBeRemoved,
-				fmt.Sprintf("subclusters in sandbox %q either all exist or all terminated",
-					sandboxToBeRemoved))
-			allErrs = append(allErrs, err)
-		}
+		} // else is expected
 	}
 	return allErrs
 }

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -106,8 +106,8 @@ func (v *VerticaDB) ValidateCreate() error {
 	verticadblog.Info("validate create", "name", v.Name, "GroupVersion", GroupVersion)
 
 	allErrs := v.validateVerticaDBSpec()
-	v.hasNoShutdownSubclusters(allErrs)
-	v.hasNoShutdownSandboxes(allErrs)
+	allErrs = v.hasNoShutdownSubclusters(allErrs)
+	allErrs = v.hasNoShutdownSandboxes(allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -119,10 +119,10 @@ func (v *VerticaDB) ValidateUpdate(old runtime.Object) error {
 	verticadblog.Info("validate update", "name", v.Name, "GroupVersion", GroupVersion)
 
 	allErrs := append(v.validateImmutableFields(old), v.validateVerticaDBSpec()...)
-	v.validateShutdownSandboxImage(old, allErrs)
-	v.validateTerminatingSandboxes(old, allErrs)
-	v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
-	v.validateUnsandboxShutdownConditions(old, allErrs)
+	allErrs = v.validateShutdownSandboxImage(old, allErrs)
+	allErrs = v.validateTerminatingSandboxes(old, allErrs)
+	allErrs = v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
+	allErrs = v.validateUnsandboxShutdownConditions(old, allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -275,7 +275,7 @@ func (v *VerticaDB) hasNoShutdownSubclusters(allErrs field.ErrorList) field.Erro
 		fieldPrefix := field.NewPath("spec").Child("subclusters").Index(i)
 		err := field.Invalid(fieldPrefix.Child("shutdown"),
 			subcluster.Shutdown,
-			"Shutdown setting for a subcluster to be created should be set be false")
+			"Shutdown field for a subcluster to be created should be set be false")
 		allErrs = append(allErrs, err)
 	}
 	return allErrs
@@ -291,7 +291,7 @@ func (v *VerticaDB) hasNoShutdownSandboxes(allErrs field.ErrorList) field.ErrorL
 		}
 		err := field.Invalid(path.Index(i),
 			sandboxes[i],
-			"Shutdown setting for a sandbox to be created should be set to false")
+			"Shutdown field for a sandbox to be created should be set to false")
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1790,7 +1790,7 @@ func (v *VerticaDB) checkUnsandboxShutdownConditions(old runtime.Object, allErrs
 			}
 			if oldSandbox.Shutdown {
 				i := newSubclusterIndexMap[oldSubclusterName]
-				p := field.NewPath("spec").Child("subclusters").Index(i)
+				p := field.NewPath("spec").Child("subclusters")
 				err := field.Invalid(p.Index(i),
 					oldSubclusterName,
 					fmt.Sprintf("cannot unsandbox subcluster %q in sandbox %q that is to be shut down",

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1807,13 +1807,15 @@ func (v *VerticaDB) checkUnsandboxShutdownConditions(old runtime.Object, allErrs
 func (v *VerticaDB) validateAnnotatedSubclustersInShutdownSandbox(old runtime.Object, allErrs field.ErrorList) field.ErrorList {
 	oldObj := old.(*VerticaDB)
 	persistSandboxes := v.findPersistSandboxes(oldObj)
+	newSandboxMap := v.GenSandboxMap()
 	oldSandboxMap := oldObj.GenSandboxMap()
 	newSubclusterIndexMap := v.GenSubclusterIndexMap()
 	newSubclusterMap := v.GenSubclusterMap()
 	oldSubclusterMap := oldObj.GenSubclusterMap()
 	for _, sandboxName := range persistSandboxes {
+		newSandbox := newSandboxMap[sandboxName]
 		oldSandbox := oldSandboxMap[sandboxName]
-		if oldSandbox.Shutdown {
+		if newSandbox.Shutdown {
 			for _, subclusterName := range oldSandbox.Subclusters {
 				oldSubcluster := oldSubclusterMap[subclusterName.Name]
 				if drivenby, ok := oldSubcluster.Annotations["vertica.com/shutdown-driven-by-sandbox"]; ok && drivenby == trueString {

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -122,6 +122,7 @@ func (v *VerticaDB) ValidateUpdate(old runtime.Object) error {
 	v.validateSandboxImage(old, allErrs)
 	v.validateTerminatingSandbox(old, allErrs)
 	v.validateSubclustersInSandboxToBeShutdown(old, allErrs)
+	v.checkUnsandboxShutdownConditions(old, allErrs)
 	if allErrs == nil {
 		return nil
 	}
@@ -154,7 +155,6 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 	allErrs = v.checkImmutableStsName(oldObj, allErrs)
 	allErrs = v.checkValidSubclusterTypeTransition(oldObj, allErrs)
 	allErrs = v.checkSandboxesDuringUpgrade(oldObj, allErrs)
-	allErrs = v.checkUnsandboxShutdownConditions(oldObj, allErrs)
 
 	return allErrs
 }
@@ -1761,7 +1761,8 @@ func (v *VerticaDB) checkSandboxPrimary(allErrs field.ErrorList, oldObj *Vertica
 
 // checkUnsandboxShutdownConditions ensures we will not unsandbox a subcluster that is to be shut down, or a subcluster
 // in a sandbox that is to be shut down
-func (v *VerticaDB) checkUnsandboxShutdownConditions(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
+func (v *VerticaDB) checkUnsandboxShutdownConditions(old runtime.Object, allErrs field.ErrorList) field.ErrorList {
+	oldObj := old.(*VerticaDB)
 	oldSubclusterInSandbox := oldObj.GenSubclusterSandboxMap()
 	newSuclusterInSandbox := v.GenSubclusterSandboxMap()
 	oldSubclusterMap := oldObj.GenSubclusterMap()

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -278,7 +278,7 @@ func (v *VerticaDB) hasNoShutdownSubclusters(allErrs field.ErrorList) field.Erro
 		fieldPrefix := field.NewPath("spec").Child("subclusters").Index(i)
 		err := field.Invalid(fieldPrefix.Child("shutdown"),
 			subcluster.Shutdown,
-			"Shutdown field for a subcluster to be created should be set be false")
+			"Shutdown field for a subcluster to be created should be set to false")
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1746,10 +1746,10 @@ func (v *VerticaDB) validateNewSBoxOrSClusterShutdownUnset(allErrs field.ErrorLi
 	for i := range v.Spec.Subclusters {
 		newSCluster := v.Spec.Subclusters[i]
 		if _, foundInStatus := statusSClusterMap[newSCluster.Name]; !foundInStatus && newSCluster.Shutdown {
-			p := field.NewPath("spec").Child("subclusters")
-			err := field.Invalid(p.Index(i),
-				newSCluster.Name,
-				fmt.Sprintf("cannot add subcluster %q that has Shutdown field set to true",
+			p := field.NewPath("spec").Child("subclusters").Index(i).Shutdown
+			err := field.Invalid(p,
+				newSCluster.Shutdown,
+				fmt.Sprintf("shutdown must be false when adding subcluster %q",
 					newSCluster.Name))
 			allErrs = append(allErrs, err)
 		}

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -108,6 +108,9 @@ func (v *VerticaDB) ValidateCreate() error {
 	allErrs := v.validateVerticaDBSpec()
 	v.hasNoShutdownSubclusters(allErrs)
 	v.hasNoShutdownSandboxes(allErrs)
+	if len(allErrs) == 0 {
+		return nil
+	}
 	return apierrors.NewInvalid(schema.GroupKind{Group: Group, Kind: VerticaDBKind}, v.Name, allErrs)
 }
 
@@ -120,6 +123,9 @@ func (v *VerticaDB) ValidateUpdate(old runtime.Object) error {
 	v.validateTerminatingSandboxes(old, allErrs)
 	v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
 	v.validateUnsandboxShutdownConditions(old, allErrs)
+	if len(allErrs) == 0 {
+		return nil
+	}
 	return apierrors.NewInvalid(schema.GroupKind{Group: Group, Kind: VerticaDBKind}, v.Name, allErrs)
 }
 
@@ -227,9 +233,6 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.hasValidReplicaGroups(allErrs)
 	allErrs = v.validateVersionAnnotation(allErrs)
 	allErrs = v.validateSandboxes(allErrs)
-	if len(allErrs) == 0 {
-		return nil
-	}
 	return allErrs
 }
 

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1804,12 +1804,13 @@ func (v *VerticaDB) validateUnsandboxShutdownConditions(old runtime.Object, allE
 	oldSubclusterMap := oldObj.GenSubclusterMap()
 	oldSandboxMap := oldObj.GenSandboxMap()
 	oldSubclusterIndexMap := oldObj.GenSubclusterIndexMap()
+	newSubclusterMap := v.GenSubclusterMap()
 
 	for oldSubclusterName, oldSandboxName := range oldSubclusterInSandbox {
 		_, oldSubclusterInNewSandboxes := newSuclusterInSandbox[oldSubclusterName]
-
+		_, oldSubclusterInPersist := newSubclusterMap[oldSubclusterName]
 		// for unsandboxing, check shutdown field of the subcluster and sandbox
-		if !oldSubclusterInNewSandboxes {
+		if !oldSubclusterInNewSandboxes && oldSubclusterInPersist {
 			oldSubcluster := oldSubclusterMap[oldSubclusterName]
 			oldSandbox := oldSandboxMap[oldSandboxName]
 			oldSubclusterIndex := oldSubclusterIndexMap[oldSubclusterName]

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -121,8 +121,8 @@ func (v *VerticaDB) ValidateUpdate(old runtime.Object) error {
 	allErrs := append(v.validateImmutableFields(old), v.validateVerticaDBSpec()...)
 	allErrs = v.validateShutdownSandboxImage(old, allErrs)
 	allErrs = v.validateTerminatingSandboxes(old, allErrs)
-	allErrs = v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
 	allErrs = v.validateUnsandboxShutdownConditions(old, allErrs)
+	allErrs = v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -1819,8 +1819,8 @@ func (v *VerticaDB) validateAnnotatedSubclustersInShutdownSandbox(old runtime.Ob
 			for _, subclusterName := range oldSandbox.Subclusters {
 				oldSubcluster := oldSubclusterMap[subclusterName.Name]
 				if drivenby, ok := oldSubcluster.Annotations["vertica.com/shutdown-driven-by-sandbox"]; ok && drivenby == trueString {
-					newSubcluster := newSubclusterMap[subclusterName.Name]
-					if oldSubcluster.Shutdown != newSubcluster.Shutdown {
+					newSubcluster, oldSclusterPersist := newSubclusterMap[subclusterName.Name]
+					if oldSclusterPersist && oldSubcluster.Shutdown != newSubcluster.Shutdown {
 						index := newSubclusterIndexMap[subclusterName.Name]
 						p := field.NewPath("spec").Child("subclusters")
 						err := field.Invalid(p.Index(index),

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -117,11 +117,7 @@ func (v *VerticaDB) ValidateUpdate(old runtime.Object) error {
 	verticadblog.Info("validate update", "name", v.Name, "GroupVersion", GroupVersion)
 
 	allErrs := append(v.validateImmutableFields(old), v.validateVerticaDBSpec()...)
-	allErrs = v.validateShutdownSandboxImage(old, allErrs)
-	allErrs = v.validateTerminatingSandboxes(old, allErrs)
-	allErrs = v.validateUnsandboxShutdownConditions(old, allErrs)
-	allErrs = v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
-	allErrs = v.validateNewSBoxOrSClusterShutdownUnset(allErrs)
+
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -154,6 +150,11 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 	allErrs = v.checkImmutableStsName(oldObj, allErrs)
 	allErrs = v.checkValidSubclusterTypeTransition(oldObj, allErrs)
 	allErrs = v.checkSandboxesDuringUpgrade(oldObj, allErrs)
+	allErrs = v.validateShutdownSandboxImage(old, allErrs)
+	allErrs = v.validateTerminatingSandboxes(old, allErrs)
+	allErrs = v.validateUnsandboxShutdownConditions(old, allErrs)
+	allErrs = v.validateAnnotatedSubclustersInShutdownSandbox(old, allErrs)
+	allErrs = v.validateNewSBoxOrSClusterShutdownUnset(allErrs)
 	return allErrs
 }
 

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1470,12 +1470,6 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
 		}
 		Ω(newVdb.validateTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(0))
-		newVdb.Spec.Subclusters = []Subcluster{
-			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
-			{Name: "sc3", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
-			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
-		}
-		Ω(newVdb.validateTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 
 	})
 

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1378,19 +1378,19 @@ var _ = Describe("verticadb_webhook", func() {
 		}
 		oldVdb.Spec.Subclusters[2].Shutdown = true // cause of error
 		// check subcluster shutdown in spec
-		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Subclusters[2].Shutdown = false
-		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[2].Shutdown = true
 		// check subcluster shutdown in status
-		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[2].Shutdown = false
-		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		oldVdb.Spec.Sandboxes[0].Shutdown = true
 		// check sandbox shutdown in spec
-		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Sandboxes[0].Shutdown = false
-		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not change image for a sandbox if shutdown is set for it or its subcluster in either spec or status", func() {
@@ -1420,25 +1420,25 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc4"},
 		}
 		newVdb.Spec.Sandboxes[0].Shutdown = true
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Sandboxes[0].Shutdown = false
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Spec.Subclusters[2].Shutdown = true
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Subclusters[2].Shutdown = false
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Spec.Subclusters[3].Shutdown = true
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Subclusters[3].Shutdown = false
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[2].Shutdown = true
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[2].Shutdown = false
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[3].Shutdown = true
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[3].Shutdown = false
-		Ω(newVdb.validateSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 
 	})
 

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1435,6 +1435,20 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Sandboxes[0].Shutdown = false
 		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+
+		oldVdb.Spec.Subclusters[1].Shutdown = true
+		oldVdb.Spec.Subclusters[2].Shutdown = true
+		oldVdb.Spec.Subclusters[3].Shutdown = true
+		oldVdb.Spec.Sandboxes[0].Shutdown = true
+		newVdb = oldVdb.DeepCopy()
+		newVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Shutdown: true, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc4"}}}, // to unsandbox sc3
+		}
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Shutdown: true, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}, {Name: "sc4"}}}, // to unsandbox sc3
+		}
+		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not change image for a sandbox if shutdown is set for it or its subcluster in either spec or status", func() {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1052,7 +1052,7 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sandbox1", Image: mainClusterImageVer, Subclusters: []SubclusterName{{Name: "sc1"}}},
 			{Name: "sandbox2", Image: mainClusterImageVer, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
 		}
-		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(2))
+		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(3))
 
 		// can remove a subcluster if it is removed
 		// from any sandbox at the same time
@@ -1332,6 +1332,30 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(vdb.hasNoShutdownSubclusters(field.ErrorList{})).Should(HaveLen(0))
 		vdb.Spec.Subclusters[1].Shutdown = true
 		Ω(vdb.hasNoShutdownSubclusters(field.ErrorList{})).Should(HaveLen(1))
+	})
+
+	It("should not allow a user to annotate a subcluster in a sandbox with \"vertica.com/shutdown-driven-by-sandbox\"", func() {
+		oldVdb := MakeVDB()
+		oldVdb.Spec.Subclusters = []Subcluster{
+			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc2", Type: SandboxPrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc3", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
+		}
+		oldVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+		}
+		newVdb := oldVdb.DeepCopy()
+		for _, sCluster := range newVdb.Spec.Subclusters {
+			verticadblog.Info("libo: ", "new cluster name", sCluster.Name)
+		}
+		// verticadblog.Info("libo: " )
+		newVdb.Spec.Subclusters[2].Annotations = map[string]string{"vertica.com/shutdown-driven-by-sandbox": "true"}
+		newVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+		}
+		Ω(newVdb.checkImmutableSubclusterInSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Subclusters[2].Annotations = map[string]string{}
+		Ω(newVdb.checkImmutableSubclusterInSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not update a subcluster's shutdown field when its sandbox has shutdown set and the subcluster is annotated with \"vertica.com/shutdown-driven-by-sandbox\"", func() {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1312,6 +1312,8 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}, Shutdown: true},
 		}
 		Ω(vdb.hasNoShutdownSandboxes(field.ErrorList{})).Should(HaveLen(1))
+		vdb.Spec.Sandboxes[0].Shutdown = false
+		Ω(vdb.hasNoShutdownSandboxes(field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not allow to create a vdb with a shutdown subcluster", func() {
@@ -1325,6 +1327,10 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Sandboxes = []Sandbox{
 			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
 		}
+		Ω(vdb.hasNoShutdownSubclusters(field.ErrorList{})).Should(HaveLen(1))
+		vdb.Spec.Subclusters[2].Shutdown = false
+		Ω(vdb.hasNoShutdownSubclusters(field.ErrorList{})).Should(HaveLen(0))
+		vdb.Spec.Subclusters[1].Shutdown = true
 		Ω(vdb.hasNoShutdownSubclusters(field.ErrorList{})).Should(HaveLen(1))
 	})
 

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1328,9 +1328,9 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Sandboxes = []Sandbox{
 			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}, Shutdown: true},
 		}
-		Ω(vdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		Ω(vdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
 		vdb.Spec.Sandboxes[0].Shutdown = false
-		Ω(vdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		Ω(vdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not allow to create a vdb with a shutdown subcluster", func() {
@@ -1344,13 +1344,13 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.Sandboxes = []Sandbox{
 			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
 		}
-		Ω(vdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		Ω(vdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
 		vdb.Spec.Subclusters[2].Shutdown = false
-		Ω(vdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		Ω(vdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
 		vdb.Spec.Subclusters[1].Shutdown = true
-		Ω(vdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		Ω(vdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
 		vdb.Spec.Subclusters[1].Shutdown = false
-		Ω(vdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		Ω(vdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not allow to add a subcluster whose Shutdown is true to a vdb", func() {
@@ -1372,9 +1372,9 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc3", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
 			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort, Shutdown: true}, // cause of error
 		}
-		Ω(newVdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Subclusters[3].Shutdown = false
-		Ω(newVdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not allow to add a sanbox whose Shutdown is true to a vdb", func() {
@@ -1391,9 +1391,9 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc2"},
 			{Name: "sc3"},
 		}
-		Ω(newVdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Sandboxes[1].Shutdown = false
-		Ω(newVdb.validateNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkNewSBoxOrSClusterShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	// When a cluster is annotated with \"vertica.com/shutdown-driven-by-sandbox\", its shutdown field will be immutable
@@ -1412,13 +1412,13 @@ var _ = Describe("verticadb_webhook", func() {
 			}
 			newVdb := oldVdb.DeepCopy()
 			newVdb.Spec.Subclusters[2].Shutdown = false
-			Ω(newVdb.validateAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 			newVdb.Spec.Subclusters[2].Shutdown = true
-			Ω(newVdb.validateAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 			newVdb.Spec.Subclusters[1].Shutdown = false
-			Ω(newVdb.validateAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 			newVdb.Spec.Subclusters[1].Shutdown = true
-			Ω(newVdb.validateAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 
 		})
 
@@ -1448,19 +1448,19 @@ var _ = Describe("verticadb_webhook", func() {
 		}
 		oldVdb.Spec.Subclusters[2].Shutdown = true // cause of error
 		// check subcluster shutdown in spec
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Subclusters[2].Shutdown = false
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[2].Shutdown = true
 		// check subcluster shutdown in status
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[2].Shutdown = false
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		oldVdb.Spec.Sandboxes[0].Shutdown = true
 		// check sandbox shutdown in spec
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Sandboxes[0].Shutdown = false
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 
 		oldVdb.Spec.Subclusters[1].Shutdown = true
 		oldVdb.Spec.Subclusters[2].Shutdown = true
@@ -1470,11 +1470,11 @@ var _ = Describe("verticadb_webhook", func() {
 		newVdb.Spec.Sandboxes = []Sandbox{
 			{Name: "sand1", Shutdown: true, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc4"}}}, // to unsandbox sc3
 		}
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Sandboxes = []Sandbox{
 			{Name: "sand1", Shutdown: true, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}, {Name: "sc4"}}}, // to unsandbox sc3
 		}
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not unsandbox a sandbox when its shutdown field or its sandbox's shutdown field is set", func() {
@@ -1503,19 +1503,19 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc3"},
 			{Name: "sc4"},
 		}
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		oldVdb.Spec.Sandboxes[1].Shutdown = true
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Sandboxes[1].Shutdown = false
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		oldVdb.Spec.Subclusters[3].Shutdown = true
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Subclusters[3].Shutdown = false
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[3].Shutdown = true
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[3].Shutdown = false
-		Ω(newVdb.validateUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkUnsandboxShutdownConditions(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not change image for a sandbox if shutdown is set for it or its subcluster in either spec or status", func() {
@@ -1545,29 +1545,29 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc4"},
 		}
 		newVdb.Spec.Sandboxes[0].Shutdown = true
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Sandboxes[0].Shutdown = false
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Spec.Subclusters[2].Shutdown = true
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Subclusters[2].Shutdown = false
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Spec.Subclusters[3].Shutdown = true
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Spec.Subclusters[3].Shutdown = false
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[2].Shutdown = true
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[2].Shutdown = false
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[3].Shutdown = true
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[3].Shutdown = false
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Status.Subclusters[0].Shutdown = true
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Spec.Sandboxes[0].Shutdown = false
-		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 
 	})
 
@@ -1589,16 +1589,16 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
 		}
 		oldVdb.Spec.Sandboxes[0].Shutdown = true
-		Ω(newVdb.validateTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+		Ω(newVdb.checkTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		oldVdb.Spec.Sandboxes[0].Shutdown = false
-		Ω(newVdb.validateTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 		newVdb.Spec.Subclusters = []Subcluster{ // unsandbox
 			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
 			{Name: "sc2", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
 			{Name: "sc3", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
 			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
 		}
-		Ω(newVdb.validateTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		Ω(newVdb.checkTerminatingSandboxes(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 
 	})
 

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1334,31 +1334,7 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(vdb.hasNoShutdownSubclusters(field.ErrorList{})).Should(HaveLen(1))
 	})
 
-	/* It("should not allow a user to annotate a subcluster in a sandbox with \"vertica.com/shutdown-driven-by-sandbox\"", func() {
-		oldVdb := MakeVDB()
-		oldVdb.Spec.Subclusters = []Subcluster{
-			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
-			{Name: "sc2", Type: SandboxPrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
-			{Name: "sc3", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
-		}
-		oldVdb.Spec.Sandboxes = []Sandbox{
-			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
-		}
-		newVdb := oldVdb.DeepCopy()
-		for _, sCluster := range newVdb.Spec.Subclusters {
-			verticadblog.Info("libo: ", "new cluster name", sCluster.Name)
-		}
-		// verticadblog.Info("libo: " )
-		newVdb.Spec.Subclusters[2].Annotations = map[string]string{"vertica.com/shutdown-driven-by-sandbox": "true"}
-		newVdb.Spec.Sandboxes = []Sandbox{
-			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
-		}
-		Ω(newVdb.checkImmutableSubclusterInSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
-		newVdb.Spec.Subclusters[2].Annotations = map[string]string{}
-		Ω(newVdb.checkImmutableSubclusterInSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
-	}) */
-
-	/* It("should not update a subcluster's shutdown field when its sandbox has shutdown set and the subcluster is annotated with \"vertica.com/shutdown-driven-by-sandbox\"", func() {
+	It("should not update a subcluster's shutdown field when its sandbox has shutdown set and the subcluster is annotated with \"vertica.com/shutdown-driven-by-sandbox\"", func() {
 		oldVdb := MakeVDB()
 		oldVdb.Spec.Subclusters = []Subcluster{
 			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
@@ -1374,26 +1350,6 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}, Shutdown: true},
 		}
 		Ω(newVdb.validateAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
-	}) */
-
-	It("should not set a subcluster's shutdown field to false when its sandbox has shutdown set", func() {
-		oldVdb := MakeVDB()
-		oldVdb.Spec.Subclusters = []Subcluster{
-			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
-			{Name: "sc2", Shutdown: true, Type: SandboxPrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
-			{Name: "sc3", Shutdown: true, Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort, Annotations: map[string]string{"vertica.com/shutdown-driven-by-sandbox": "true"}},
-		}
-		oldVdb.Spec.Sandboxes = []Sandbox{
-			{Name: "sand1", Shutdown: true, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
-		}
-		newVdb := oldVdb.DeepCopy()
-		newVdb.Spec.Subclusters[2].Shutdown = false
-		// newVdb.Spec.Sandboxes = []Sandbox{
-		//	{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}, Shutdown: true},
-		// }
-		Ω(newVdb.validateShutdownInSBoxAndSCluster(oldVdb, field.ErrorList{})).Should(HaveLen(1))
-		newVdb.Spec.Subclusters[2].Shutdown = true
-		Ω(newVdb.validateShutdownInSBoxAndSCluster(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 	})
 
 	It("should not unsandbox a subcluster when its shutdown field is set or its sandbox's shutdown field is set", func() {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1412,13 +1412,13 @@ var _ = Describe("verticadb_webhook", func() {
 			}
 			newVdb := oldVdb.DeepCopy()
 			newVdb.Spec.Subclusters[2].Shutdown = false
-			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+			Ω(newVdb.checkSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 			newVdb.Spec.Subclusters[2].Shutdown = true
-			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+			Ω(newVdb.checkSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 			newVdb.Spec.Subclusters[1].Shutdown = false
-			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
+			Ω(newVdb.checkSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 			newVdb.Spec.Subclusters[1].Shutdown = true
-			Ω(newVdb.checkAnnotatedSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+			Ω(newVdb.checkSubclustersInShutdownSandbox(oldVdb, field.ErrorList{})).Should(HaveLen(0))
 
 		})
 

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1547,6 +1547,11 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(1))
 		newVdb.Status.Subclusters[3].Shutdown = false
 		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Status.Subclusters[0].Shutdown = true
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes[0].Shutdown = false
+		Ω(newVdb.validateShutdownSandboxImage(oldVdb, field.ErrorList{})).Should(HaveLen(0))
+
 	})
 
 	It("should not terminate a sandbox whose shutdown field is set", func() {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1028,6 +1028,13 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sandbox1", Image: mainClusterImageVer, Subclusters: []SubclusterName{{Name: "sc1"}}},
 			{Name: "sandbox2", Image: mainClusterImageVer, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
 		}
+		newVdb.Status.Subclusters = []SubclusterStatus{
+			{Name: "main"},
+			{Name: "sc1"},
+			{Name: "sc2"},
+			{Name: "sc3"},
+			{Name: "sc4"},
+		}
 		newVdb.ObjectMeta.Annotations[vmeta.VersionAnnotation] = SandboxSupportedMinVersion
 		newVdb.ObjectMeta.Annotations[vmeta.VClusterOpsAnnotation] = vmeta.VClusterOpsAnnotationTrue
 		resetStatusConditionsForDBInitialized(newVdb)
@@ -1215,6 +1222,11 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
 		}
 		newVdb := oldVdb.DeepCopy()
+		newVdb.Status.Subclusters = []SubclusterStatus{
+			{Name: "sc1"},
+			{Name: "sc2"},
+			{Name: "sc3"},
+		}
 		newVdb.Spec.Sandboxes[0].Subclusters = []SubclusterName{{Name: "sc2"}}
 		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(1))
 		newVdb.Spec.Sandboxes[0].Subclusters = []SubclusterName{{Name: "sc3"}}
@@ -1286,6 +1298,11 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc3", Type: SecondarySubcluster, Size: 1},
 		}
 		newVdb := oldVdb.DeepCopy()
+		newVdb.Status.Subclusters = []SubclusterStatus{
+			{Name: "sc1"},
+			{Name: "sc2"},
+			{Name: "sc3"},
+		}
 		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
 		newVdb.Spec.Sandboxes = []Sandbox{
 			{Name: sbName, Subclusters: []SubclusterName{{Name: "sc3"}}},


### PR DESCRIPTION
Here are the rules that are implemented by this change.

- When creating a vdb, all subclusters and sandboxes(if any) must not have `shutdown` set to true.
- If a sandbox has `shutdown`(spec) true and any of its subclusters has the annotation "vertica.com/shutdown-driven-by-sandbox" set to true in the old vdb, we should prevent the user from updating that subcluster's shutdown field.
- You cannot unsandbox a subcluster with `shutdown` true(spec and/or status) or part of a sandbox with `shutdown` true
- You cannot change spec.sandboxes[].image if the sandbox has `shutdown` true or has any subcluster with `shutdown` true(spec and/or status)
- You cannot terminate a sandbox if it has has `shutdown` true. terminate means removing the sandbox in spec.sandboxes[] and its subclusters in spec.subclusters[] at the same time. 