### PR TITLE
bug fix on image push action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -666,7 +666,7 @@ jobs:
       e2e-udx-admintools
     ]
     runs-on: ubuntu-latest 
-    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && contains('server daily version', github.event.workflow_run.display_title) && contains('verticareleng', github.actor) }}  
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && contains(github.event.workflow_run.display_title, 'server daily version') && contains(github.actor, 'verticareleng') }}  
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -666,7 +666,7 @@ jobs:
       e2e-udx-admintools
     ]
     runs-on: ubuntu-latest 
-    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && contains(github.event.workflow_run.display_title, 'server daily version') && contains(github.actor, 'verticareleng') }}  
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && contains(inputs.reason, 'server daily version') && contains(github.actor, 'verticareleng') }}  
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
The order of the contains method expect contains(search, items)
We saw unexpected pushes to the Opentext private repo because the order of variables got mixed up.
The expected case should be:
contains(github.event.workflow_run.display_title, 'server daily version')
For example: contains('e2e: server daily version 20241023', 'server daily version')

But seems like the github.event.workflow_run.display_title is an empty string, which causes the condition to be true contains('server daily version, '')

So instead, lets use the inputs.reason as the condition. 