### PR TITLE
Ver 97254 shutdown webhook

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -186,6 +186,17 @@ func (v *VerticaDB) GenSandboxMap() map[string]*Sandbox {
 	return sbMap
 }
 
+// findSubclusterIndexInSandbox will return the index of the suclusterName in sandbox.
+// when the sandboxName is not found in the sandbox, -1 will be returned
+func (v *VerticaDB) findSubclusterIndexInSandbox(targetSclusterName string, sandbox *Sandbox) int {
+	for i, subclusterName := range sandbox.Subclusters {
+		if subclusterName.Name == targetSclusterName {
+			return i
+		}
+	}
+	return -1
+}
+
 // GenSubclusterSandboxMap will scan all sandboxes and return a map
 // with subcluster name as the key and sandbox name as the value
 func (v *VerticaDB) GenSubclusterSandboxMap() map[string]string {

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -186,8 +186,8 @@ func (v *VerticaDB) GenSandboxMap() map[string]*Sandbox {
 	return sbMap
 }
 
-// findSubclusterIndexInSandbox will return the index of the suclusterName in sandbox.
-// when the sandboxName is not found in the sandbox, -1 will be returned
+// findSubclusterIndexInSandbox will return the index of the targetSclusterName in sandbox.
+// when the targetSclusterName is not found in the sandbox, -1 will be returned
 func (v *VerticaDB) findSubclusterIndexInSandbox(targetSclusterName string, sandbox *Sandbox) int {
 	for i, subclusterName := range sandbox.Subclusters {
 		if subclusterName.Name == targetSclusterName {

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1781,17 +1781,17 @@ func (v *VerticaDB) checkShutdownForScaleUpOrDown(oldObj *VerticaDB, allErrs fie
 	for subclusterName, sandboxName := range newSclusterSboxMap {
 		oldScluster, foundSclusterInOld := oldSclusterMap[subclusterName]
 		if !foundSclusterInOld {
-			continue // avoid panic
+			continue // we only need to deal with persistent subclusters
 		}
 		newScluster, foundSclusterInNew := newSclusterMap[subclusterName]
 		if !foundSclusterInNew {
-			continue // avoid panic
+			continue // avoid unexpected panic when something is wrong
 		}
 		sandbox := newSandboxMap[sandboxName]
 		if oldScluster.Size != newScluster.Size { // scale up/down
 			errMsgs := v.checkSboxForShutdown(sandbox, newSclusterMap, statusSclusterIndexMap)
 			if len(errMsgs) != 0 {
-				_, found := sandboxWithError[sandboxName]
+				_, found := sandboxWithError[sandboxName] // avoid duplicate errMsgs from same sandbox
 				if !found {
 					i := newSclusterIndexMap[subclusterName]
 					sandboxWithError[sandboxName] = true

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1769,8 +1769,7 @@ func (v *VerticaDB) checkNewSBoxOrSClusterShutdownUnset(allErrs field.ErrorList)
 	return allErrs
 }
 
-// checkShutdownForScaleUpOrDown ensures a subcluster to be scaled up/down has Shutdown field set to false and
-// live in a sandbox where Shutdown is set to false in spec/status for all pieces
+// checkShutdownForScaleUpOrDown ensures a subcluster to be scaled up/down has Shutdown field set to false
 func (v *VerticaDB) checkShutdownForScaleUpOrDown(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
 	newSclusterMap := v.GenSubclusterMap()
 	oldSclusterMap := oldObj.GenSubclusterMap()

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -155,6 +155,8 @@ func (v *VerticaDB) validateImmutableFields(old runtime.Object) field.ErrorList 
 	allErrs = v.checkUnsandboxShutdownConditions(oldObj, allErrs)
 	allErrs = v.checkSubclustersInShutdownSandbox(oldObj, allErrs)
 	allErrs = v.checkNewSBoxOrSClusterShutdownUnset(allErrs)
+	allErrs = v.checkSClusterToBeSandboxedShutdownUnset(allErrs)
+	allErrs = v.checkShutdownForScaleUpOrDown(old, allErrs)
 	return allErrs
 }
 
@@ -1760,6 +1762,43 @@ func (v *VerticaDB) checkNewSBoxOrSClusterShutdownUnset(allErrs field.ErrorList)
 				fmt.Sprintf("shutdown must be false when adding subcluster %q",
 					newSCluster.Name))
 			allErrs = append(allErrs, err)
+		}
+	}
+	return allErrs
+}
+
+// checkSClusterToBeSandboxedShutdownUnset ensures a subcluster to be sandboxed has Shutdown field set to false
+func (v *VerticaDB) checkShutdownForScaleUpOrDown(old runtime.Object, allErrs field.ErrorList) field.ErrorList {
+	oldObj := old.(*VerticaDB)
+
+	oldSclusterMap := oldObj.GenSubclusterMap()
+	subclusterIndexMap := v.GenSubclusterIndexMap()
+	newSclusterMap := v.GenSubclusterMap()
+	newSclusterSboxMap := v.GenSubclusterSandboxMap()
+	newSandboxMap := v.GenSandboxMap()
+	statusSclusterIndexMap := v.GenStatusSClusterIndexMap()
+	for subclusterName, sandboxName := range newSclusterSboxMap {
+		newScluster, foundSclusterInNew := newSclusterMap[subclusterName]
+		if !foundSclusterInNew { // this error should be captured by other piece of code
+			continue
+		}
+		oldScluter, foundScluterInOld := oldSclusterMap[subclusterName]
+		if !foundScluterInOld {
+			continue
+		}
+		if oldScluter.Size != newScluster.Size { // scale up/down
+			sandbox := newSandboxMap[sandboxName]
+			errMsgs := v.checkSboxForShutdown(sandbox, newSclusterMap, statusSclusterIndexMap)
+			if len(errMsgs) != 0 {
+				i := subclusterIndexMap[subclusterName]
+				p := field.NewPath("spec").Child("subclusters").Index(i).Child("size")
+				err := field.Invalid(p,
+					newScluster.Size,
+					fmt.Sprintf("cannot scale up/down subcluster %q because %q",
+						subclusterName, strings.Join(errMsgs, ",")))
+				allErrs = append(allErrs, err)
+				continue
+			}
 		}
 	}
 	return allErrs

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1800,32 +1800,31 @@ func (v *VerticaDB) checkShutdownForScaleUpOrDown(old runtime.Object, allErrs fi
 // 2 B's Shutdown field is set to false
 // 3 B does not have any subcluster in it that has Shutdown set to true (spec/status)
 func (v *VerticaDB) checkSClusterToBeSandboxedShutdownUnset(allErrs field.ErrorList) field.ErrorList {
-	statusSClusterMap := v.GenStatusSubclusterMap()
 	newSclusterMap := v.GenSubclusterMap()
 	statusScluterSboxMap := v.GenSubclusterSandboxStatusMap()
 	newSclusterSboxMap := v.GenSubclusterSandboxMap()
 	newSandboxIndexMap := v.GenSandboxIndexMap()
 	newSandboxMap := v.GenSandboxMap()
 	statusSclusterIndexMap := v.GenStatusSClusterIndexMap()
-	shutdownSboxIndex := -1
+	sandboxWithError := map[string]bool{}
 	for subclusterName, sandboxName := range newSclusterSboxMap {
 		oldSandboxName, isInOldSandbox := statusScluterSboxMap[subclusterName]
 		_, foundSubcluster := newSclusterMap[subclusterName]
 		if !foundSubcluster {
 			continue // avoid panic. this error should have been reported by other functions
 		}
-		_, hasStatus := statusSClusterMap[subclusterName]
 		// the subcluster to be sandboxed is either a new subcluster to be added (not found in status)
 		// or an existing subcluster (found in status), the latter of which includes two scenarios:
 		//   1 the subcluster was in a sandbox (whose name is different from current sandbox name)
 		//   2 the subcluster was not in a sandbox previously
-		if !hasStatus || (hasStatus && (!isInOldSandbox || isInOldSandbox && oldSandboxName != sandboxName)) {
+		if !isInOldSandbox || isInOldSandbox && oldSandboxName != sandboxName {
 			sandbox := newSandboxMap[sandboxName]
 			errMsgs := v.checkSboxForShutdown(sandbox, newSclusterMap, statusSclusterIndexMap)
 			if len(errMsgs) != 0 {
 				sandboxIndex := newSandboxIndexMap[sandboxName]
-				if shutdownSboxIndex != sandboxIndex {
-					shutdownSboxIndex = sandboxIndex // avoid duplicate err msg
+				_, found := sandboxWithError[sandboxName]
+				if !found {
+					sandboxWithError[sandboxName] = true
 					p := field.NewPath("spec").Child("sandboxes").Index(sandboxIndex).Child("Shutdown")
 					err := field.Invalid(p,
 						sandbox.Shutdown,

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -1837,9 +1837,10 @@ func (v *VerticaDB) checkSClusterToBeSandboxedShutdownUnset(allErrs field.ErrorL
 				_, found := sandboxWithError[sandboxName]
 				if !found {
 					sandboxWithError[sandboxName] = true
-					p := field.NewPath("spec").Child("sandboxes").Index(sandboxIndex).Child("Shutdown")
+					sclusterIndex := v.findSubclusterIndexInSandbox(subclusterName, sandbox)
+					p := field.NewPath("spec").Child("sandboxes").Index(sandboxIndex).Child("subclusters").Index(sclusterIndex)
 					err := field.Invalid(p,
-						sandbox.Shutdown,
+						subclusterName,
 						fmt.Sprintf("cannot sandbox subcluster %q in sandbox %q because %q",
 							subclusterName, sandboxName, strings.Join(errMsgs, ",")))
 					allErrs = append(allErrs, err)

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1593,6 +1593,120 @@ var _ = Describe("verticadb_webhook", func() {
 
 	})
 
+	It("should not sandbox a subcluster when its shutdown field or its sandbox's shutdown field is set", func() {
+		// another scenario where one subcluster is moved from one sandbox to another
+		newVdb := MakeVDB()
+		newVdb.Spec.Subclusters = []Subcluster{
+			{Name: "main", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc1", Type: SandboxPrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc2", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
+			{Name: "sc3", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
+		}
+		// to sandbox sc3 in sand2. sc3 was existing previously but not in a sandbox
+		newVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc1"}}},
+			{Name: "sand2", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+		}
+		newVdb.Status.Sandboxes = []SandboxStatus{
+			{Name: "sand1", Subclusters: []string{"sc1"}},
+			{Name: "sand2", Subclusters: []string{"sc2"}},
+		}
+		newVdb.Status.Subclusters = []SubclusterStatus{
+			{Name: "main"},
+			{Name: "sc1"},
+			{Name: "sc2"},
+			{Name: "sc3"},
+		}
+		newVdb.Spec.Subclusters[3].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Subclusters[3].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Status.Subclusters[3].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Status.Subclusters[3].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes[1].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Sandboxes[1].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+
+		// sc3 not found in status and to be added
+		newVdb.Status.Subclusters = []SubclusterStatus{
+			{Name: "main"},
+			{Name: "sc1"},
+			{Name: "sc2"},
+		}
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes[1].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Sandboxes[1].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		// sc3 is to be unsandboxsed from sand1 and sandboxed in sand2
+		newVdb.Status.Subclusters = []SubclusterStatus{
+			{Name: "main"},
+			{Name: "sc1"},
+			{Name: "sc2"},
+			{Name: "sc3"},
+		}
+		newVdb.Status.Sandboxes = []SandboxStatus{
+			{Name: "sand1", Subclusters: []string{"sc1", "sc3"}},
+			{Name: "sand2", Subclusters: []string{"sc2"}},
+		}
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Spec.Subclusters[3].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Subclusters[3].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Status.Subclusters[3].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Status.Subclusters[3].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes[1].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Sandboxes[1].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+	})
+
+	It("should not sandbox a subcluster when sandbox/ other subclusters has shutdown set", func() {
+		// another scenario where one subcluster is moved from one sandbox to another
+		newVdb := MakeVDB()
+		newVdb.Spec.Subclusters = []Subcluster{
+			{Name: "main", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc1", Type: SandboxPrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
+			{Name: "sc2", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
+			{Name: "sc3", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
+		}
+		// to sandbox sc3 in sand2. sc3 was existing previously but not in a sandbox
+		newVdb.Spec.Sandboxes = []Sandbox{
+			{Name: "sand1", Subclusters: []SubclusterName{{Name: "sc1"}}},
+			{Name: "sand2", Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
+		}
+		newVdb.Status.Sandboxes = []SandboxStatus{
+			{Name: "sand1", Subclusters: []string{"sc1"}},
+			{Name: "sand2", Subclusters: []string{"sc2"}},
+		}
+		newVdb.Status.Subclusters = []SubclusterStatus{
+			{Name: "main"},
+			{Name: "sc1"},
+			{Name: "sc2"},
+			{Name: "sc3"},
+		}
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Spec.Sandboxes[1].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Sandboxes[1].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Spec.Subclusters[2].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Spec.Subclusters[2].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+		newVdb.Status.Subclusters[2].Shutdown = true
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(1))
+		newVdb.Status.Subclusters[2].Shutdown = false
+		Ω(newVdb.checkSClusterToBeSandboxedShutdownUnset(field.ErrorList{})).Should(HaveLen(0))
+
+	})
+
 	It("should not change image for a sandbox if shutdown is set for it or its subcluster in either spec or status", func() {
 		oldVdb := MakeVDB()
 		oldVdb.Spec.Subclusters = []Subcluster{

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -1857,7 +1857,7 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sand1", Image: "vertica-k8s:v1", Shutdown: true, Subclusters: []SubclusterName{{Name: "sc2"}, {Name: "sc3"}}},
 		}
 		newVdb := oldVdb.DeepCopy()
-		newVdb.Spec.Subclusters = []Subcluster{ //sc3 is removed from sandbox and vdb
+		newVdb.Spec.Subclusters = []Subcluster{ // sc3 is removed from sandbox and vdb
 			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
 			{Name: "sc2", Type: SandboxPrimarySubcluster, Shutdown: true, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
 			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
@@ -1881,7 +1881,7 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},
 		}
 		newVdb = oldVdb.DeepCopy()
-		newVdb.Spec.Subclusters = []Subcluster{ //sc3 is removed from vdb
+		newVdb.Spec.Subclusters = []Subcluster{ // sc3 is removed from vdb
 			{Name: "sc1", Type: PrimarySubcluster, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
 			{Name: "sc2", Type: SandboxPrimarySubcluster, Shutdown: true, Size: 3, ServiceType: v1.ServiceTypeClusterIP},
 			{Name: "sc4", Type: SecondarySubcluster, Size: 3, ServiceType: v1.ServiceTypeNodePort},


### PR DESCRIPTION
Here are the rules implemented in this PR:

- you cannot sandbox a subcluster with shutdown true(spec or status).
- you cannot add a subcluster to a sandbox that has the shutdown field set to true
- you cannot add a subcluster to a sandbox that already has at least one subcluster with shutdown true
- you cannot scale (up/down) a subcluster with shutdown true(spec or status)
- You cannot remove a subcluster with shutdown true(spec or status)