### PR TITLE
Added client routing label to proxy pods

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -810,7 +810,7 @@ type Subcluster struct {
 }
 
 type Proxy struct {
-	// +kubebuilder:default:="opentext/vertica-client-proxy:latest"
+	// +kubebuilder:default:="opentext/client-proxy:latest"
 	// +kubebuilder:validation:required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// The docker image name that contains the Vertica proxy server.

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -862,20 +862,30 @@ func makeScrutinizeInitContainers(vscr *v1beta1.VerticaScrutinize, vdb *vapi.Ver
 
 // BuildVProxyDeployment builds manifest for a subclusters VProxy deployment
 func BuildVProxyDeployment(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subcluster) *appsv1.Deployment {
+	proxyLabels := MakeLabelsForVProxyObject(vdb, sc, true)
+	depSelectorLabels := MakeDepSelectorLabels(vdb, sc)
+	// pod should have both proxy labels and deployment selector labels
+	depPodLabels := make(map[string]string)
+	for k, v := range proxyLabels {
+		depPodLabels[k] = v
+	}
+	for k, v := range depSelectorLabels {
+		depPodLabels[k] = v
+	}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nm.Name,
 			Namespace:   nm.Namespace,
-			Labels:      MakeLabelsForVProxyObject(vdb, sc, true),
+			Labels:      proxyLabels,
 			Annotations: MakeAnnotationsForVProxyObject(vdb),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: MakeDepSelectorLabels(vdb, sc),
+				MatchLabels: depSelectorLabels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      MakeDepSelectorLabels(vdb, sc),
+					Labels:      depPodLabels,
 					Annotations: MakeAnnotationsForVProxyObject(vdb),
 				},
 				Spec: buildVProxyPodSpec(vdb, sc),
@@ -948,7 +958,7 @@ func makeDataForVProxyConfigMap(vdb *vapi.VerticaDB, sc *vapi.Subcluster) string
 	port := 5433
 
 	for i := int32(0); i < sc.Size; i++ {
-		nodeItem := fmt.Sprintf("%s:%d", names.GenPodName(vdb, sc, i).Name, port)
+		nodeItem := fmt.Sprintf("%s:%d", names.GenPodDNSName(vdb, sc, i), port)
 		nodeList = append(nodeList, nodeItem)
 	}
 

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -113,7 +113,6 @@ func MakeLabelsForSvcObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, svcType st
 // MakeLabelsForVProxyObject constructs the labels of the client proxy config map and pods
 func MakeLabelsForVProxyObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster, forPod bool) map[string]string {
 	labels := makeLabelsForObject(vdb, sc, forPod)
-	labels[vmeta.ClientProxyLabel] = vmeta.ClientProxyTrue
 	return labels
 }
 
@@ -220,6 +219,8 @@ func MakeDepSelectorLabels(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[string]
 	// derived from the deployment name as that stays constant and is unique in
 	// a namespace.
 	m[vmeta.DeploymentSelectorLabel] = sc.GetVProxyDeploymentName(vdb)
+	// Set the common proxy pod selector
+	m[vmeta.ProxyPodSelectorLabel] = vmeta.ProxyPodSelectorVal
 	return m
 }
 

--- a/pkg/controllers/vdb/clientroutinglabel_reconciler.go
+++ b/pkg/controllers/vdb/clientroutinglabel_reconciler.go
@@ -28,6 +28,7 @@ import (
 	config "github.com/vertica/vertica-kubernetes/pkg/vdbconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -71,6 +72,11 @@ func MakeClientRoutingLabelReconciler(recon config.ReconcilerInterface, log logr
 func (c *ClientRoutingLabelReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
 	c.Log.Info("Reconcile client routing label", "applyMethod", c.ApplyMethod)
 
+	// If we are using vproxy, we don't need to modify client routing label on pods
+	if vmeta.UseVProxy(c.Vdb.Annotations) {
+		return c.reconcileProxy(ctx)
+	}
+
 	if err := c.PFacts.Collect(ctx, c.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -90,6 +96,53 @@ func (c *ClientRoutingLabelReconciler) Reconcile(ctx context.Context, _ *ctrl.Re
 		}
 	}
 	return savedRes, nil
+}
+
+// reconcileProxy will reconcile client routing label for all proxy pods
+func (c *ClientRoutingLabelReconciler) reconcileProxy(ctx context.Context) (ctrl.Result, error) {
+	pods := corev1.PodList{}
+	proxyLabels := map[string]string{
+		vmeta.ProxyPodSelectorLabel: vmeta.ProxyPodSelectorVal,
+		vmeta.VDBInstanceLabel:      c.Vdb.Name,
+	}
+	listOps := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set(proxyLabels)),
+		Namespace:     c.Vdb.GetNamespace(),
+	}
+	err := c.Rec.GetClient().List(ctx, &pods, listOps)
+	if err != nil {
+		c.Log.Error(err, "unable to list proxy pods")
+		return ctrl.Result{}, nil
+	}
+	for inx := range pods.Items {
+		pod := &pods.Items[inx]
+		labelVal, labelExists := pod.Labels[vmeta.ClientRoutingLabel]
+		if labelExists && labelVal == vmeta.ClientRoutingVal {
+			continue
+		}
+		// Check if the pod's conditions include 'Ready' being true
+		podIsReady := false
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				podIsReady = true
+				break
+			}
+		}
+		if pod.Status.Phase != corev1.PodRunning || !podIsReady {
+			c.Log.Info("Proxy pod is not ready", "pod", pod.Name)
+			continue
+		}
+		patch := client.MergeFrom(pod.DeepCopy())
+		pod.Labels[vmeta.ClientRoutingLabel] = vmeta.ClientRoutingVal
+		c.Log.Info("Adding client routing label to proxy pod", "pod",
+			pod.Name, "label", fmt.Sprintf("%s=%s", vmeta.ClientRoutingLabel, vmeta.ClientRoutingVal))
+		err := c.Rec.GetClient().Patch(ctx, pod, patch)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		c.Log.Info("Proxy pod has been patched", "pod", pod.Name, "labels", pod.Labels)
+	}
+	return ctrl.Result{}, nil
 }
 
 // reconcilePod will handle checking for the label of a single pod

--- a/pkg/meta/labels.go
+++ b/pkg/meta/labels.go
@@ -114,6 +114,13 @@ const (
 	// subcluster rename. So, it shouldn't be treated as such.
 	DeploymentSelectorLabel = "vertica.com/deployment-selector-name"
 
+	// This is set in all proxy pods, and is used to filter out all proxy pods
+	// in vdb reconcilers as a pod selector. This stays constant for the life
+	// of the deployment. If it is set to true, then the pod is a proxy pod;
+	// if it is set to other value or not set, then the pod is not a proxy pod.
+	ProxyPodSelectorLabel = "vertica.com/proxy-pod"
+	ProxyPodSelectorVal   = "true"
+
 	// ConfigMap objects
 	//
 	// This indicates that the object is watched by the sandbox controller.

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -105,6 +105,11 @@ func GenPodName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) types.
 	return GenNamespacedName(vdb, fmt.Sprintf("%s-%d", stsName, podIndex))
 }
 
+// GenPodDNSName returns the DNS name of a specific pod
+func GenPodDNSName(vdb *vapi.VerticaDB, sc *vapi.Subcluster, podIndex int32) string {
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", GenPodName(vdb, sc, podIndex).Name, vdb.Name, vdb.Namespace)
+}
+
 // GenPodNameFromSts returns the name of a specific pod in a statefulset
 func GenPodNameFromSts(vdb *vapi.VerticaDB, sts *appsv1.StatefulSet, podIndex int32) types.NamespacedName {
 	return types.NamespacedName{

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -42,6 +42,14 @@ var _ = Describe("k8s/names", func() {
 		))
 	})
 
+	It("pod dns name should be correct", func() {
+		vdb := vapi.MakeVDB()
+		vdb.ObjectMeta.Name = "name-test"
+		vdb.ObjectMeta.Namespace = "my-ns"
+		vdb.Spec.Subclusters[0].Name = "my-sc"
+		Ω(GenPodDNSName(vdb, &vdb.Spec.Subclusters[0], 9)).Should(Equal("name-test-my-sc-9.name-test.my-ns.svc.cluster.local"))
+	})
+
 	It("subcluster and external service generated names should not contain `_`", func() {
 		vdb := vapi.MakeVDB()
 		vdb.ObjectMeta.Name = "v"

--- a/pkg/podfacts/podfacts.go
+++ b/pkg/podfacts/podfacts.go
@@ -1652,7 +1652,7 @@ func (p *PodFacts) QuorumCheckForRestartCluster(restartOnly bool) bool {
 		}
 		return 0
 	})
-	return restartablePrimaryNodeCount >= (primaryNodeCount+1)/2
+	return restartablePrimaryNodeCount > primaryNodeCount/2
 }
 
 // DoesDBHaveQuorum returns true if the cluster will keep quorum

--- a/pkg/podfacts/podfacts_test.go
+++ b/pkg/podfacts/podfacts_test.go
@@ -387,7 +387,7 @@ var _ = Describe("podfacts", func() {
 
 		// 4 primary nodes, 2 restartable primary nodes
 		result := pf.QuorumCheckForRestartCluster(true)
-		Expect(result).Should(BeTrue())
+		Expect(result).Should(BeFalse())
 		// 5 primary nodes, 3 restartable primary nodes
 		pf.Detail[types.NamespacedName{Name: "p3"}].isPrimary = true
 		result = pf.QuorumCheckForRestartCluster(true)


### PR DESCRIPTION
This PR added client routing label to proxy pods for routing traffic from service to client proxy pods. After this change, the service will only communicate with the proxy pods rather than vertica pods.