### PR TITLE
Add VerticaReplicator webhook

### DIFF
--- a/api/v1beta1/verticareplicator_webhook.go
+++ b/api/v1beta1/verticareplicator_webhook.go
@@ -1,0 +1,138 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var verticareplicatorlog = logf.Log.WithName("verticareplicator-resource")
+
+func (vrep *VerticaReplicator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(vrep).
+		Complete()
+}
+
+var _ webhook.Defaulter = &VerticaReplicator{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (vrep *VerticaReplicator) Default() {
+	verticareplicatorlog.Info("default", "name", vrep.Name)
+}
+
+var _ webhook.Validator = &VerticaReplicator{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (vrep *VerticaReplicator) ValidateCreate() error {
+	verticareplicatorlog.Info("validate create", "name", vrep.Name)
+
+	allErrs := vrep.validateVrepSpec()
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(GkVR, vrep.Name, allErrs)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (vrep *VerticaReplicator) ValidateUpdate(_ runtime.Object) error {
+	verticareplicatorlog.Info("validate update", "name", vrep.Name)
+
+	allErrs := vrep.validateVrepSpec()
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GkVR, vrep.Name, allErrs)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (vrep *VerticaReplicator) ValidateDelete() error {
+	verticareplicatorlog.Info("validate delete", "name", vrep.Name)
+	return nil
+}
+
+// validateVrepSpec will validate the current VerticaScrutinize to see if it is valid
+func (vrep *VerticaReplicator) validateVrepSpec() field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = vrep.ValidateAsyncReplicationOptions(allErrs)
+
+	return allErrs
+}
+
+func (vrep *VerticaReplicator) ValidateAsyncReplicationOptions(allErrs field.ErrorList) field.ErrorList {
+	if vrep.Spec.Mode != "" && vrep.Spec.Mode != ReplicationModeSync && vrep.Spec.Mode != ReplicationModeAsync {
+		err := field.Invalid(field.NewPath("spec").Child("mode"),
+			vrep.Spec.Mode,
+			fmt.Sprintf("Mode must be either '%s' or '%s'", ReplicationModeSync, ReplicationModeAsync))
+		allErrs = append(allErrs, err)
+	}
+
+	if vrep.Spec.Mode == ReplicationModeSync {
+		if vrep.Spec.Source.IncludePattern != "" {
+			err := field.Invalid(field.NewPath("spec").Child("source").Child("includePattern"),
+				vrep.Spec.Source.IncludePattern,
+				fmt.Sprintf("Include pattern cannot be used in replication mode '%s'", ReplicationModeSync))
+			allErrs = append(allErrs, err)
+		}
+		if vrep.Spec.Source.ExcludePattern != "" {
+			err := field.Invalid(field.NewPath("spec").Child("source").Child("excludePattern"),
+				vrep.Spec.Source.ExcludePattern,
+				fmt.Sprintf("Exclude pattern cannot be used in replication mode '%s'", ReplicationModeSync))
+			allErrs = append(allErrs, err)
+		}
+		if vrep.Spec.Source.ObjectName != "" {
+			err := field.Invalid(field.NewPath("spec").Child("source").Child("objectName"),
+				vrep.Spec.Source.ObjectName,
+				fmt.Sprintf("Object name cannot be used in replication mode '%s'", ReplicationModeSync))
+			allErrs = append(allErrs, err)
+		}
+		if vrep.Spec.Target.Namespace != "" {
+			err := field.Invalid(field.NewPath("spec").Child("target").Child("namespace"),
+				vrep.Spec.Target.Namespace,
+				fmt.Sprintf("Target namespace cannot be used in replication mode '%s'", ReplicationModeSync))
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	if vrep.Spec.Source.ObjectName != "" && vrep.Spec.Source.IncludePattern != "" {
+		err := field.Invalid(field.NewPath("spec").Child("source").Child("includePattern"),
+			vrep.Spec.Source.IncludePattern,
+			"Object name and include pattern cannot be used together")
+		allErrs = append(allErrs, err)
+	}
+	if vrep.Spec.Source.ObjectName != "" && vrep.Spec.Source.ExcludePattern != "" {
+		err := field.Invalid(field.NewPath("spec").Child("source").Child("excludePattern"),
+			vrep.Spec.Source.ExcludePattern,
+			"Object name and exclude pattern cannot be used together")
+		allErrs = append(allErrs, err)
+	}
+	if vrep.Spec.Source.ExcludePattern != "" && vrep.Spec.Source.IncludePattern == "" {
+		err := field.Invalid(field.NewPath("spec").Child("source").Child("excludePattern"),
+			vrep.Spec.Source.ExcludePattern,
+			"Exclude pattern cannot be used without include pattern")
+		allErrs = append(allErrs, err)
+	}
+
+	return allErrs
+}

--- a/api/v1beta1/verticareplicator_webhook_test.go
+++ b/api/v1beta1/verticareplicator_webhook_test.go
@@ -1,0 +1,143 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("verticascrutinize_webhook", func() {
+	const (
+		validObjectName      = "test.test"
+		validIncludePattern  = "testinc.*"
+		validExcludePattern  = "testexc.*"
+		validTargetNamespace = "target"
+	)
+
+	It("should succeed with default async options", func() {
+		vrep := MakeVrep()
+		Expect(vrep.ValidateCreate()).Should(Succeed())
+		Expect(vrep.ValidateUpdate(vrep)).Should(Succeed())
+	})
+
+	It("should succeed with default sync options", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeSync
+		Expect(vrep.ValidateCreate()).Should(Succeed())
+		Expect(vrep.ValidateUpdate(vrep)).Should(Succeed())
+	})
+
+	It("should succeed with default sync options", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = "invalid"
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Mode must be either 'sync' or 'async'"))
+	})
+
+	It("should succeed if valid object name is used in async replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeAsync
+		vrep.Spec.Source.ObjectName = validObjectName
+		Expect(vrep.ValidateCreate()).Should(Succeed())
+		Expect(vrep.ValidateUpdate(vrep)).Should(Succeed())
+	})
+
+	It("should succeed if valid include pattern is used in async replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeAsync
+		vrep.Spec.Source.IncludePattern = validIncludePattern
+		Expect(vrep.ValidateCreate()).Should(Succeed())
+		Expect(vrep.ValidateUpdate(vrep)).Should(Succeed())
+	})
+
+	It("should succeed if valid exclude pattern is used in async replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeAsync
+		vrep.Spec.Source.IncludePattern = validIncludePattern
+		vrep.Spec.Source.ExcludePattern = validExcludePattern
+		Expect(vrep.ValidateCreate()).Should(Succeed())
+		Expect(vrep.ValidateUpdate(vrep)).Should(Succeed())
+	})
+
+	It("should succeed if valid target namespace is used in async replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeAsync
+		vrep.Spec.Target.Namespace = validTargetNamespace
+		Expect(vrep.ValidateCreate()).Should(Succeed())
+		Expect(vrep.ValidateUpdate(vrep)).Should(Succeed())
+	})
+
+	It("should fail if object name is used in sync replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeSync
+		vrep.Spec.Source.ObjectName = validObjectName
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Object name cannot be used in replication mode 'sync'"))
+	})
+
+	It("should fail if include pattern is used in sync replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeSync
+		vrep.Spec.Source.IncludePattern = validIncludePattern
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Include pattern cannot be used in replication mode 'sync'"))
+	})
+
+	It("should fail if exclude pattern is used in sync replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeSync
+		vrep.Spec.Source.IncludePattern = validIncludePattern
+		vrep.Spec.Source.ExcludePattern = validExcludePattern
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Exclude pattern cannot be used in replication mode 'sync'"))
+	})
+
+	It("should fail if target namespace is used in sync replication mode", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeSync
+		vrep.Spec.Target.Namespace = validTargetNamespace
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Target namespace cannot be used in replication mode 'sync'"))
+	})
+
+	It("should fail if object name and include pattern are used together", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeAsync
+		vrep.Spec.Source.ObjectName = validObjectName
+		vrep.Spec.Source.IncludePattern = validIncludePattern
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Object name and include pattern cannot be used together"))
+	})
+
+	It("should fail if object name and exclude pattern are used together", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeAsync
+		vrep.Spec.Source.ObjectName = validObjectName
+		vrep.Spec.Source.IncludePattern = validIncludePattern
+		vrep.Spec.Source.ExcludePattern = validExcludePattern
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Object name and exclude pattern cannot be used together"))
+	})
+
+	It("should fail if exclude pattern is specified without include pattern", func() {
+		vrep := MakeVrep()
+		vrep.Spec.Mode = ReplicationModeAsync
+		vrep.Spec.Source.ExcludePattern = validExcludePattern
+		err := vrep.ValidateCreate()
+		Expect(err.Error()).To(ContainSubstring("Exclude pattern cannot be used without include pattern"))
+	})
+})

--- a/api/v1beta1/verticareplicator_webhook_test.go
+++ b/api/v1beta1/verticareplicator_webhook_test.go
@@ -41,7 +41,7 @@ var _ = Describe("verticascrutinize_webhook", func() {
 		Expect(vrep.ValidateUpdate(vrep)).Should(Succeed())
 	})
 
-	It("should succeed with default sync options", func() {
+	It("should fail with invalid mode", func() {
 		vrep := MakeVrep()
 		vrep.Spec.Mode = "invalid"
 		err := vrep.ValidateCreate()

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -200,6 +200,10 @@ func addWebhooksToManager(mgr manager.Manager) {
 		setupLog.Error(err, "unable to create webhook", "webhook", "VerticaScrutinize", "version", vapiB1.Version)
 		os.Exit(1)
 	}
+	if err := (&vapiB1.VerticaReplicator{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "VerticaReplicator", "version", vapiB1.Version)
+		os.Exit(1)
+	}
 }
 
 // setupWebhook will setup the webhook in the manager if enabled

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -215,3 +215,23 @@ webhooks:
     resources:
     - verticascrutinizers
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-vertica-com-v1beta1-verticareplicator
+  failurePolicy: Fail
+  name: vverticareplicator.kb.io
+  rules:
+  - apiGroups:
+    - vertica.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - verticareplicators
+  sideEffects: None


### PR DESCRIPTION
Add webhook for VerticaReplicator. It enforces the following rules:
- Only one of the following should be specified: table, schema, pattern, or pattern with exclusion
- Make sure the new field "mode" only has one of the following fields: async, sync or empty string(for backward compatibility)
- Object name, include/exclude pattern, and target namespace cannot be used in sync mode