### PR TITLE
in undeploy script, add remove crd logic

### DIFF
--- a/scripts/undeploy.sh
+++ b/scripts/undeploy.sh
@@ -66,6 +66,11 @@ function remove_cluster_objects
             kubectl delete $obj $(kubectl get $obj | grep '^verticadb-operator-' | cut -d' ' -f1) || true
         fi
     done
+    # Remove CRD
+    if kubectl get crd | grep '^vertica'
+    then
+        kubectl delete crd $(kubectl get crd | grep '^vertica' | cut -d' ' -f1) || true
+    fi
     set -o xtrace
 }
 


### PR DESCRIPTION
After changing the content of the spec, I noticed that the CRD is not updated through 'make undeploy && make deploy'.
Qin helped me checked the CRD and we found it was not refreshed. Adding logic in the undeploy.sh so we will delete the old crds.  