### PR TITLE
add trace profile data collector clean up

### DIFF
--- a/tests/e2e-leg-6/verify-server-logrotate/expected-output/logrotateTimerServiceOut.txt
+++ b/tests/e2e-leg-6/verify-server-logrotate/expected-output/logrotateTimerServiceOut.txt
@@ -3,6 +3,11 @@
  CLEAR
 (1 row)
 
+ clear_data_collector 
+----------------------
+ CLEAR
+(1 row)
+
         hurry_service         
 ------------------------------
  Service hurried and finished

--- a/tests/e2e-leg-6/verify-server-logrotate/sql-input/logrotate.sql
+++ b/tests/e2e-leg-6/verify-server-logrotate/sql-input/logrotate.sql
@@ -1,3 +1,7 @@
+-- This test covers profile clean up through in-server logrotate
+-- clear before testing
+select clear_data_collector('TraceProfiles');
+
 -- Cleanup the DC table
 select clear_data_collector('LogRotateOperations');
 


### PR DESCRIPTION
This PR add a new method in server log rotate SQL file, select clear_data_collector('TraceProfiles');
and new expected output to match the server test cases.