### PR TITLE
use annotations proxy log level

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -962,7 +962,7 @@ func makeDataForVProxyConfigMap(vdb *vapi.VerticaDB, sc *vapi.Subcluster) string
 			"nodes": nodeList,
 		},
 		Log: map[string]string{
-			"level": "INFO",
+			"level": vmeta.GetVProxyLogLevel(vdb.Annotations),
 		},
 	}
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -572,7 +572,7 @@ func GetNMAHealthProbeOverride(annotations map[string]string, probeName, field s
 
 // GetVProxyLogLevel returns scrutinize log age hours
 func GetVProxyLogLevel(annotations map[string]string) string {
-	return lookupStringAnnotation(annotations, VProxyLogLevelAnnotation, "INFO" /* default value */)
+	return lookupStringAnnotation(annotations, VProxyLogLevelAnnotation, VProxyLogLevelDefaultLevel)
 }
 
 // GetScrutinizePodTTL returns how long the scrutinize pod will keep running


### PR DESCRIPTION
The proxy config map should use the annotation value of vertica.com/client-proxy-log-level. This pr is for updating the logic by replacing the hardcoded value. 