### PR TITLE
Prevent proxy deployment update

### DIFF
--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -171,8 +171,7 @@ func MakeAnnotationsForStsObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[s
 // MakeAnnotationsForVProxyObject builds the list of annotations that are included
 // in the proxy config object.
 func MakeAnnotationsForVProxyObject(vdb *vapi.VerticaDB) map[string]string {
-	annotations := MakeAnnotationsForObject(vdb)
-	return annotations
+	return MakeAnnotationsForObject(vdb)
 }
 
 // MakeAnnotationsForSandboxConfigMap builds the list of annotations that are included

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -172,9 +172,6 @@ func MakeAnnotationsForStsObject(vdb *vapi.VerticaDB, sc *vapi.Subcluster) map[s
 // in the proxy config object.
 func MakeAnnotationsForVProxyObject(vdb *vapi.VerticaDB) map[string]string {
 	annotations := MakeAnnotationsForObject(vdb)
-	if ver, ok := vdb.Annotations[vmeta.VersionAnnotation]; ok {
-		annotations[vmeta.VersionAnnotation] = ver
-	}
 	return annotations
 }
 

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -95,6 +95,12 @@ func (o *ObjReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Re
 		return ctrl.Result{}, errors.New("no podfacts provided")
 	}
 
+	if vmeta.UseVProxy(o.Vdb.Annotations) {
+		if o.Vdb.Spec.Proxy == nil {
+			return ctrl.Result{}, errors.New("spec.proxy must be set when client proxy is enabled")
+		}
+	}
+
 	if err := o.PFacts.Collect(ctx, o.Vdb); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -591,6 +597,9 @@ func (o *ObjReconciler) reconcileSts(ctx context.Context, sc *vapi.Subcluster) (
 
 	var curDep *appsv1.Deployment
 	if vmeta.UseVProxy(o.Vdb.Annotations) {
+		if sc.Proxy == nil {
+			return ctrl.Result{}, fmt.Errorf("subcluster %s must have proxy set when client proxy is enabled", sc.Name)
+		}
 		if curDep, err = o.reconcileVProxy(ctx, sc); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/tests/e2e-leg-11/client-proxy/40-add-subcluster.yaml
+++ b/tests/e2e-leg-11/client-proxy/40-add-subcluster.yaml
@@ -25,5 +25,3 @@ spec:
     - name: sec1
       size: 2
       type: secondary
-      proxy:
-        replicas: 1

--- a/tests/e2e-leg-11/client-proxy/40-assert.yaml
+++ b/tests/e2e-leg-11/client-proxy/40-assert.yaml
@@ -59,6 +59,16 @@ apiVersion: vertica.com/v1
 kind: VerticaDB
 metadata:
   name: v-client-proxy
+spec:
+  subclusters:
+    - name: pri1
+      size: 4
+      proxy:
+        replicas: 2
+    - name: sec1
+      size: 2
+      proxy:
+        replicas: 1
 status:
   subclusters:
     - addedToDBCount: 4


### PR DESCRIPTION
When creating a deployment, a replicaset is created for each replica. When the update strategy is `RollingUpdate`, each time there is a change in the deployment spec, an extra pod will be created with the update and the old one will be deleted once the new one is ready. So there is a timing where you may see twice the number of pods with respect to what you expect. 
During testing, QA found that each time we create a proxy deployment, at first we had twice the number of required pods before getting the correct number after a few seconds. That is because we updated the deployment by adding the server version annotation when it is available in the vdb. That annotation does't serve any purpose so I just removed to avoid updating the deployment.