### PR TITLE
Fix sandbox-upgrade-happy-path

### DIFF
--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -164,7 +164,8 @@ runs:
           fi
         fi
 
-        if [[ "${{ inputs.leg-identifier }}" == "leg-4" ]]; then
+        if [[ "${{ inputs.leg-identifier }}" == "leg-4" || \
+                "${{ inputs.leg-identifier }}" == "leg-10" ]]; then
           export CONCURRENCY_VERTICADB=10
         fi
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -213,6 +213,8 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Check the version information ahead of restart. The version is needed
 		// to properly pick the correct NMA deployment (monolithic vs sidecar).
 		MakeImageVersionReconciler(r, log, vdb, prunner, pfacts, false /* enforceUpgradePath */),
+		// Update the vertica image for unsandboxed subclusters
+		MakeUnsandboxImageVersionReconciler(r, vdb, log, pfacts),
 		// Handles restart + re_ip of vertica
 		MakeRestartReconciler(r, log, vdb, prunner, pfacts, true, dispatcher),
 		MakeMetricReconciler(r, log, vdb, prunner, pfacts),

--- a/tests/e2e-leg-10/sandbox-upgrade-happy-path/55-assert.yaml
+++ b/tests/e2e-leg-10/sandbox-upgrade-happy-path/55-assert.yaml
@@ -11,6 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 1200
+---
 apiVersion: v1
 kind: Event
 reason: UnsandboxSubclusterSucceeded


### PR DESCRIPTION
A bug was found in sandbox-upgrade-happy-path test case. The sandbox is upgraded and then removed (unsandboxed). After unsandboxing, we restart all the pods of the former sandbox. The issue is that the subcluster that joins the main cluster is not running the same image, so we get stuck for a while in startnode(HTTPSPollNodeStateIndirectOp) until the timeout(1200s). After timeout expires, it will requeue and run `UnsandboxImageVersionReconciler` which will recreate the pods with the correct image and next the next startnode attempt will succeed.  The solution consists in calling `UnsandboxImageVersionReconciler` just before the restart reconciler.