### PR TITLE
Fixed CVE-2024-45338

### DIFF
--- a/changes/unreleased/Security-20241219-123023.yaml
+++ b/changes/unreleased/Security-20241219-123023.yaml
@@ -1,0 +1,5 @@
+kind: Security
+body: Fix for CVE-2024-45338
+time: 2024-12-19T12:30:23.788944488-05:00
+custom:
+    Issue: "1009"

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -59,7 +59,7 @@ const (
 	UseVProxyAnnotationFalse = "false"
 
 	// This is the log level of the proxy server will have.
-	// Log level: 0=TRACE|1=DEBUG|2=INFO|3=WARN|4=FATAL|5=NONE
+	// Log level: TRACE|DEBUG|INFO|WARN|FATAL|NONE
 	VProxyLogLevelAnnotation   = "vertica.com/client-proxy-log-level"
 	VProxyLogLevelDefaultLevel = "INFO"
 


### PR DESCRIPTION
This PR updated GO net library to 0.33 for fixing CVE-2024-45338.