### PR TITLE
Implement a retry mechanism in e2e test

### DIFF
--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -94,134 +94,137 @@ runs:
         password: ${{ inputs.dockerhub-token }}
 
     - name: Run e2e tests
-      shell: bash
-      run: |
-        set -o errexit
-        set -o xtrace
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 1
+        max_attempts: 3
+        shell: bash
+        command: |
+          set -o errexit
+          set -o xtrace
 
-        export FOR_GITHUB_CI=${{ inputs.skip-download-test-packages }}
+          export FOR_GITHUB_CI=${{ inputs.skip-download-test-packages }}
 
-        # Set KUSTOMIZE_CFG based on communal storage type
-        if [[ "${{ inputs.communal-storage-type }}" == "azb" ]]; then
-          export KUSTOMIZE_CFG=tests/kustomize-defaults-azb-ci.cfg;
-        elif [[ "${{ inputs.communal-storage-type }}" == "hostpath" ]]; then
-          export KUSTOMIZE_CFG=tests/kustomize-defaults-hostpath-ci.cfg;
-        fi
-        # No need to set KUSTOMIZE_CFG if communal storage is s3
+          # Set KUSTOMIZE_CFG based on communal storage type
+          if [[ "${{ inputs.communal-storage-type }}" == "azb" ]]; then
+            export KUSTOMIZE_CFG=tests/kustomize-defaults-azb-ci.cfg;
+          elif [[ "${{ inputs.communal-storage-type }}" == "hostpath" ]]; then
+            export KUSTOMIZE_CFG=tests/kustomize-defaults-hostpath-ci.cfg;
+          fi
+          # No need to set KUSTOMIZE_CFG if communal storage is s3
 
-        export VERTICA_IMG=${{ inputs.vertica-image }}
-        export OPERATOR_IMG=${{ inputs.operator-image }}
-        export VLOGGER_IMG=${{ inputs.vlogger-image }}
-        if [[ "${{ inputs.vproxy-image }}" != "" ]]; then
-          export VPROXY_IMG=${{ inputs.vproxy-image }}
-        fi
+          export VERTICA_IMG=${{ inputs.vertica-image }}
+          export OPERATOR_IMG=${{ inputs.operator-image }}
+          export VLOGGER_IMG=${{ inputs.vlogger-image }}
+          if [[ "${{ inputs.vproxy-image }}" != "" ]]; then
+            export VPROXY_IMG=${{ inputs.vproxy-image }}
+          fi
 
-        if [[ "${{ inputs.vertica-license }}" != "" ]]; then
-          export LICENSE_FILE=/tmp/vertica-license.dat
-          echo -n "${{ inputs.vertica-license }}" > $LICENSE_FILE
-        fi
+          if [[ "${{ inputs.vertica-license }}" != "" ]]; then
+            export LICENSE_FILE=/tmp/vertica-license.dat
+            echo -n "${{ inputs.vertica-license }}" > $LICENSE_FILE
+          fi
 
-        # Set DEPLOY_WITH
-        export DEPLOY_WITH="${{ inputs.deploy-with }}";
+          # Set DEPLOY_WITH
+          export DEPLOY_WITH="${{ inputs.deploy-with }}";
 
-        # Set E2E_PARALLELISM
-        if [[ "${{ inputs.e2e-parallelism }}" != "" ]]; then
-          export E2E_PARALLELISM="${{ inputs.e2e-parallelism }}";
-        fi
+          # Set E2E_PARALLELISM
+          if [[ "${{ inputs.e2e-parallelism }}" != "" ]]; then
+            export E2E_PARALLELISM="${{ inputs.e2e-parallelism }}";
+          fi
 
-        # Set VERTICA_DEPLOYMENT_METHOD (default value is admintools)
-        export VERTICA_DEPLOYMENT_METHOD=${{ inputs.vertica-deployment-method }};
+          # Set VERTICA_DEPLOYMENT_METHOD (default value is admintools)
+          export VERTICA_DEPLOYMENT_METHOD=${{ inputs.vertica-deployment-method }};
 
-        # Set VERTICA_SUPERUSER_NAME
-        export VERTICA_SUPERUSER_NAME=${{ inputs.vertica-superuser-name }};
-        if [[ "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]]; then
-          # Only "dbadmin" can be used when deployment type is admintools
-          export VERTICA_SUPERUSER_NAME="dbadmin";
-        fi
+          # Set VERTICA_SUPERUSER_NAME
+          export VERTICA_SUPERUSER_NAME=${{ inputs.vertica-superuser-name }};
+          if [[ "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]]; then
+            # Only "dbadmin" can be used when deployment type is admintools
+            export VERTICA_SUPERUSER_NAME="dbadmin";
+          fi
 
-        # Set CONTROLLERS_SCOPE
-        export CONTROLLERS_SCOPE="${{ inputs.controllers-scope }}";
+          # Set CONTROLLERS_SCOPE
+          export CONTROLLERS_SCOPE="${{ inputs.controllers-scope }}";
 
-        # Set HELM_OVERRIDES
-        if [[ "${{ inputs.helm-overrides }}" != "" ]]; then
-          export HELM_OVERRIDES="${{ inputs.helm-overrides }}";
-        fi
+          # Set HELM_OVERRIDES
+          if [[ "${{ inputs.helm-overrides }}" != "" ]]; then
+            export HELM_OVERRIDES="${{ inputs.helm-overrides }}";
+          fi
 
-        # Set E2E_TEST_DIRS
-        if [[ "${{ inputs.leg-identifier }}" == "operator-upgrade" ]]; then
-          export E2E_TEST_DIRS="tests/e2e-operator-upgrade-overlays";
-        else
-          export E2E_TEST_DIRS="tests/e2e-${{ inputs.leg-identifier }}"
-          if [[ "${{ inputs.leg-identifier }}" == "leg-1" || \
-                "${{ inputs.leg-identifier }}" == "leg-2" || \
-                "${{ inputs.leg-identifier }}" == "leg-3" || \
-                "${{ inputs.leg-identifier }}" == "leg-5" || \
-                "${{ inputs.leg-identifier }}" == "server-upgrade" ]]; then
-            # These legs have some tests that only run with admintools deployment
-            if [[ "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]]; then
-              E2E_TEST_DIRS+=" tests/e2e-${{ inputs.leg-identifier }}-at-only";
+          # Set E2E_TEST_DIRS
+          if [[ "${{ inputs.leg-identifier }}" == "operator-upgrade" ]]; then
+            export E2E_TEST_DIRS="tests/e2e-operator-upgrade-overlays";
+          else
+            export E2E_TEST_DIRS="tests/e2e-${{ inputs.leg-identifier }}"
+            if [[ "${{ inputs.leg-identifier }}" == "leg-1" || \
+                  "${{ inputs.leg-identifier }}" == "leg-2" || \
+                  "${{ inputs.leg-identifier }}" == "leg-3" || \
+                  "${{ inputs.leg-identifier }}" == "leg-5" || \
+                  "${{ inputs.leg-identifier }}" == "server-upgrade" ]]; then
+              # These legs have some tests that only run with admintools deployment
+              if [[ "${VERTICA_DEPLOYMENT_METHOD}" != "vclusterops" ]]; then
+                E2E_TEST_DIRS+=" tests/e2e-${{ inputs.leg-identifier }}-at-only";
+              fi
             fi
           fi
-        fi
 
-        if [[ "${{ inputs.leg-identifier }}" == "leg-4" || \
-                "${{ inputs.leg-identifier }}" == "leg-10" ]]; then
-          export CONCURRENCY_VERTICADB=10
-        fi
-
-        # Set BASE_VERTICA_IMG based on $VERTICA_IMG
-        # Some tests in some suites do an upgrade, so set the base image to upgrade from
-        if [[ "${{ inputs.need-base-vertica-image }}" == "true" ]]; then
-          export BASE_VERTICA_IMG=$(scripts/guess-server-upgrade-base-image.sh $VERTICA_IMG);
-        fi
-
-        # Enforce server image version
-        if [[ "${{ inputs.minimum-vertica-image }}" != "" ]]; then
-          # The image must be at least a ${{ inputs.minimum-vertica-image }}+.
-          # If it is older, we complete this leg as a no-op.
-          if scripts/is-image.sh -i $VERTICA_IMG older ${{ inputs.minimum-vertica-image }}
-          then
-            echo "Old version detected, skipping all of the tests"
-            exit 0
+          if [[ "${{ inputs.leg-identifier }}" == "leg-4" || \
+                  "${{ inputs.leg-identifier }}" == "leg-10" ]]; then
+            export CONCURRENCY_VERTICADB=10
           fi
-        fi
 
-        # Set an env var that will later be checked to pull an extra
-        # vertica image used for multi-online-upgrade test
-        if [[ "${{ inputs.leg-identifier }}" == "leg-9" ]]; then
-          export LEG9=yes
-        fi
-
-        # Special setup for e2e-udx
-        if [[ "${{ inputs.leg-identifier }}" == "udx" ]]; then
-          # Setup the udx environment by compiling examples in the vertica image.
-          # This downloads packages, so to improve its reliability we retry in
-          # case any intermittent network issues arise.
-          for i in $(seq 1 5); do
-            scripts/setup-e2e-udx.sh $VERTICA_IMG rockylinux:8 && s=0 && break || s=$? && sleep 60;
-          done
-          if [[ $s != "0" ]]; then
-            echo "*** Give up trying to setup the udx env";
-            exit 1;
+          # Set BASE_VERTICA_IMG based on $VERTICA_IMG
+          # Some tests in some suites do an upgrade, so set the base image to upgrade from
+          if [[ "${{ inputs.need-base-vertica-image }}" == "true" ]]; then
+            export BASE_VERTICA_IMG=$(scripts/guess-server-upgrade-base-image.sh $VERTICA_IMG);
           fi
-        fi
 
-        # Setup prometheus and prometheus-adapter
-        if [[ "${{ inputs.leg-identifier }}" == "leg-12" ]]; then
-          export NEED_PROMETHEUS=true
-          export CONCURRENCY_VERTICAAUTOSCALER=5
-        fi
+          # Enforce server image version
+          if [[ "${{ inputs.minimum-vertica-image }}" != "" ]]; then
+            # The image must be at least a ${{ inputs.minimum-vertica-image }}+.
+            # If it is older, we complete this leg as a no-op.
+            if scripts/is-image.sh -i $VERTICA_IMG older ${{ inputs.minimum-vertica-image }}
+            then
+              echo "Old version detected, skipping all of the tests"
+              exit 0
+            fi
+          fi
 
-        # Run int test script
-        if [[ "${{ inputs.communal-storage-type }}" == "azb" ]]; then
-          scripts/run-k8s-int-tests.sh -s -e tests/external-images-azb-ci.txt;
-        elif [[ "${{ inputs.communal-storage-type }}" == "hostpath" ]]; then
-          mkdir -p $GITHUB_WORKSPACE/../host-path;
-          scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s;
-        else
-          scripts/run-k8s-int-tests.sh -s -e tests/external-images-s3-ci.txt;
-        fi
+          # Set an env var that will later be checked to pull an extra
+          # vertica image used for multi-online-upgrade test
+          if [[ "${{ inputs.leg-identifier }}" == "leg-9" ]]; then
+            export LEG9=yes
+          fi
 
+          # Special setup for e2e-udx
+          if [[ "${{ inputs.leg-identifier }}" == "udx" ]]; then
+            # Setup the udx environment by compiling examples in the vertica image.
+            # This downloads packages, so to improve its reliability we retry in
+            # case any intermittent network issues arise.
+            for i in $(seq 1 5); do
+              scripts/setup-e2e-udx.sh $VERTICA_IMG rockylinux:8 && s=0 && break || s=$? && sleep 60;
+            done
+            if [[ $s != "0" ]]; then
+              echo "*** Give up trying to setup the udx env";
+              exit 1;
+            fi
+          fi
+
+          # Setup prometheus and prometheus-adapter
+          if [[ "${{ inputs.leg-identifier }}" == "leg-12" ]]; then
+            export NEED_PROMETHEUS=true
+            export CONCURRENCY_VERTICAAUTOSCALER=5
+          fi
+
+          # Run int test script
+          if [[ "${{ inputs.communal-storage-type }}" == "azb" ]]; then
+            scripts/run-k8s-int-tests.sh -s -e tests/external-images-azb-ci.txt;
+          elif [[ "${{ inputs.communal-storage-type }}" == "hostpath" ]]; then
+            mkdir -p $GITHUB_WORKSPACE/../host-path;
+            scripts/run-k8s-int-tests.sh -m $GITHUB_WORKSPACE/../host-path -s;
+          else
+            scripts/run-k8s-int-tests.sh -s -e tests/external-images-s3-ci.txt;
+          fi
 
     - uses: actions/upload-artifact@v4
       if: failure()

--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -82,7 +82,7 @@ inputs:
   e2e-retry-times:
     description: 'Number of times to retry failed e2e tests'
     required: false
-    default: '3'
+    default: '2'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -75,6 +75,14 @@ inputs:
     description: 'If skip downloading test packages inside vertica image'
     required: false
     default: 'true'
+  e2e-timeout-minutes:
+    description: 'Number of minutes to wait for e2e tests'
+    required: false
+    default: '60'
+  e2e-retry-times:
+    description: 'Number of times to retry failed e2e tests'
+    required: false
+    default: '3'
 runs:
   using: "composite"
   steps:
@@ -96,8 +104,8 @@ runs:
     - name: Run e2e tests
       uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 1
-        max_attempts: 3
+        timeout_minutes: ${{ inputs.e2e-timeout-minutes }}
+        max_attempts: ${{ inputs.e2e-retry-times }}
         shell: bash
         command: |
           set -o errexit

--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -76,9 +76,9 @@ inputs:
     required: false
     default: 'true'
   e2e-timeout-minutes:
-    description: 'Number of minutes to wait for e2e tests'
+    description: 'Duration (in minutes) to wait for e2e tests to complete before timing out.'
     required: false
-    default: '60'
+    default: '600'
   e2e-retry-times:
     description: 'Number of times to retry failed e2e tests'
     required: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,10 +58,6 @@ on:
         - vcluster leg 11
         - vcluster server upgrade
         - vcluster udx
-      e2e_timeout_minutes:
-        description: 'Duration (in minutes) to wait for e2e tests to complete before timing out.'
-        required: false
-        default: '600'
       e2e_retry_times:
         description: 'Number of times to retry failed e2e tests'
         required: false
@@ -136,7 +132,6 @@ jobs:
           communal-storage-type: azb
           deploy-with: olm
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-1-admintools-previous-release:
@@ -159,7 +154,6 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           deploy-with: olm
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-1-vcluster:
@@ -181,7 +175,6 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: azb
           deploy-with: olm
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-2-admintools:
@@ -204,7 +197,6 @@ jobs:
           communal-storage-type: hostpath
           controllers-scope: namespace
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-2-admintools-previous-release:
@@ -227,7 +219,6 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: hostpath
           controllers-scope: namespace
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-2-vcluster:
@@ -249,7 +240,6 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           controllers-scope: namespace
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-3-admintools:
@@ -271,7 +261,6 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: hostpath
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-3-vclusterops-previous-release:
@@ -293,7 +282,6 @@ jobs:
           artifact-suffix: "-24.1.0-release"
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-3-vcluster:
@@ -314,7 +302,6 @@ jobs:
           vertica-image: ${{ needs.build.outputs.full-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-4-admintools:
@@ -339,7 +326,6 @@ jobs:
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-4-vcluster:
@@ -363,7 +349,6 @@ jobs:
           vertica-superuser-name: myadmin
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-4-admintools-vdb-gen:
@@ -388,7 +373,6 @@ jobs:
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-4-vcluster-vdb-gen:
@@ -412,7 +396,6 @@ jobs:
           vertica-superuser-name: myadmin
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-5-admintools:
@@ -439,7 +422,6 @@ jobs:
           e2e-parallelism: 1
           need-base-vertica-image: 'true'
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-5-vcluster:
@@ -465,7 +447,6 @@ jobs:
           # operator running in the k8s cluster.
           e2e-parallelism: 1
           need-base-vertica-image: 'true'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-6-vcluster:
@@ -487,7 +468,6 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-6-vcluster-revivedb:
@@ -509,7 +489,6 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-7-vcluster:
@@ -531,7 +510,6 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-8-admintools-offline:
@@ -555,7 +533,6 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           minimum-vertica-image: '24.2.0'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-8-admintools-online:
@@ -579,7 +556,6 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           minimum-vertica-image: '24.2.0'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-9-vcluster:
@@ -604,7 +580,6 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-10-vcluster:
@@ -629,7 +604,6 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-11-vcluster:
@@ -655,7 +629,6 @@ jobs:
           # Include the vertica license so we can test multiple subclusters.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-12-vcluster:
@@ -699,7 +672,6 @@ jobs:
           communal-storage-type: s3
           need-base-vertica-image: 'true'
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-server-upgrade-vcluster:
@@ -721,7 +693,6 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           need-base-vertica-image: 'true'
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-operator-upgrade:
@@ -747,7 +718,6 @@ jobs:
           e2e-parallelism: 1
           vertica-deployment-method: admintools
           need-legacy-image: true
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-udx-admintools:
@@ -772,7 +742,6 @@ jobs:
           # For admintools udx test, we are not using the test image,
           # and we still need to download some test packages.
           skip-download-test-packages: false
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-udx-vcluster:
@@ -794,7 +763,6 @@ jobs:
           vertica-image: ${{ needs.build.outputs.full-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
-          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
           e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   upload-operator-to-private-repo:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,7 +132,7 @@ jobs:
           communal-storage-type: azb
           deploy-with: olm
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
   
   e2e-leg-1-admintools-previous-release:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 1' || inputs.e2e_test_suites == '') }}
@@ -154,7 +154,7 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           deploy-with: olm
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-1-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 1' || inputs.e2e_test_suites == '')}}
@@ -175,7 +175,7 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: azb
           deploy-with: olm
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-2-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 2' || inputs.e2e_test_suites == '') }}
@@ -197,7 +197,7 @@ jobs:
           communal-storage-type: hostpath
           controllers-scope: namespace
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-2-admintools-previous-release:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 2' || inputs.e2e_test_suites == '') }}
@@ -219,7 +219,7 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: hostpath
           controllers-scope: namespace
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-2-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 2' || inputs.e2e_test_suites == '')}}
@@ -240,7 +240,7 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           controllers-scope: namespace
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-3-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 3' || inputs.e2e_test_suites == '') }}
@@ -261,7 +261,7 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: hostpath
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
   
   e2e-leg-3-vclusterops-previous-release:
     if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 3' || inputs.e2e_test_suites == '' }}
@@ -282,7 +282,7 @@ jobs:
           artifact-suffix: "-24.1.0-release"
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-3-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 3' || inputs.e2e_test_suites == '')}}
@@ -302,7 +302,7 @@ jobs:
           vertica-image: ${{ needs.build.outputs.full-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-4-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 4' || inputs.e2e_test_suites == '') }}
@@ -326,7 +326,7 @@ jobs:
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
   
   e2e-leg-4-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 4' || inputs.e2e_test_suites == '')}}
@@ -349,7 +349,7 @@ jobs:
           vertica-superuser-name: myadmin
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-4-admintools-vdb-gen:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 4 vdb-gen' || inputs.e2e_test_suites == '') }}
@@ -373,7 +373,7 @@ jobs:
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
   
   e2e-leg-4-vcluster-vdb-gen:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 4 vdb-gen' || inputs.e2e_test_suites == '')}}
@@ -396,7 +396,7 @@ jobs:
           vertica-superuser-name: myadmin
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-5-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 5' || inputs.e2e_test_suites == '') }}
@@ -422,7 +422,7 @@ jobs:
           e2e-parallelism: 1
           need-base-vertica-image: 'true'
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-5-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 5' || inputs.e2e_test_suites == '')}}
@@ -447,7 +447,7 @@ jobs:
           # operator running in the k8s cluster.
           e2e-parallelism: 1
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-6-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 6' || inputs.e2e_test_suites == '')}}
@@ -468,7 +468,7 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-6-vcluster-revivedb:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 6 revivedb' || inputs.e2e_test_suites == '')}}
@@ -489,7 +489,7 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-7-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 7' || inputs.e2e_test_suites == '')}}
@@ -510,7 +510,7 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-8-admintools-offline:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'leg 8' || inputs.e2e_test_suites == '')}}
@@ -533,7 +533,7 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           minimum-vertica-image: '24.2.0'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-8-admintools-online:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'leg 8' || inputs.e2e_test_suites == '')}}
@@ -556,7 +556,7 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           minimum-vertica-image: '24.2.0'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-9-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 9' || inputs.e2e_test_suites == '')}}
@@ -580,7 +580,7 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-10-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 10' || inputs.e2e_test_suites == '')}}
@@ -604,7 +604,7 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-11-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 11' || inputs.e2e_test_suites == '')}}
@@ -629,7 +629,7 @@ jobs:
           # Include the vertica license so we can test multiple subclusters.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-leg-12-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 12' || inputs.e2e_test_suites == '')}}
@@ -672,7 +672,7 @@ jobs:
           communal-storage-type: s3
           need-base-vertica-image: 'true'
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-server-upgrade-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster server upgrade' || inputs.e2e_test_suites == '')}}
@@ -693,7 +693,7 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-operator-upgrade:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools operator upgrade' || inputs.e2e_test_suites == '') }}
@@ -718,7 +718,7 @@ jobs:
           e2e-parallelism: 1
           vertica-deployment-method: admintools
           need-legacy-image: true
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-udx-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools udx' || inputs.e2e_test_suites == '') }}
@@ -742,7 +742,7 @@ jobs:
           # For admintools udx test, we are not using the test image,
           # and we still need to download some test packages.
           skip-download-test-packages: false
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
   e2e-udx-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster udx' || inputs.e2e_test_suites == '')}}
@@ -763,7 +763,7 @@ jobs:
           vertica-image: ${{ needs.build.outputs.full-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
-          e2e-retry-times: ${{ inputs.e2e_retry_times }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
   
   upload-operator-to-private-repo:
     needs: [

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,6 +58,14 @@ on:
         - vcluster leg 11
         - vcluster server upgrade
         - vcluster udx
+      e2e_timeout_minutes:
+        description: 'Duration (in minutes) to wait for e2e tests to complete before timing out.'
+        required: false
+        default: '600'
+      e2e_retry_times:
+        description: 'Number of times to retry failed e2e tests'
+        required: false
+        default: '2'
       run_security_scan:
         description: 'What images to scan?'
         type: choice
@@ -128,6 +136,8 @@ jobs:
           communal-storage-type: azb
           deploy-with: olm
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-1-admintools-previous-release:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 1' || inputs.e2e_test_suites == '') }}
@@ -149,6 +159,8 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           deploy-with: olm
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-1-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 1' || inputs.e2e_test_suites == '')}}
@@ -169,6 +181,8 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: azb
           deploy-with: olm
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-2-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 2' || inputs.e2e_test_suites == '') }}
@@ -190,6 +204,8 @@ jobs:
           communal-storage-type: hostpath
           controllers-scope: namespace
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-2-admintools-previous-release:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 2' || inputs.e2e_test_suites == '') }}
@@ -211,6 +227,8 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: hostpath
           controllers-scope: namespace
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-2-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 2' || inputs.e2e_test_suites == '')}}
@@ -231,6 +249,8 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           controllers-scope: namespace
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-3-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 3' || inputs.e2e_test_suites == '') }}
@@ -251,6 +271,8 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: hostpath
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-3-vclusterops-previous-release:
     if: ${{ inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 3' || inputs.e2e_test_suites == '' }}
@@ -271,6 +293,8 @@ jobs:
           artifact-suffix: "-24.1.0-release"
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-3-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 3' || inputs.e2e_test_suites == '')}}
@@ -290,6 +314,8 @@ jobs:
           vertica-image: ${{ needs.build.outputs.full-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-4-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 4' || inputs.e2e_test_suites == '') }}
@@ -313,6 +339,8 @@ jobs:
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-4-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 4' || inputs.e2e_test_suites == '')}}
@@ -335,6 +363,8 @@ jobs:
           vertica-superuser-name: myadmin
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-4-admintools-vdb-gen:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 4 vdb-gen' || inputs.e2e_test_suites == '') }}
@@ -358,6 +388,8 @@ jobs:
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   e2e-leg-4-vcluster-vdb-gen:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 4 vdb-gen' || inputs.e2e_test_suites == '')}}
@@ -380,6 +412,8 @@ jobs:
           vertica-superuser-name: myadmin
           # All helm deployments will use cert-manager to create the webhook cert
           helm-overrides: '--set webhook.certSource=cert-manager'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-5-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools leg 5' || inputs.e2e_test_suites == '') }}
@@ -405,6 +439,8 @@ jobs:
           e2e-parallelism: 1
           need-base-vertica-image: 'true'
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-5-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 5' || inputs.e2e_test_suites == '')}}
@@ -429,6 +465,8 @@ jobs:
           # operator running in the k8s cluster.
           e2e-parallelism: 1
           need-base-vertica-image: 'true'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-6-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 6' || inputs.e2e_test_suites == '')}}
@@ -449,6 +487,8 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-6-vcluster-revivedb:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 6 revivedb' || inputs.e2e_test_suites == '')}}
@@ -469,6 +509,8 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-7-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 7' || inputs.e2e_test_suites == '')}}
@@ -489,6 +531,8 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: hostpath
           minimum-vertica-image: '24.2.0'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-8-admintools-offline:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'leg 8' || inputs.e2e_test_suites == '')}}
@@ -511,6 +555,8 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           minimum-vertica-image: '24.2.0'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-8-admintools-online:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'leg 8' || inputs.e2e_test_suites == '')}}
@@ -533,6 +579,8 @@ jobs:
           vertica-deployment-method: admintools
           communal-storage-type: azb
           minimum-vertica-image: '24.2.0'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-9-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 9' || inputs.e2e_test_suites == '')}}
@@ -556,6 +604,8 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-10-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 10' || inputs.e2e_test_suites == '')}}
@@ -579,6 +629,8 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-11-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 11' || inputs.e2e_test_suites == '')}}
@@ -603,6 +655,8 @@ jobs:
           # Include the vertica license so we can test multiple subclusters.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-leg-12-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 12' || inputs.e2e_test_suites == '')}}
@@ -645,6 +699,8 @@ jobs:
           communal-storage-type: s3
           need-base-vertica-image: 'true'
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-server-upgrade-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster server upgrade' || inputs.e2e_test_suites == '')}}
@@ -665,6 +721,8 @@ jobs:
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
           need-base-vertica-image: 'true'
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-operator-upgrade:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools operator upgrade' || inputs.e2e_test_suites == '') }}
@@ -689,6 +747,8 @@ jobs:
           e2e-parallelism: 1
           vertica-deployment-method: admintools
           need-legacy-image: true
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-udx-admintools:
     if: ${{ ! contains(github.ref, 'k8s-sync')  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'admintools udx' || inputs.e2e_test_suites == '') }}
@@ -712,6 +772,8 @@ jobs:
           # For admintools udx test, we are not using the test image,
           # and we still need to download some test packages.
           skip-download-test-packages: false
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
 
   e2e-udx-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster udx' || inputs.e2e_test_suites == '')}}
@@ -732,6 +794,8 @@ jobs:
           vertica-image: ${{ needs.build.outputs.full-vertica-image }}
           vertica-deployment-method: vclusterops
           communal-storage-type: s3
+          e2e-timeout-minutes: ${{ inputs.e2e_timeout_minutes }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times }}
   
   upload-operator-to-private-repo:
     needs: [

--- a/scripts/setup-minio.sh
+++ b/scripts/setup-minio.sh
@@ -58,7 +58,7 @@ set -o xtrace
 
 # First setup the operator
 kubectl krew update
-kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/d1817869b86fd040a923682b1392bdb232947bf5/plugins/minio.yaml
+echo "minio" | kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/d1817869b86fd040a923682b1392bdb232947bf5/plugins/minio.yaml
 # If these images ever change, they must be updated in tests/external-images-s3-ci.txt
 kubectl minio init --image minio/operator:v4.5.7
 

--- a/scripts/setup-minio.sh
+++ b/scripts/setup-minio.sh
@@ -58,7 +58,8 @@ set -o xtrace
 
 # First setup the operator
 kubectl krew update
-echo "minio" | kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/d1817869b86fd040a923682b1392bdb232947bf5/plugins/minio.yaml
+# Use echo "" to resolve krew install hang issue with nick-fields/retry plugin
+echo "" | kubectl krew install --manifest-url https://raw.githubusercontent.com/kubernetes-sigs/krew-index/d1817869b86fd040a923682b1392bdb232947bf5/plugins/minio.yaml
 # If these images ever change, they must be updated in tests/external-images-s3-ci.txt
 kubectl minio init --image minio/operator:v4.5.7
 


### PR DESCRIPTION
This PR uses a Github extension to auto retry e2e test upon failure. Given the instability of K8s e2e test, a retry mechanism reduces the need for manual reruns and enhances the success rate of the CI/CD pipeline.