### PR TITLE
Add threshold for scale down

### DIFF
--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -206,6 +206,11 @@ runs:
           fi
         fi
 
+        # Setup prometheus and prometheus-adapter
+        if [[ "${{ inputs.leg-identifier }}" == "leg-12" ]]; then
+          export NEED_PROMETHEUS=true
+        fi
+
         # Run int test script
         if [[ "${{ inputs.communal-storage-type }}" == "azb" ]]; then
           scripts/run-k8s-int-tests.sh -s -e tests/external-images-azb-ci.txt;

--- a/api/v1beta1/helpers.go
+++ b/api/v1beta1/helpers.go
@@ -194,6 +194,52 @@ func (v *VerticaAutoscaler) GetHPAMetrics() []autoscalingv2.MetricSpec {
 	return metrics
 }
 
+// HasScaleDownThreshold returns true if scale down threshold is set
+func (v *VerticaAutoscaler) HasScaleDownThreshold() bool {
+	if !v.IsCustomMetricsEnabled() {
+		return false
+	}
+	for i := range v.Spec.CustomAutoscaler.Metrics {
+		m := &v.Spec.CustomAutoscaler.Metrics[i]
+		if m.ScaleDownThreshold != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// GetMinReplicas calculates the minReplicas based on the scale down
+// threshold, and returns it
+func (v *VerticaAutoscaler) GetMinReplicas() *int32 {
+	if v.HasScaleDownThreshold() {
+		return &v.Spec.TargetSize
+	}
+	return v.Spec.CustomAutoscaler.MinReplicas
+}
+
+// GetMetricMap returns a map whose key is the metric name and the value is
+// the metric's definition.
+func (v *VerticaAutoscaler) GetMetricMap() map[string]*MetricDefinition {
+	mMap := make(map[string]*MetricDefinition)
+	for i := range v.Spec.CustomAutoscaler.Metrics {
+		m := &v.Spec.CustomAutoscaler.Metrics[i]
+		var name string
+		if m.Metric.Pods != nil {
+			name = m.Metric.Pods.Metric.Name
+		} else if m.Metric.Object != nil {
+			name = m.Metric.Object.Metric.Name
+		} else if m.Metric.External != nil {
+			name = m.Metric.External.Metric.Name
+		} else if m.Metric.Resource != nil {
+			name = m.Metric.Resource.Name.String()
+		} else {
+			name = m.Metric.ContainerResource.Name.String()
+		}
+		mMap[name] = m
+	}
+	return mMap
+}
+
 func MakeSampleVrpqName() types.NamespacedName {
 	return types.NamespacedName{Name: "vrpq-sample", Namespace: "default"}
 }

--- a/api/v1beta1/verticaautoscaler_types.go
+++ b/api/v1beta1/verticaautoscaler_types.go
@@ -121,6 +121,12 @@ type MetricDefinition struct {
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// The threshold to use for scaling down. It must be of the same type as
+	// the one used for scaling up, defined in the metric field.
+	ScaleDownThreshold *autoscalingv2.MetricTarget `json:"scaleDownThreshold,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// The custom metric to be used for autocaling.
 	Metric autoscalingv2.MetricSpec `json:"metric,omitempty"`
 }
@@ -173,12 +179,21 @@ type VerticaAutoscalerConditionType string
 const (
 	// TargetSizeInitialized indicates whether the operator has initialized targetSize in the spec
 	TargetSizeInitialized VerticaAutoscalerConditionType = "TargetSizeInitialized"
+	// ScalingActive indicates that the horizontal pod autoscaler can fetch the metric
+	// and is ready for whenever scaling is needed.
+	ScalingActive VerticaAutoscalerConditionType = "ScalingActive"
 )
 
 // Fixed index entries for each condition.
 const (
 	TargetSizeInitializedIndex = iota
+	ScalingActiveIndex
 )
+
+var VasConditionIndexMap = map[VerticaAutoscalerConditionType]int{
+	TargetSizeInitialized: TargetSizeInitializedIndex,
+	ScalingActive:         ScalingActiveIndex,
+}
 
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:categories=all;vertica,shortName=vas
@@ -258,7 +273,7 @@ func MakeVASWithMetrics() *VerticaAutoscaler {
 				Metric: autoscalingv2.MetricSpec{
 					Type: autoscalingv2.ResourceMetricSourceType,
 					Resource: &autoscalingv2.ResourceMetricSource{
-						Name: "cpu",
+						Name: corev1.ResourceCPU,
 						Target: autoscalingv2.MetricTarget{
 							Type:               autoscalingv2.UtilizationMetricType,
 							AverageUtilization: &cpu, // Scale when CPU exceeds 80%

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -76,3 +76,7 @@ commands:
   - script: make undeploy || true
   - script: if [ "$CONTROLLERS_SCOPE" != "namespace" ]; then NAMESPACE=verticadb-operator make deploy; fi
   - script: if [ "$CONTROLLERS_SCOPE" = "namespace" ]; then NAMESPACE=verticadb-operator make deploy-webhook; fi
+  - script: make undeploy-prometheus || true
+  - script: if [ "$NEED_PROMETHEUS" = "true" ]; then make deploy-prometheus; fi
+  - script: make undeploy-prometheus-adapter || true
+  - script: if [ "$NEED_PROMETHEUS" = "true" ]; then make deploy-prometheus-adapter; fi

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -877,7 +877,7 @@ func BuildHorizontalPodAutoscaler(nm types.NamespacedName, vas *v1beta1.VerticaA
 				Kind:       v1beta1.VerticaAutoscalerKind,
 				Name:       vas.Name,
 			},
-			MinReplicas: vas.Spec.CustomAutoscaler.MinReplicas,
+			MinReplicas: vas.GetMinReplicas(),
 			MaxReplicas: vas.Spec.CustomAutoscaler.MaxReplicas,
 			Metrics:     vas.GetHPAMetrics(),
 			Behavior:    vas.Spec.CustomAutoscaler.Behavior,

--- a/pkg/controllers/vas/hpa.go
+++ b/pkg/controllers/vas/hpa.go
@@ -1,0 +1,88 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vas
+
+import (
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+)
+
+const (
+	errorCmpResult = iota - 2
+	lowerThanCmpResult
+	equalToCmpResult
+	greaterThanCmpResult
+)
+
+type metricStatus struct {
+	name   string
+	status autoscalingv2.MetricValueStatus
+}
+
+// getCurrentMetricStatus extracts and returns a metric's status from the
+// hpa's status.
+func getCurrentMetricStatus(m *autoscalingv2.MetricStatus) *metricStatus {
+	ms := &metricStatus{}
+	switch m.Type {
+	case autoscalingv2.PodsMetricSourceType:
+		ms.name = m.Pods.Metric.Name
+		ms.status = m.Pods.Current
+	case autoscalingv2.ObjectMetricSourceType:
+		ms.name = m.Object.Metric.Name
+		ms.status = m.Object.Current
+	case autoscalingv2.ExternalMetricSourceType:
+		ms.name = m.External.Metric.Name
+		ms.status = m.External.Current
+	case autoscalingv2.ResourceMetricSourceType:
+		ms.name = m.Resource.Name.String()
+		ms.status = m.Resource.Current
+	case autoscalingv2.ContainerResourceMetricSourceType:
+		ms.name = m.ContainerResource.Name.String()
+		ms.status = m.ContainerResource.Current
+	default:
+		return nil
+	}
+	return ms
+}
+
+// cmp returns 0 if the metric's value is equal to the target,
+// -1 if it is less than the target, or 1 if it is greater than the target.
+func (ms *metricStatus) cmp(mt *autoscalingv2.MetricTarget) int {
+	if ms.status.AverageUtilization != nil {
+		if mt.AverageUtilization != nil {
+			return ms.cmpAverageUtilization(*mt.AverageUtilization)
+		}
+	}
+	if ms.status.Value != nil {
+		if mt.Value != nil {
+			return ms.status.Value.Cmp(*mt.Value)
+		}
+	}
+	if ms.status.AverageValue != nil {
+		if mt.AverageValue != nil {
+			return ms.status.AverageValue.Cmp(*mt.AverageValue)
+		}
+	}
+	return errorCmpResult
+}
+
+func (ms *metricStatus) cmpAverageUtilization(au int32) int {
+	if *ms.status.AverageUtilization > au {
+		return greaterThanCmpResult
+	} else if *ms.status.AverageUtilization == au {
+		return equalToCmpResult
+	}
+	return lowerThanCmpResult
+}

--- a/pkg/controllers/vas/hpareconciler.go
+++ b/pkg/controllers/vas/hpareconciler.go
@@ -58,6 +58,10 @@ func (h *HorizontalPodAutoscalerReconciler) Reconcile(ctx context.Context, req *
 		h.Log.Info("Creating horizontalpodautoscaler", "Name", nm.Name)
 		return ctrl.Result{}, createHpa(ctx, h.VRec, expHpa, h.Vas)
 	}
+	if h.Vas.HasScaleDownThreshold() {
+		// We keep the current value because it will be changed elsewhere.
+		*expHpa.Spec.MinReplicas = *curHpa.Spec.MinReplicas
+	}
 	return ctrl.Result{}, h.updateHPA(ctx, curHpa, expHpa)
 }
 

--- a/pkg/controllers/vas/scaledown_reconciler.go
+++ b/pkg/controllers/vas/scaledown_reconciler.go
@@ -1,0 +1,90 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ScaledownReconciler is a reconciler handle scale down when a lower
+// threshold is set.
+type ScaledownReconciler struct {
+	VRec *VerticaAutoscalerReconciler
+	Vas  *vapi.VerticaAutoscaler
+	Log  logr.Logger
+}
+
+func MakeScaledownReconciler(v *VerticaAutoscalerReconciler, vas *vapi.VerticaAutoscaler,
+	log logr.Logger) controllers.ReconcileActor {
+	return &ScaledownReconciler{VRec: v, Vas: vas, Log: log.WithName("ScaledownReconciler")}
+}
+
+// Reconcile will handle updating the hpa based on the metrics current value.
+// Only metrics with a scale down threshold set are taken into account.
+func (s *ScaledownReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if !s.Vas.HasScaleDownThreshold() {
+		return ctrl.Result{}, nil
+	}
+	nm := names.GenHPAName(s.Vas)
+	curHpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	err := s.VRec.Client.Get(ctx, nm, curHpa)
+	if err != nil {
+		s.Log.Info("Cannot get the hpa. Requeueing to retry.", "Name", nm.Name)
+		return ctrl.Result{Requeue: true}, err
+	}
+	mMap := s.Vas.GetMetricMap()
+	var newMinReplicas int32
+	for i := range curHpa.Status.CurrentMetrics {
+		cm := &curHpa.Status.CurrentMetrics[i]
+		mStatus := getCurrentMetricStatus(cm)
+		if mStatus == nil {
+			continue
+		}
+		md, found := mMap[mStatus.name]
+		if !found {
+			return ctrl.Result{}, fmt.Errorf("could not find metric %s in VAS spec", mStatus.name)
+		}
+		if md.ScaleDownThreshold == nil {
+			// skip the metric because it does not have scale down threshold.
+			continue
+		}
+		cmpResult := mStatus.cmp(md.ScaleDownThreshold)
+		if cmpResult == errorCmpResult {
+			return ctrl.Result{}, errors.New("hpa status not set correctly")
+		}
+		if cmpResult < 0 {
+			s.Log.Info("Metric's value is lower than the scale-down threshold.", "metric", mStatus.name)
+			newMinReplicas = *s.Vas.Spec.CustomAutoscaler.MinReplicas
+		} else {
+			newMinReplicas = s.Vas.Spec.TargetSize
+			break
+		}
+	}
+	if *curHpa.Spec.MinReplicas != newMinReplicas {
+		*curHpa.Spec.MinReplicas = newMinReplicas
+		return ctrl.Result{}, s.VRec.Client.Update(ctx, curHpa)
+	}
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/vas/scaledown_reconciler_test.go
+++ b/pkg/controllers/vas/scaledown_reconciler_test.go
@@ -1,0 +1,80 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vas
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("scaledown_reconcile", func() {
+	ctx := context.Background()
+
+	It("should set minreplicas based on current metric", func() {
+		vas := v1beta1.MakeVASWithMetrics()
+		vas.Spec.TargetSize = 4
+		m := &vas.Spec.CustomAutoscaler.Metrics[0]
+		cpu := int32(60)
+		m.ScaleDownThreshold = &autoscalingv2.MetricTarget{
+			Type:               autoscalingv2.UtilizationMetricType,
+			AverageUtilization: &cpu,
+		}
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
+
+		r := MakeHorizontalPodAutoscalerReconciler(vasRec, vas, logger)
+		res, err := r.Reconcile(ctx, &ctrl.Request{})
+		defer v1beta1_test.DeleteHPA(ctx, k8sClient, vas)
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(err).Should(Succeed())
+
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+		nm := names.GenHPAName(vas)
+		Expect(k8sClient.Get(ctx, nm, hpa)).Should(Succeed())
+		Expect(*hpa.Spec.MinReplicas).Should(Equal(vas.Spec.TargetSize))
+		Expect(hpa.Spec.MaxReplicas).Should(Equal(vas.Spec.CustomAutoscaler.MaxReplicas))
+
+		// Update hpa status
+		curCPU := int32(55)
+		hpa.Status.CurrentMetrics = []autoscalingv2.MetricStatus{
+			{
+				Type: autoscalingv2.ResourceMetricSourceType,
+				Resource: &autoscalingv2.ResourceMetricStatus{
+					Name: corev1.ResourceCPU,
+					Current: autoscalingv2.MetricValueStatus{
+						AverageUtilization: &curCPU,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, hpa)).Should(Succeed())
+
+		r = MakeScaledownReconciler(vasRec, vas, logger)
+		res, err = r.Reconcile(ctx, &ctrl.Request{})
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(err).Should(Succeed())
+		Expect(k8sClient.Get(ctx, nm, hpa)).Should(Succeed())
+		Expect(*hpa.Spec.MinReplicas).Should(Equal(*vas.Spec.CustomAutoscaler.MinReplicas))
+	})
+})

--- a/pkg/controllers/vas/verifyhpa_reconciler.go
+++ b/pkg/controllers/vas/verifyhpa_reconciler.go
@@ -1,0 +1,78 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vas
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/vasstatus"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// VerifyHPAReconciler is a reconciler to check if the hpa is ready for scaling.
+type VerifyHPAReconciler struct {
+	VRec *VerticaAutoscalerReconciler
+	Vas  *v1beta1.VerticaAutoscaler
+	Log  logr.Logger
+}
+
+func MakeVerifyHPAReconciler(v *VerticaAutoscalerReconciler, vas *v1beta1.VerticaAutoscaler,
+	log logr.Logger) controllers.ReconcileActor {
+	return &VerifyHPAReconciler{VRec: v, Vas: vas, Log: log.WithName("VerifyHPAReconciler")}
+}
+
+// Reconcile will check the hpa status and requeue if the hpa is not ready.
+func (v *VerifyHPAReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
+	if !v.Vas.IsCustomMetricsEnabled() {
+		return ctrl.Result{}, nil
+	}
+	nm := names.GenHPAName(v.Vas)
+	curHpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	err := v.VRec.Client.Get(ctx, nm, curHpa)
+	if err != nil {
+		v.Log.Info("Cannot get the hpa. Requeueing to retry.", "hpa", nm.Name)
+		return ctrl.Result{Requeue: true}, err
+	}
+	conds := curHpa.Status.Conditions
+	cond := v1beta1.VerticaAutoscalerCondition{
+		Type:   v1beta1.ScalingActive,
+		Status: corev1.ConditionFalse,
+	}
+	scalingActive := isStatusConditionPresentAndEqual(conds, autoscalingv2.ScalingActive, corev1.ConditionTrue) &&
+		len(curHpa.Status.CurrentMetrics) == len(v.Vas.Spec.CustomAutoscaler.Metrics)
+	if scalingActive {
+		cond.Status = corev1.ConditionTrue
+	} else {
+		v.Log.Info("hpa is not ready for autoscaling. Requeueing", "hpa", nm.Name)
+	}
+	return ctrl.Result{Requeue: !scalingActive}, vasstatus.UpdateCondition(ctx, v.VRec.Client, v.VRec.Log, req, cond)
+}
+
+func isStatusConditionPresentAndEqual(conditions []autoscalingv2.HorizontalPodAutoscalerCondition,
+	conditionType autoscalingv2.HorizontalPodAutoscalerConditionType, status corev1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}

--- a/pkg/controllers/vas/verifyhpa_reconciler_test.go
+++ b/pkg/controllers/vas/verifyhpa_reconciler_test.go
@@ -1,0 +1,91 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vas
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1beta1 "github.com/vertica/vertica-kubernetes/api/v1beta1"
+	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/v1beta1_test"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("scaledown_reconcile", func() {
+	ctx := context.Background()
+
+	It("should requeue if hpa is not ready", func() {
+		vas := v1beta1.MakeVASWithMetrics()
+		v1beta1_test.CreateVAS(ctx, k8sClient, vas)
+		defer v1beta1_test.DeleteVAS(ctx, k8sClient, vas)
+
+		r := MakeHorizontalPodAutoscalerReconciler(vasRec, vas, logger)
+		res, err := r.Reconcile(ctx, &ctrl.Request{})
+		defer v1beta1_test.DeleteHPA(ctx, k8sClient, vas)
+		Expect(res).Should(Equal(ctrl.Result{}))
+		Expect(err).Should(Succeed())
+
+		req := ctrl.Request{NamespacedName: v1beta1.MakeVASName()}
+		r = MakeVerifyHPAReconciler(vasRec, vas, logger)
+		res, err = r.Reconcile(ctx, &req)
+		Expect(res.Requeue).Should(BeTrue())
+		Expect(err).Should(Succeed())
+
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+		nm := names.GenHPAName(vas)
+		Expect(k8sClient.Get(ctx, nm, hpa)).Should(Succeed())
+		hpa.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{
+				Type:               autoscalingv2.ScalingActive,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, hpa)).Should(Succeed())
+		r = MakeVerifyHPAReconciler(vasRec, vas, logger)
+		res, err = r.Reconcile(ctx, &req)
+		Expect(res.Requeue).Should(BeTrue())
+		Expect(err).Should(Succeed())
+
+		curCPU := int32(55)
+		hpa.Status.CurrentMetrics = []autoscalingv2.MetricStatus{
+			{
+				Type: autoscalingv2.ResourceMetricSourceType,
+				Resource: &autoscalingv2.ResourceMetricStatus{
+					Name: corev1.ResourceCPU,
+					Current: autoscalingv2.MetricValueStatus{
+						AverageUtilization: &curCPU,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, hpa)).Should(Succeed())
+		r = MakeVerifyHPAReconciler(vasRec, vas, logger)
+		res, err = r.Reconcile(ctx, &req)
+		Expect(err).Should(Succeed())
+		Expect(res.Requeue).Should(BeFalse())
+		fetchVas := &v1beta1.VerticaAutoscaler{}
+		Expect(k8sClient.Get(ctx, v1beta1.MakeVASName(), fetchVas)).Should(Succeed())
+		Expect(len(fetchVas.Status.Conditions)).Should(Equal(2))
+		Expect(fetchVas.Status.Conditions[1].Type).Should(Equal(v1beta1.ScalingActive))
+		Expect(fetchVas.Status.Conditions[1].Status).Should(Equal(corev1.ConditionTrue))
+	})
+})

--- a/pkg/controllers/vas/verticaautoscaler_controller.go
+++ b/pkg/controllers/vas/verticaautoscaler_controller.go
@@ -87,7 +87,12 @@ func (r *VerticaAutoscalerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		MakeRefreshCurrentSizeReconciler(r, vas),
 		// Update the selector in the status
 		MakeRefreshSelectorReconciler(r, vas),
+		// Create/Update the hpa
 		MakeHorizontalPodAutoscalerReconciler(r, vas, log),
+		// Check if the hpa is ready
+		MakeVerifyHPAReconciler(r, vas, log),
+		// Scale down based on the lower threshold
+		MakeScaledownReconciler(r, vas, log),
 		// If scaling granularity is Pod, this will resize existing subclusters
 		// depending on the targetSize.
 		MakeSubclusterResizeReconciler(r, vas),

--- a/pkg/vasstatus/status.go
+++ b/pkg/vasstatus/status.go
@@ -66,10 +66,14 @@ func UpdateCondition(ctx context.Context, clnt client.Client, log logr.Logger,
 		if len(vas.Status.Conditions) == 0 {
 			vas.Status.Conditions = append(vas.Status.Conditions, vapi.VerticaAutoscalerCondition{})
 		}
+		if condition.Type == vapi.ScalingActive && len(vas.Status.Conditions) < 2 {
+			vas.Status.Conditions = append(vas.Status.Conditions, vapi.VerticaAutoscalerCondition{})
+		}
 		// Only update if status is different change.  Cannot compare the entire
 		// condition since LastTransitionTime will be different each time.
-		if vas.Status.Conditions[vapi.TargetSizeInitializedIndex].Status != condition.Status {
-			vas.Status.Conditions[vapi.TargetSizeInitializedIndex] = condition
+		index := vapi.VasConditionIndexMap[condition.Type]
+		if vas.Status.Conditions[index].Status != condition.Status {
+			vas.Status.Conditions[index] = condition
 		}
 	}
 

--- a/prometheus/adapter.yaml
+++ b/prometheus/adapter.yaml
@@ -33,21 +33,15 @@ rules:
           pod:
             resource: pod
       metricsQuery: 'avg_over_time(vertica_process_memory_usage_percent[60m])'
-    # # Number of active sessions. Type: guage
-    # - seriesQuery: 'vertica_sessions_running_counter{namespace!="", pod!=""}'
-    #   resources:
-    #     overrides:
-    #       namespace:
-    #         resource: namespace
-    #       pod:
-    #         resource: pod
-    #   metricsQuery: 'sum(increase(vertica_sessions_running_counter[1m])) by (namespace, pod)'
-    # # Number of requests that are queued in the resource pool. Type: guage
-    # - seriesQuery: 'vertica_queued_requests_total{namespace!="", pod!=""}'
-    #   resources:
-    #     overrides:
-    #       namespace:
-    #         resource: namespace
-    #       pod:
-    #         resource: pod
-    #   metricsQuery: 'sum(increase(vertica_queued_requests_total[1m])) by (namespace, pod)'
+    # Total number of active sessions. Used for testing
+    - metricsQuery: sum(vertica_sessions_running_counter{type="active", initiator="user"}) by (namespace, pod)
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: "^(.*)_counter$"
+        as: "${1}_total" # vertica_sessions_running_total
+      seriesQuery: vertica_sessions_running_counter{namespace!="", pod!="", type="active", initiator="user"}

--- a/tests/e2e-leg-12/prometheus-sanity/35-verify-custom-metrics.yaml
+++ b/tests/e2e-leg-12/prometheus-sanity/35-verify-custom-metrics.yaml
@@ -15,7 +15,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      NAMESPACE=$(kubectl get pod v-prometheus-pri1-0 -o=jsonpath='{.metadata.namespace}')
       RESULT=$(kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/pods/v-prometheus-pri1-0/vertica_cpu_aggregate_usage_percentage)
       OUTPUT=$(echo $RESULT | jq -r '.items[0].value')
       # verify the metrics result
@@ -24,7 +23,6 @@ commands:
         exit 1
       fi
   - script: |
-      NAMESPACE=$(kubectl get pod v-prometheus-pri1-0 -o=jsonpath='{.metadata.namespace}')
       RESULT=$(kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/pods/v-prometheus-pri1-0/vertica_process_memory_usage_percent)
       OUTPUT=$(echo $RESULT | jq -r '.items[0].value')
       # verify the metrics result

--- a/tests/e2e-leg-12/scale-down-with-threshold/00-create-secrets.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/00-create-secrets.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/vertica-license/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-12/scale-down-with-threshold/01-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/01-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-12/scale-down-with-threshold/01-deploy-operator.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/01-deploy-operator.yaml
@@ -10,8 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: cd ../../.. && make undeploy-prometheus-adapter PROMETHEUS_ADAPTER_NAMESPACE=$NAMESPACE

--- a/tests/e2e-leg-12/scale-down-with-threshold/02-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/02-assert.yaml
@@ -11,15 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: prometheus-adapter
-status:
-  replicas: 1
-  readyReplicas: 1
+  name: integration-test-role
 ---
-apiVersion: v1
-kind: Service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  name: prometheus-adapter
+  name: integration-test-rb

--- a/tests/e2e-leg-12/scale-down-with-threshold/02-rbac.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/02-rbac.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-12/scale-down-with-threshold/03-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/03-assert.yaml
@@ -11,7 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: cd ../../.. && make deploy-prometheus PROMETHEUS_NAMESPACE=$NAMESPACE
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: su-passwd
+type: Opaque
+data:
+  username: ZGJhZG1pbg==
+  password: dG9wc2VjcmV0

--- a/tests/e2e-leg-12/scale-down-with-threshold/03-password-secret.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/03-password-secret.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: su-passwd
+type: Opaque
+stringData:
+  username: dbadmin
+  password: topsecret

--- a/tests/e2e-leg-12/scale-down-with-threshold/05-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/05-assert.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-scale-down-threshold-pri1
+status:
+  currentReplicas: 5
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-scale-down-threshold

--- a/tests/e2e-leg-12/scale-down-with-threshold/05-setup-vdb.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/05-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-12/scale-down-with-threshold/06-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/06-assert.yaml
@@ -1,0 +1,29 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-scale-down-threshold-pri1
+status:
+  currentReplicas: 5
+  readyReplicas: 5
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-scale-down-threshold
+status:
+  subclusters:
+    - addedToDBCount: 5
+      upNodeCount: 5

--- a/tests/e2e-leg-12/scale-down-with-threshold/06-wait-for-createdb.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/06-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-12/scale-down-with-threshold/15-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/15-assert.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-v-scale-down-threshold
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: k8s-vertica-prometheus-v-scale-down-threshold
+  labels:
+    release: prometheus

--- a/tests/e2e-leg-12/scale-down-with-threshold/15-deploy-prometheus-service-monitor.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/15-deploy-prometheus-service-monitor.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: cd ../../.. && make deploy-prometheus-adapter PROMETHEUS_NAMESPACE=$NAMESPACE PROMETHEUS_ADAPTER_NAMESPACE=$NAMESPACE
+  - script: cd ../../.. && make deploy-prometheus-service-monitor VDB_NAMESPACE=$NAMESPACE DB_USER=dbadmin DB_PASSWORD=topsecret VDB_NAME=v-scale-down-threshold 

--- a/tests/e2e-leg-12/scale-down-with-threshold/20-wait-for-data-pull.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/20-wait-for-data-pull.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "sleep 10"

--- a/tests/e2e-leg-12/scale-down-with-threshold/25-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/25-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: script-verity-prometheus-metrics
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0 

--- a/tests/e2e-leg-12/scale-down-with-threshold/25-verify-prometheus-metrics.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/25-verify-prometheus-metrics.yaml
@@ -24,7 +24,8 @@ data:
     # Setup start and end time for query, e.g: 2024-09-14
     START_TIME=$(date +%Y-%m-%d) 
     END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
-    CMD="kubectl exec v-prometheus-pri1-0 -it -c server -- curl -g http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    NAMESPACE=$(kubectl get pod v-scale-down-threshold-pri1-0 -o=jsonpath='{.metadata.namespace}')
+    CMD="kubectl exec v-scale-down-threshold-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
     RESULT=$(eval $CMD)
     METRICS=$(echo $RESULT | jq -r '.data.result') 
     

--- a/tests/e2e-leg-12/scale-down-with-threshold/30-verify-prometheus-adapter.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/30-verify-prometheus-adapter.yaml
@@ -11,12 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: prometheus-adapter
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus-adapter
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      RESULT=$(kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1)
+      VERSION=$(echo $RESULT | jq -r '.groupVersion')
+      if [ "$VERSION" != "custom.metrics.k8s.io/v1beta1" ]; then
+        echo "Assertion failed: expected group version custom.metrics.k8s.io/v1beta1, got $VERSION."
+        exit 1
+      fi

--- a/tests/e2e-leg-12/scale-down-with-threshold/35-verify-custom-metrics.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/35-verify-custom-metrics.yaml
@@ -1,0 +1,26 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      echo "sleep 120 seconds before starting to verify metrics"
+      sleep 120
+      RESULT=$(kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/pods/v-scale-down-threshold-pri1-0/vertica_sessions_running_total)
+      OUTPUT=$(echo $RESULT | jq -r '.items[0].value')
+      # verify the metrics result
+      if [[ "$OUTPUT" == "" ]]; then
+        echo "empty custom metrics result on vertica_sessions_running_total. Result: $RESULT"
+        exit 1
+      fi

--- a/tests/e2e-leg-12/scale-down-with-threshold/35-verify-custom-metrics.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/35-verify-custom-metrics.yaml
@@ -15,8 +15,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      echo "sleep 120 seconds before starting to verify metrics"
-      sleep 120
+      echo "sleep 60 seconds before starting to verify metrics"
+      sleep 60
       RESULT=$(kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1/namespaces/$NAMESPACE/pods/v-scale-down-threshold-pri1-0/vertica_sessions_running_total)
       OUTPUT=$(echo $RESULT | jq -r '.items[0].value')
       # verify the metrics result

--- a/tests/e2e-leg-12/scale-down-with-threshold/40-create-sessions.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/40-create-sessions.yaml
@@ -14,30 +14,27 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: script-verity-prometheus-metrics
+  name: script-create-sessions
 data:
   entrypoint.sh: |-
     #!/bin/bash
     set -o errexit
     set -o xtrace
-    
-    # Setup start and end time for query, e.g: 2024-09-14
-    START_TIME=$(date +%Y-%m-%d) 
-    END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
-    CMD="kubectl exec v-prometheus-pri1-0 -it -c server -- curl -g http://prometheus-kube-prometheus-prometheus.prometheus.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
-    RESULT=$(eval $CMD)
-    METRICS=$(echo $RESULT | jq -r '.data.result') 
-    
-    # verify the metrics result
-    if [[ "$METRICS" == "" || "$METRICS" == "\[\]" ]]; then
-      echo "empty metrics result: $RESULT found."
-      exit 1
-    fi
+
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    sleep 60
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: script-verity-prometheus-metrics
+  name: script-create-sessions
   labels:
     stern: include
 spec:
@@ -55,4 +52,5 @@ spec:
     - name: entrypoint-volume
       configMap:
         defaultMode: 0777
-        name: script-verity-prometheus-metrics
+        name: script-create-sessions
+

--- a/tests/e2e-leg-12/scale-down-with-threshold/40-create-sessions.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/40-create-sessions.yaml
@@ -24,6 +24,7 @@ data:
     for i in {1..8}; do
       kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
     done
+    sleep 60
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e-leg-12/scale-down-with-threshold/40-create-sessions.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/40-create-sessions.yaml
@@ -21,15 +21,9 @@ data:
     set -o errexit
     set -o xtrace
 
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
-    sleep 60
+    for i in {1..8}; do
+      kubectl exec svc/v-scale-down-threshold-pri1 -c server -- vsql -U dbadmin -w topsecret -c "select sleep('240');" &
+    done
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e-leg-12/scale-down-with-threshold/45-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/45-assert.yaml
@@ -1,0 +1,46 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-scale-down-threshold-vas
+status:
+  conditions:
+  - status: "True"
+    type: TargetSizeInitialized
+  - status: "True"
+    type: ScalingActive
+  selector: vertica.com/subcluster-svc=pri1,app.kubernetes.io/instance=v-scale-down-threshold,app.kubernetes.io/managed-by=verticadb-operator
+  scalingCount: 0
+  currentSize: 5
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: v-scale-down-threshold-vas-hpa
+spec:
+  maxReplicas: 7
+  metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: vertica_sessions_running_total
+      target:
+        type: AverageValue
+        averageValue: "5"
+  minReplicas: 5
+  scaleTargetRef:
+    apiVersion: vertica.com/v1beta1
+    kind: VerticaAutoscaler
+    name: v-scale-down-threshold-vas

--- a/tests/e2e-leg-12/scale-down-with-threshold/45-create-vas.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/45-create-vas.yaml
@@ -1,0 +1,23 @@
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-scale-down-threshold-vas
+spec:
+  verticaDBName: v-scale-down-threshold
+  serviceName: pri1
+  scalingGranularity: Pod
+  customAutoscaler:
+    minReplicas: 3
+    maxReplicas: 7
+    metrics:
+      - metric:
+          type: Pods
+          pods:
+            metric:
+              name: vertica_sessions_running_total
+            target:
+              type: AverageValue
+              averageValue: 5
+        scaleDownThreshold:
+          type: AverageValue
+          averageValue: 1

--- a/tests/e2e-leg-12/scale-down-with-threshold/50-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/50-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-scale-down-threshold-vas
+spec:
+  targetSize: 5
+status:
+  scalingCount: 0
+  currentSize: 5

--- a/tests/e2e-leg-12/scale-down-with-threshold/50-check-scale-down1.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/50-check-scale-down1.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "sleep 120"

--- a/tests/e2e-leg-12/scale-down-with-threshold/55-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/55-assert.yaml
@@ -20,3 +20,11 @@ spec:
 status:
   scalingCount: 1
   currentSize: 3
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: v-scale-down-threshold-vas-hpa
+spec:
+  maxReplicas: 7
+  minReplicas: 3

--- a/tests/e2e-leg-12/scale-down-with-threshold/55-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/55-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1beta1
+kind: VerticaAutoscaler
+metadata:
+  name: v-scale-down-threshold-vas
+spec:
+  targetSize: 3
+status:
+  scalingCount: 1
+  currentSize: 3

--- a/tests/e2e-leg-12/scale-down-with-threshold/55-check-scale-down2.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/55-check-scale-down2.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "sleep 120"

--- a/tests/e2e-leg-12/scale-down-with-threshold/95-delete-cr.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-12/scale-down-with-threshold/95-errors.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/95-errors.yaml
@@ -11,7 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: cd ../../.. && make undeploy-prometheus PROMETHEUS_NAMESPACE=$NAMESPACE
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator

--- a/tests/e2e-leg-12/scale-down-with-threshold/96-assert.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/96-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-12/scale-down-with-threshold/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-12/scale-down-with-threshold/96-errors.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/96-errors.yaml
@@ -11,23 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: prometheus-prometheus-kube-prometheus-prometheus
-status:
-  replicas: 1
-  readyReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: prometheus-kube-prometheus-operator
-status:
-  replicas: 1
-  readyReplicas: 1
----
 apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus-kube-prometheus-prometheus
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-12/scale-down-with-threshold/99-delete-ns.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/99-delete-ns.yaml
@@ -11,22 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Secret
-metadata:
-  name: prometheus-v-prometheus
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: k8s-vertica-prometheus-v-prometheus
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: prometheus-kube-prometheus-operator
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus-kube-prometheus-prometheus
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-12/scale-down-with-threshold/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-12/scale-down-with-threshold/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-12/scale-down-with-threshold/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-scale-down-threshold
+  annotations:
+    vertica.com/include-uid-in-path: true
+    vertica.com/vcluster-ops: true
+spec:
+  image: kustomize-vertica-image
+  initPolicy: CreateSkipPackageInstall
+  communal: {}
+  local:
+    requestSize: 250Mi
+  imagePullPolicy: IfNotPresent
+  passwordSecret: su-passwd
+  # We pick a cluster size that is too big for the CE license. This relies on
+  # having a license, which will be added by kustomize.
+  subclusters:
+    - name: pri1
+      size: 5
+      type: primary
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
This adds a new field `scaleDownThreshold` to the metric's definition. It will be used to control scale down i.e scale down will happen only when the metric's value is lower than this new field's value.
As the hpa does not natively support 2 thresholds, this works through a hack: we know that scaling cannot happen if the currentReplicas is equal to the minReplicas so the operator sets the hpa minReplicas to the VerticaAutoscaler's targetSize as long as the metric's value is greater than scaleDownThreshold thus preventing scale down. The moment the value is lower than scaleDownThreshold, the operator update the hpa minReplicas to its correct value (from vas) which will trigger scale down.
This will not work as expected with the scale-down stabilization window as the new threshold is not part of the hpa. So, it will be recommended to either set a stabilization window or set scaleDownThreshold for a stable scaling down experience

NB: Using the scale-down stabilization window is also a very good way to have a stable scaling down process. A stabilization window long enough will assure the metric has been lower long enough to safely scale down.