### PR TITLE
Add routing label to sandbox pods

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1511,7 +1511,7 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 }
 
 // BuildSandboxConfigMap builds a config map for sandbox controller
-func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox string, forUpgrade bool) *corev1.ConfigMap {
+func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox string, disableRouting bool) *corev1.ConfigMap {
 	immutable := true
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -1522,7 +1522,7 @@ func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox
 			Name:            nm.Name,
 			Namespace:       nm.Namespace,
 			Labels:          MakeLabelsForSandboxConfigMap(vdb),
-			Annotations:     MakeAnnotationsForSandboxConfigMap(vdb, forUpgrade),
+			Annotations:     MakeAnnotationsForSandboxConfigMap(vdb, disableRouting),
 			OwnerReferences: []metav1.OwnerReference{vdb.GenerateOwnerReference()},
 		},
 		// the data should be immutable since dbName and sandboxName are fixed

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1511,7 +1511,7 @@ func BuildStsSpec(nm types.NamespacedName, vdb *vapi.VerticaDB, sc *vapi.Subclus
 }
 
 // BuildSandboxConfigMap builds a config map for sandbox controller
-func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox string) *corev1.ConfigMap {
+func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox string, forUpgrade bool) *corev1.ConfigMap {
 	immutable := true
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -1522,7 +1522,7 @@ func BuildSandboxConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB, sandbox
 			Name:            nm.Name,
 			Namespace:       nm.Namespace,
 			Labels:          MakeLabelsForSandboxConfigMap(vdb),
-			Annotations:     MakeAnnotationsForSandboxConfigMap(vdb),
+			Annotations:     MakeAnnotationsForSandboxConfigMap(vdb, forUpgrade),
 			OwnerReferences: []metav1.OwnerReference{vdb.GenerateOwnerReference()},
 		},
 		// the data should be immutable since dbName and sandboxName are fixed

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -179,8 +179,11 @@ func MakeAnnotationsForVProxyObject(vdb *vapi.VerticaDB) map[string]string {
 
 // MakeAnnotationsForSandboxConfigMap builds the list of annotations that are included
 // in the sandbox config map.
-func MakeAnnotationsForSandboxConfigMap(vdb *vapi.VerticaDB) map[string]string {
+func MakeAnnotationsForSandboxConfigMap(vdb *vapi.VerticaDB, forUpgrade bool) map[string]string {
 	annotations := MakeAnnotationsForObject(vdb)
+	if forUpgrade {
+		annotations[vmeta.DisableRoutingAnnotation] = "true"
+	}
 	if ver, ok := vdb.Annotations[vmeta.VersionAnnotation]; ok {
 		annotations[vmeta.VersionAnnotation] = ver
 	}

--- a/pkg/controllers/sandbox/sandbox_controller.go
+++ b/pkg/controllers/sandbox/sandbox_controller.go
@@ -174,6 +174,9 @@ func (r *SandboxConfigMapReconciler) constructActors(vdb *v1.VerticaDB, log logr
 		// Update the vdb status including subclusters[].shutdown, after a stop_db, stop_sc
 		// or a restart
 		vdbcontroller.MakeStatusReconcilerWithShutdown(r.Client, r.Scheme, log, vdb, pfacts),
+		// Ensure we add labels to any pod rescheduled so that Service objects route traffic to it.
+		vdbcontroller.MakeClientRoutingLabelReconcilerWithDisableRouting(r, log, vdb, pfacts, vdbcontroller.PodRescheduleApplyMethod, "",
+			vmeta.GetDisableRouting(configMap.Annotations)),
 		// Scale down the subclusters' statefulsets to zero after the subclusters are shut down
 		MakeScaleStafulsetReconciler(r, vdb, pfacts),
 	}

--- a/pkg/controllers/sandbox/unsandboxsubcluster_reconciler_test.go
+++ b/pkg/controllers/sandbox/unsandboxsubcluster_reconciler_test.go
@@ -33,7 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var _ = Describe("sandboxsubcluster_reconcile", func() {
+var _ = Describe("unsandboxsubcluster_reconcile", func() {
 	ctx := context.Background()
 	maincluster := "main"
 	subcluster1 := "sc1"
@@ -92,7 +92,7 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 		nm := names.GenSandboxConfigMapName(vdb, sandbox1)
-		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1)
+		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1, false)
 		Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
 		defer test.DeleteConfigMap(ctx, k8sClient, vdb, sandbox1)
 
@@ -127,7 +127,7 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		nm := names.GenSandboxConfigMapName(vdb, sandbox1)
-		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1)
+		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1, false)
 		Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
@@ -201,7 +201,7 @@ var _ = Describe("sandboxsubcluster_reconcile", func() {
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		nm := names.GenSandboxConfigMapName(vdb, sandbox1)
-		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1)
+		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1, false)
 		Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -1052,6 +1052,13 @@ func (r *OnlineUpgradeReconciler) redirectConnectionsToReplicaGroupB(ctx context
 	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
+	// Now that routing to the sandbox is allowed, we no longer need
+	// disableRouting annotation so we can safely turn it off.
+	sbMan := MakeSandboxConfigMapManager(r.VRec, r.VDB, r.sandboxName, "" /*no uuid*/)
+	_, err = sbMan.turnOffDisableRoutingAnnotation(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	// then remove client routing labels from replica group a so no traffic is routed to the old main cluster
 	methodType := DrainNodeApplyMethod
 	if vmeta.UseVProxy(r.VDB.Annotations) {

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -583,6 +583,7 @@ func (r *OnlineUpgradeReconciler) sandboxReplicaGroupB(ctx context.Context) (ctr
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Drive the actual sandbox command. When this returns we know the sandbox is complete.
 	actor := MakeSandboxSubclusterReconciler(r.VRec, r.Log, r.VDB, r.PFacts[vapi.MainCluster], r.Dispatcher,
 		r.VRec.Client, true /* forUpgrade */)
 	r.Manager.traceActorReconcile(actor)

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -583,8 +583,8 @@ func (r *OnlineUpgradeReconciler) sandboxReplicaGroupB(ctx context.Context) (ctr
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	// Drive the actual sandbox command. When this returns we know the sandbox is complete.
-	actor := MakeSandboxSubclusterReconciler(r.VRec, r.Log, r.VDB, r.PFacts[vapi.MainCluster], r.Dispatcher, r.VRec.Client, true)
+	actor := MakeSandboxSubclusterReconciler(r.VRec, r.Log, r.VDB, r.PFacts[vapi.MainCluster], r.Dispatcher,
+		r.VRec.Client, true /* forUpgrade */)
 	r.Manager.traceActorReconcile(actor)
 	res, err := actor.Reconcile(ctx, &ctrl.Request{})
 	if verrors.IsReconcileAborted(res, err) {
@@ -1052,12 +1052,15 @@ func (r *OnlineUpgradeReconciler) redirectConnectionsToReplicaGroupB(ctx context
 	if verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
-	// Now that routing to the sandbox is allowed, we no longer need
-	// disableRouting annotation so we can safely turn it off.
-	sbMan := MakeSandboxConfigMapManager(r.VRec, r.VDB, r.sandboxName, "" /*no uuid*/)
-	_, err = sbMan.turnOffDisableRoutingAnnotation(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
+
+	if !vmeta.UseVProxy(r.VDB.Annotations) {
+		// Now that routing to the sandbox is allowed, we no longer need
+		// disableRouting annotation so we can safely turn it off.
+		sbMan := MakeSandboxConfigMapManager(r.VRec, r.VDB, r.sandboxName, "" /* no uuid */)
+		_, err = sbMan.turnOffDisableRoutingAnnotation(ctx)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	// then remove client routing labels from replica group a so no traffic is routed to the old main cluster
 	methodType := DrainNodeApplyMethod

--- a/pkg/controllers/vdb/sandbox_configmap.go
+++ b/pkg/controllers/vdb/sandbox_configmap.go
@@ -85,6 +85,20 @@ func (s *SandboxConfigMapManager) triggerSandboxController(ctx context.Context, 
 	return vk8s.MetaUpdate(ctx, s.vrec.GetClient(), nm, s.configMap, chgs)
 }
 
+// turnOffDisableRoutingAnnotation sets the disable routing annotation in the configMap to false.
+func (s *SandboxConfigMapManager) turnOffDisableRoutingAnnotation(ctx context.Context) (bool, error) {
+	if err := s.fetchConfigMap(ctx); err != nil {
+		return false, err
+	}
+	anns := make(map[string]string)
+	anns[vmeta.DisableRoutingAnnotation] = "false"
+	chgs := vk8s.MetaChanges{
+		NewAnnotations: anns,
+	}
+	nm := names.GenSandboxConfigMapName(s.vdb, s.sandbox)
+	return vk8s.MetaUpdate(ctx, s.vrec.GetClient(), nm, s.configMap, chgs)
+}
+
 // fetchConfigMap will fetch the sandbox configmap
 func (s *SandboxConfigMapManager) fetchConfigMap(ctx context.Context) error {
 	nm := names.GenSandboxConfigMapName(s.vdb, s.sandbox)

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
@@ -289,7 +289,9 @@ func (s *SandboxSubclusterReconciler) findInitiatorIPs(ctx context.Context, sand
 func (s *SandboxSubclusterReconciler) checkSandboxConfigMap(ctx context.Context, sandbox string) error {
 	nm := names.GenSandboxConfigMapName(s.Vdb, sandbox)
 	curCM := &corev1.ConfigMap{}
-	newCM := builder.BuildSandboxConfigMap(nm, s.Vdb, sandbox, s.ForUpgrade)
+	// if proxy is enabled, we do not need to disable routing to the sandbox pods.
+	disableRouting := !vmeta.UseVProxy(s.Vdb.Annotations) && s.ForUpgrade
+	newCM := builder.BuildSandboxConfigMap(nm, s.Vdb, sandbox, disableRouting)
 	err := s.Client.Get(ctx, nm, curCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		s.Log.Info("Creating sandbox config map", "Name", nm)

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
@@ -289,7 +289,7 @@ func (s *SandboxSubclusterReconciler) findInitiatorIPs(ctx context.Context, sand
 func (s *SandboxSubclusterReconciler) checkSandboxConfigMap(ctx context.Context, sandbox string) error {
 	nm := names.GenSandboxConfigMapName(s.Vdb, sandbox)
 	curCM := &corev1.ConfigMap{}
-	newCM := builder.BuildSandboxConfigMap(nm, s.Vdb, sandbox)
+	newCM := builder.BuildSandboxConfigMap(nm, s.Vdb, sandbox, s.ForUpgrade)
 	err := s.Client.Get(ctx, nm, curCM)
 	if err != nil && kerrors.IsNotFound(err) {
 		s.Log.Info("Creating sandbox config map", "Name", nm)

--- a/pkg/controllers/vdb/unsandboxsubcluster_reconciler_test.go
+++ b/pkg/controllers/vdb/unsandboxsubcluster_reconciler_test.go
@@ -78,7 +78,7 @@ var _ = Describe("unsandboxsubcluster_reconcile", func() {
 		test.CreatePods(ctx, k8sClient, vdb, test.AllPodsRunning)
 		defer test.DeletePods(ctx, k8sClient, vdb)
 		nm := names.GenSandboxConfigMapName(vdb, sandbox1)
-		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1)
+		cm := builder.BuildSandboxConfigMap(nm, vdb, sandbox1, false)
 		Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
 		defer test.DeleteConfigMap(ctx, k8sClient, vdb, sandbox1)
 		test.CreateVDB(ctx, k8sClient, vdb)

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -373,6 +373,10 @@ const (
 	ReplicationDefaultTimeout             = 60 * 60
 	ReplicationPollingFrequencyAnnotation = "vertica.com/replication-polling-frequency"
 	ReplicationDefaultPollingFrequency    = 5
+
+	// Annotation set in a sandbox configMap. Indicates that routing must be disabled
+	// on the sandbox nodes.
+	DisableRoutingAnnotation = "vertica.com/disable-routing"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -718,6 +722,12 @@ func GetReplicationTimeout(annotations map[string]string) int {
 // GetReplicationPollingFrequency returns the frequency (in seconds) operator will poll async replication status
 func GetReplicationPollingFrequency(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, ReplicationPollingFrequencyAnnotation, ReplicationDefaultPollingFrequency)
+}
+
+// GetDisableRouting returns true if routing must be disabled on the sandbox
+// nodes.
+func GetDisableRouting(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, DisableRoutingAnnotation, false)
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/tests/e2e-leg-10/sandbox-restart/57-check-connection.yaml
+++ b/tests/e2e-leg-10/sandbox-restart/57-check-connection.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      SERVICE_DNS=v-sandbox-restart-sec1.$NAMESPACE.svc.cluster.local
+      kubectl exec -i v-sandbox-restart-pri1-0 -n $NAMESPACE -c server -- bash -c "vsql -h $SERVICE_DNS -c 'select 1;'" 2> /dev/null || exit 1


### PR DESCRIPTION
When a sandbox pod is deleted, the operator does not put back the routing label. This adds the ClientRoutingLabelReconciler in the sandbox controller. It also adds an annotation in the configMap to sometimes disable routing, like in the case of online upgrade where routing to the sandbox must not be allowed until replication is done.