### PR TITLE
Add back nma certs mount

### DIFF
--- a/api/v1/version.go
+++ b/api/v1/version.go
@@ -90,6 +90,8 @@ const (
 	// starting in v24.3-4, v24.4-1, and v25.0-0 pausing sessions works a little differently
 	MinPauseSessionsVersion243 = "v24.3.0-4"
 	MinPauseSessionsVersion244 = "v24.4.0-1"
+	// The NMA TLS certificate can be rotated
+	NMATLSCertRotationMinVersion = "v25.2.0"
 )
 
 // GetVerticaVersionStr returns the vertica version, in string form, that is stored

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -51,6 +51,7 @@ const (
 	HadoopConfigMountName = "hadoop-conf"
 	Krb5SecretMountName   = "krb5"
 	SSHMountName          = "ssh"
+	NMACertsMountName     = "nma-certs"
 	NMATLSConfigMapName   = "nma-tls-config"
 	DepotMountName        = "depot"
 	S3Prefix              = "s3://"

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -356,9 +356,14 @@ func buildStartupConfVolumeMount() corev1.VolumeMount {
 	}
 }
 
-func buildScrutinizeVolumeMounts(vscr *v1beta1.VerticaScrutinize) []corev1.VolumeMount {
+func buildScrutinizeVolumeMounts(vscr *v1beta1.VerticaScrutinize, vdb *vapi.VerticaDB) []corev1.VolumeMount {
 	volMnts := []corev1.VolumeMount{
 		buildScrutinizeSharedVolumeMount(vscr),
+	}
+	if vmeta.UseNMACertsMount(vdb.Annotations) &&
+		vdb.Spec.NMATLSSecret != "" &&
+		secrets.IsK8sSecret(vdb.Spec.NMATLSSecret) {
+		volMnts = append(volMnts, buildNMACertsVolumeMount()...)
 	}
 	return volMnts
 }
@@ -420,6 +425,11 @@ func buildSSHVolumeMounts() []corev1.VolumeMount {
 // used with NMA
 func buildCommonNMAVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 	volMnts := buildScrutinizeVolumeMountForVerticaPod(vdb)
+	if vmeta.UseNMACertsMount(vdb.Annotations) &&
+		vdb.Spec.NMATLSSecret != "" &&
+		secrets.IsK8sSecret(vdb.Spec.NMATLSSecret) {
+		volMnts = append(volMnts, buildNMACertsVolumeMount()...)
+	}
 	return volMnts
 }
 
@@ -436,6 +446,15 @@ func buildScrutinizeVolumeMountForVerticaPod(vdb *vapi.VerticaDB) []corev1.Volum
 			Name:      vapi.LocalDataPVC,
 			SubPath:   vdb.GetPVSubPath("scrutinize"),
 			MountPath: paths.ScrutinizeTmp,
+		},
+	}
+}
+
+func buildNMACertsVolumeMount() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      vapi.NMACertsMountName,
+			MountPath: paths.NMACertsRoot,
 		},
 	}
 }
@@ -468,6 +487,12 @@ func buildVolumes(vdb *vapi.VerticaDB) []corev1.Volume {
 	if vdb.GetSSHSecretName() != "" {
 		vols = append(vols, buildSSHVolume(vdb))
 	}
+	if vmeta.UseVClusterOps(vdb.Annotations) &&
+		vmeta.UseNMACertsMount(vdb.Annotations) &&
+		vdb.Spec.NMATLSSecret != "" &&
+		secrets.IsK8sSecret(vdb.Spec.NMATLSSecret) {
+		vols = append(vols, buildNMACertsSecretVolume(vdb))
+	}
 	if vdb.IsDepotVolumeEmptyDir() {
 		vols = append(vols, buildDepotVolume())
 	}
@@ -482,6 +507,12 @@ func buildVolumes(vdb *vapi.VerticaDB) []corev1.Volume {
 // buildScrutinizeVolumes returns volumes that will be used by the scrutinize pod
 func buildScrutinizeVolumes(vscr *v1beta1.VerticaScrutinize, vdb *vapi.VerticaDB) []corev1.Volume {
 	vols := []corev1.Volume{}
+	if vmeta.UseVClusterOps(vdb.Annotations) &&
+		vmeta.UseNMACertsMount(vdb.Annotations) &&
+		vdb.Spec.NMATLSSecret != "" &&
+		secrets.IsK8sSecret(vdb.Spec.NMATLSSecret) {
+		vols = append(vols, buildNMACertsSecretVolume(vdb))
+	}
 	// we add a volume for the password when the password secret
 	// is on k8s
 	if vdb.Spec.PasswordSecret != "" &&
@@ -738,6 +769,17 @@ func buildSSHVolume(vdb *vapi.VerticaDB) corev1.Volume {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: vdb.GetSSHSecretName(),
+			},
+		},
+	}
+}
+
+func buildNMACertsSecretVolume(vdb *vapi.VerticaDB) corev1.Volume {
+	return corev1.Volume{
+		Name: vapi.NMACertsMountName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: vdb.Spec.NMATLSSecret,
 			},
 		},
 	}
@@ -1132,7 +1174,7 @@ func makeScrutinizeInitContainer(vscr *v1beta1.VerticaScrutinize, vdb *vapi.Vert
 		Image:        vdb.Spec.Image,
 		Name:         names.ScrutinizeInitContainer,
 		Command:      buildScrutinizeCmd(args),
-		VolumeMounts: buildScrutinizeVolumeMounts(vscr),
+		VolumeMounts: buildScrutinizeVolumeMounts(vscr, vdb),
 		Resources:    vscr.Spec.Resources,
 		Env:          buildCommonEnvVars(vdb),
 	}
@@ -1810,6 +1852,14 @@ func buildScrutinizeDBPasswordEnvVars(nm types.NamespacedName) []corev1.EnvVar {
 // buildNMATLSCertsEnvVars returns environment variables about NMA certs,
 // that are needed by NMA and vcluster scrutinize
 func buildNMATLSCertsEnvVars(vdb *vapi.VerticaDB) []corev1.EnvVar {
+	if vmeta.UseNMACertsMount(vdb.Annotations) && secrets.IsK8sSecret(vdb.Spec.NMATLSSecret) {
+		return []corev1.EnvVar{
+			// Provide the path to each of the certs that are mounted in the container.
+			{Name: NMARootCAEnv, Value: fmt.Sprintf("%s/%s", paths.NMACertsRoot, paths.HTTPServerCACrtName)},
+			{Name: NMACertEnv, Value: fmt.Sprintf("%s/%s", paths.NMACertsRoot, corev1.TLSCertKey)},
+			{Name: NMAKeyEnv, Value: fmt.Sprintf("%s/%s", paths.NMACertsRoot, corev1.TLSPrivateKeyKey)},
+		}
+	}
 	notTrue := false
 	configMapName := fmt.Sprintf("%s-%s", vdb.Name, vapi.NMATLSConfigMapName)
 	return []corev1.EnvVar{

--- a/pkg/controllers/vdb/nmacertconfigmapgen_reconciler.go
+++ b/pkg/controllers/vdb/nmacertconfigmapgen_reconciler.go
@@ -23,6 +23,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,6 +48,9 @@ func MakeNMACertConfigMapGenReconciler(vdbrecon *VerticaDBReconciler, log logr.L
 
 // Reconcile will create a TLS secret for the https server if one is missing
 func (h *NMACertConfigMapGenReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
+	if vmeta.UseNMACertsMount(h.Vdb.Annotations) {
+		return ctrl.Result{}, nil
+	}
 	nmaSecret := corev1.Secret{}
 	if !h.tlsSecretsReady(ctx, &nmaSecret) {
 		h.Log.Info("nma secret is not ready yet to create configmap. will retry")

--- a/pkg/controllers/vdb/serviceaccount_reconciler.go
+++ b/pkg/controllers/vdb/serviceaccount_reconciler.go
@@ -76,7 +76,7 @@ func (s *ServiceAccountReconciler) Reconcile(ctx context.Context, _ *ctrl.Reques
 	// There is no need to create the role and rolebinding when the following condition is met:
 	//	- NMA reads certs from mounted volume or non-k8s secret store
 	if vmeta.UseVClusterOps(s.Vdb.Annotations) &&
-		!secrets.IsK8sSecret(s.Vdb.Spec.NMATLSSecret) {
+		(vmeta.UseNMACertsMount(s.Vdb.Annotations) || !secrets.IsK8sSecret(s.Vdb.Spec.NMATLSSecret)) {
 		return ctrl.Result{}, s.saveServiceAccountNameInVDB(ctx, sa.Name)
 	}
 

--- a/pkg/controllers/vdb/tlsservercertgen_reconciler.go
+++ b/pkg/controllers/vdb/tlsservercertgen_reconciler.go
@@ -23,6 +23,7 @@ import (
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/secrets"
@@ -35,8 +36,8 @@ import (
 )
 
 const (
-	ClientServerTLSSecret = "ClientServerTLSSecret"
-	NMATLSSecret          = "NMATLSSecret"
+	clientServerTLSSecret = "ClientServerTLSSecret"
+	nmaTLSSecret          = "NMATLSSecret"
 )
 
 // TLSServerCertGenReconciler will create a secret that has TLS credentials.  This
@@ -58,8 +59,10 @@ func MakeTLSServerCertGenReconciler(vdbrecon *VerticaDBReconciler, log logr.Logg
 // Reconcile will create a TLS secret for the http server if one is missing
 func (h *TLSServerCertGenReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
 	secretFieldNameMap := map[string]string{
-		ClientServerTLSSecret: h.Vdb.Spec.ClientServerTLSSecret,
-		NMATLSSecret:          h.Vdb.Spec.NMATLSSecret,
+		nmaTLSSecret: h.Vdb.Spec.NMATLSSecret,
+	}
+	if !vmeta.UseNMACertsMount(h.Vdb.Annotations) && vmeta.EnableTLSCertsRotation(h.Vdb.Annotations) {
+		secretFieldNameMap[clientServerTLSSecret] = h.Vdb.Spec.ClientServerTLSSecret
 	}
 	err := error(nil)
 	for secretFieldName, secretName := range secretFieldNameMap {
@@ -140,7 +143,7 @@ func (h *TLSServerCertGenReconciler) createSecret(secretFieldName, secretName st
 	// the name already present is the case where the name was filled in but the
 	// secret didn't exist.
 	if secretName == "" {
-		if secretFieldName == NMATLSSecret {
+		if secretFieldName == nmaTLSSecret {
 			secret.GenerateName = fmt.Sprintf("%s-nma-tls-", h.Vdb.Name)
 		} else {
 			secret.GenerateName = fmt.Sprintf("%s-clientserver-tls-", h.Vdb.Name)
@@ -160,9 +163,9 @@ func (h *TLSServerCertGenReconciler) setSecretNameInVDB(ctx context.Context, sec
 		if err := h.VRec.Client.Get(ctx, nm, h.Vdb); err != nil {
 			return err
 		}
-		if secretFieldName == ClientServerTLSSecret {
+		if secretFieldName == clientServerTLSSecret {
 			h.Vdb.Spec.ClientServerTLSSecret = secretName
-		} else if secretFieldName == NMATLSSecret {
+		} else if secretFieldName == nmaTLSSecret {
 			h.Vdb.Spec.NMATLSSecret = secretName
 		}
 		return h.VRec.Client.Update(ctx, h.Vdb)

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -70,6 +70,17 @@ const (
 	MountVProxyCertsAnnotationTrue  = "true"
 	MountVProxyCertsAnnotationFalse = "false"
 
+	// This is a feature flag for mounting NMA certs as a secret volume in server containers
+	// if deployment method is vclusterops. When set to true the NMA reads certs from this mounted
+	// volume, when set to false it reads certs directly from k8s secret store.
+	MountNMACertsAnnotation      = "vertica.com/mount-nma-certs"
+	MountNMACertsAnnotationTrue  = "true"
+	MountNMACertsAnnotationFalse = "false"
+
+	// A temporary annotation to enable NMA certs rotation. It will be removed once we
+	// are sure to have a smooth transition from a version that supports NMA certs mount.
+	EnableTLSCertsRotationAnnotation = "vertica.com/enable-tls-certs-rotation"
+
 	// Two annotations that are set by the operator when creating objects.
 	OperatorDeploymentMethodAnnotation = "vertica.com/operator-deployment-method"
 	OperatorVersionAnnotation          = "vertica.com/operator-version"
@@ -395,6 +406,16 @@ func UseVProxy(annotations map[string]string) bool {
 // volume rather than directly from k8s secret store.
 func UseVProxyCertsMount(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, MountVProxyCertsAnnotation, true /* default value */)
+}
+
+// UseNMACertsMount returns true if the NMA reads certs from the mounted secret
+// volume rather than directly from k8s secret store.
+func UseNMACertsMount(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, MountNMACertsAnnotation, true /* default value */)
+}
+
+func EnableTLSCertsRotation(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, EnableTLSCertsRotationAnnotation, false /* default value */)
 }
 
 // IgnoreClusterLease returns true if revive/start should ignore the cluster lease

--- a/tests/e2e-leg-6/nma-certs-mount/00-create-creds.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/00-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-6/nma-certs-mount/05-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/05-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-6/nma-certs-mount/05-deploy-operator.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/05-deploy-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-6/nma-certs-mount/15-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/15-assert.yaml
@@ -11,32 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-nma-certs-sc1
+status:
+  replicas: 1
+---
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-tls-certs
-  annotations:
-    vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: "true"
-    vertica.com/enable-tls-certs-rotation: "true"
-    vertica.com/mount-nma-certs: "false"
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  communal: {}
-  local:
-    requestSize: 100Mi
-    catalogPath: /catalog
-  dbName: vertdb
-  encryptSpreadComm: vertica
+  name: v-nma-certs
+status:
   subclusters:
-    - name: sc1
-      size: 1
-  nmaTLSSecret: custom-cert
-  securityContext:
-    capabilities:
-      add: ["SYS_PTRACE"]
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 1

--- a/tests/e2e-leg-6/nma-certs-mount/15-setup-vdb.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-6/nma-certs-mount/17-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/17-assert.yaml
@@ -11,32 +11,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-nma-certs-sc1
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-tls-certs
+  name: v-nma-certs
   annotations:
-    vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: "true"
-    vertica.com/enable-tls-certs-rotation: "true"
+    vertica.com/vcluster-ops: "true"
     vertica.com/mount-nma-certs: "false"
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  communal: {}
-  local:
-    requestSize: 100Mi
-    catalogPath: /catalog
-  dbName: vertdb
-  encryptSpreadComm: vertica
+status:
   subclusters:
-    - name: sc1
-      size: 1
-  nmaTLSSecret: custom-cert
-  securityContext:
-    capabilities:
-      add: ["SYS_PTRACE"]
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-6/nma-certs-mount/17-wait-for-createdb.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/17-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-6/nma-certs-mount/25-verify-no-nma-certs-mount.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/25-verify-no-nma-certs-mount.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  # nma certs volume mount path should not exist.
+  - command: kubectl exec -n $NAMESPACE v-nma-certs-sc1-0 -- bash -c "! test -d /certs/nma"

--- a/tests/e2e-leg-6/nma-certs-mount/27-run-scrutinize.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/27-run-scrutinize.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: cd ../../..  && scripts/capture-scrutinize.sh -o /tmp/scrutinize-op -x -n $NAMESPACE

--- a/tests/e2e-leg-6/nma-certs-mount/30-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/30-assert.yaml
@@ -11,32 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-tls-certs
+  name: v-nma-certs
   annotations:
-    vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: "true"
-    vertica.com/enable-tls-certs-rotation: "true"
-    vertica.com/mount-nma-certs: "false"
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  communal: {}
-  local:
-    requestSize: 100Mi
-    catalogPath: /catalog
-  dbName: vertdb
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: sc1
-      size: 1
-  nmaTLSSecret: custom-cert
-  securityContext:
-    capabilities:
-      add: ["SYS_PTRACE"]
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    vertica.com/vcluster-ops: "true"
+    vertica.com/mount-nma-certs: "true"
+

--- a/tests/e2e-leg-6/nma-certs-mount/30-flip-mount-nma-certs-flag.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/30-flip-mount-nma-certs-flag.yaml
@@ -11,32 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-tls-certs
+  name: v-nma-certs
   annotations:
-    vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: "true"
-    vertica.com/enable-tls-certs-rotation: "true"
-    vertica.com/mount-nma-certs: "false"
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  communal: {}
-  local:
-    requestSize: 100Mi
-    catalogPath: /catalog
-  dbName: vertdb
-  encryptSpreadComm: vertica
-  subclusters:
-    - name: sc1
-      size: 1
-  nmaTLSSecret: custom-cert
-  securityContext:
-    capabilities:
-      add: ["SYS_PTRACE"]
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    vertica.com/vcluster-ops: "true"
+    vertica.com/mount-nma-certs: "true"
+

--- a/tests/e2e-leg-6/nma-certs-mount/35-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/35-assert.yaml
@@ -11,32 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-tls-certs
-  annotations:
-    vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: "true"
-    vertica.com/enable-tls-certs-rotation: "true"
-    vertica.com/mount-nma-certs: "false"
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  communal: {}
-  local:
-    requestSize: 100Mi
-    catalogPath: /catalog
-  dbName: vertdb
-  encryptSpreadComm: vertica
+  name: v-nma-certs
+status:
   subclusters:
-    - name: sc1
-      size: 1
-  nmaTLSSecret: custom-cert
-  securityContext:
-    capabilities:
-      add: ["SYS_PTRACE"]
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 0

--- a/tests/e2e-leg-6/nma-certs-mount/35-kill-sts.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/35-kill-sts.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete sts v-nma-certs-sc1
+    namespaced: true

--- a/tests/e2e-leg-6/nma-certs-mount/40-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/40-assert.yaml
@@ -11,32 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-tls-certs
-  annotations:
-    vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: "true"
-    vertica.com/enable-tls-certs-rotation: "true"
-    vertica.com/mount-nma-certs: "false"
-spec:
-  initPolicy: CreateSkipPackageInstall
-  image: kustomize-vertica-image
-  communal: {}
-  local:
-    requestSize: 100Mi
-    catalogPath: /catalog
-  dbName: vertdb
-  encryptSpreadComm: vertica
+  name: v-nma-certs
+status:
   subclusters:
-    - name: sc1
-      size: 1
-  nmaTLSSecret: custom-cert
-  securityContext:
-    capabilities:
-      add: ["SYS_PTRACE"]
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-6/nma-certs-mount/40-wait-for-restart.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/40-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-6/nma-certs-mount/50-verify-nma-certs-mount.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/50-verify-nma-certs-mount.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  # nma certs volume mount path should exist.
+  - command: kubectl exec -n $NAMESPACE v-nma-certs-sc1-0 -- bash -c "test -d /certs/nma"

--- a/tests/e2e-leg-6/nma-certs-mount/55-run-scrutinize.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/55-run-scrutinize.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: cd ../../..  && scripts/capture-scrutinize.sh -o /tmp/scrutinize-op -x -n $NAMESPACE

--- a/tests/e2e-leg-6/nma-certs-mount/65-delete-cr.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/65-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB

--- a/tests/e2e-leg-6/nma-certs-mount/65-errors.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/65-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-leg-6/nma-certs-mount/66-assert.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/66-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-6/nma-certs-mount/66-cleanup-storage.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/66-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-6/nma-certs-mount/66-errors.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/66-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-6/nma-certs-mount/99-delete-ns.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-6/nma-certs-mount/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-6/nma-certs-mount/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-6/nma-certs-mount/setup-vdb/base/setup-vdb.yaml
@@ -11,19 +11,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-tls-certs
+  name: v-nma-certs
   annotations:
-    vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: "true"
-    vertica.com/enable-tls-certs-rotation: "true"
+    vertica.com/vcluster-ops: "true"
     vertica.com/mount-nma-certs: "false"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image
-  communal: {}
+  communal:
+    includeUIDInPath: true
   local:
     requestSize: 100Mi
     catalogPath: /catalog
@@ -32,7 +31,7 @@ spec:
   subclusters:
     - name: sc1
       size: 1
-  nmaTLSSecret: custom-cert
+  kSafety: "0"
   securityContext:
     capabilities:
       add: ["SYS_PTRACE"]

--- a/tests/e2e-leg-9/nma-generated-cert-config/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-9/nma-generated-cert-config/setup-vdb/base/setup-vdb.yaml
@@ -17,7 +17,9 @@ metadata:
   name: v-tls-certs
   annotations:
     vertica.com/k-safety: "0"
-    vertica.com/include-uid-in-path: true
+    vertica.com/include-uid-in-path: "true"
+    vertica.com/enable-tls-certs-rotation: "true"
+    vertica.com/mount-nma-certs: "false"
 spec:
   initPolicy: CreateSkipPackageInstall
   image: kustomize-vertica-image


### PR DESCRIPTION
In a previous PR, `mount-nma-certs` was removed to support getting the certs from secret. 
That caused a few issues:
- when coming from an older operator version with a vdb that had `nma-certs-mount` true, the pods are crashing
- will break scrutinize as it still supports nma certs mount
Until these issues are fixed, we will still use `mount-nma-certs` to allow a smooth transition from an older operator version. Moreover, I added another annotation `enable-nma-tls-rotation` that will temporarily served as feature flag until we are sure nma certs rotation will not break the existing code.