### PR TITLE
feat(annotation): allow to disable depot volume management (#1085)

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -648,6 +648,15 @@ func (v *VerticaDB) IsKnownDepotVolumeType() bool {
 	return false
 }
 
+// IsDepotVolumeManaged returns true if vertica.com/disable-depot-volume-management
+// is false or not set
+func (v *VerticaDB) IsDepotVolumeManaged() bool {
+	if vmeta.DisableDepotVolumeManagement(v.Annotations) {
+		return false
+	}
+	return true
+}
+
 // GetFirstPrimarySubcluster returns the first primary subcluster defined in the vdb
 func (v *VerticaDB) GetFirstPrimarySubcluster() *Subcluster {
 	for i := range v.Spec.Subclusters {

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -651,10 +651,7 @@ func (v *VerticaDB) IsKnownDepotVolumeType() bool {
 // IsDepotVolumeManaged returns true if vertica.com/disable-depot-volume-management
 // is false or not set
 func (v *VerticaDB) IsDepotVolumeManaged() bool {
-	if vmeta.DisableDepotVolumeManagement(v.Annotations) {
-		return false
-	}
-	return true
+	return !vmeta.DisableDepotVolumeManagement(v.Annotations)
 }
 
 // GetFirstPrimarySubcluster returns the first primary subcluster defined in the vdb

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -147,6 +147,12 @@ const (
 	// reconciles we use the exponential backoff algorithm.
 	UpgradeRequeueTimeAnnotation = "vertica.com/upgrade-requeue-time"
 
+	// Annotation to disable depot volume management and let it be provided by
+	// a volumeMount for example. Useful for test environments and when using
+	// Ephemeral PVCs
+	NoDepotVolumeManagementAnnotation      = "vertica.com/disable-depot-volume-management"
+	NoDepotVolumeManagementAnnotationTrue  = "true"
+	NoDepotVolumeManagementAnnotationFalse = "false"
 	// A secret that has the files for /home/dbadmin/.ssh.  If this is
 	// omitted, the ssh files from the image are used (if applicable). SSH is
 	// only required when deploying via admintools and is present only in images
@@ -528,6 +534,12 @@ func IsHTTPSTLSConfGenerationEnabled(annotations map[string]string) bool {
 // the image was built for.
 func GetSkipDeploymentCheck(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, SkipDeploymentCheckAnnotation, false /* default value */)
+}
+
+// DisableDepotVolumeManagement will return true if we should not manage the depot volume
+// in the operator, allowing different provisioning mechanisms
+func DisableDepotVolumeManagement(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, NoDepotVolumeManagementAnnotation, false)
 }
 
 // GetNMAResource is used to retrieve a specific resource for the NMA


### PR DESCRIPTION
Introduce annotation `vertica.com/disable-depot-volume-management: "true"|"false"`

Its purpose is to disable volume management for the depot volume, thus allowing specific scenarios such as providing the Depot as an ephemeral PVC for scratch storage, distinct from a regular PVC (with independent lifecycle) and from an EmptyDir (residing directly on the host OS filesystem).

We use it because our ephemeral storage is a local PV bound by an ephemeral PVC and it needs to have the same lifecycle as our pod (destroyed when the pod is destroyed, created when the pod is created) and is co-located on the same node, so it can't be carried across node changes.

- EmptyDir does not work because EmptyDir specifically uses the k8s host filesystem
- a regular PVC does not have its lifecycle managed properly by the StatefulSet when nodes disappear
- a PVC that is directly an ephemeral makes the cut
- other storage options may make the cut

We chose to apply this change because it's the simplest in terms of code paths and is quite well circumscribed. Without this annotation, the operator behaves exactly as it did before.