### PR TITLE
Fixed sandbox restart issue

### DIFF
--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -484,6 +484,7 @@ func (r *RestartReconciler) reipNodes(ctx context.Context, pods []*podfacts.PodF
 	}
 	opts := []reip.Option{
 		reip.WithInitiator(r.InitiatorPod, r.InitiatorPodIP),
+		reip.WithSandbox(r.PFacts.SandboxName),
 	}
 	// If a communal path is set, include all of the EON parameters.
 	if r.Vdb.Spec.Communal.Path != "" {

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -579,12 +579,12 @@ func (r *RestartReconciler) killReadOnlyProcesses(ctx context.Context, pods []*p
 func (r *RestartReconciler) killVerticaProcesses(ctx context.Context, pods []*podfacts.PodFact, forReadOnly bool) (ctrl.Result, error) {
 	killedAtLeastOnePid := false
 	for _, pod := range pods {
-		// 1. killing read-only vertica processes
-		if !pod.GetReadOnly() {
+		// 1. skip killing non read-only vertica processes
+		if forReadOnly && !pod.GetReadOnly() {
 			continue
 		}
-		// 2. killing vertica processes in the pods with NMA as a sidecar
-		if !forReadOnly && !pod.GetHasNMASidecar() {
+		// 2. skip killing non read-only vertica processes within pods without NMA sidecar
+		if !forReadOnly && !pod.GetReadOnly() && !pod.GetHasNMASidecar() {
 			continue
 		}
 		const killMarker = "Killing process"

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -575,7 +575,7 @@ func (r *RestartReconciler) killReadOnlyProcesses(ctx context.Context, pods []*p
 }
 
 // killVerticaProcesses will remove any running vertica processes that are currently in read-only
-// or any running vertica processes that are in the pods with NMA as a sidecar.
+// or any running vertica processes that are in the pods with NMA sidecar.
 func (r *RestartReconciler) killVerticaProcesses(ctx context.Context, pods []*podfacts.PodFact, forReadOnly bool) (ctrl.Result, error) {
 	killedAtLeastOnePid := false
 	for _, pod := range pods {
@@ -599,7 +599,8 @@ func (r *RestartReconciler) killVerticaProcesses(ctx context.Context, pods []*po
 		// the NMA sidecar, it is started as PID 1, which doesn't have a signal
 		// handler. So, it doesn't respond to kills. To force vertica down we
 		// are going to kill the spread process.
-		killCmd := fmt.Sprintf("for pid in $(pgrep ^spread$); do echo \"%s $pid\"; kill -n SIGKILL $pid; done", killMarker)
+		killCmd := fmt.Sprintf("for pid in $(pgrep -f '^/opt/vertica/spread/sbin/spread'); do echo \"%s $pid\"; kill -n SIGKILL $pid; done",
+			killMarker)
 		cmd := []string{
 			// Remove the startup file first, since deleting spread will cause the container to stop
 			"bash", "-c", fmt.Sprintf("%s; %s", rmCmd, killCmd),

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -205,35 +205,41 @@ func (r *RestartReconciler) reconcileCluster(ctx context.Context) (ctrl.Result, 
 		!vmeta.UseVClusterOps(r.Vdb.Annotations), /* restartTransient */
 		true /* restartPendingDelete */)
 
-	// Kill any read-only vertica process that may still be running. This does
-	// not include any rogue process that is no longer communicating with
-	// spread; these are killed by the liveness probe. Read-only nodes need to
-	// be killed because we need to restart vertica on them so they join the new
-	// cluster and can gain write access.
-	if res, err := r.killReadOnlyProcesses(ctx, downPods); verrors.IsReconcileAborted(res, err) {
+	// Kill any read-only vertica process that may still be running and any vertica process
+	// within a pod that has NMA as a sidecar. This does not include rogue processes
+	// in pods without an NMA sidecar that are no longer communicating with spread;
+	// those are handled by the liveness probe.
+	// - Read-only nodes must be terminated to restart Vertica, allowing them to join
+	//   the new cluster and gain write access.
+	// - NMA-as-Sidecar nodes must be terminated to remove the startup config file,
+	//   enabling them to restart alongside other nodes.
+	if res, err := r.killVerticaProcesses(ctx, downPods, false); verrors.IsReconcileAborted(res, err) {
 		return res, err
 	}
 
-	// If any of the pods have finished the startupProbe, we need to wait for
-	// the livenessProbe to kill them before starting. If we don't do this, we
-	// run the risk of having the livenessProbe delete the pod while we
-	// are doing the startup. The startupProbe has a much longer timeout and can
-	// accommodate a slow startup.
-	if _, pc, err := r.filterNonActiveStartupProbe(ctx, downPods); err != nil {
-		return ctrl.Result{}, err
-	} else if pc != 0 {
-		r.Log.Info("Some pods have active livenessProbes. Waiting for them to be rescheduled before trying a restart.",
-			"podCount", pc)
-		return r.makeResultForLivenessProbeWait(ctx)
-	}
+	// For the pods without an NMA sidecar, we need to do startup check on them
+	if !r.Vdb.IsNMASideCarDeploymentEnabled() {
+		// If any of the pods have finished the startupProbe, we need to wait for
+		// the livenessProbe to kill them before starting. If we don't do this, we
+		// run the risk of having the livenessProbe delete the pod while we
+		// are doing the startup. The startupProbe has a much longer timeout and can
+		// accommodate a slow startup.
+		if _, pc, err := r.filterNonActiveStartupProbe(ctx, downPods); err != nil {
+			return ctrl.Result{}, err
+		} else if pc != 0 {
+			r.Log.Info("Some pods have active livenessProbes. Waiting for them to be rescheduled before trying a restart.",
+				"podCount", pc)
+			return r.makeResultForLivenessProbeWait(ctx)
+		}
 
-	// Similar to above, wait for any pods that are just slow starting. They
-	// probably have a large catalog. So, its best to wait it out. The health
-	// probes will eventually kill them if they can't make any progress.
-	if _, pc := r.filterSlowStartup(downPods); pc != 0 {
-		r.Log.Info("Some pods are slow starting up. Waiting for them to finish or abort before trying a cluster restart",
-			"podCount", pc)
-		return r.makeResultForLivenessProbeWait(ctx)
+		// Similar to above, wait for any pods that are just slow starting. They
+		// probably have a large catalog. So, its best to wait it out. The health
+		// probes will eventually kill them if they can't make any progress.
+		if _, pc := r.filterSlowStartup(downPods); pc != 0 {
+			r.Log.Info("Some pods are slow starting up. Waiting for them to finish or abort before trying a cluster restart",
+				"podCount", pc)
+			return r.makeResultForLivenessProbeWait(ctx)
+		}
 	}
 
 	if err := r.acceptEulaIfMissing(ctx); err != nil {
@@ -565,10 +571,20 @@ func (r *RestartReconciler) restartCluster(ctx context.Context, downPods []*podf
 // before starting a restart; this is done for the benefit of PD purposes and
 // stability in the restart test.
 func (r *RestartReconciler) killReadOnlyProcesses(ctx context.Context, pods []*podfacts.PodFact) (ctrl.Result, error) {
+	return r.killVerticaProcesses(ctx, pods, true)
+}
+
+// killVerticaProcesses will remove any running vertica processes that are currently in read-only
+// or any running vertica processes that are in the pods with NMA as a sidecar.
+func (r *RestartReconciler) killVerticaProcesses(ctx context.Context, pods []*podfacts.PodFact, forReadOnly bool) (ctrl.Result, error) {
 	killedAtLeastOnePid := false
 	for _, pod := range pods {
-		// Only killing read-only vertica processes
+		// 1. killing read-only vertica processes
 		if !pod.GetReadOnly() {
+			continue
+		}
+		// 2. killing vertica processes in the pods with NMA as a sidecar
+		if !forReadOnly && !pod.GetHasNMASidecar() {
 			continue
 		}
 		const killMarker = "Killing process"
@@ -599,7 +615,7 @@ func (r *RestartReconciler) killReadOnlyProcesses(ctx context.Context, pods []*p
 		// We are going to requeue if killed at least one process.  This is for
 		// the benefit of the status reconciler, so that we don't treat it as
 		// an up node anymore.
-		r.Log.Info("Requeue.  Killed at least one read-only vertica process.")
+		r.Log.Info("Requeue.  Killed at least one vertica process.")
 		return ctrl.Result{Requeue: true}, nil
 	}
 	return ctrl.Result{}, nil

--- a/pkg/vadmin/opts/reip/opts.go
+++ b/pkg/vadmin/opts/reip/opts.go
@@ -26,6 +26,7 @@ type Parms struct {
 	Hosts               []Host
 	CommunalPath        string
 	ConfigurationParams map[string]string
+	Sandbox             string
 }
 
 type Host struct {
@@ -72,5 +73,11 @@ func WithCommunalPath(path string) Option {
 func WithConfigurationParams(parms map[string]string) Option {
 	return func(s *Parms) {
 		s.ConfigurationParams = parms
+	}
+}
+
+func WithSandbox(sandbox string) Option {
+	return func(s *Parms) {
+		s.Sandbox = sandbox
 	}
 }

--- a/pkg/vadmin/re_ip_vc.go
+++ b/pkg/vadmin/re_ip_vc.go
@@ -74,6 +74,9 @@ func (v *VClusterOps) genReIPOptions(s *reip.Parms, certs *HTTPSCerts) vops.VReI
 	// database name
 	opts.DBName = v.VDB.Spec.DBName
 
+	// sandbox name
+	opts.SandboxName = s.Sandbox
+
 	// re-ip list
 	for _, h := range s.Hosts {
 		var reIPInfo vops.ReIPInfo

--- a/pkg/vadmin/re_ip_vc_test.go
+++ b/pkg/vadmin/re_ip_vc_test.go
@@ -50,6 +50,11 @@ func (m *MockVClusterOps) VReIP(options *vops.VReIPOptions) error {
 	if options.IsEon != TestIsEon {
 		return fmt.Errorf("failed to retrieve eon mode")
 	}
+
+	// verify sandbox name
+	if options.SandboxName != TestSandboxName {
+		return fmt.Errorf("failed to retrieve sandbox name")
+	}
 	return m.VerifyCommunalStorageOptions(options.CommunalStorageLocation, options.ConfigurationParameters)
 }
 
@@ -80,7 +85,8 @@ var _ = Describe("re_ip_vc", func() {
 			reip.WithHost(hosts[1].VNode, hosts[1].Compat21Node, hosts[1].IP),
 			reip.WithHost(hosts[1].VNode, hosts[1].Compat21Node, hosts[1].IP),
 			reip.WithCommunalPath(TestCommunalPath),
-			reip.WithConfigurationParams(TestCommunalStorageParams))
+			reip.WithConfigurationParams(TestCommunalStorageParams),
+			reip.WithSandbox(TestSandboxName))
 		Ω(err).Should(Succeed())
 		Ω(ctrlRes).Should(Equal(ctrl.Result{}))
 	})


### PR DESCRIPTION
This PR will fix two sandbox restart issues:
1. cannot find vertica nodes to re-ip.
2. some vertica nodes have HTTPs service up but haven't joined the main cluster.

The first issue is fixed by adding the option "sandboxName" in vclusterOps re-ip call.

The second issue is fixed by killing all vertica nodes before start_db.