### PR TITLE
Add addtional webhook custom autoscaler

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1359,21 +1359,30 @@ func (v *VerticaAutoscaler) GetMetricMap() map[string]*MetricDefinition {
 }
 
 // GetMetricTarget returns the autoscalingv2 metric target
-func GetMetricTarget(metric *autoscalingv2.MetricSpec) autoscalingv2.MetricTarget {
-	var metricTarget autoscalingv2.MetricTarget
-
-	if metric.Pods != nil {
-		metricTarget = metric.Pods.Target
-	} else if metric.Object != nil {
-		metricTarget = metric.Object.Target
-	} else if metric.External != nil {
-		metricTarget = metric.External.Target
-	} else if metric.Resource != nil {
-		metricTarget = metric.Resource.Target
-	} else {
-		metricTarget = metric.ContainerResource.Target
+func GetMetricTarget(metric *autoscalingv2.MetricSpec) *autoscalingv2.MetricTarget {
+	switch metric.Type {
+	case autoscalingv2.PodsMetricSourceType:
+		if metric.Pods != nil {
+			return &metric.Pods.Target
+		}
+	case autoscalingv2.ObjectMetricSourceType:
+		if metric.Object != nil {
+			return &metric.Object.Target
+		}
+	case autoscalingv2.ExternalMetricSourceType:
+		if metric.External != nil {
+			return &metric.External.Target
+		}
+	case autoscalingv2.ResourceMetricSourceType:
+		if metric.Resource != nil {
+			return &metric.Resource.Target
+		}
+	case autoscalingv2.ContainerResourceMetricSourceType:
+		if metric.ContainerResource != nil {
+			return &metric.ContainerResource.Target
+		}
 	}
-	return metricTarget
+	return nil
 }
 
 func IsK8sSecretFound(ctx context.Context, vdb *VerticaDB, k8sClient client.Client, secretName *string,

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1358,6 +1358,24 @@ func (v *VerticaAutoscaler) GetMetricMap() map[string]*MetricDefinition {
 	return mMap
 }
 
+// GetMetricTarget returns the autoscalingv2 metric target
+func GetMetricTarget(metric *autoscalingv2.MetricSpec) autoscalingv2.MetricTarget {
+	var metricTarget autoscalingv2.MetricTarget
+
+	if metric.Pods != nil {
+		metricTarget = metric.Pods.Target
+	} else if metric.Object != nil {
+		metricTarget = metric.Object.Target
+	} else if metric.External != nil {
+		metricTarget = metric.External.Target
+	} else if metric.Resource != nil {
+		metricTarget = metric.Resource.Target
+	} else {
+		metricTarget = metric.ContainerResource.Target
+	}
+	return metricTarget
+}
+
 func IsK8sSecretFound(ctx context.Context, vdb *VerticaDB, k8sClient client.Client, secretName *string,
 	secret *corev1.Secret) (bool, error) {
 	nm := types.NamespacedName{

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1307,3 +1307,14 @@ func IsK8sSecretFound(ctx context.Context, vdb *VerticaDB, k8sClient client.Clie
 		return true, nil
 	}
 }
+
+func hasDuplicates[T comparable](s []T) bool {
+	seen := make(map[T]bool)
+	for _, element := range s {
+		if seen[element] {
+			return false // Duplicate found
+		}
+		seen[element] = true
+	}
+	return true // No duplicates found
+}

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1373,14 +1373,3 @@ func IsK8sSecretFound(ctx context.Context, vdb *VerticaDB, k8sClient client.Clie
 		return true, nil
 	}
 }
-
-func hasDuplicates[T comparable](s []T) bool {
-	seen := make(map[T]bool)
-	for _, element := range s {
-		if seen[element] {
-			return false // Duplicate found
-		}
-		seen[element] = true
-	}
-	return true // No duplicates found
-}

--- a/api/v1/verticaautoscaler_types.go
+++ b/api/v1/verticaautoscaler_types.go
@@ -526,6 +526,11 @@ func (v *VerticaAutoscaler) IsHpaEnabled() bool {
 	return v.IsCustomAutoScalerSet() && v.Spec.CustomAutoscaler.Type == HPA && v.Spec.CustomAutoscaler.Hpa != nil
 }
 
+// IsHpaType returns true if custom autoscaler type is HPA.
+func (v *VerticaAutoscaler) IsHpaType() bool {
+	return v.IsCustomAutoScalerSet() && v.Spec.CustomAutoscaler.Type == HPA
+}
+
 // IsScaledObjectEnabled returns true if custom autoscaling with scaledObject is set.
 func (v *VerticaAutoscaler) IsScaledObjectEnabled() bool {
 	return v.IsCustomAutoScalerSet() && v.Spec.CustomAutoscaler.Type == ScaledObject && v.Spec.CustomAutoscaler.ScaledObject != nil

--- a/api/v1/verticaautoscaler_webhook.go
+++ b/api/v1/verticaautoscaler_webhook.go
@@ -146,12 +146,6 @@ func (v *VerticaAutoscaler) validateScalingGranularity(allErrs field.ErrorList) 
 // validateSubclusterTemplate will validate the subcluster template
 func (v *VerticaAutoscaler) validateSubclusterTemplate(allErrs field.ErrorList) field.ErrorList {
 	pathPrefix := field.NewPath("spec").Child("template")
-	if v.Spec.CustomAutoscaler == nil && v.Spec.Template.ServiceName == "" && v.Spec.ServiceName == "" {
-		err := field.Invalid(pathPrefix.Child("serviceName"),
-			v.Spec.Template.ServiceName,
-			"Service name can not be empty if customAutoscaler is empty.")
-		allErrs = append(allErrs, err)
-	}
 	if v.CanUseTemplate() && v.Spec.ServiceName != "" && v.Spec.Template.ServiceName != v.Spec.ServiceName {
 		err := field.Invalid(pathPrefix.Child("serviceName"),
 			v.Spec.Template.ServiceName,

--- a/api/v1/verticaautoscaler_webhook.go
+++ b/api/v1/verticaautoscaler_webhook.go
@@ -360,7 +360,7 @@ func (v *VerticaAutoscaler) validateHPA(allErrs field.ErrorList) field.ErrorList
 		v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown != nil && *v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds != 0 {
 		err := field.Invalid(pathPrefix.Child("hpa").Child("behavior").Child("scaleDown").Child("stabilizationWindowSeconds"),
 			v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds,
-			"When scaleInThreshold is set, scalein stabilization window must be 0")
+			"When scaleInThreshold is set, scaleDown stabilization window must be 0")
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1/verticaautoscaler_webhook.go
+++ b/api/v1/verticaautoscaler_webhook.go
@@ -345,7 +345,7 @@ func (v *VerticaAutoscaler) validateHPA(allErrs field.ErrorList) field.ErrorList
 	pathPrefix := field.NewPath("spec").Child("customAutoscaler")
 	// validate stabilization window
 	if v.HasScaleInThreshold() && v.Spec.CustomAutoscaler.Hpa.Behavior != nil &&
-		v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleIn != nil && *v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleIn.StabilizationWindowSeconds != 0 {
+		v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown != nil && *v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds != 0 {
 		err := field.Invalid(pathPrefix.Child("hpa"),
 			v.Spec.CustomAutoscaler.Hpa,
 			"When scaleInThreshold is set, scalein stabilization window must be 0")
@@ -363,7 +363,7 @@ func (v *VerticaAutoscaler) validateHPA(allErrs field.ErrorList) field.ErrorList
 					err := field.Invalid(pathPrefix.Child("hpa").Child("metrics").Index(i).Child("scaleInThreshold").Child("type"),
 						v.Spec.CustomAutoscaler.Hpa.Metrics[i].ScaleInThreshold.Type,
 						fmt.Sprintf("scaleInThreshold %s must be of the same type as the threshold used for scale out %s",
-							metric.ScaleInThreshold.Type, &metric.Metric.Pods.Target.Type),
+							metric.ScaleInThreshold.Type, metric.Metric.Pods.Target.Type),
 					)
 					allErrs = append(allErrs, err)
 				}
@@ -372,7 +372,7 @@ func (v *VerticaAutoscaler) validateHPA(allErrs field.ErrorList) field.ErrorList
 					err := field.Invalid(pathPrefix.Child("hpa").Child("metrics").Index(i).Child("scaleInThreshold").Child("type"),
 						v.Spec.CustomAutoscaler.Hpa.Metrics[i].ScaleInThreshold.Type,
 						fmt.Sprintf("scaleInThreshold %s must be of the same type as the threshold used for scale out %s",
-							metric.ScaleInThreshold.Type, &metric.Metric.Object.Target.Type),
+							metric.ScaleInThreshold.Type, metric.Metric.Object.Target.Type),
 					)
 					allErrs = append(allErrs, err)
 				}

--- a/api/v1/verticaautoscaler_webhook.go
+++ b/api/v1/verticaautoscaler_webhook.go
@@ -361,7 +361,6 @@ func (v *VerticaAutoscaler) validateScaleInThreshold(allErrs field.ErrorList) fi
 	// validate scaleInThreshold type
 	if v.HasScaleInThreshold() {
 		pathPrefix := field.NewPath("spec").Child("customAutoscaler").Child("hpa").Child("metrics")
-
 		for i := range v.Spec.CustomAutoscaler.Hpa.Metrics {
 			metric := &v.Spec.CustomAutoscaler.Hpa.Metrics[i]
 			targetType := GetMetricTarget(&metric.Metric).Type
@@ -374,7 +373,6 @@ func (v *VerticaAutoscaler) validateScaleInThreshold(allErrs field.ErrorList) fi
 				)
 				allErrs = append(allErrs, err)
 			}
-
 		}
 	}
 	return allErrs

--- a/api/v1/verticaautoscaler_webhook_test.go
+++ b/api/v1/verticaautoscaler_webhook_test.go
@@ -150,7 +150,7 @@ var _ = Describe("verticaautoscaler_webhook", func() {
 		vas.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Type = PrometheusTriggerType
 		vas.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Prometheus = nil
 		_, err := vas.ValidateCreate()
-		Expect(err.Error()).To(ContainSubstring("metrics[].prometheus must not be nil"))
+		Expect(err.Error()).To(ContainSubstring("metrics[].prometheus must be set"))
 	})
 
 	It("should fail if scaledobject metrics type is cpu/mem and metrics[].resource is nil", func() {
@@ -158,12 +158,12 @@ var _ = Describe("verticaautoscaler_webhook", func() {
 		vas.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Type = CPUTriggerType
 		vas.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Resource = nil
 		_, err := vas.ValidateCreate()
-		Expect(err.Error()).To(ContainSubstring("metrics[].resource must not be nil"))
+		Expect(err.Error()).To(ContainSubstring("metrics[].resource must be set"))
 
 		vas.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Type = MemTriggerType
 		vas.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Resource = nil
 		_, err = vas.ValidateCreate()
-		Expect(err.Error()).To(ContainSubstring("metrics[].resource must not be nil"))
+		Expect(err.Error()).To(ContainSubstring("metrics[].resource must be set"))
 	})
 
 	It("should fail if scaledobject metrics type is prometheus and metricType is not set properly", func() {

--- a/api/v1/verticaautoscaler_webhook_test.go
+++ b/api/v1/verticaautoscaler_webhook_test.go
@@ -237,12 +237,14 @@ var _ = Describe("verticaautoscaler_webhook", func() {
 		_, err := vas.ValidateCreate()
 		Expect(err).ShouldNot(Succeed())
 
+	})
+
 	It("should fail if scaledownThreshold is set, scaledown stabilization window is not 0", func() {
 		vas := MakeVASWithMetrics()
 		validValue := int32(0)
 		invalidValue := int32(3)
 		vas.Spec.CustomAutoscaler.Hpa.Metrics[0].ScaleInThreshold = &autoscalingv2.MetricTarget{
-			Type: autoscalingv2.AverageValueMetricType,
+			Type: autoscalingv2.UtilizationMetricType,
 		}
 		_, err := vas.ValidateCreate()
 		Expect(err).Should(Succeed())


### PR DESCRIPTION
Add webhook rules for custom autoscaler as continued work of #1071:
- maxReplicas cannot be less than minReplicas
- maxReplicas must be set
- cannot set customAutoscaler after CR creation
- 2 metrics cannot have the same name
- if spec.customAutoscaler.scaledObject.metrics[].type is "prometheus", spec.customAutoscaler.scaledObject.metrics[].prometheus must not be nil, if it is "cpu" or "memory", spec.customAutoscaler.scaledObject.metrics[].resource must not be nil
- scaledownThreshold must be of the same type as the threshold used for scaleup.
- customAutoscaler.hpa must be non-nil if customAutoscaler.type == "HPA" / - customAutoscaler.scaledObject must be non-nil if customAutoscaler.type == "ScaledObject" or empty