### PR TITLE
fix default value condition

### DIFF
--- a/api/v1/verticaautoscaler_webhook.go
+++ b/api/v1/verticaautoscaler_webhook.go
@@ -56,10 +56,19 @@ func (v *VerticaAutoscaler) Default() {
 	if v.Spec.Template.Type == "" {
 		v.Spec.Template.Type = v.Spec.Template.GetType()
 	}
-	if v.HasScaleInThreshold() && v.Spec.CustomAutoscaler.Hpa.Behavior != nil && v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown != nil &&
-		v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds == nil {
+	if v.HasScaleInThreshold() {
 		defaultV := int32(defaultStabilizationWindowSeconds)
-		v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds = &defaultV
+		if v.Spec.CustomAutoscaler.Hpa.Behavior == nil {
+			v.Spec.CustomAutoscaler.Hpa.Behavior = &autoscalingv2.HorizontalPodAutoscalerBehavior{
+				ScaleDown: &autoscalingv2.HPAScalingRules{},
+			}
+		}
+		if v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown == nil {
+			v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown = &autoscalingv2.HPAScalingRules{}
+		}
+		if v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds == nil {
+			v.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds = &defaultV
+		}
 	}
 }
 

--- a/api/v1/verticaautoscaler_webhook_test.go
+++ b/api/v1/verticaautoscaler_webhook_test.go
@@ -291,5 +291,15 @@ var _ = Describe("verticaautoscaler_webhook", func() {
 		_, err = vas.ValidateCreate()
 		Expect(err).Should(Succeed())
 		Expect(*vas.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds).Should(Equal(int32(0)))
+		vas.Spec.CustomAutoscaler.Hpa.Behavior = &autoscalingv2.HorizontalPodAutoscalerBehavior{}
+		vas.Default()
+		_, err = vas.ValidateCreate()
+		Expect(err).Should(Succeed())
+		Expect(*vas.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds).Should(Equal(int32(0)))
+		vas.Spec.CustomAutoscaler.Hpa.Behavior = &autoscalingv2.HorizontalPodAutoscalerBehavior{ScaleDown: &autoscalingv2.HPAScalingRules{}}
+		vas.Default()
+		_, err = vas.ValidateCreate()
+		Expect(err).Should(Succeed())
+		Expect(*vas.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds).Should(Equal(int32(0)))
 	})
 })


### PR DESCRIPTION
Made a mistake when I read the rule: - When spec.customAutoscaler.hpa.scaledownThreshold is set, scaledown stabilisation window must be 0, where the scaledownThreshold should be scaleInThreshold, not behavior.ScaleDown. So the condition shouldn't check the behavior field. 
Also need to instantiate the attribute to make sure there is no nil pointer. Added some unit more unit test to cover the case