### PR TITLE
Add types in status.subclusters

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -1031,6 +1031,12 @@ type SubclusterStatus struct {
 	Oid string `json:"oid"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +optional
+	// The type of the subcluster. It could be primary, secondary, transient, or empty if
+	// it's not in the db yet.
+	Type string `json:"type"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
 	// A count of the number of pods that have been added to the database for this subcluster.
 	AddedToDBCount int32 `json:"addedToDBCount"`
 

--- a/pkg/controllers/vdb/status_reconciler.go
+++ b/pkg/controllers/vdb/status_reconciler.go
@@ -213,6 +213,9 @@ func (s *StatusReconciler) calculateSubclusterStatus(ctx context.Context, sc *va
 		if pf.GetSubclusterOid() != "" {
 			curStat.Oid = pf.GetSubclusterOid()
 		}
+		if pf.GetSubclusterType() != "" {
+			curStat.Type = pf.GetSubclusterType()
+		}
 	}
 	// Refresh the counts
 	curStat.AddedToDBCount = 0

--- a/pkg/controllers/vdb/suite_test.go
+++ b/pkg/controllers/vdb/suite_test.go
@@ -126,6 +126,7 @@ func defaultPodFactOverrider(_ context.Context, _ *vapi.VerticaDB, pf *podfacts.
 	pf.SetStartupInProgress(false)
 	pf.SetUpNode(true)
 	pf.SetSubclusterOid("123456")
+	pf.SetSubclusterType("Primary")
 	pf.SetShardSubscriptions(1)
 	return nil
 }

--- a/pkg/podfacts/podfacts.go
+++ b/pkg/podfacts/podfacts.go
@@ -63,6 +63,9 @@ type PodFact struct {
 	// The oid of the subcluster the pod is part of
 	subclusterOid string
 
+	// The type of the subcluster the pod is part of
+	subclusterType string
+
 	// The sandbox a pod is part of
 	sandbox string
 
@@ -260,6 +263,7 @@ func (p *PodFacts) ConstructsDetail(subclusters []vapi.Subcluster, upNodes []uin
 			pf := PodFact{
 				name:           types.NamespacedName{Name: fmt.Sprintf("%s-%d", sc.Name, j)},
 				subclusterName: sc.Name,
+				subclusterType: sc.Type,
 				isPrimary:      sc.IsPrimary(),
 				shutdown:       sc.Shutdown,
 				upNode:         isUp,
@@ -378,6 +382,7 @@ func (p *PodFacts) collectPodByStsIndex(ctx context.Context, vdb *vapi.VerticaDB
 	pf := PodFact{
 		name:              names.GenPodName(vdb, sc, podIndex),
 		subclusterName:    sc.Name,
+		subclusterType:    sc.Type,
 		isPrimary:         sc.IsPrimary(),
 		podIndex:          podIndex,
 		execContainerName: getExecContainerName(sts),
@@ -717,6 +722,11 @@ func (p *PodFact) GetSubclusterOid() string {
 	return p.subclusterOid
 }
 
+// GetSubclusterType returns the string value of subclusterOid in PodFact
+func (p *PodFact) GetSubclusterType() string {
+	return p.subclusterType
+}
+
 // GetAdmintoolsExists returns the bool value of admintoolsExists in PodFact
 func (p *PodFact) GetAdmintoolsExists() bool {
 	return p.admintoolsExists
@@ -895,6 +905,11 @@ func (p *PodFact) SetStartupInProgress(startupInProgress bool) {
 // SetSubclusterOid set the bool value of subclusterOid in PodFact
 func (p *PodFact) SetSubclusterOid(subclusterOid string) {
 	p.subclusterOid = subclusterOid
+}
+
+// SetSubclusterOid set the bool value of subclusterOid in PodFact
+func (p *PodFact) SetSubclusterType(subclusterType string) {
+	p.subclusterType = subclusterType
 }
 
 // SetDirExists set the map[string]bool value of dirExists in PodFact


### PR DESCRIPTION
This PR is the Task 1 to support subcluster promotion/demotion: adds types in status.subclusters. 

status:
  subclusters:
  - name: sc1
    type: primary/secondary/sandboxprimary/sandboxsecondary (default as empty if it's not in the db yet)

Following tasks will be:
Task 2. add new types in spec.sandboxes.subclusters.type. For example:
Task 3. Remove the updates in spec.subclusters.subcluster.type
