### PR TITLE
Make final changes for the autoscaler

### DIFF
--- a/api/v1/verticaautoscaler_types.go
+++ b/api/v1/verticaautoscaler_types.go
@@ -54,7 +54,7 @@ type VerticaAutoscalerSpec struct {
 	ServiceName string `json:"serviceName,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:fieldDependency:scalingGranularity:Subcluster"
 	// When the scaling granularity is Subcluster, this field defines a template
 	// to use for when a new subcluster needs to be created.  If size is 0, then
 	// the operator will use an existing subcluster to use as the template.  If
@@ -281,9 +281,16 @@ type PrometheusSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	// Used for skipping certificate check e.g: using self-signed certs.
 	UnsafeSsl bool `json:"unsafeSsl,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	// Enables caching of metric values during polling interval. It is Used to control whether the autoscaler should use cached metrics for scaling
+	// decisions rather than querying the external metric provider (e.g., Prometheus) on each scale event. This feature is not supported for cpu and memory.
+	UseCachedMetrics bool `json:"useCachedMetrics,omitempty"`
 }
 
 type CPUMemorySpec struct {
@@ -299,12 +306,6 @@ type CPUMemorySpec struct {
 
 // MetricDefinition defines increment and metric to be used for autoscaling
 type MetricDefinition struct {
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:Minimum:=0
-	// The value used to increase the threshold after a scale out or a scale in.
-	ThresholdAdjustmentValue int `json:"thresholdAdjustmentValue,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1beta1/helpers.go
+++ b/api/v1beta1/helpers.go
@@ -101,32 +101,6 @@ func MakeVscr() *VerticaScrutinize {
 	}
 }
 
-// CopyLabels returns a copy of vscr.Spec.Labels. This is not cheap
-// as we have to iterate over the map and copy it entry by entry.
-// This is to be used when you want to do a deep copy of the map.
-// Once we move to go1.21, we can replace this with maps.Clone()
-// from the standard ibrary
-func (vscr *VerticaScrutinize) CopyLabels() map[string]string {
-	labels := make(map[string]string, len(vscr.Spec.Labels))
-	for k, v := range vscr.Spec.Labels {
-		labels[k] = v
-	}
-	return labels
-}
-
-// CopyAnnotations returns a copy of vscr.Spec.Annotations. This is not cheap
-// as we have to iterate over the map and copy it entry by entry.
-// This is to be used when you want to do a deep copy of the map.
-// Once we move to go1.21, we can replace this with maps.Clone()
-// from the standard ibrary
-func (vscr *VerticaScrutinize) CopyAnnotations() map[string]string {
-	annotations := make(map[string]string, len(vscr.Spec.Annotations))
-	for k, v := range vscr.Spec.Annotations {
-		annotations[k] = v
-	}
-	return annotations
-}
-
 // GenerateLogAgeTime returns a string in the format of YYYY-MM-DD HH [+/-XX]
 func GenerateLogAgeTime(hourOffset time.Duration, timeZone string) string {
 	timeOffset := time.Now().Add(hourOffset * time.Hour)

--- a/api/v1beta1/verticaautoscaler_conversion.go
+++ b/api/v1beta1/verticaautoscaler_conversion.go
@@ -135,6 +135,8 @@ func convertVasFromScaledObjectSpec(src *v1.ScaledObjectSpec) *ScaledObjectSpec 
 				Threshold:        srcMetric.Prometheus.Threshold,
 				ScaleInThreshold: srcMetric.Prometheus.ScaleInThreshold,
 				AuthModes:        PrometheusAuthModes(srcMetric.Prometheus.AuthModes),
+				UnsafeSsl:        srcMetric.Prometheus.UnsafeSsl,
+				UseCachedMetrics: srcMetric.Prometheus.UseCachedMetrics,
 			}
 		}
 		if srcMetric.Resource != nil {
@@ -226,6 +228,8 @@ func convertVasToScaledObjectSpec(src *ScaledObjectSpec) *v1.ScaledObjectSpec {
 				Threshold:        srcMetric.Prometheus.Threshold,
 				ScaleInThreshold: srcMetric.Prometheus.ScaleInThreshold,
 				AuthModes:        v1.PrometheusAuthModes(srcMetric.Prometheus.AuthModes),
+				UnsafeSsl:        srcMetric.Prometheus.UnsafeSsl,
+				UseCachedMetrics: srcMetric.Prometheus.UseCachedMetrics,
 			}
 		}
 		if srcMetric.Resource != nil {

--- a/api/v1beta1/verticaautoscaler_conversion.go
+++ b/api/v1beta1/verticaautoscaler_conversion.go
@@ -102,9 +102,8 @@ func convertVasFromHPASpec(src *v1.HPASpec) *HPASpec {
 	for i := range src.Metrics {
 		srcMetric := &src.Metrics[i]
 		dst.Metrics[i] = MetricDefinition{
-			ThresholdAdjustmentValue: srcMetric.ThresholdAdjustmentValue,
-			Metric:                   srcMetric.Metric,
-			ScaleInThreshold:         ptrOrNil(srcMetric.ScaleInThreshold),
+			Metric:           srcMetric.Metric,
+			ScaleInThreshold: ptrOrNil(srcMetric.ScaleInThreshold),
 		}
 	}
 	return dst
@@ -195,9 +194,8 @@ func convertVasToHPASpec(src *HPASpec) *v1.HPASpec {
 	for i := range src.Metrics {
 		srcMetric := &src.Metrics[i]
 		dst.Metrics[i] = v1.MetricDefinition{
-			ThresholdAdjustmentValue: srcMetric.ThresholdAdjustmentValue,
-			Metric:                   srcMetric.Metric,
-			ScaleInThreshold:         ptrOrNil(srcMetric.ScaleInThreshold),
+			Metric:           srcMetric.Metric,
+			ScaleInThreshold: ptrOrNil(srcMetric.ScaleInThreshold),
 		}
 	}
 	return dst

--- a/api/v1beta1/verticaautoscaler_conversion_test.go
+++ b/api/v1beta1/verticaautoscaler_conversion_test.go
@@ -1,0 +1,153 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/vertica/vertica-kubernetes/api/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("verticaautoscaler_conversion", func() {
+	It("should convert VerticaAutoscaler Spec from v1beta1 to v1", func() {
+		v1beta1VAS := MakeVASWithMetrics() // function to generate test data for v1beta1
+		v1VAS := v1.VerticaAutoscaler{}    // v1 version of VerticaAutoscaler
+
+		// Set up a test scenario with v1beta1 data
+		v1beta1VAS.Spec.VerticaDBName = "test-db"
+		v1beta1VAS.Spec.ServiceName = "test-service"
+		v1beta1VAS.Spec.TargetSize = 5
+		v1beta1VAS.Spec.ScalingGranularity = ScalingGranularityType("node")
+
+		// Perform conversion from v1beta1 to v1
+		Ω(v1beta1VAS.ConvertTo(&v1VAS)).Should(Succeed())
+
+		// Validate the conversion from v1beta1 to v1
+		Ω(v1VAS.Spec.VerticaDBName).Should(Equal("test-db"))
+		Ω(v1VAS.Spec.ServiceName).Should(Equal("test-service"))
+		Ω(v1VAS.Spec.TargetSize).Should(Equal(int32(5)))
+		Ω(v1VAS.Spec.ScalingGranularity).Should(Equal(v1.ScalingGranularityType("node")))
+
+		// v1 -> v1beta1 conversion
+		v1VAS.Spec.VerticaDBName = "new-db"
+		v1VAS.Spec.ServiceName = "new-service"
+		v1VAS.Spec.TargetSize = 10
+		v1VAS.Spec.ScalingGranularity = v1.ScalingGranularityType("column")
+
+		// Perform conversion from v1 to v1beta1
+		Ω(v1beta1VAS.ConvertFrom(&v1VAS)).Should(Succeed())
+		Ω(v1beta1VAS.Spec.VerticaDBName).Should(Equal("new-db"))
+		Ω(v1beta1VAS.Spec.ServiceName).Should(Equal("new-service"))
+		Ω(v1beta1VAS.Spec.TargetSize).Should(Equal(int32(10)))
+		Ω(v1beta1VAS.Spec.ScalingGranularity).Should(Equal(ScalingGranularityType("column")))
+	})
+
+	It("should convert HPASpec from v1beta1 to v1", func() {
+		v1beta1VAS := MakeVASWithMetrics() // function to generate test data for v1beta1
+		v1VAS := v1.VerticaAutoscaler{}    // v1 version of VerticaAutoscaler
+
+		// Perform conversion from v1beta1 to v1
+		Ω(v1beta1VAS.ConvertTo(&v1VAS)).Should(Succeed())
+
+		// Validate the conversion from v1beta1 to v1
+		Ω(*v1VAS.Spec.CustomAutoscaler.Hpa.MinReplicas).Should(Equal(int32(3)))
+		Ω(v1VAS.Spec.CustomAutoscaler.Hpa.MaxReplicas).Should(Equal(int32(6)))
+		Ω(v1VAS.Spec.CustomAutoscaler.Hpa.Metrics[0].Metric.Type).Should(Equal(autoscalingv2.ResourceMetricSourceType))
+		Ω(v1VAS.Spec.CustomAutoscaler.Hpa.Metrics[0].Metric.Resource.Name).Should(Equal(corev1.ResourceCPU))
+
+		// v1 -> v1beta1 conversion
+		minRep := int32(1)
+		maxRep := int32(10)
+		v1VAS.Spec.CustomAutoscaler.Hpa.MinReplicas = &minRep
+		v1VAS.Spec.CustomAutoscaler.Hpa.MaxReplicas = maxRep
+		v1VAS.Spec.CustomAutoscaler.Hpa.Metrics[0].Metric.Resource.Name = corev1.ResourceMemory
+
+		// Perform conversion from v1 to v1beta1
+		Ω(v1beta1VAS.ConvertFrom(&v1VAS)).Should(Succeed())
+		Ω(*v1beta1VAS.Spec.CustomAutoscaler.Hpa.MinReplicas).Should(Equal(minRep))
+		Ω(v1beta1VAS.Spec.CustomAutoscaler.Hpa.MaxReplicas).Should(Equal(maxRep))
+		Ω(v1beta1VAS.Spec.CustomAutoscaler.Hpa.Metrics[0].Metric.Resource.Name).Should(Equal(corev1.ResourceMemory))
+	})
+
+	It("should convert ScaledObjectSpec from v1beta1 to v1", func() {
+		v1beta1VAS := MakeVASWithScaledObject() // function to generate test data for v1beta1
+		v1VAS := v1.VerticaAutoscaler{}         // v1 version of VerticaAutoscaler
+
+		// Set up a test scenario with v1beta1 data
+		pi := int32(10)
+		cp := int32(30)
+		v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.PollingInterval = &pi
+		v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.CooldownPeriod = &cp
+
+		// Perform conversion from v1beta1 to v1
+		Ω(v1beta1VAS.ConvertTo(&v1VAS)).Should(Succeed())
+
+		// Validate the conversion from v1beta1 to v1
+		Ω(*v1VAS.Spec.CustomAutoscaler.ScaledObject.MinReplicas).Should(Equal(int32(3)))
+		Ω(*v1VAS.Spec.CustomAutoscaler.ScaledObject.MaxReplicas).Should(Equal(int32(6)))
+		Ω(*v1VAS.Spec.CustomAutoscaler.ScaledObject.PollingInterval).Should(Equal(pi))
+		Ω(*v1VAS.Spec.CustomAutoscaler.ScaledObject.CooldownPeriod).Should(Equal(cp))
+
+		// v1 -> v1beta1 conversion
+		minRep := int32(1)
+		maxRep := int32(10)
+		pi = int32(20)
+		cp = int32(40)
+		v1VAS.Spec.CustomAutoscaler.ScaledObject.MinReplicas = &minRep
+		v1VAS.Spec.CustomAutoscaler.ScaledObject.MaxReplicas = &maxRep
+		v1VAS.Spec.CustomAutoscaler.ScaledObject.PollingInterval = &pi
+		v1VAS.Spec.CustomAutoscaler.ScaledObject.CooldownPeriod = &cp
+
+		// Perform conversion from v1 to v1beta1
+		Ω(v1beta1VAS.ConvertFrom(&v1VAS)).Should(Succeed())
+		Ω(*v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.MinReplicas).Should(Equal(minRep))
+		Ω(*v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.MaxReplicas).Should(Equal(maxRep))
+		Ω(*v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.PollingInterval).Should(Equal(pi))
+		Ω(*v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.CooldownPeriod).Should(Equal(cp))
+	})
+
+	It("should convert PrometheusSpec from v1beta1 to v1 with useCachedMetrics", func() {
+		v1beta1VAS := MakeVASWithScaledObject() // function to generate test data for v1beta1
+		v1VAS := v1.VerticaAutoscaler{}         // v1 version of VerticaAutoscaler
+
+		v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.Metrics = []ScaleTrigger{
+			{
+				Prometheus: &PrometheusSpec{
+					ServerAddress:    "http://prometheus.local",
+					Query:            "cpu_usage",
+					Threshold:        80,
+					UseCachedMetrics: true, // Test use of cached metrics
+				},
+			},
+		}
+
+		// Perform conversion from v1beta1 to v1
+		Ω(v1beta1VAS.ConvertTo(&v1VAS)).Should(Succeed())
+
+		// Validate the conversion from v1beta1 to v1
+		Ω(v1VAS.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Prometheus.UseCachedMetrics).Should(BeTrue())
+		Ω(v1VAS.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Prometheus.ServerAddress).Should(Equal("http://prometheus.local"))
+
+		// v1 -> v1beta1 conversion
+		v1VAS.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Prometheus.UseCachedMetrics = false
+
+		// Perform conversion from v1 to v1beta1
+		Ω(v1beta1VAS.ConvertFrom(&v1VAS)).Should(Succeed())
+		Ω(v1beta1VAS.Spec.CustomAutoscaler.ScaledObject.Metrics[0].Prometheus.UseCachedMetrics).Should(BeFalse())
+	})
+})

--- a/api/v1beta1/verticaautoscaler_types.go
+++ b/api/v1beta1/verticaautoscaler_types.go
@@ -54,7 +54,7 @@ type VerticaAutoscalerSpec struct {
 	ServiceName string `json:"serviceName,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:fieldDependency:scalingGranularity:Subcluster"
 	// When the scaling granularity is Subcluster, this field defines a template
 	// to use for when a new subcluster needs to be created.  If size is 0, then
 	// the operator will use an existing subcluster to use as the template.  If
@@ -281,9 +281,16 @@ type PrometheusSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	// Used for skipping certificate check e.g: using self-signed certs.
 	UnsafeSsl bool `json:"unsafeSsl,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+	// Enables caching of metric values during polling interval. It is Used to control whether the autoscaler should use cached metrics for scaling
+	// decisions rather than querying the external metric provider (e.g., Prometheus) on each scale event. This feature is not supported for cpu and memory.
+	UseCachedMetrics bool `json:"useCachedMetrics,omitempty"`
 }
 
 type CPUMemorySpec struct {
@@ -299,13 +306,6 @@ type CPUMemorySpec struct {
 
 // MetricDefinition defines increment and metric to be used for autoscaling
 type MetricDefinition struct {
-
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +kubebuilder:Minimum:=0
-	// The value used to increase the threshold after a scale out or a scale in.
-	ThresholdAdjustmentValue int `json:"thresholdAdjustmentValue,omitempty"`
-
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// The threshold to use for scaling in. It must be of the same type as

--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -194,10 +194,6 @@ spec:
           the one used for scaling up, defined in the metric field.
         displayName: Scale In Threshold
         path: customAutoscaler.hpa.metrics[0].scaleInThreshold
-      - description: The value used to increase the threshold after a scale out or
-          a scale in.
-        displayName: Threshold Adjustment Value
-        path: customAutoscaler.hpa.metrics[0].thresholdAdjustmentValue
       - description: The miminum number of pods when scaling.
         displayName: Min Replicas
         path: customAutoscaler.hpa.minReplicas
@@ -297,7 +293,13 @@ spec:
         path: customAutoscaler.scaledObject.metrics[0].prometheus.unsafeSsl
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          Enables caching of metric values during polling interval. It is Used to control whether the autoscaler should use cached metrics for scaling
+          decisions rather than querying the external metric provider (e.g., Prometheus) on each scale event. This feature is not supported for cpu and memory.
+        displayName: Use Cached Metrics
+        path: customAutoscaler.scaledObject.metrics[0].prometheus.useCachedMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: |-
           The detail about the target value and container name. if type is cpu/memory
           this must be set.
@@ -672,10 +674,6 @@ spec:
           the one used for scaling up, defined in the metric field.
         displayName: Scale In Threshold
         path: customAutoscaler.hpa.metrics[0].scaleInThreshold
-      - description: The value used to increase the threshold after a scale out or
-          a scale in.
-        displayName: Threshold Adjustment Value
-        path: customAutoscaler.hpa.metrics[0].thresholdAdjustmentValue
       - description: The miminum number of pods when scaling.
         displayName: Min Replicas
         path: customAutoscaler.hpa.minReplicas
@@ -775,7 +773,13 @@ spec:
         path: customAutoscaler.scaledObject.metrics[0].prometheus.unsafeSsl
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-        - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          Enables caching of metric values during polling interval. It is Used to control whether the autoscaler should use cached metrics for scaling
+          decisions rather than querying the external metric provider (e.g., Prometheus) on each scale event. This feature is not supported for cpu and memory.
+        displayName: Use Cached Metrics
+        path: customAutoscaler.scaledObject.metrics[0].prometheus.useCachedMetrics
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: |-
           The detail about the target value and container name. if type is cpu/memory
           this must be set.

--- a/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/verticadb-operator.clusterserviceversion.yaml
@@ -395,6 +395,8 @@ spec:
           subclusters.
         displayName: Template
         path: template
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:scalingGranularity:Subcluster
       - description: |-
           Like nodeSelector this allows you to constrain the pod only to certain
           pods. It is more expressive than just using node selectors.
@@ -871,6 +873,8 @@ spec:
           subclusters.
         displayName: Template
         path: template
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:scalingGranularity:Subcluster
       - description: |-
           Like nodeSelector this allows you to constrain the pod only to certain
           pods. It is more expressive than just using node selectors.

--- a/pkg/builder/labels_annotations.go
+++ b/pkg/builder/labels_annotations.go
@@ -21,6 +21,11 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/opcfg"
 )
 
+const (
+	kedaPausingAutoscalingAnnotation         = "autoscaling.keda.sh/paused"
+	kedaPausingAutoscalingReplicasAnnotation = "autoscaling.keda.sh/paused-replicas"
+)
+
 // MakeSubclusterLabels returns the labels added for the subcluster
 func MakeSubclusterLabels(sc *vapi.Subcluster) map[string]string {
 	m := map[string]string{
@@ -186,6 +191,23 @@ func MakeAnnotationsForSandboxConfigMap(vdb *vapi.VerticaDB, forUpgrade bool) ma
 	}
 	if ver, ok := vdb.Annotations[vmeta.VersionAnnotation]; ok {
 		annotations[vmeta.VersionAnnotation] = ver
+	}
+	return annotations
+}
+
+// MakeAnnotationsForScaledObject builds the list of annotations that are included
+// in the scaledobject.
+func MakeAnnotationsForScaledObject(vas *vapi.VerticaAutoscaler) map[string]string {
+	annotations := make(map[string]string, len(vas.Annotations))
+	for k, v := range vas.Annotations {
+		key := k
+		if key == vmeta.PausingAutoscalingAnnotation {
+			key = kedaPausingAutoscalingAnnotation
+		}
+		if key == vmeta.PausingAutoscalingReplicasAnnotation {
+			key = kedaPausingAutoscalingReplicasAnnotation
+		}
+		annotations[key] = v
 	}
 	return annotations
 }

--- a/pkg/controllers/vas/obj_reconciler.go
+++ b/pkg/controllers/vas/obj_reconciler.go
@@ -69,6 +69,9 @@ func (o *ObjReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.
 	if o.Vas.IsHpaEnabled() {
 		return ctrl.Result{}, o.reconcileHpa(ctx)
 	}
+	if !o.Vas.IsScaledObjectEnabled() {
+		return ctrl.Result{}, errors.New("invalid customAutoscaler spec")
+	}
 	return ctrl.Result{}, o.reconcileScaledObject(ctx)
 }
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -387,6 +387,15 @@ const (
 	// Annotation set in a sandbox configMap. Indicates that routing must be disabled
 	// on the sandbox nodes.
 	DisableRoutingAnnotation = "vertica.com/disable-routing"
+
+	// It will pause scaling immediately and use the current instance count.
+	// This only works for a scaledobject.
+	PausingAutoscalingAnnotation = "vertica.com/paused"
+
+	// It will scale your current workload to specified amount of replicas and pause autoscaling.
+	// You can set the value of replicas for an object to be paused to any arbitrary number.
+	// This only works for a scaledobject.
+	PausingAutoscalingReplicasAnnotation = "vertica.com/paused-replicas"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will

--- a/tests/e2e-leg-12/scale-in-with-threshold-keda/45-assert.yaml
+++ b/tests/e2e-leg-12/scale-in-with-threshold-keda/45-assert.yaml
@@ -24,6 +24,9 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: v-scale-in-threshold-vas-keda
+  annotations:
+    autoscaling.keda.sh/paused: "false"
+    test: "0"
 spec:
   maxReplicaCount: 7
   minReplicaCount: 3
@@ -42,6 +45,7 @@ spec:
     authenticationRef: 
       name: v-scale-in-threshold-vas-prometheus-tls-creds
     metricType: AverageValue
+    useCachedMetrics: true
     name: vertica_sessions_running_total
     type: prometheus
 ---

--- a/tests/e2e-leg-12/scale-in-with-threshold-keda/45-create-vas.yaml
+++ b/tests/e2e-leg-12/scale-in-with-threshold-keda/45-create-vas.yaml
@@ -15,6 +15,9 @@ apiVersion: vertica.com/v1
 kind: VerticaAutoscaler
 metadata:
   name: v-scale-in-threshold-vas
+  annotations:
+    vertica.com/paused: "false"
+    test: "0"
 spec:
   verticaDBName: v-scale-in-threshold
   serviceName: pri1
@@ -34,3 +37,4 @@ spec:
           threshold: 5
           scaleInThreshold: 1
           authModes: tls
+          useCachedMetrics: true


### PR DESCRIPTION
- Adds a new field `useCachedMetric` to read metric from the cache first.
- Adds annotations to pause the autoscaler
- Remove threshold adjustment field as it is not used