### PR TITLE
Add webhook for autoscaler pausing annotations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @roypaulin @cchen-vertica @fenic-fawkes @HaoYang0000 @qindotguan @LiboYu2
+* @roypaulin @cchen-vertica @HaoYang0000 @qindotguan @LiboYu2

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1400,3 +1400,21 @@ func IsK8sSecretFound(ctx context.Context, vdb *VerticaDB, k8sClient client.Clie
 		return true, nil
 	}
 }
+
+func convertToBool(src string) bool {
+	converted := false
+	_, err := strconv.ParseBool(src)
+	if err == nil {
+		converted = true
+	}
+	return converted
+}
+
+func convertToInt(src string) (int, bool) {
+	converted := false
+	varAsInt, err := strconv.ParseInt(src, 10, 0)
+	if err == nil {
+		converted = true
+	}
+	return int(varAsInt), converted
+}

--- a/api/v1/verticaautoscaler_webhook_test.go
+++ b/api/v1/verticaautoscaler_webhook_test.go
@@ -18,6 +18,7 @@ package v1
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 )
 
@@ -413,5 +414,47 @@ var _ = Describe("verticaautoscaler_webhook", func() {
 		_, err = vas.ValidateCreate()
 		Expect(err).Should(Succeed())
 		Expect(*vas.Spec.CustomAutoscaler.Hpa.Behavior.ScaleDown.StabilizationWindowSeconds).Should(Equal(int32(0)))
+	})
+
+	It("should validate pause scaling annotations", func() {
+		vas := MakeVASWithMetrics()
+		_, err := vas.ValidateCreate()
+		Expect(err).Should(Succeed())
+		vas.Annotations = map[string]string{
+			vmeta.PausingAutoscalingAnnotation: "wrong",
+		}
+		_, err = vas.ValidateCreate()
+		Expect(err).ShouldNot(Succeed())
+		vas.Annotations = map[string]string{
+			vmeta.PausingAutoscalingAnnotation: "true",
+		}
+		_, err = vas.ValidateCreate()
+		Expect(err).Should(Succeed())
+		vas.Annotations = map[string]string{
+			vmeta.PausingAutoscalingReplicasAnnotation: "xxxx",
+		}
+		_, err = vas.ValidateCreate()
+		Expect(err).ShouldNot(Succeed())
+		vas.Annotations = map[string]string{
+			vmeta.PausingAutoscalingReplicasAnnotation: "-1",
+		}
+		_, err = vas.ValidateCreate()
+		Expect(err).ShouldNot(Succeed())
+		vas.Annotations = map[string]string{
+			vmeta.PausingAutoscalingReplicasAnnotation: "2",
+		}
+		_, err = vas.ValidateCreate()
+		Expect(err).ShouldNot(Succeed())
+		vas.Annotations = map[string]string{
+			vmeta.PausingAutoscalingReplicasAnnotation: "4",
+		}
+		_, err = vas.ValidateCreate()
+		Expect(err).Should(Succeed())
+		vas.Annotations = map[string]string{
+			vmeta.PausingAutoscalingAnnotation:         "true",
+			vmeta.PausingAutoscalingReplicasAnnotation: "4",
+		}
+		_, err = vas.ValidateCreate()
+		Expect(err).ShouldNot(Succeed())
 	})
 })


### PR DESCRIPTION
- make sure the 2 annotations are not same at same time
- make sure their value after conversion is valid
- make sure `paused-autoscaling-replicas` is lower than replicas and positive