### PR TITLE
Handle checking secret from any secret stores before generating nma cert configmap

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -29,7 +29,6 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1386,22 +1385,6 @@ func GetMetricTarget(metric *autoscalingv2.MetricSpec) *autoscalingv2.MetricTarg
 		}
 	}
 	return nil
-}
-
-func IsK8sSecretFound(ctx context.Context, vdb *VerticaDB, k8sClient client.Client, secretName *string,
-	secret *corev1.Secret) (bool, error) {
-	nm := types.NamespacedName{
-		Name:      *secretName,
-		Namespace: vdb.GetNamespace(),
-	}
-	err := k8sClient.Get(ctx, nm, secret)
-	if k8sErrors.IsNotFound(err) {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	} else {
-		return true, nil
-	}
 }
 
 func convertToBool(src string) bool {

--- a/pkg/controllers/vdb/nmacertconfigmapgen_reconciler.go
+++ b/pkg/controllers/vdb/nmacertconfigmapgen_reconciler.go
@@ -22,7 +22,9 @@ import (
 	"github.com/go-logr/logr"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	"github.com/vertica/vertica-kubernetes/pkg/cloud"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -51,10 +53,10 @@ func (h *NMACertConfigMapGenReconciler) Reconcile(ctx context.Context, _ *ctrl.R
 	if vmeta.UseNMACertsMount(h.Vdb.Annotations) || !vmeta.EnableTLSCertsRotation(h.Vdb.Annotations) {
 		return ctrl.Result{}, nil
 	}
-	nmaSecret := corev1.Secret{}
-	if !h.tlsSecretsReady(ctx, &nmaSecret) {
-		h.Log.Info("nma secret is not ready yet to create configmap. will retry")
-		return ctrl.Result{Requeue: true}, nil
+
+	res, err := h.checkSecret(ctx)
+	if verrors.IsReconcileAborted(res, err) {
+		return res, err
 	}
 	name := fmt.Sprintf("%s-%s", h.Vdb.Name, vapi.NMATLSConfigMapName)
 	configMapName := types.NamespacedName{
@@ -62,7 +64,7 @@ func (h *NMACertConfigMapGenReconciler) Reconcile(ctx context.Context, _ *ctrl.R
 		Namespace: h.Vdb.GetNamespace(),
 	}
 	configMap := &corev1.ConfigMap{}
-	err := h.VRec.Client.Get(ctx, configMapName, configMap)
+	err = h.VRec.Client.Get(ctx, configMapName, configMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			configMap = builder.BuildNMATLSConfigMap(name, h.Vdb)
@@ -73,8 +75,7 @@ func (h *NMACertConfigMapGenReconciler) Reconcile(ctx context.Context, _ *ctrl.R
 		h.Log.Info("failed to retrieve TLS cert secret configmap", "nm", configMapName.Name)
 		return ctrl.Result{}, err
 	}
-	if configMap.Data[builder.NMASecretNamespaceEnv] != h.Vdb.GetObjectMeta().GetNamespace() ||
-		configMap.Data[builder.NMASecretNameEnv] != h.Vdb.Spec.NMATLSSecret {
+	if configMap.Data[builder.NMASecretNameEnv] != h.Vdb.Spec.NMATLSSecret {
 		configMap = builder.BuildNMATLSConfigMap(name, h.Vdb)
 		err = h.VRec.Client.Update(ctx, configMap)
 		h.Log.Info("config map " + name + " is updated for new nma secret " + h.Vdb.Spec.NMATLSSecret)
@@ -83,21 +84,22 @@ func (h *NMACertConfigMapGenReconciler) Reconcile(ctx context.Context, _ *ctrl.R
 	return ctrl.Result{}, err
 }
 
-// tlsSecretsReady returns true when all TLS secrets are found in k8s env
-func (h *NMACertConfigMapGenReconciler) tlsSecretsReady(ctx context.Context, secret *corev1.Secret) bool {
+// checkSecret checks if the secret exists in the secret store.
+func (h *NMACertConfigMapGenReconciler) checkSecret(ctx context.Context) (ctrl.Result, error) {
 	if h.Vdb.Spec.NMATLSSecret == "" {
 		h.Log.Info("nma secret name is not ready. wait for it to be created")
-		return false
+		return ctrl.Result{Requeue: true}, nil
 	}
-	found, err := vapi.IsK8sSecretFound(ctx, h.Vdb, h.VRec.Client, &h.Vdb.Spec.NMATLSSecret, secret)
-	if !found || err != nil {
-		if err == nil {
-			h.Log.Info("did not find nma tls secret " + h.Vdb.Spec.NMATLSSecret)
-		} else {
-			h.Log.Info("failed to find nma tls secret " + h.Vdb.Spec.NMATLSSecret + " because of err: " + err.Error())
-		}
-
-		return false
+	sf := cloud.SecretFetcher{
+		Client:   h.VRec.Client,
+		Log:      h.Log,
+		Obj:      h.Vdb,
+		EVWriter: h.VRec.EVRec,
 	}
-	return true
+	nm := types.NamespacedName{
+		Name:      h.Vdb.Spec.NMATLSSecret,
+		Namespace: h.Vdb.GetNamespace(),
+	}
+	_, res, err := sf.FetchAllowRequeue(ctx, nm)
+	return res, err
 }

--- a/pkg/controllers/vdb/nmacertconfigmapgen_reconciler_test.go
+++ b/pkg/controllers/vdb/nmacertconfigmapgen_reconciler_test.go
@@ -1,0 +1,135 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/builder"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
+	"github.com/vertica/vertica-kubernetes/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("nmacertconfigmapgen_reconcile", func() {
+	ctx := context.Background()
+	const trueStr = "true"
+	const falseStr = "false"
+
+	It("should be a no-op if UseNMACertsMount is enabled", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Annotations[vmeta.MountNMACertsAnnotation] = trueStr
+		vdb.Annotations[vmeta.EnableTLSCertsRotationAnnotation] = falseStr
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		r := MakeNMACertConfigMapGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+	})
+
+	It("should be a no-op if TLSCertsRotation is disabled", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Annotations[vmeta.MountNMACertsAnnotation] = falseStr
+		vdb.Annotations[vmeta.EnableTLSCertsRotationAnnotation] = falseStr
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		r := MakeNMACertConfigMapGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+	})
+
+	It("should requeue if secret name is not set", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Annotations[vmeta.MountNMACertsAnnotation] = falseStr
+		vdb.Annotations[vmeta.EnableTLSCertsRotationAnnotation] = trueStr
+		vdb.Spec.NMATLSSecret = ""
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		r := MakeNMACertConfigMapGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
+	})
+
+	It("should create the ConfigMap if it does not exist", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Annotations[vmeta.MountNMACertsAnnotation] = falseStr
+		vdb.Annotations[vmeta.EnableTLSCertsRotationAnnotation] = trueStr
+		const existing = "existing-secret"
+		vdb.Spec.NMATLSSecret = existing
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		r := MakeTLSServerCertGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		Expect(vdb.Spec.NMATLSSecret).Should(Equal(existing))
+
+		// Ensure the ConfigMap doesn't exist
+		configMapName := fmt.Sprintf("%s-%s", vdb.Name, vapi.NMATLSConfigMapName)
+		configMap := &corev1.ConfigMap{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: vdb.Namespace}, configMap)
+		Expect(errors.IsNotFound(err)).Should(BeTrue())
+
+		r = MakeNMACertConfigMapGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		defer deleteConfigMap(ctx, vdb, configMapName)
+
+		// Verify that the ConfigMap was created
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: vdb.Namespace}, configMap)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(configMap.Data[builder.NMASecretNameEnv]).Should(Equal(vdb.Spec.NMATLSSecret))
+	})
+
+	It("should update the ConfigMap if the secret name changes", func() {
+		vdb := vapi.MakeVDB()
+		vdb.Annotations[vmeta.MountNMACertsAnnotation] = falseStr
+		vdb.Annotations[vmeta.EnableTLSCertsRotationAnnotation] = trueStr
+		const initial = "initial-secret"
+		vdb.Spec.NMATLSSecret = initial
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		r := MakeTLSServerCertGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		Expect(vdb.Spec.NMATLSSecret).Should(Equal(initial))
+
+		nm := fmt.Sprintf("%s-%s", vdb.Name, vapi.NMATLSConfigMapName)
+		configMap := builder.BuildNMATLSConfigMap(nm, vdb)
+		Expect(k8sClient.Create(ctx, configMap)).Should(Succeed())
+		defer deleteConfigMap(ctx, vdb, nm)
+
+		vdb.Spec.NMATLSSecret = "updated-secret"
+		Expect(k8sClient.Update(ctx, vdb)).Should(Succeed())
+
+		r = MakeTLSServerCertGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+		Expect(vdb.Spec.NMATLSSecret).Should(Equal("updated-secret"))
+
+		r = MakeNMACertConfigMapGenReconciler(vdbRec, logger, vdb)
+		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{}))
+
+		// Verify that the ConfigMap was updated
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: nm, Namespace: vdb.Namespace}, configMap)
+		Expect(err).Should(Succeed())
+		Expect(configMap.Data[builder.NMASecretNameEnv]).Should(Equal("updated-secret"))
+	})
+})

--- a/pkg/controllers/vdb/tlsservercertgen_reconciler_test.go
+++ b/pkg/controllers/vdb/tlsservercertgen_reconciler_test.go
@@ -30,7 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var _ = Describe("httpservercertgen_reconcile", func() {
+var _ = Describe("tlsservercertgen_reconcile", func() {
 	ctx := context.Background()
 
 	It("should be a op if not using vclusterops", func() {


### PR DESCRIPTION
In `pkg/controllers/vdb/nmacertconfigmapgen_reconciler.go` we were checking for k8s secrets only. This checks for any supported secret store. I also addded unit tests.