### PR TITLE
Mtls e2e leg4 fix

### DIFF
--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -426,11 +426,11 @@ func UseVProxyCertsMount(annotations map[string]string) bool {
 // UseNMACertsMount returns true if the NMA reads certs from the mounted secret
 // volume rather than directly from k8s secret store.
 func UseNMACertsMount(annotations map[string]string) bool {
-	return lookupBoolAnnotation(annotations, MountNMACertsAnnotation, true /* default value */)
+	return lookupBoolAnnotation(annotations, MountNMACertsAnnotation, false /* default value */)
 }
 
 func EnableTLSCertsRotation(annotations map[string]string) bool {
-	return lookupBoolAnnotation(annotations, EnableTLSCertsRotationAnnotation, false /* default value */)
+	return lookupBoolAnnotation(annotations, EnableTLSCertsRotationAnnotation, true /* default value */)
 }
 
 // IgnoreClusterLease returns true if revive/start should ignore the cluster lease

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -426,11 +426,11 @@ func UseVProxyCertsMount(annotations map[string]string) bool {
 // UseNMACertsMount returns true if the NMA reads certs from the mounted secret
 // volume rather than directly from k8s secret store.
 func UseNMACertsMount(annotations map[string]string) bool {
-	return lookupBoolAnnotation(annotations, MountNMACertsAnnotation, false /* default value */)
+	return lookupBoolAnnotation(annotations, MountNMACertsAnnotation, true /* default value */)
 }
 
 func EnableTLSCertsRotation(annotations map[string]string) bool {
-	return lookupBoolAnnotation(annotations, EnableTLSCertsRotationAnnotation, true /* default value */)
+	return lookupBoolAnnotation(annotations, EnableTLSCertsRotationAnnotation, false /* default value */)
 }
 
 // IgnoreClusterLease returns true if revive/start should ignore the cluster lease

--- a/tests/e2e-leg-4/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/vdb-to-create/base/setup-vdb.yaml
@@ -15,6 +15,9 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-create-1-node
+  annotations:
+    vertica.com/mount-nma-certs: "true"
+    vertica.com/enable-tls-certs-rotation: "false"
 spec:
   image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd

--- a/tests/e2e-leg-4/revivedb-1-node/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-1-node/vdb-to-revive/base/setup-vdb.yaml
@@ -15,6 +15,9 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-revive-1-node
+  annotations:
+    vertica.com/mount-nma-certs: "true"
+    vertica.com/enable-tls-certs-rotation: "false"
 spec:
   image: kustomize-vertica-image
   superuserPasswordSecret: su-passwd

--- a/tests/e2e-leg-4/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-3-node/vdb-to-revive/base/setup-vdb.yaml
@@ -19,6 +19,8 @@ metadata:
     vertica.com/ignore-cluster-lease: true
     vertica.com/requeue-time: "5"
     vertica.com/include-uid-in-path: false
+    vertica.com/mount-nma-certs: "true"
+    vertica.com/enable-tls-certs-rotation: "false"
 spec:
   image: kustomize-vertica-image
   communal: {}

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/01-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/01-assert.yaml
@@ -11,28 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/01-rbac.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/01-rbac.yaml
@@ -11,28 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/05-create-communal-creds.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/05-create-communal-creds.yaml
@@ -11,28 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/06-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/06-assert.yaml
@@ -11,28 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/06-deploy-operator.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/06-deploy-operator.yaml
@@ -10,29 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/07-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/07-assert.yaml
@@ -11,28 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/07-clean-communal.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/07-clean-communal.yaml
@@ -11,28 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/08-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/08-assert.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-cert

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/08-create-cert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/08-create-cert.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "envsubst < cert.yaml | kubectl apply -n $NAMESPACE -f -"

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/15-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/15-assert.yaml
@@ -11,28 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-multi-sc-main
+status:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-multi-sc-secondary
+status:
+  replicas: 1
+---
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
+  name: v-create-multi-sc
+status:
   subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 1
+    - installCount: 1

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/15-create-crd.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/15-create-crd.yaml
@@ -11,28 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build vdb-to-create/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/20-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/20-assert.yaml
@@ -11,28 +11,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-multi-sc-main
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-multi-sc-secondary
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
+  name: v-create-multi-sc
+status:
   subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/20-wait-for-create-db.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/20-wait-for-create-db.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/30-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/30-assert.yaml
@@ -11,28 +11,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-multi-sc-main
+status:
+  replicas: 2
+  readyReplicas: 2
+---
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
+  name: v-create-multi-sc
+status:
+  subclusterCount: 2
+  installCount: 3
+  addedToDBCount: 3
+  upNodeCount: 3
   subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 2
+      addedToDBCount: 2
+      upNodeCount: 2
+      name: main
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1
+      name: secondary

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/30-scale-sc.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/30-scale-sc.yaml
@@ -11,28 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
+  name: v-create-multi-sc
 spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
   subclusters:
     - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+      size: 2
+      isPrimary: true
+    - name: secondary
+      size: 1
+      isPrimary: false

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/35-delete-crd.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/35-delete-crd.yaml
@@ -11,28 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/35-errors.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/35-errors.yaml
@@ -11,28 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: v-create-multi-sc-main
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-create-multi-sc-secondary
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/40-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/40-assert.yaml
@@ -11,28 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-multi-sc-main
+status:
+  replicas: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-multi-sc-secondary
+status:
+  replicas: 1
+---
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
+  name: v-revive-multi-sc
+status:
   subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 2
+    - installCount: 1

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/40-revive-setup-sts.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/40-revive-setup-sts.yaml
@@ -11,28 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build vdb-to-revive/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/45-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/45-assert.yaml
@@ -11,28 +11,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-multi-sc-main
+status:
+  replicas: 2
+  readyReplicas: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-revive-multi-sc-secondary
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
+  name: v-revive-multi-sc
+status:
   subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    - installCount: 2
+      addedToDBCount: 2
+      upNodeCount: 2
+    - installCount: 1
+      addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/45-wait-for-revive.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/45-wait-for-revive.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/50-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/50-assert.yaml
@@ -11,28 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 180
+---
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: test-verify-connected-subcluster-after-revive
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/50-verify-subclusters.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/50-verify-subclusters.yaml
@@ -1,0 +1,72 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify that the subcluster we attach to is the correct one.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-connected-subcluster
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    cat << EOF > /tmp/verify.sh
+    #!/bin/sh
+    set -o xtrace
+    set -o errexit
+
+    EXPECTED_SUBCLUSTER=\$1
+    Q="select subcluster_name from subclusters where node_name = (select node_name from sessions where session_id = current_session())"
+    vsql -U dbadmin -tAc "\$Q"
+    vsql -U dbadmin -tAc "\$Q" | grep \$EXPECTED_SUBCLUSTER
+    EOF
+
+    VDB_NAME=v-revive-multi-sc
+    SUBCLUSTERS="main secondary"
+    for subcluster in $SUBCLUSTERS
+    do
+      SELECTOR=app.kubernetes.io/name=vertica,app.kubernetes.io/instance=$VDB_NAME,vertica.com/subcluster=$subcluster
+      ALL_PODS=$(kubectl get pods --selector=$SELECTOR -o=jsonpath='{.items[*].metadata.name}')
+      for pod_name in $ALL_PODS
+      do
+        kubectl cp /tmp/verify.sh $pod_name:/home/dbadmin/verify.sh -c server
+        kubectl exec $pod_name -i -c server -- sh /home/dbadmin/verify.sh $subcluster
+      done
+    done
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-verify-connected-subcluster-after-revive
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: quay.io/helmpack/chart-testing:v3.3.1
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0700
+        name: script-verify-connected-subcluster

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/55-run-scrutinize.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/55-run-scrutinize.yaml
@@ -11,28 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: cd ../../..  && scripts/capture-scrutinize.sh -o /tmp/scrutinize-op -x -n $NAMESPACE

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/90-delete-clean-communal-pod.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/90-delete-clean-communal-pod.yaml
@@ -11,28 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: v1
+    kind: Pod
+    name: clean-communal

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/90-errors.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/90-errors.yaml
@@ -11,28 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: clean-communal

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/95-assert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/95-assert.yaml
@@ -11,28 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: v1
+kind: Pod
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/95-delete-crd.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/95-delete-crd.yaml
@@ -11,28 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1beta1
+    kind: VerticaDB
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/95-errors.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/95-errors.yaml
@@ -11,28 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
 metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+    labels:
+        app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1beta1
+kind: VerticaDB
+---
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/99-delete-ns.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/99-delete-ns.yaml
@@ -11,28 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/README.txt
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/README.txt
@@ -1,0 +1,1 @@
+This will do a revive against a database that created with multiple subclusters.

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/cert.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/cert.yaml
@@ -1,0 +1,33 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is applied through envsubst so that the $NAMESPACE gets filled in
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+spec:
+  commonName: dbadmin
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: custom-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-create/base/kustomization.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-create/base/kustomization.yaml
@@ -11,28 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-create/base/setup-vdb.yaml
@@ -11,28 +11,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
+  name: v-create-multi-sc
   annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
+    vertica.com/mount-nma-certs: "false"
+    vertica.com/enable-tls-certs-rotation: "true"
 spec:
   image: kustomize-vertica-image
-  communal: {}
+  sidecars:
+    - name: vlogger
+      image: kustomize-vlogger-image
+  communal:
+    includeUIDInPath: false
   initPolicy: CreateSkipPackageInstall
   local:
-    dataPath: /my-data
-    depotPath: /my-data
+    dataPath: /data
+    depotPath: /depot
     requestSize: 100Mi
-  dbName: vertdb
+  dbName: vert_db
   subclusters:
     - name: main
-      size: 3
+      isPrimary: true
+      size: 1
+    - name: secondary
+      isPrimary: false
+      size: 1
+  kSafety: "0"
   certSecrets: []
+  httpServerTLSSecret: custom-cert
   imagePullSecrets: []
   volumes: []
   volumeMounts: []

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-revive/base/kustomization.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-revive/base/kustomization.yaml
@@ -11,28 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
-kind: VerticaDB
-metadata:
-  name: v-create-3-node
-  annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
-spec:
-  image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
-  local:
-    dataPath: /my-data
-    depotPath: /my-data
-    requestSize: 100Mi
-  dbName: vertdb
-  subclusters:
-    - name: main
-      size: 3
-  certSecrets: []
-  imagePullSecrets: []
-  volumes: []
-  volumeMounts: []
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc-mtls/vdb-to-revive/base/setup-vdb.yaml
@@ -11,28 +11,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: vertica.com/v1
+apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
-  name: v-create-3-node
+  name: v-revive-multi-sc
   annotations:
-    vertica.com/requeue-time: "5"
-    vertica.com/include-uid-in-path: false
-    vertica.com/mount-nma-certs: "true"
-    vertica.com/enable-tls-certs-rotation: "false"
+    vertica.com/mount-nma-certs: "false"
+    vertica.com/enable-tls-certs-rotation: "true"
 spec:
   image: kustomize-vertica-image
-  communal: {}
-  initPolicy: CreateSkipPackageInstall
+  sidecars:
+    - name: vlogger
+      image: kustomize-vlogger-image
+  ignoreClusterLease: true
+  communal:
+    includeUIDInPath: false
+  initPolicy: Revive
+  reviveOrder:
+    - subclusterIndex: 0
+      podCount: 1
+    - subclusterIndex: 1
+      podCount: 1
+    - subclusterIndex: 0
+      podCount: 1
   local:
-    dataPath: /my-data
-    depotPath: /my-data
+    dataPath: /data
+    depotPath: /depot
     requestSize: 100Mi
-  dbName: vertdb
+  dbName: vert_db
   subclusters:
     - name: main
-      size: 3
+      isPrimary: true
+      size: 2
+    - name: secondary
+      isPrimary: false
+      size: 1
+  kSafety: "0"
   certSecrets: []
   imagePullSecrets: []
+  httpServerTLSSecret: custom-cert
   volumes: []
   volumeMounts: []

--- a/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-create/base/setup-vdb.yaml
@@ -15,6 +15,9 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-create-multi-sc
+  annotations:
+    vertica.com/mount-nma-certs: "true"
+    vertica.com/enable-tls-certs-rotation: "false"
 spec:
   image: kustomize-vertica-image
   sidecars:

--- a/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
+++ b/tests/e2e-leg-4/revivedb-multi-sc/vdb-to-revive/base/setup-vdb.yaml
@@ -15,6 +15,9 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-revive-multi-sc
+  annotations:
+    vertica.com/mount-nma-certs: "true"
+    vertica.com/enable-tls-certs-rotation: "false"
 spec:
   image: kustomize-vertica-image
   sidecars:


### PR DESCRIPTION
major changes for this leg:
1 Make revive multi-subcluster with mutual tls a separate case
2 When reviving a db, provide the secret name that is used to create the db.
3  When creating a certificate, make sure the common name is dbadmin. 