### PR TITLE
use FALLTHROUGH, rename auth_tls to k8s_tls_builtin_auth

### DIFF
--- a/pkg/controllers/vdb/createdb_reconciler.go
+++ b/pkg/controllers/vdb/createdb_reconciler.go
@@ -234,8 +234,8 @@ func (c *CreateDBReconciler) generatePostDBCreateSQL(ctx context.Context, initia
 
 		sb.WriteString(`ALTER TLS CONFIGURATION https CERTIFICATE https_cert_0 ADD CA CERTIFICATES https_ca_cert_0 TLSMODE 'TRY_VERIFY';`)
 		sb.WriteString(`ALTER TLS CONFIGURATION https CERTIFICATE https_cert_0 REMOVE CA CERTIFICATES httpServerRootca;`)
-		sb.WriteString(`CREATE AUTHENTICATION auth_tls METHOD 'tls' HOST TLS '0.0.0.0/0';`)
-		sb.WriteString(fmt.Sprintf(`GRANT AUTHENTICATION auth_tls TO %s;`, c.Vdb.GetVerticaUser()))
+		sb.WriteString(`CREATE AUTHENTICATION k8s_tls_builtin_auth METHOD 'tls' HOST TLS '0.0.0.0/0' FALLTHROUGH;`)
+		sb.WriteString(fmt.Sprintf(`GRANT AUTHENTICATION k8s_tls_builtin_auth TO %s;`, c.Vdb.GetVerticaUser()))
 		sb.WriteString(`select sync_catalog();`)
 		pcFile = PostDBCreateSQLFileVclusterOps
 	}


### PR DESCRIPTION
Use "FALLTHROUGH" to create authentication. That allows users to use password to connect to https service when TLS is enabled. 

The authentication is also renamed from "auth_tls" to "k8s_tls_builtin_auth" to avoid being deleted by users.

This change will fix "k-safety-0-scaling" and "k-safety-1-scaling" in leg 1.

All test cases in leg 1 can be run both with and without TLS.
  
