### PR TITLE
Fix upgrade with certs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -656,6 +656,32 @@ jobs:
           need-base-vertica-image: 'true'
           e2e-retry-times: ${{ inputs.e2e_retry_times || 3 }}
 
+  e2e-leg-9-vcluster-cert:
+    if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 9 cert' || inputs.e2e_test_suites == '')}}
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Test
+        uses: ./.github/actions/run-e2e-leg
+        with:
+          leg-identifier: 'leg-9'
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          vlogger-image: ${{ needs.build.outputs.vlogger-image }}
+          operator-image: ${{ needs.build.outputs.operator-image }}
+          vertica-image: ${{ needs.build.outputs.minimal-vertica-image }}
+          vertica-deployment-method: vclusterops
+          communal-storage-type: s3
+          minimum-vertica-image: '24.3.0'
+          use-cert: true
+          cert-suffix: cert
+          # Include the vertica license so we can test scaling past 3 nodes.
+          vertica-license: ${{ secrets.VERTICA_LICENSE }}
+          need-base-vertica-image: 'true'
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
+
   e2e-leg-10-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 10' || inputs.e2e_test_suites == '')}}
     needs: [build]
@@ -902,6 +928,7 @@ jobs:
       e2e-leg-6-vcluster-revivedb,
       e2e-leg-7-vcluster,
       e2e-leg-9-vcluster,
+      e2e-leg-9-vcluster-cert,
       e2e-leg-10-vcluster,
       e2e-leg-11-vcluster,
       e2e-leg-12-vcluster,
@@ -943,7 +970,9 @@ jobs:
     name: Sync-vcluster-code
     needs: [
       e2e-leg-1-vcluster,
+      e2e-leg-1-vcluster-cert,
       e2e-leg-2-vcluster,
+      e2e-leg-2-vcluster-cert,
       e2e-leg-3-vclusterops-previous-release,
       e2e-leg-3-vcluster,
       e2e-leg-4-vcluster,
@@ -953,6 +982,7 @@ jobs:
       e2e-leg-6-vcluster-revivedb,
       e2e-leg-7-vcluster,
       e2e-leg-9-vcluster,
+      e2e-leg-9-vcluster-cert,
       e2e-leg-10-vcluster,
       e2e-leg-11-vcluster,
       e2e-leg-12-vcluster,

--- a/Makefile
+++ b/Makefile
@@ -550,7 +550,7 @@ endif
 docker-push-extra-vertica: # Push a hard-coded image used in multi-online-upgrade test
 ifeq ($(LEG9), yes)
 ifeq ($(shell $(KIND_CHECK)), 1)
-	scripts/push-to-kind.sh -i opentext/vertica-k8s-private:20240929-minimal
+	scripts/push-to-kind.sh -i opentext/vertica-k8s-private:20250423-minimal
 endif
 endif
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -856,6 +856,10 @@ func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Co
 		return ctrl.Result{}, nil
 	}
 
+	tlsConfig := ""
+	if r.VDB.IsCertRotationEnabled() {
+		tlsConfig = "server"
+	}
 	vrep := &v1beta1.VerticaReplicator{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1beta1.GroupVersion.String(),
@@ -878,6 +882,8 @@ func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Co
 					SandboxName: r.sandboxName,
 				},
 			},
+			Mode:      v1beta1.ReplicationModeSync,
+			TLSConfig: tlsConfig,
 		},
 	}
 	err := r.VRec.Client.Create(ctx, vrep)

--- a/pkg/vadmin/get_config_parameter_vc.go
+++ b/pkg/vadmin/get_config_parameter_vc.go
@@ -53,8 +53,6 @@ func (v *VClusterOps) genGetConfigurationParameterOptions(s *getconfigparameter.
 
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
 	opts.DBName = v.VDB.Spec.DBName
-	opts.UserName = s.UserName
-	opts.Password = &v.Password
 
 	opts.Sandbox = s.Sandbox
 	opts.ConfigParameter = s.ConfigParameter

--- a/pkg/vadmin/get_config_parameter_vc.go
+++ b/pkg/vadmin/get_config_parameter_vc.go
@@ -61,6 +61,7 @@ func (v *VClusterOps) genGetConfigurationParameterOptions(s *getconfigparameter.
 	opts.IsEon = v.VDB.IsEON()
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
+	opts.UserName = v.VDB.GetVerticaUser()
 	v.setAuthentication(&opts.DatabaseOptions, v.VDB.GetVerticaUser(), &v.Password, certs)
 
 	return &opts

--- a/pkg/vadmin/get_config_parameter_vc_test.go
+++ b/pkg/vadmin/get_config_parameter_vc_test.go
@@ -50,6 +50,10 @@ func (m *MockVClusterOps) VGetConfigurationParameters(options *vops.VGetConfigur
 		return "", err
 	}
 
+	if options.Password == nil || *options.Password != TestPassword {
+		return "", fmt.Errorf("missing password")
+	}
+
 	return TestConfigParamValue, nil
 }
 
@@ -72,5 +76,15 @@ var _ = Describe("get_config_parameter_vc", func() {
 		)
 		Ω(err).Should(Succeed())
 		Ω(value).Should(Equal(TestConfigParamValue))
+
+		vapi.SetVDBForTLS(dispatcher.VDB)
+		_, err = dispatcher.GetConfigurationParameter(ctx,
+			getconfigparameter.WithUserName(vapi.SuperUser),
+			getconfigparameter.WithInitiatorIP(TestSourceIP),
+			getconfigparameter.WithSandbox(TestConfigParamSandbox),
+			getconfigparameter.WithConfigParameter(TestConfigParamName),
+			getconfigparameter.WithLevel(TestConfigParamLevel),
+		)
+		Ω(err.Error()).Should(ContainSubstring("missing password"))
 	})
 })

--- a/pkg/vadmin/manage_connection_draining_vc.go
+++ b/pkg/vadmin/manage_connection_draining_vc.go
@@ -62,6 +62,7 @@ func (v *VClusterOps) genManageConnectionDrainingOptions(s *manageconnectiondrai
 	opts.IsEon = v.VDB.IsEON()
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
+	opts.UserName = v.VDB.GetVerticaUser()
 	v.setAuthentication(&opts.DatabaseOptions, v.VDB.GetVerticaUser(), &v.Password, certs)
 
 	return &opts

--- a/pkg/vadmin/set_config_parameter_vc.go
+++ b/pkg/vadmin/set_config_parameter_vc.go
@@ -66,6 +66,7 @@ func (v *VClusterOps) genSetConfigurationParameterOptions(s *setconfigparameter.
 	opts.IsEon = v.VDB.IsEON()
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
+	opts.UserName = s.UserName
 	v.setAuthentication(&opts.DatabaseOptions, s.UserName, &v.Password, certs)
 
 	return &opts

--- a/pkg/vadmin/vc.go
+++ b/pkg/vadmin/vc.go
@@ -102,8 +102,8 @@ func (v *VClusterOps) setAuthentication(opts *vops.DatabaseOptions, username str
 	opts.Key = certs.Key
 	opts.Cert = certs.Cert
 	opts.CaCert = certs.CaCert
+	opts.UserName = username
 	if !v.VDB.IsCertRotationEnabled() {
-		opts.UserName = username
 		opts.Password = password
 	}
 }

--- a/scripts/guess-server-upgrade-base-image.sh
+++ b/scripts/guess-server-upgrade-base-image.sh
@@ -72,8 +72,14 @@ then
         # upgrade from. We will pick a random 24.2.0 image.
         print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "1f759615f0f723080b398edcf096a0bc8bc03aef-minimal"
     else
-        # For all newer versions, we pick a random 24.4.0 image.
-        print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20240928-minimal"
+        if [ "$USE_CERT" == "true" ]
+        then
+            # For all newer versions, we pick a random 25.3.0 image.
+            print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20250401-minimal"
+        else
+            # For all newer versions, we pick a random 24.4.0 image.
+            print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20240928-minimal"
+        fi
     fi
 else
     print_vertica_k8s_img $PUBLIC_REPO $PUBLIC_IMAGE 12 0 2

--- a/scripts/guess-server-upgrade-base-image.sh
+++ b/scripts/guess-server-upgrade-base-image.sh
@@ -75,7 +75,7 @@ then
         if [ "$USE_CERT" == "true" ]
         then
             # For all newer versions, we pick a random 25.3.0 image.
-            print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20250401-minimal"
+            print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20250421-minimal"
         else
             # For all newer versions, we pick a random 24.4.0 image.
             print_vertica_k8s_img_with_tag $PRIVATE_REPO $PRIVATE_IMAGE "20240928-minimal"

--- a/tests/e2e-leg-9/multi-online-upgrade/30-initiate-upgrade.yaml
+++ b/tests/e2e-leg-9/multi-online-upgrade/30-initiate-upgrade.yaml
@@ -14,4 +14,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-online-upgrade opentext/vertica-k8s-private:20240929-minimal
+  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-online-upgrade opentext/vertica-k8s-private:20250423-minimal


### PR DESCRIPTION
The base version for upgrade is 24.4.0 so if you upgrade to 25.3.0, as there is no tls config, http calls after upgrade will all fail.
This picks a 25.3.0 image if certs are enabled .