### PR TITLE
Add webhook to validate restore point archive name has no invalid chars

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1434,6 +1434,7 @@ func convertToInt(src string) (int, bool) {
 func findInvalidChars(objName string, allowDash bool) string {
 	invalidChars := invalidNameChars
 
+	// Dash is supported in some object names (eg archive name) but not others (eg db name)
 	if !allowDash {
 		invalidChars += "-"
 	}

--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -51,6 +51,7 @@ const (
 
 	VerticaDBNameKey = "verticaDBName"
 	SandboxNameKey   = "sandboxName"
+	invalidNameChars = "$=<>`" + `'^\".@*?#&/:;{}()[] \~!%+|,`
 )
 
 // ExtractNamespacedName gets the name and returns it as a NamespacedName
@@ -1427,4 +1428,21 @@ func convertToInt(src string) (int, bool) {
 		converted = true
 	}
 	return int(varAsInt), converted
+}
+
+// Check for invalid characters in an object name (such as DB or archive name)
+func findInvalidChars(objName string, allowDash bool) string {
+	invalidChars := invalidNameChars
+
+	if !allowDash {
+		invalidChars += "-"
+	}
+
+	foundChars := ""
+	for _, c := range invalidChars {
+		if strings.Contains(objName, string(c)) {
+			foundChars += string(c)
+		}
+	}
+	return foundChars
 }

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	invalidDBNameChars    = "$=<>`" + `'^\".@*?#&/-:;{}()[] \~!%+|,`
 	dbNameLengthLimit     = 30
 	KSafety0MinHosts      = 1
 	KSafety0MaxHosts      = 3
@@ -335,6 +334,15 @@ func (v *VerticaDB) hasValidSaveRestorePointConfig(allErrs field.ErrorList) fiel
 				"archive must be specified.")
 		allErrs = append(allErrs, err)
 	}
+	if v.Spec.RestorePoint != nil {
+		invalidChars := findInvalidChars(v.Spec.RestorePoint.Archive, true)
+		if invalidChars != "" {
+			err := field.Invalid(field.NewPath("spec").Child("restorePoint").Child("archive"),
+				v.Spec.RestorePoint.Archive,
+				fmt.Sprintf(`archive cannot have the characters '%s'`, invalidChars))
+			allErrs = append(allErrs, err)
+		}
+	}
 	return allErrs
 }
 
@@ -461,14 +469,12 @@ func (v *VerticaDB) hasValidDBName(allErrs field.ErrorList) field.ErrorList {
 			"dbName cannot exceed 30 characters")
 		allErrs = append(allErrs, err)
 	}
-	invalidChar := invalidDBNameChars
-	for _, c := range invalidChar {
-		if strings.Contains(dbName, string(c)) {
-			err := field.Invalid(field.NewPath("spec").Child("dbName"),
-				v.Spec.DBName,
-				fmt.Sprintf(`dbName cannot have the '%s' character`, string(c)))
-			allErrs = append(allErrs, err)
-		}
+	invalidChars := findInvalidChars(dbName, false)
+	if invalidChars != "" {
+		err := field.Invalid(field.NewPath("spec").Child("dbName"),
+			v.Spec.DBName,
+			fmt.Sprintf(`dbName cannot have the characters '%s'`, invalidChars))
+		allErrs = append(allErrs, err)
 	}
 	return allErrs
 }

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -339,7 +339,7 @@ func (v *VerticaDB) hasValidSaveRestorePointConfig(allErrs field.ErrorList) fiel
 		if invalidChars != "" {
 			err := field.Invalid(field.NewPath("spec").Child("restorePoint").Child("archive"),
 				v.Spec.RestorePoint.Archive,
-				fmt.Sprintf(`archive cannot have the characters '%s'`, invalidChars))
+				fmt.Sprintf(`archive cannot have the characters %q`, invalidChars))
 			allErrs = append(allErrs, err)
 		}
 	}
@@ -473,7 +473,7 @@ func (v *VerticaDB) hasValidDBName(allErrs field.ErrorList) field.ErrorList {
 	if invalidChars != "" {
 		err := field.Invalid(field.NewPath("spec").Child("dbName"),
 			v.Spec.DBName,
-			fmt.Sprintf(`dbName cannot have the characters '%s'`, invalidChars))
+			fmt.Sprintf(`dbName cannot have the characters %q`, invalidChars))
 		allErrs = append(allErrs, err)
 	}
 	return allErrs

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -494,6 +494,11 @@ var _ = Describe("verticadb_webhook", func() {
 		vdb.Spec.RestorePoint.ID = ""
 		vdb.Spec.RestorePoint.Index = 1
 		validateSpecValuesHaveErr(vdb, false)
+		// archive name cannot have invalid chars
+		vdb.Spec.RestorePoint.Archive = "bad@archive"
+		validateSpecValuesHaveErr(vdb, true)
+		vdb.Spec.RestorePoint.Archive = "archive"
+		validateSpecValuesHaveErr(vdb, false)
 	})
 
 	It("should only allow nodePort if serviceType allows for it", func() {

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -497,6 +497,9 @@ var _ = Describe("verticadb_webhook", func() {
 		// archive name cannot have invalid chars
 		vdb.Spec.RestorePoint.Archive = "bad@archive"
 		validateSpecValuesHaveErr(vdb, true)
+		// dash character is valid in archive name
+		vdb.Spec.RestorePoint.Archive = "good-archive"
+		validateSpecValuesHaveErr(vdb, false)
 		vdb.Spec.RestorePoint.Archive = "archive"
 		validateSpecValuesHaveErr(vdb, false)
 	})


### PR DESCRIPTION
Added webhook to error if restore point archive name contains an invalid character. Supported characters for archive name are the same as DB name, except archive name also supports dash character.