### PR TITLE
Add timeout to drain before remove node/subcluster

### DIFF
--- a/pkg/controllers/vdb/drainnode_reconciler.go
+++ b/pkg/controllers/vdb/drainnode_reconciler.go
@@ -18,12 +18,15 @@ package vdb
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/podfacts"
 	corev1 "k8s.io/api/core/v1"
@@ -55,17 +58,46 @@ func (s *DrainNodeReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	// Note: this reconciler depends on the clien routing reconciler to have run
-	// and directed traffic away from pending delete pods.
-	for _, pf := range s.PFacts.Detail {
-		if pf.GetIsPendingDelete() && pf.GetUpNode() {
-			if res, err := s.reconcilePod(ctx, pf); verrors.IsReconcileAborted(res, err) {
-				return res, err
-			}
-		}
+	timeout := vmeta.GetRemoveDrainSeconds(s.Vdb.Annotations)
+	if timeout == vmeta.RemoveDrainSecondsDisabledValue {
+		return s.reconcilePods(ctx)
+	}
+	hasTimeoutZero := false
+	if timeout == 0 {
+		timeout = 1
+		hasTimeoutZero = true
 	}
 
-	return ctrl.Result{}, nil
+	// Note: this reconciler depends on the client routing reconciler to have run
+	// and directed traffic away from pending delete pods.
+	pfs := []*podfacts.PodFact{}
+	for i := 0; i < timeout; i++ {
+		active := false
+		for _, pf := range s.PFacts.Detail {
+			if pf.GetIsPendingDelete() && pf.GetUpNode() {
+				result, err := s.reconcilePod(ctx, pf)
+				if err != nil {
+					return ctrl.Result{}, err
+				} else if result.Requeue {
+					active = true
+					// we start collecting pods that needs connections to be killed in
+					// the last second
+					if i+1 == timeout {
+						pfs = append(pfs, pf)
+					}
+				}
+			}
+		}
+		if !active {
+			return ctrl.Result{}, nil
+		}
+		if hasTimeoutZero {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	return ctrl.Result{}, s.waitForConnectionsToEnd(ctx, pfs)
 }
 
 // reconcilePod will handle drain logic for a single pod
@@ -90,4 +122,39 @@ func (s *DrainNodeReconciler) reconcilePod(ctx context.Context, pf *podfacts.Pod
 			"Pod '%s' has active connections preventing the drain from succeeding", pf.GetName().Name)
 	}
 	return ctrl.Result{Requeue: activeConnections}, nil
+}
+
+func (s *DrainNodeReconciler) waitForConnectionsToEnd(ctx context.Context, pfs []*podfacts.PodFact) error {
+	if len(pfs) == 0 {
+		return nil
+	}
+	sessionIds := []string{}
+	for _, pf := range pfs {
+		sql := fmt.Sprintf(
+			"select session_id"+
+				" from sessions"+
+				" where node_name = '%s'"+
+				" and session_id not in ("+
+				" select session_id from current_session"+
+				" )", pf.GetVnodeName())
+		stdout, stderr, err := s.PFacts.PRunner.ExecVSQL(ctx, pf.GetName(), names.ServerContainer, "-tAc", sql)
+		if err != nil {
+			s.VRec.Log.Error(err, "failed to retrieve active sessions", "stderr", stderr)
+			return err
+		}
+		sessionIds = append(sessionIds, strings.Split(strings.TrimSuffix(stdout, "\n"), "\n")...)
+	}
+
+	return killSessions(ctx, sessionIds, s.PFacts, pfs[0], s.VRec.Log)
+}
+
+func (s *DrainNodeReconciler) reconcilePods(ctx context.Context) (ctrl.Result, error) {
+	for _, pf := range s.PFacts.Detail {
+		if pf.GetIsPendingDelete() && pf.GetUpNode() {
+			if res, err := s.reconcilePod(ctx, pf); verrors.IsReconcileAborted(res, err) {
+				return res, err
+			}
+		}
+	}
+	return ctrl.Result{}, nil
 }

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -109,6 +109,10 @@ const (
 	ShutdownDrainSecondsAnnotation = "vertica.com/shutdown-drain-seconds"
 	ShutdownDefaultDrainSeconds    = 60
 
+	// The time at which draining pending delete pods has started. When greater than 'vertica.com/remove-drain-seconds'
+	// it means the timeout has expired and all active connections will be closed.
+	DrainStartAnnotation = "vertica.com/drain-start-time"
+
 	RemoveDrainSecondsAnnotation    = "vertica.com/remove-drain-seconds"
 	RemoveDrainSecondsDisabledValue = -1
 

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -109,6 +109,9 @@ const (
 	ShutdownDrainSecondsAnnotation = "vertica.com/shutdown-drain-seconds"
 	ShutdownDefaultDrainSeconds    = 60
 
+	RemoveDrainSecondsAnnotation    = "vertica.com/remove-drain-seconds"
+	RemoveDrainSecondsDisabledValue = -1
+
 	// The timeout, in seconds, to use when the operator is performing online upgrade
 	// for various tasks. If omitted, we use the default timeout of 5 minutes.
 	OnlineUpgradeTimeoutAnnotation = "vertica.com/online-upgrade-timeout"
@@ -456,9 +459,17 @@ func GetCreateDBNodeStartTimeout(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, CreateDBTimeoutAnnotation, 0 /* default value */)
 }
 
-// GetShutdownCDrainSeconds returns the time in seconds to wait for a subcluster/database users' disconnection
+// GetShutdownDrainSeconds returns the time in seconds to wait for a subcluster/database users' disconnection
 func GetShutdownDrainSeconds(annotations map[string]string) int {
 	return lookupIntAnnotation(annotations, ShutdownDrainSecondsAnnotation, ShutdownDefaultDrainSeconds /* default value */)
+}
+
+func GetRemoveDrainSeconds(annotations map[string]string) int {
+	val := lookupIntAnnotation(annotations, RemoveDrainSecondsAnnotation, RemoveDrainSecondsDisabledValue /* default value */)
+	if val < 0 {
+		return RemoveDrainSecondsDisabledValue
+	}
+	return val
 }
 
 // GetOnlineUpgradeTimeout returns the timeout to use for pause/redirect sessions

--- a/pkg/podfacts/podfacts.go
+++ b/pkg/podfacts/podfacts.go
@@ -1251,6 +1251,12 @@ func (p *PodFacts) FindInstalledPods() []*PodFact {
 	}))
 }
 
+func (p *PodFacts) FindPendingDeletePods() []*PodFact {
+	return p.filterPods((func(v *PodFact) bool {
+		return v.isPendingDelete && v.upNode
+	}))
+}
+
 // FindReIPPods returns a list of pod facts that may need their IPs to be refreshed with re-ip.
 // An empty list implies there are no pods that match the criteria.
 func (p *PodFacts) FindReIPPods(chk dBCheckType) []*PodFact {

--- a/tests/e2e-leg-7/multi-sc-sanity/52-create-session.yaml
+++ b/tests/e2e-leg-7/multi-sc-sanity/52-create-session.yaml
@@ -1,0 +1,60 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-create-session
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+
+    execute_query() {
+      # setting a 1h long session
+      if kubectl exec v-multi-sc-sc-1-0 -c server -- vsql -U dbadmin -w superuser -tAc "select sleep('3600')"; then
+          return 0
+      fi
+      return 1
+    }
+
+    execute_query &
+
+    # Wait for all background jobs to complete
+    wait
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: script-create-session
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-create-session
+

--- a/tests/e2e-leg-7/multi-sc-sanity/55-remove-default-sc.yaml
+++ b/tests/e2e-leg-7/multi-sc-sanity/55-remove-default-sc.yaml
@@ -15,6 +15,8 @@ apiVersion: vertica.com/v1beta1
 kind: VerticaDB
 metadata:
   name: v-multi-sc
+  annotations:
+    vertica.com/remove-drain-seconds: "30"
 spec:
   subclusters:
     - name: new-sc3


### PR DESCRIPTION
The current drain just requeue as long as there is at least one connection to a pending delete node.
This adds a timeout to allow users to close the active sessions on pending pods once the timeout has expired.
2 new annotations:
- vertica.com/remove-drain-seconds: the timeout
- vertica.com/drain-start-time: the time at which draining started

We don't use a sleep because it is very inefficient, we instead requeue after 1s until the timeout expires, to not block a thread. 