### PR TITLE
feat(annotations): add vertica.com/disable-extra-paths-auto-mount

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -273,7 +273,7 @@ func buildVolumeMounts(vdb *vapi.VerticaDB) []corev1.VolumeMount {
 	volMnts = append(volMnts, vdb.Spec.VolumeMounts...)
 
 	extraPathsStr := vmeta.GetExtraLocalPaths(vdb.Annotations)
-	if extraPathsStr != "" {
+	if extraPathsStr != "" && !vmeta.DisableExtraPathsAutoMount(vdb.Annotations) {
 		extraPaths := strings.Split(extraPathsStr, ",")
 		for _, path := range extraPaths {
 			volMnts = append(volMnts, corev1.VolumeMount{

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -153,6 +153,13 @@ const (
 	NoDepotVolumeManagementAnnotation      = "vertica.com/disable-depot-volume-management"
 	NoDepotVolumeManagementAnnotationTrue  = "true"
 	NoDepotVolumeManagementAnnotationFalse = "false"
+
+	// Annotation to disable auto-mounting of extraPaths to local volumes
+	// as this behavior interferes with manual volume management
+	NoExtraPathsAutoMountAnnotation      = "vertica.com/disable-extra-paths-auto-mount"
+	NoExtraPathsAutoMountAnnotationTrue  = "true"
+	NoExtraPathsAutoMountAnnotationFalse = "false"
+
 	// A secret that has the files for /home/dbadmin/.ssh.  If this is
 	// omitted, the ssh files from the image are used (if applicable). SSH is
 	// only required when deploying via admintools and is present only in images
@@ -549,6 +556,12 @@ func GetSkipDeploymentCheck(annotations map[string]string) bool {
 // in the operator, allowing different provisioning mechanisms
 func DisableDepotVolumeManagement(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, NoDepotVolumeManagementAnnotation, false)
+}
+
+// DisableExtraPathsAutoMount will return true if we should not auto-mount the extra paths
+// in the operator, allowing different provisioning mechanisms (such as manual mounts)
+func DisableExtraPathsAutoMount(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, NoExtraPathsAutoMountAnnotation, false)
 }
 
 // GetNMAResource is used to retrieve a specific resource for the NMA


### PR DESCRIPTION
This complements the disable-depot-volume-management annotation.

When a database is revived, the extraPaths annotation get automatically populated from the metadata. This has negative effects when volumes are managed manually such as when they're self-managed. In our case, the temp volume is on a local fast SSD, and our config ("local-data" in Vertica parlance) is on a RBD to allow for rescheduling. We don't want temp storage on RBD, so we don't want to get our TEMP storage location force-mounted as the RBD.

Using this annotation allows to skip the extraPaths auto-mounting thus disabling this detrimental feature in an explicit way.

# How to use 

Set the following annotation in your VerticaDB object:

`"vertica.com/disable-extra-paths-auto-mount": "true"`

