### PR TITLE
Cert rotation webhook

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -562,6 +562,11 @@ func (v *VerticaDB) IsUpgradeInProgress() bool {
 	return v.IsStatusConditionTrue(UpgradeInProgress)
 }
 
+// IsCertRotationInProgress returns true if an online upgrade is in progress
+func (v *VerticaDB) IsCertRotationInProgress() bool {
+	return v.IsStatusConditionTrue(TLSCertRotationInProgress)
+}
+
 // IsStatusConditionTrue returns true when the conditionType is present and set to
 // `metav1.ConditionTrue`
 func (v *VerticaDB) IsStatusConditionTrue(statusCondition string) bool {


### PR DESCRIPTION
- user should not change nmaTLSSecret to empty string if cert rotation is enabled.

- If cert rotation is already in progress, user must not trigger another one by changing nmaTLSSecret