### PR TITLE
Add back the feature gate flag to disable the RBAC creation for metrics

### DIFF
--- a/changes/unreleased/Fixed-20250414-174731.yaml
+++ b/changes/unreleased/Fixed-20250414-174731.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Added back the feature gate flag to disable the RBAC creation for metrics
+time: 2025-04-14T17:47:31.706120445+02:00
+custom:
+    Issue: "1190"

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -126,12 +126,14 @@ echo "{{- end }}" >> $TEMPLATE_DIR/verticadb-operator-metrics-service-svc.yaml
 
 # 13.  Template the roles/rolebindings for access to prometheus metrics
 for f in verticadb-operator-metrics-reader-cr.yaml \
-    verticadb-operator-metrics-reader-crb.yaml
+    verticadb-operator-metrics-reader-crb.yaml \
+    verticadb-operator-metrics-auth-role-cr.yaml \
+    verticadb-operator-metrics-auth-rolebinding-crb.yaml
 do
     perl -i -pe 's/^/{{- if and (.Values.prometheus.createProxyRBAC) (eq .Values.prometheus.expose "EnableWithAuth") -}}\n/ if 1 .. 1' $TEMPLATE_DIR/$f
     echo "{{- end }}" >> $TEMPLATE_DIR/$f
     perl -i -0777 -pe 's/-metrics-reader/-{{ include "vdb-op.metricsRbacPrefix" . }}metrics-reader/g' $TEMPLATE_DIR/$f
-    perl -i -0777 -pe 's/-(proxy-role.*)/-{{ include "vdb-op.metricsRbacPrefix" . }}$1/g' $TEMPLATE_DIR/$f
+    perl -i -0777 -pe 's/-(metrics-auth-role.*)/-{{ include "vdb-op.metricsRbacPrefix" . }}$1/g' $TEMPLATE_DIR/$f
 done
 
 # 14.  Template the metrics bind address

--- a/scripts/template-helm-chart.sh
+++ b/scripts/template-helm-chart.sh
@@ -130,7 +130,7 @@ for f in verticadb-operator-metrics-reader-cr.yaml \
     verticadb-operator-metrics-auth-role-cr.yaml \
     verticadb-operator-metrics-auth-rolebinding-crb.yaml
 do
-    perl -i -pe 's/^/{{- if and (.Values.prometheus.createProxyRBAC) (eq .Values.prometheus.expose "EnableWithAuth") -}}\n/ if 1 .. 1' $TEMPLATE_DIR/$f
+    perl -i -pe 's/^/{{- if and (.Values.prometheus.createProxyRBAC) (ne .Values.prometheus.expose "Disable") -}}\n/ if 1 .. 1' $TEMPLATE_DIR/$f
     echo "{{- end }}" >> $TEMPLATE_DIR/$f
     perl -i -0777 -pe 's/-metrics-reader/-{{ include "vdb-op.metricsRbacPrefix" . }}metrics-reader/g' $TEMPLATE_DIR/$f
     perl -i -0777 -pe 's/-(metrics-auth-role.*)/-{{ include "vdb-op.metricsRbacPrefix" . }}$1/g' $TEMPLATE_DIR/$f


### PR DESCRIPTION
The issue was found in #1188. We will always try to create the metrics rbac avan when createRbacProxy is "Disable". This will conditionally create the rbac like before.