### PR TITLE
allow manager binary to run outside of cluster (#1195)

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -350,14 +350,15 @@ func main() {
 		cacheNamespaces[opcfg.GetWatchNamespace()] = cache.Config{}
 	}
 	mgr, err := ctrl.NewManager(restCfg, ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsServerOptions,
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: ":8081",
-		LeaderElection:         true,
-		LeaderElectionID:       opcfg.GetLeaderElectionID(),
-		Cache:                  cache.Options{DefaultNamespaces: cacheNamespaces},
-		EventBroadcaster:       multibroadcaster,
+		Scheme:                  scheme,
+		Metrics:                 metricsServerOptions,
+		WebhookServer:           webhookServer,
+		HealthProbeBindAddress:  ":8081",
+		LeaderElection:          true,
+		LeaderElectionID:        opcfg.GetLeaderElectionID(),
+		LeaderElectionNamespace: opcfg.GetOperatorNamespace(),
+		Cache:                   cache.Options{DefaultNamespaces: cacheNamespaces},
+		EventBroadcaster:        multibroadcaster,
 		Controller: config.Controller{
 			GroupKindConcurrency: map[string]int{
 				vapiB1.GkVDB.String():  opcfg.GetVerticaDBConcurrency(),


### PR DESCRIPTION
In the current state, we run into the following when trying to run this outside of cluster.
```bash
2025-04-15T07:58:23.096Z        INFO    setup   Operator Config {"controllersScope": "cluster", "version": "", "watchNamespace": "", "webhooksEnabled": true, "controllersEnabled": true, "broadcasterBurstSize": 25}
2025-04-15T07:58:23.097Z        ERROR   setup   unable to start manager {"error": "unable to find leader election namespace: not running in-cluster, please specify LeaderElectionNamespace"}
```

with this commit the manager binary can run of cluster as well.

```bash
make build
export CONCURRENCY_VERTICADB=5
export CONCURRENCY_VERTICAAUTOSCALER=1
export CONCURRENCY_EVENTTRIGGER=1
export CONCURRENCY_VERTICARESTOREPOINTSQUERY=1
export CONCURRENCY_VERTICASCRUTINIZE=1
export CONCURRENCY_SANDBOXCONFIGMAP=1
export CONCURRENCY_VERTICAREPLICATOR=3
export WEBHOOKS_ENABLED=true
export CONTROLLERS_ENABLED=true
export OPERATOR_NAMESPACE=default
./bin/mangaer
```