### PR TITLE
Fixed the issue where users cannot create restore point

### DIFF
--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -302,7 +302,7 @@ func (v *VerticaDB) hasValidInitPolicy(allErrs field.ErrorList) field.ErrorList 
 }
 
 func (v *VerticaDB) hasValidRestorePolicy(allErrs field.ErrorList) field.ErrorList {
-	if v.IsRestoreDuringReviveEnabled() && !v.Spec.RestorePoint.IsValidRestorePointPolicy() {
+	if !v.isDBInitialized() && v.IsRestoreDuringReviveEnabled() && !v.Spec.RestorePoint.IsValidRestorePointPolicy() {
 		if v.Spec.RestorePoint.Archive == "" {
 			err := field.Invalid(field.NewPath("spec").Child("restorePoint"),
 				v.Spec.RestorePoint,

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -526,6 +526,17 @@ var _ = Describe("verticadb_webhook", func() {
 		validateSpecValuesHaveErr(vdb, false)
 		vdb.Spec.RestorePoint.Archive = "archive"
 		validateSpecValuesHaveErr(vdb, false)
+
+		// when db is already initialized, we shouldn't report an error about missing archive or restore point
+		vdb2 := createVDBHelper()
+		vdb2.Spec.InitPolicy = "Revive"
+		vdb2.Spec.RestorePoint = &RestorePointPolicy{}
+		resetStatusConditionsForDBInitialized(vdb2)
+		// archive is not provided
+		validateSpecValuesHaveErr(vdb2, false)
+		vdb2.Spec.RestorePoint.Archive = "archive2"
+		// neither id nor index is provided
+		validateSpecValuesHaveErr(vdb2, false)
 	})
 
 	It("should only allow nodePort if serviceType allows for it", func() {

--- a/changes/unreleased/Fixed-20250417-183709.yaml
+++ b/changes/unreleased/Fixed-20250417-183709.yaml
@@ -2,4 +2,4 @@ kind: Fixed
 body: Users cannot create restore points when initPolicy is set to Revive
 time: 2025-04-17T18:37:09.755433245Z
 custom:
-  Issue: "1122"
+  Issue: "1212"

--- a/changes/unreleased/Fixed-20250417-183709.yaml
+++ b/changes/unreleased/Fixed-20250417-183709.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Users cannot create restore points when initPolicy is set to Revive
+time: 2025-04-17T18:37:09.755433245Z
+custom:
+  Issue: "1122"


### PR DESCRIPTION
When initPolicy is set to Revive and database is initialized, we have a webhook to prevent users to create restore points. I fixed that webhook.