### PR TITLE
Fixed Issue with Restarting Pods in Sandbox Subcluster

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @roypaulin @cchen-vertica @HaoYang0000 @qindotguan @LiboYu2
+* @roypaulin @cchen-vertica @HaoYang0000 @qindotguan @LiboYu2 @kcmackeen

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ on:
       e2e_retry_times:
         description: 'Number of times to retry failed e2e tests'
         required: false
-        default: '2'
+        default: '3'
       run_security_scan:
         description: 'What images to scan?'
         type: choice
@@ -653,7 +653,7 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 3 }}
 
   e2e-leg-10-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 10' || inputs.e2e_test_suites == '')}}
@@ -677,7 +677,7 @@ jobs:
           # Include the vertica license so we can test scaling past 3 nodes.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 3 }}
 
   e2e-leg-11-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 11' || inputs.e2e_test_suites == '')}}
@@ -702,7 +702,7 @@ jobs:
           # Include the vertica license so we can test multiple subclusters.
           vertica-license: ${{ secrets.VERTICA_LICENSE }}
           need-base-vertica-image: 'true'
-          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
+          e2e-retry-times: ${{ inputs.e2e_retry_times || 3 }}
 
   e2e-leg-12-vcluster:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'vcluster leg 12' || inputs.e2e_test_suites == '')}}

--- a/pkg/controllers/vdb/restart_reconciler.go
+++ b/pkg/controllers/vdb/restart_reconciler.go
@@ -162,8 +162,9 @@ func (r *RestartReconciler) reconcileClusterPreCheck() ctrl.Result {
 		return ctrl.Result{Requeue: true}
 	}
 	// Check if cluster start needs to include all of the pods.
+	scStatus := r.Vdb.GenStatusSubclusterMap()
 	if r.Vdb.IsKSafety0() &&
-		r.PFacts.CountNotRestartablePods(vmeta.UseVClusterOps(r.Vdb.Annotations)) > 0 {
+		r.PFacts.CountNotRestartablePods(vmeta.UseVClusterOps(r.Vdb.Annotations), scStatus) > 0 {
 		// For k-safety 0, we need all of the pods because the absence of one
 		// will cause us not to have enough pods for cluster quorum.
 		r.Log.Info("Waiting for all installed pods to be running before attempt a cluster restart")
@@ -750,7 +751,8 @@ func (r *RestartReconciler) setInitiatorPod(findFunc func() (*podfacts.PodFact, 
 // whether a requeue of the reconcile is necessary because some pods are not yet
 // running.
 func (r *RestartReconciler) shouldRequeueIfPodsNotRunning() bool {
-	if r.PFacts.CountNotRestartablePods(vmeta.UseVClusterOps(r.Vdb.Annotations)) > 0 {
+	scStatus := r.Vdb.GenStatusSubclusterMap()
+	if r.PFacts.CountNotRestartablePods(vmeta.UseVClusterOps(r.Vdb.Annotations), scStatus) > 0 {
 		r.Log.Info("Requeue since some pods needed by restart are not yet running.")
 		return true
 	}

--- a/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
+++ b/pkg/controllers/vdb/sandboxsubcluster_reconciler.go
@@ -309,19 +309,18 @@ func (s *SandboxSubclusterReconciler) checkSandboxConfigMap(ctx context.Context,
 // if so, we will update the content of that config map and return true
 func (s *SandboxSubclusterReconciler) updateSandboxConfigMapFields(curCM, newCM *corev1.ConfigMap) bool {
 	updated := false
-	// exclude sandbox controller upgrade & unsandbox trigger ID from the annotations
+	// exclude sandbox controller upgrade, unsandbox, shutdown trigger ID from the annotations
 	// because vdb controller will set this in current config map, and the new
 	// config map cannot get it
 	upgradeTriggerID, hasUpgradeTriggerID := curCM.Annotations[vmeta.SandboxControllerUpgradeTriggerID]
-	if hasUpgradeTriggerID {
-		delete(curCM.Annotations, vmeta.SandboxControllerUpgradeTriggerID)
-	}
+	delete(curCM.Annotations, vmeta.SandboxControllerUpgradeTriggerID)
 	delete(newCM.Annotations, vmeta.SandboxControllerUpgradeTriggerID)
 	unsandboxTriggerID, hasUnsandboxTriggerID := curCM.Annotations[vmeta.SandboxControllerUnsandboxTriggerID]
-	if hasUnsandboxTriggerID {
-		delete(curCM.Annotations, vmeta.SandboxControllerUnsandboxTriggerID)
-	}
+	delete(curCM.Annotations, vmeta.SandboxControllerUnsandboxTriggerID)
 	delete(newCM.Annotations, vmeta.SandboxControllerUnsandboxTriggerID)
+	shutdownTriggerID, hasShutdownTriggerID := curCM.Annotations[vmeta.SandboxControllerShutdownTriggerID]
+	delete(curCM.Annotations, vmeta.SandboxControllerShutdownTriggerID)
+	delete(newCM.Annotations, vmeta.SandboxControllerShutdownTriggerID)
 
 	// exclude version annotation because vdb controller can set a different
 	// vertica version annotation for a sandbox in current config map
@@ -342,6 +341,9 @@ func (s *SandboxSubclusterReconciler) updateSandboxConfigMapFields(curCM, newCM 
 	}
 	if hasUnsandboxTriggerID {
 		curCM.Annotations[vmeta.SandboxControllerUnsandboxTriggerID] = unsandboxTriggerID
+	}
+	if hasShutdownTriggerID {
+		curCM.Annotations[vmeta.SandboxControllerShutdownTriggerID] = shutdownTriggerID
 	}
 	// add vertica version back to the annotations
 	if hasVersion {

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -366,8 +366,6 @@ const (
 	// This will  be set in a sandbox configMap by the vdb controller to wake up the sandbox
 	// controller for stopping/starting a sandbox
 	SandboxControllerShutdownTriggerID = "vertica.com/sandbox-controller-shutdown-trigger-id"
-	// This will  be set in a subclusters configMap by the vdb controller to stop/start a subcluter
-	VdbControllerShutdownClusterTriggerID = "vertica.com/vdb-controller-shutdown-subcluster-trigger-id"
 
 	// Use this to override the name of the statefulset and its pods. This needs
 	// to be set in the spec.subclusters[].annotations field to take effect. If

--- a/pkg/vadmin/restart_node_vc.go
+++ b/pkg/vadmin/restart_node_vc.go
@@ -66,5 +66,6 @@ func (v *VClusterOps) genStartNodeOptions(s *restartnode.Parms, certs *HTTPSCert
 	if v.VDB.IsNMASideCarDeploymentEnabled() {
 		opts.StartUpConf = paths.StartupConfFile
 	}
+	opts.DoAllowStartUnboundNodes = true
 	return &opts
 }


### PR DESCRIPTION
In K8s realdb, when a sandbox subcluster is shut down and then restarted, it may remain down and never come back up. This happens because, during the restart reconciliation, the pods in the sandbox subcluster are not in a Running state—so the reconciler skips the restart and does not requeue the task. As a result, the sandbox restart reconciler is never triggered again.
This PR addresses that issue.