### PR TITLE
Disable fetch_node_details info log

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1057,6 +1057,10 @@ func (v *VerticaDB) IsKSafetyCheckStrict() bool {
 	return vmeta.IsKSafetyCheckStrict(v.Annotations)
 }
 
+func (v *VerticaDB) IsFetchNodeDetailsLogDisabled() bool {
+	return vmeta.IsFetchNodeDetailsLogDisabled(v.Annotations)
+}
+
 // IsValidRestorePointPolicy returns true if the RestorePointPolicy is properly specified,
 // i.e., it has a non-empty archive, and either a valid index or a valid id (but not both).
 func (r *RestorePointPolicy) IsValidRestorePointPolicy() bool {

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -413,6 +413,9 @@ const (
 	// You can set the value of replicas for an object to be paused to any arbitrary number.
 	// This only works for a scaledobject.
 	PausingAutoscalingReplicasAnnotation = "vertica.com/paused-scaling-replicas"
+
+	// It will disable fetch_node_details log info. This makes debugging easier.
+	DisableFetchNodeDetailsInfoLog = "vertica.com/disable-fetch-node-details-log-info"
 )
 
 // IsPauseAnnotationSet will check the annotations for a special value that will
@@ -798,6 +801,12 @@ func GetReplicationPollingFrequency(annotations map[string]string) int {
 // nodes.
 func GetDisableRouting(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, DisableRoutingAnnotation, false)
+}
+
+// IsFetchNodeDetailsLogDisabled returns true if fetch node details vcluster api's
+// log info must be disabled.
+func IsFetchNodeDetailsLogDisabled(annotations map[string]string) bool {
+	return lookupBoolAnnotation(annotations, DisableFetchNodeDetailsInfoLog, false)
 }
 
 // lookupBoolAnnotation is a helper function to lookup a specific annotation and

--- a/pkg/vadmin/fetch_node_details_vc.go
+++ b/pkg/vadmin/fetch_node_details_vc.go
@@ -26,7 +26,7 @@ import (
 
 // FetchNodeDetails will return details for a node, including its state, sandbox, and storage locations
 func (v *VClusterOps) FetchNodeDetails(ctx context.Context, opts ...fetchnodedetails.Option) (vops.NodeDetails, error) {
-	v.setupForAPICall("FetchNodeDetails")
+	v.setupForAPICall(fetchNodeDetails)
 	defer v.tearDownForAPICall()
 	v.Log.Info("Starting vcluster FetchNodeDetails")
 

--- a/pkg/vadmin/interface.go
+++ b/pkg/vadmin/interface.go
@@ -165,6 +165,8 @@ type Dispatcher interface {
 const (
 	// Constant for an up node, this is taken from the STATE column in NODES table
 	StateUp = "UP"
+
+	fetchNodeDetails = "FetchNodeDetails"
 )
 
 // Admintools is the legacy style of running admin commands. All commands are
@@ -267,6 +269,12 @@ func SetupVClusterOps(log logr.Logger, apiName string) (VClusterProvider, logr.L
 //	}
 func (v *VClusterOps) setupForAPICall(apiName string) {
 	v.VClusterProvider, v.Log = v.APISetupFunc(v.BaseLog, apiName)
+	if apiName == fetchNodeDetails {
+		vc, ok := v.VClusterProvider.(*vops.VClusterCommands)
+		if ok {
+			vc.VClusterCommandsLogger.Log.Mute = v.VDB.IsFetchNodeDetailsLogDisabled()
+		}
+	}
 }
 
 // tearDownForAPICall will cleanup from the setupForAPICall. This function


### PR DESCRIPTION
This will make debugging easier by disabling the fetch_node_details info log.