### PR TITLE
Add brackets to IPv6 address to check if node up

### DIFF
--- a/changes/unreleased/Fixed-20250428-160725.yaml
+++ b/changes/unreleased/Fixed-20250428-160725.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Added brackets for IPv6 address to check if nodes up
+time: 2025-04-28T16:07:25.154116225-04:00
+custom:
+    Issue: "1237"

--- a/pkg/podfacts/podfacts.go
+++ b/pkg/podfacts/podfacts.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/iter"
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/names"
+	"github.com/vertica/vertica-kubernetes/pkg/net"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	config "github.com/vertica/vertica-kubernetes/pkg/vdbconfig"
 	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
@@ -1545,6 +1546,10 @@ func (p *PodFacts) GetClusterExtendedName() string {
 // checkIfNodeUpCmd builds and returns the command to check
 // if a node is up using an HTTPS endpoint
 func checkIfNodeUpCmd(podIP string) string {
+	if net.IsIPv6(podIP) {
+		podIP = "[" + podIP + "]"
+	}
+
 	url := fmt.Sprintf("https://%s:%d%s",
 		podIP, builder.VerticaHTTPPort, builder.HTTPServerVersionPath)
 	curlCmd := "curl -k -s -o /dev/null -w '%{http_code}'"


### PR DESCRIPTION
On the IPv6-enabled k8s cluster, the operator would restart the Vertica pods after the database creation. The root cause is that it could not detect the node's up status with the IPv6 URL. A bracket was added to the IPv6 address to resolve the issue.