### PR TITLE
Fix sandboxshutdown _reconciler

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -446,6 +446,17 @@ func (v *VerticaDB) GetCommunalPath() string {
 	return fmt.Sprintf("%s/%s", strings.TrimSuffix(v.Spec.Communal.Path, "/"), v.UID)
 }
 
+// IsSubclusterInSandbox returns true if the given subcluster is in the
+// sandbox status
+func (s *SandboxStatus) IsSubclusterInSandbox(scName string) bool {
+	for i := range s.Subclusters {
+		if scName == s.Subclusters[i] {
+			return true
+		}
+	}
+	return false
+}
+
 // GenCompatibleFQDN returns a name of the subcluster that is
 // compatible inside a fully-qualified domain name.
 func (s *Subcluster) GenCompatibleFQDN() string {

--- a/pkg/controllers/vdb/sandboxshutdown_reconciler.go
+++ b/pkg/controllers/vdb/sandboxshutdown_reconciler.go
@@ -34,17 +34,20 @@ type SandboxShutdownReconciler struct {
 	Log     logr.Logger
 	Vdb     *vapi.VerticaDB // Vdb is the CRD we are acting on
 	Manager UpgradeManager
-	Requeue bool
+	// This means some errors can be ignored because they are expected.
+	// It is set to true when we need to call the reconciler early when
+	// some subclusters might not exist yet.
+	IgnoreError bool
 }
 
 // MakeSandboxShutdownReconciler will build a SandboxShutdownReconciler object
 func MakeSandboxShutdownReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger,
-	vdb *vapi.VerticaDB, requeue bool) controllers.ReconcileActor {
+	vdb *vapi.VerticaDB, ignore bool) controllers.ReconcileActor {
 	return &SandboxShutdownReconciler{
-		VRec:    vdbrecon,
-		Log:     log.WithName("SandboxShutdownReconciler"),
-		Vdb:     vdb,
-		Requeue: requeue,
+		VRec:        vdbrecon,
+		Log:         log.WithName("SandboxShutdownReconciler"),
+		Vdb:         vdb,
+		IgnoreError: ignore,
 	}
 }
 
@@ -69,13 +72,14 @@ func (s *SandboxShutdownReconciler) reconcileSandboxShutdown(ctx context.Context
 	sbName := sb.Name
 	sbStatus := s.Vdb.GetSandboxStatus(sbName)
 	if sbStatus == nil {
-		if s.Requeue {
+		requeue := !s.IgnoreError
+		if requeue {
 			s.Log.Info("Requeue because the sandbox does not exist yet", "sandbox", sbName)
 		} else {
 			s.Log.Info("sandbox does not exist in the database yet", "sandbox", sbName)
 		}
 
-		return ctrl.Result{Requeue: s.Requeue}, nil
+		return ctrl.Result{Requeue: requeue}, nil
 	}
 	scMap := s.Vdb.GenSubclusterMap()
 	scStatusMap := s.Vdb.GenSubclusterStatusMap()
@@ -83,6 +87,12 @@ func (s *SandboxShutdownReconciler) reconcileSandboxShutdown(ctx context.Context
 		sc := scMap[sb.Subclusters[i].Name]
 		scStatus := scStatusMap[sb.Subclusters[i].Name]
 		if sc == nil || scStatus == nil {
+			if s.IgnoreError {
+				// when calling this reconciler early, it is expected that
+				// some subclusters might not be in the db yet. Instead of returning
+				// an error, we simply skipped to the next subcluster
+				continue
+			}
 			return ctrl.Result{}, fmt.Errorf("subcluster %s not found", sb.Subclusters[i].Name)
 		}
 		// Proceeds only if the status does not match the spec

--- a/pkg/controllers/vdb/shutdownspec_reconciler.go
+++ b/pkg/controllers/vdb/shutdownspec_reconciler.go
@@ -59,10 +59,21 @@ func (r *ShutdownSpecReconciler) updateSubclustersShutdownState(ctx context.Cont
 func (r *ShutdownSpecReconciler) updateSubclustersShutdownStateCallback() (bool, error) {
 	needUpdate := false
 	scMap := r.Vdb.GenSubclusterMap()
+	scStatusMap := r.Vdb.GenSubclusterStatusMap()
 	for i := range r.Vdb.Spec.Sandboxes {
 		sb := &r.Vdb.Spec.Sandboxes[i]
+		sbStatus := r.Vdb.GetSandboxStatus(sb.Name)
+		if sbStatus == nil {
+			continue
+		}
 		for j := range sb.Subclusters {
-			sc := scMap[sb.Subclusters[j].Name]
+			scName := sb.Subclusters[j].Name
+			sc := scMap[scName]
+			scStatus := scStatusMap[scName]
+			if !sbStatus.IsSubclusterInSandbox(scName) || scStatus == nil {
+				break
+			}
+
 			if sb.Shutdown {
 				if sc.Annotations == nil {
 					sc.Annotations = make(map[string]string, 1)

--- a/pkg/controllers/vdb/shutdownspec_reconciler_test.go
+++ b/pkg/controllers/vdb/shutdownspec_reconciler_test.go
@@ -51,6 +51,18 @@ var _ = Describe("shutdownspec_reconciler", func() {
 		test.CreateVDB(ctx, k8sClient, vdb)
 		defer test.DeleteVDB(ctx, k8sClient, vdb)
 
+		vdb.Status.Sandboxes = []vapi.SandboxStatus{
+			{Name: sandbox1, Subclusters: []string{subcluster1, subcluster2}},
+		}
+
+		vdb.Status.Subclusters = []vapi.SubclusterStatus{
+			{Name: maincluster, Type: vapi.PrimarySubcluster, Detail: []vapi.VerticaDBPodStatus{}},
+			{Name: subcluster1, Type: vapi.SecondarySubcluster, Detail: []vapi.VerticaDBPodStatus{}},
+			{Name: subcluster2, Type: vapi.SecondarySubcluster, Detail: []vapi.VerticaDBPodStatus{}},
+		}
+
+		Ω(k8sClient.Status().Update(ctx, vdb)).Should(Succeed())
+
 		fpr := &cmds.FakePodRunner{}
 		pfacts := podfacts.MakePodFacts(vdbRec, fpr, logger, TestPassword)
 		pfacts.SandboxName = sandbox1

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -194,9 +194,6 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Update the sandbox/subclusters' shutdown field to match the value of
 		// the spec.
 		MakeShutdownSpecReconciler(r, vdb),
-		// Trigger sandbox shutdown when the shutdown field of the sandbox
-		// is changed
-		MakeSandboxShutdownReconciler(r, log, vdb, false),
 		// Update the vertica image for unsandboxed subclusters
 		MakeUnsandboxImageVersionReconciler(r, vdb, log, pfacts),
 		// Always start with a status reconcile in case the prior reconcile failed.
@@ -223,6 +220,9 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 			ObjReconcileModePreserveScaling|ObjReconcileModePreserveUpdateStrategy),
 		// Add annotations/labels to each pod about the host running them
 		MakeAnnotateAndLabelPodReconciler(r, log, vdb, pfacts),
+		// Trigger sandbox shutdown when the shutdown field of the sandbox
+		// is changed
+		MakeSandboxShutdownReconciler(r, log, vdb, true),
 		// Handles vertica server upgrade (i.e., when spec.image changes)
 		MakeOfflineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeReadOnlyOnlineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
@@ -297,7 +297,7 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeSandboxUpgradeReconciler(r, log, vdb, true),
 		// Trigger sandbox shutdown when the shutdown field of the sandbox
 		// is changed
-		MakeSandboxShutdownReconciler(r, log, vdb, true),
+		MakeSandboxShutdownReconciler(r, log, vdb, false),
 		// Add the label after update the sandbox subcluster status field
 		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeAll),
 		// Handle calls to create a restore point


### PR DESCRIPTION
In a previous PR, I decided to call sandboxshutdown _reconciler early in the reconcile loop, to prevent some failures to affect some sandbox ops. The issue is that it might be possible that (ex: realdb) someone is adding a new sandbox +subclusters and that will fail sandboxshutdown _reconciler. The 2nd sandboxshutdown _reconciler does not have this issue because it happens towards the end when all critical reconcilers have been run.
To fix this, I added a field `IgnoreError` that is true for the 1st sandboxshutdown _reconciler. When true, if a subcluster is not yet in the status, we just skip that sc knowing a later reconciler will add it to the db.