### PR TITLE
use a reconciler to monitor additional buckets updates

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -446,17 +446,6 @@ func (v *VerticaDB) GetCommunalPath() string {
 	return fmt.Sprintf("%s/%s", strings.TrimSuffix(v.Spec.Communal.Path, "/"), v.UID)
 }
 
-// IsSubclusterInSandbox returns true if the given subcluster is in the
-// sandbox status
-func (s *SandboxStatus) IsSubclusterInSandbox(scName string) bool {
-	for i := range s.Subclusters {
-		if scName == s.Subclusters[i] {
-			return true
-		}
-	}
-	return false
-}
-
 // GenCompatibleFQDN returns a name of the subcluster that is
 // compatible inside a fully-qualified domain name.
 func (s *Subcluster) GenCompatibleFQDN() string {
@@ -943,14 +932,19 @@ func (v *VerticaDB) IncludeUIDInPath() bool {
 	return vmeta.IncludeUIDInPath(v.Annotations)
 }
 
-// IsHDFS returns true if the communal path is stored in an HDFS path
-func (v *VerticaDB) IsHDFS() bool {
+// IsPathHDFS returns true if the path is an HDFS path
+func (v *VerticaDB) IsPathHDFS(path string) bool {
 	for _, p := range hdfsPrefixes {
-		if strings.HasPrefix(v.Spec.Communal.Path, p) {
+		if strings.HasPrefix(path, p) {
 			return true
 		}
 	}
 	return false
+}
+
+// IsHDFS returns true if the communal path is stored in an HDFS path
+func (v *VerticaDB) IsHDFS() bool {
+	return v.IsPathHDFS(v.Spec.Communal.Path)
 }
 
 // IsS3 returns true if VerticaDB has a communal path for S3 compatible storage.
@@ -1014,6 +1008,11 @@ func (v *VerticaDB) GetKerberosRealm() string {
 
 func (v *VerticaDB) GetKerberosServiceName() string {
 	return v.Spec.Communal.AdditionalConfig[vmeta.KerberosServiceNameConfig]
+}
+
+// HasAdditionalBuckets returns true if addtionalBuckets is configured for data replication
+func (v *VerticaDB) HasAdditionalBuckets() bool {
+	return v.Spec.AdditionalBuckets != nil
 }
 
 func (s *Subcluster) IsPrimary() bool {

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -177,6 +177,11 @@ type VerticaDBSpec struct {
 	Communal CommunalStorage `json:"communal"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Contains details about the addtionsl buckets for data replication
+	AdditionalBuckets []CommunalStorage `json:"additionalBuckets,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={requestSize:"500Gi", dataPath:"/data", depotPath:"/depot"}
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// Contain details about the local storage
@@ -980,6 +985,11 @@ type VerticaDBStatus struct {
 	// +optional
 	// The details about the last created restore point
 	RestorePoint *RestorePointInfo `json:"restorePoint"`
+
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +Optional
+	// The details of the current using addtionsl buckets
+	AdditionalBuckets []CommunalStorage `json:"additionalBuckets,omitempty"`
 
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -782,6 +782,13 @@ func (in *VerticaDBSpec) DeepCopyInto(out *VerticaDBSpec) {
 		copy(*out, *in)
 	}
 	in.Communal.DeepCopyInto(&out.Communal)
+	if in.AdditionalBuckets != nil {
+		in, out := &in.AdditionalBuckets, &out.AdditionalBuckets
+		*out = make([]CommunalStorage, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Local.DeepCopyInto(&out.Local)
 	if in.Subclusters != nil {
 		in, out := &in.Subclusters, &out.Subclusters
@@ -903,6 +910,13 @@ func (in *VerticaDBStatus) DeepCopyInto(out *VerticaDBStatus) {
 		in, out := &in.RestorePoint, &out.RestorePoint
 		*out = new(RestorePointInfo)
 		**out = **in
+	}
+	if in.AdditionalBuckets != nil {
+		in, out := &in.AdditionalBuckets, &out.AdditionalBuckets
+		*out = make([]CommunalStorage, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.SecretRefs != nil {
 		in, out := &in.SecretRefs, &out.SecretRefs

--- a/pkg/controllers/vdb/createdb_reconciler.go
+++ b/pkg/controllers/vdb/createdb_reconciler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+	"github.com/vertica/vertica-kubernetes/pkg/cloud"
 	"github.com/vertica/vertica-kubernetes/pkg/cmds"
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
@@ -177,6 +178,18 @@ func (c *CreateDBReconciler) preCmdSetup(ctx context.Context, initiatorPod types
 	}
 
 	return c.generatePostDBCreateSQL(ctx, initiatorPod)
+}
+
+// GetCredsSecret returns the contents of the credentials
+// secret. It handles if the secret is not found and will log an event.
+func (c *CreateDBReconciler) GetCredsSecret(ctx context.Context, credsSecret string) (map[string][]byte, ctrl.Result, error) {
+	fetcher := cloud.SecretFetcher{
+		Client:   c.VRec.GetClient(),
+		Log:      c.Log,
+		Obj:      c.Vdb,
+		EVWriter: c.VRec,
+	}
+	return fetcher.FetchAllowRequeue(ctx, names.GenNamespacedName(c.Vdb, credsSecret))
 }
 
 // generatePostDBCreateSQL is a function that creates a file with sql commands

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -194,6 +194,9 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Update the sandbox/subclusters' shutdown field to match the value of
 		// the spec.
 		MakeShutdownSpecReconciler(r, vdb),
+		// Trigger sandbox shutdown when the shutdown field of the sandbox
+		// is changed
+		MakeSandboxShutdownReconciler(r, log, vdb, false),
 		// Update the vertica image for unsandboxed subclusters
 		MakeUnsandboxImageVersionReconciler(r, vdb, log, pfacts),
 		// Always start with a status reconcile in case the prior reconcile failed.
@@ -220,9 +223,6 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 			ObjReconcileModePreserveScaling|ObjReconcileModePreserveUpdateStrategy),
 		// Add annotations/labels to each pod about the host running them
 		MakeAnnotateAndLabelPodReconciler(r, log, vdb, pfacts),
-		// Trigger sandbox shutdown when the shutdown field of the sandbox
-		// is changed
-		MakeSandboxShutdownReconciler(r, log, vdb, true),
 		// Handles vertica server upgrade (i.e., when spec.image changes)
 		MakeOfflineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		MakeReadOnlyOnlineUpgradeReconciler(r, log, vdb, prunner, pfacts, dispatcher),
@@ -268,6 +268,8 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeCreateDBReconciler(r, log, vdb, prunner, pfacts, dispatcher),
 		// Handle calls to revive a database
 		MakeReviveDBReconciler(r, log, vdb, prunner, pfacts, dispatcher),
+		// Add additional buckets for data replication
+		MakeAddtionalBucketsReconciler(r, log, vdb, prunner, pfacts, r.Client),
 		MakeMetricReconciler(r, log, vdb, prunner, pfacts),
 		// Create and revive are mutually exclusive exclusive, so this handles
 		// status updates after both of them.
@@ -295,12 +297,9 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		// Trigger sandbox upgrade when the image field for the sandbox
 		// is changed
 		MakeSandboxUpgradeReconciler(r, log, vdb, true),
-		// Update the sandbox/subclusters' shutdown field to match the value of
-		// the spec.
-		MakeShutdownSpecReconciler(r, vdb),
 		// Trigger sandbox shutdown when the shutdown field of the sandbox
 		// is changed
-		MakeSandboxShutdownReconciler(r, log, vdb, false),
+		MakeSandboxShutdownReconciler(r, log, vdb, true),
 		// Add the label after update the sandbox subcluster status field
 		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeAll),
 		// Handle calls to create a restore point

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -41,6 +41,7 @@ const (
 	S3BucketDoesNotExist             = "S3BucketDoesNotExist"
 	S3WrongRegion                    = "S3WrongRegion"
 	S3SseCustomerWrongKey            = "S3SseCustomerWrongKey"
+	AdditionalBucketsUpdated         = "AdditionalBucketsUpdated"
 	InvalidS3SseCustomerKey          = "InvalidS3SseCustomerKey"
 	InvalidConfigParm                = "InvalidConfigParm"
 	CommunalPathIsNotEmpty           = "CommunalPathIsNotEmpty"

--- a/pkg/vdbconfig/config.go
+++ b/pkg/vdbconfig/config.go
@@ -467,21 +467,24 @@ func (g *ConfigParamsGenerator) GetS3SseCustomerKeySecret(ctx context.Context) (
 	return getSecret(ctx, g.VRec, g.Vdb, names.GenS3SseCustomerKeySecretName(g.Vdb))
 }
 
-// GetCommunalEndpoint get the communal endpoint for inclusion in the auth files.
-// Takes the endpoint from vdb and strips off the protocol.
-func (g *ConfigParamsGenerator) GetCommunalEndpoint() string {
-	// Early out if the endpoint isn't set. For this case, we let the server
-	// pick the endpoint based on the communal path chosen.
-	if g.Vdb.Spec.Communal.Endpoint == "" {
+// GetEndpoint gets the endpoint from the endpoint URL and strips off the protocol.
+func GetEndpoint(endPoint string) string {
+	if endPoint == "" {
 		return ""
 	}
 	prefix := []string{"https://", "http://"}
 	for _, pref := range prefix {
-		if i := strings.Index(g.Vdb.Spec.Communal.Endpoint, pref); i == 0 {
-			return strings.TrimSuffix(g.Vdb.Spec.Communal.Endpoint[len(pref):], "/")
+		if i := strings.Index(endPoint, pref); i == 0 {
+			return strings.TrimSuffix(endPoint[len(pref):], "/")
 		}
 	}
-	return g.Vdb.Spec.Communal.Endpoint
+	return endPoint
+}
+
+// GetCommunalEndpoint get the communal endpoint for inclusion in the auth files.
+// Takes the endpoint from vdb and strips off the protocol.
+func (g *ConfigParamsGenerator) GetCommunalEndpoint() string {
+	return GetEndpoint(g.Vdb.Spec.Communal.Endpoint)
 }
 
 // getEnableHTTPS will return "1" if connecting to https otherwise return "0"
@@ -594,6 +597,23 @@ func GetEndpointHostPort(blobEndpoint string) string {
 		return blobEndpoint
 	}
 	return strings.TrimSuffix(m[0][2], "/")
+}
+
+// GetBucket returns the bucket name from the path URL
+func GetBucket(path string) string {
+	re := regexp.MustCompile(`([a-z]\d+)://(.*)`)
+	m := re.FindAllStringSubmatch(path, 1)
+
+	if len(m) == 0 || len(m[0]) < 3 {
+		return path
+	}
+
+	p := strings.Split(m[0][2], "/")
+	if len(p) == 0 || len(p[0]) < 3 {
+		return m[0][2]
+	}
+
+	return strings.TrimRight(p[0], "/")
 }
 
 // setHadoopConfDir adds an entry to the config parms map for


### PR DESCRIPTION
The user requires configuring the secondary bucket’s ([endpoint and credentials](https://docs.vertica.com/25.2.x/en/sql-reference/file-systems-and-object-stores/s3-object-store/per-bucket-s3-configs/)) directly through the VerticaDB CRD so they can copy the data from one vdb to another.

Example additional buckets:

spec: 
   additionalBuckets:
    - path: "s3://vertica-fleeting/k8s"
      endpoint: "http://<endpoint>:9000/"
      credentialSecret: s3-creds-minio
      ...
    - path: "azb://myaccount/mycontainer/k8s"
      endpoint: "<endpoint>"
      credentialSecret: azure-creds
      ... 
    - path: "gs://vertica-fleeting/k8s"
      endpoint: "<endpoint>"
      credentialSecret: gcp-creds