### PR TITLE
Add skeleton for rollback after https/nma cert rotation failure

### DIFF
--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -1065,6 +1065,15 @@ const (
 	HTTPSCertRotationFinished = "HTTPSCertRotationFinished"
 	// TLSCertRotationInProgress indicates the TLS cert rotation has started
 	TLSCertRotationInProgress = "TLSCertRotationInProgress"
+	// TLSCertRollbackNeeded indicates tls cert rotation failed and we need
+	// to rollback
+	TLSCertRollbackNeeded = "TLSCertRollbackNeeded"
+)
+
+const (
+	RollbackAfterHTTPSCertRotationReason = "HTTPSCertRotationFailed"
+	FailureBeforeCertHealthPollingReason = "HTTPSCertRotationFailedBeforeCertHealthPolling"
+	RollbackAfterNMACertRotationReason   = "NMACertRotationFailed"
 )
 
 const (

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -2160,8 +2160,13 @@ func GetTarballName(cmd []string) string {
 // The configmap will be mapped to two environmental variables in NMA pod
 func BuildNMATLSConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.ConfigMap {
 	secretMap := map[string]string{
-		NMASecretNamespaceEnv:       vdb.ObjectMeta.Namespace,
-		NMASecretNameEnv:            vdb.Spec.NMATLSSecret,
+		NMASecretNamespaceEnv: vdb.ObjectMeta.Namespace,
+		// https cert rotation comes before nma's. So, we don't want to
+		// (don't have to) change the secret name in the config map up until
+		// https cert rotation completes successfully. This makes nma rollback
+		// as if https cert rotation fails, we don't have to do anything to
+		// nma containers.
+		NMASecretNameEnv:            vdb.GetNMATLSSecretNameForConfigMap(),
 		NMAClientSecretNamespaceEnv: vdb.ObjectMeta.Namespace,
 		NMAClientSecretNameEnv:      vdb.Spec.ClientServerTLSSecret,
 	}

--- a/pkg/controllers/vdb/helpers.go
+++ b/pkg/controllers/vdb/helpers.go
@@ -1,0 +1,28 @@
+/*
+ (c) Copyright [2021-2025] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+)
+
+func traceActorReconcile(actor controllers.ReconcileActor, log logr.Logger, reason string) {
+	msg := fmt.Sprintf("starting actor for %s", reason)
+	log.Info(msg, "name", fmt.Sprintf("%T", actor))
+}

--- a/pkg/controllers/vdb/httpscertrotation_reconciler_test.go
+++ b/pkg/controllers/vdb/httpscertrotation_reconciler_test.go
@@ -17,6 +17,7 @@ package vdb
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,6 +65,30 @@ var _ = Describe("httpscertrotation_reconciler", func() {
 
 		r := MakeHTTPSCertRotationReconciler(vdbRec, logger, vdb, dispatcher, pfacts)
 		Expect(r.Reconcile(ctx, &ctrl.Request{})).Should(Equal(ctrl.Result{Requeue: true}))
+	})
+
+	It("should set rollback after cert rotation", func() {
+		vdb := vapi.MakeVDB()
+		test.CreateVDB(ctx, k8sClient, vdb)
+		defer test.DeleteVDB(ctx, k8sClient, vdb)
+
+		err := fmt.Errorf("random error")
+		fpr := &cmds.FakePodRunner{}
+		dispatcher := vdbRec.makeDispatcher(logger, vdb, fpr, TestPassword)
+		pfacts := createPodFactsWithNoDB(ctx, vdb, fpr, 3)
+		act := MakeHTTPSCertRotationReconciler(vdbRec, logger, vdb, dispatcher, pfacts)
+		r := act.(*HTTPSCertRotationReconciler)
+		err = r.triggerRollback(ctx, err)
+		Expect(err).Should(Succeed())
+		Expect(len(vdb.Status.Conditions)).Should(Equal(1))
+		Expect(vdb.IsTLSCertRollbackNeeded()).Should(BeTrue())
+		Expect(vdb.Status.Conditions[0].Reason).Should(Equal(vapi.FailureBeforeCertHealthPollingReason))
+		Expect(vdb.IsRollbackFailureBeforeCertHealthPolling()).Should(BeTrue())
+
+		err = fmt.Errorf("HTTPSPollCertificateHealthOp error during polling")
+		err = r.triggerRollback(ctx, err)
+		Expect(err).Should(Succeed())
+		Expect(r.Vdb.IsRollbackFailureBeforeCertHealthPolling()).Should(BeFalse())
 	})
 
 })

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -52,6 +52,8 @@ const (
 	ObjReconcileModePreserveScaling = 1 << iota
 	// Must maintain the same delete policy when reconciling statefulsets
 	ObjReconcileModePreserveUpdateStrategy
+	// Must reconcile only nma config map
+	ObjReconcileModeNMAConfigMap
 	// Reconcile to consider every change. Without this we will skip svc objects.
 	ObjReconcileModeAll
 )
@@ -120,6 +122,11 @@ func (o *ObjReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Re
 	err := o.reconcileNMACertConfigMap(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if o.Mode&ObjReconcileModeNMAConfigMap != 0 {
+		// return since we only want to reconcile the nma config map
+		return ctrl.Result{}, nil
 	}
 
 	// Check the objects for subclusters that should exist.  This will create

--- a/pkg/controllers/vdb/rollbackafternmacertrotation_reconciler.go
+++ b/pkg/controllers/vdb/rollbackafternmacertrotation_reconciler.go
@@ -1,0 +1,131 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
+	"github.com/vertica/vertica-kubernetes/pkg/podfacts"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type RollbackAfterNMACertRotationReconciler struct {
+	VRec       *VerticaDBReconciler
+	Vdb        *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	Log        logr.Logger
+	Dispatcher vadmin.Dispatcher
+	PFacts     *podfacts.PodFacts
+}
+
+func MakeRollbackAfterNMACertRotationReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger, vdb *vapi.VerticaDB,
+	dispatcher vadmin.Dispatcher, pfacts *podfacts.PodFacts) controllers.ReconcileActor {
+	return &RollbackAfterNMACertRotationReconciler{
+		VRec:       vdbrecon,
+		Vdb:        vdb,
+		Log:        log.WithName("RollbackAfterNMACertRotationReconciler"),
+		Dispatcher: dispatcher,
+		PFacts:     pfacts,
+	}
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
+	if !r.Vdb.IsTLSCertRollbackNeeded() {
+		return ctrl.Result{}, nil
+	}
+
+	funcs := []func(context.Context) (ctrl.Result, error){
+		r.runObjReconciler,
+		r.shutdownNMA,
+		r.waitForNMAUp,
+		r.pollNMACertHealth,
+		r.httpsCertRotation,
+		r.updateNMATLSSecretInVdb,
+		r.cleanUpConditions,
+	}
+
+	for _, fn := range funcs {
+		if res, err := fn(ctx); verrors.IsReconcileAborted(res, err) {
+			return res, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) runObjReconciler(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+	rec := MakeObjReconciler(r.VRec, r.Log, r.Vdb, r.PFacts, ObjReconcileModeNMAConfigMap)
+	traceActorReconcile(rec, r.Log, "tls cert rollback")
+	return rec.Reconcile(ctx, &ctrl.Request{})
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) shutdownNMA(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: restart all nma containers so they can read the old cert.
+	// We want to do it once, so we need to add something (e.g: a status condition)
+	// that will set once we restart nma
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) waitForNMAUp(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: find all pods and wait for each pod's nma container to be ready
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) pollNMACertHealth(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: call rotate_nma_certs vclusterops API. We only want to poll the cert health
+	// so we will skip kill NMA
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) httpsCertRotation(ctx context.Context) (ctrl.Result, error) {
+	if r.Vdb.IsRollbackFailureBeforeCertHealthPolling() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: call httpscertrotation_reconciler. Changes are needed there so it can be
+	// reused for rollback
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) updateNMATLSSecretInVdb(ctx context.Context) (ctrl.Result, error) {
+	// TODO: change spec.NMATLSSecret to its original value before cert rotation
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) cleanUpConditions(ctx context.Context) (ctrl.Result, error) {
+	// TODO: we can clean up all conditions set for cert rotation and rollback
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -627,7 +627,7 @@ func (i *UpgradeManager) isPrimary(l map[string]string) bool {
 }
 
 func (i *UpgradeManager) traceActorReconcile(actor controllers.ReconcileActor) {
-	i.Log.Info("starting actor for upgrade", "name", fmt.Sprintf("%T", actor))
+	traceActorReconcile(actor, i.Log, "upgrade")
 }
 
 // isSubclusterIdle will run a query to see the number of connections

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -307,8 +307,12 @@ func (r *VerticaDBReconciler) constructActors(log logr.Logger, vdb *vapi.Vertica
 		MakeSaveRestorePointReconciler(r, vdb, log, pfacts, dispatcher, r.Client),
 		// rotate https tls cert when tls cert secret name is changed in vdb.spec
 		MakeHTTPSCertRotationReconciler(r, log, vdb, dispatcher, pfacts),
+		// updates nma config map with the name of the new secret
+		MakeObjReconciler(r, log, vdb, pfacts, ObjReconcileModeNMAConfigMap),
 		// rotate nma tls cert when tls cert secret name is changed in vdb.spec
 		MakeNMACertRotationReconciler(r, log, vdb, dispatcher, pfacts),
+		// rollback, in case of failure, any cert rotation op related to nmaTLSSecret
+		MakeRollbackAfterNMACertRotationReconciler(r, log, vdb, dispatcher, pfacts),
 		// Resize any PVs if the local data size changed in the vdb
 		MakeResizePVReconciler(r, log, vdb, prunner, pfacts),
 		// This must be the last reconciler. It makes sure that all dependent

--- a/pkg/vdbstatus/status.go
+++ b/pkg/vdbstatus/status.go
@@ -71,6 +71,18 @@ func UpdateCondition(ctx context.Context, clnt client.Client, vdb *vapi.VerticaD
 	return Update(ctx, clnt, vdb, refreshConditionInPlace)
 }
 
+func UpdateConditions(ctx context.Context, clnt client.Client, vdb *vapi.VerticaDB, conditions []*metav1.Condition) error {
+	// refreshConditionInPlace will update the status condition. The update
+	// will be applied in-place.
+	refreshConditionInPlace := func(vdb *vapi.VerticaDB) error {
+		for _, condition := range conditions {
+			meta.SetStatusCondition(&vdb.Status.Conditions, *condition)
+		}
+		return nil
+	}
+	return Update(ctx, clnt, vdb, refreshConditionInPlace)
+}
+
 // UpdateSecretRef will update a secret status. There is no-op if the status secret is already set.
 func UpdateSecretRef(ctx context.Context, clnt client.Client, vdb *vapi.VerticaDB, sRef *vapi.SecretRef) error {
 	// refreshConditionInPlace will update the status secretRef in vdb.  The update


### PR DESCRIPTION
This lays the foundations for rollback after tls cert rotation failure. 
The failure scenarios are the following (simplified summary):
- https cert rotation fails but before any change was made in the tls config. We are still using the old cert so we just need to undo the secret name change. (no-op on nma)
- https cert rotation fails, we altered the tls config but polling the new cert health failed (it is unlikely): We need to rollback the rotation by re-running cert rotation with reverse params; to get back to the old cert. (no-op on nma)
- htts cert rotation succeeded but nma cert rotation failed: we need to roll back both nma and https. First nma, we need to restart nma containers with the old cert. Once nma is back running with old cert, we re-run cert rotation with reverse params;

I added a new reconciler that will incapsulate the rollback logic. In the cert rotation reconcilers, we will set a status condition with a specific "reason". The rollback reconciler will use that condition to decide how far it needs to go to undo what has been done.

This is only the skeleton and currently does not do any rollback. 