### PR TITLE
Fix bug in obj_reconciler

### DIFF
--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/names"
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/podfacts"
+	"github.com/vertica/vertica-kubernetes/pkg/secrets"
 	config "github.com/vertica/vertica-kubernetes/pkg/vdbconfig"
 	"github.com/vertica/vertica-kubernetes/pkg/vk8s"
 	appsv1 "k8s.io/api/apps/v1"
@@ -756,6 +757,10 @@ func (o *ObjReconciler) reconcileTLSSecrets(ctx context.Context) error {
 		o.Vdb.Spec.ClientServerTLSSecret,
 	}
 	for _, tlsSecret := range tlsSecrets {
+		// non-k8s secrets are ignored
+		if !secrets.IsK8sSecret(tlsSecret) {
+			continue
+		}
 		err := o.updateOwnerReferenceInTLSSecret(ctx, tlsSecret)
 		if err != nil {
 			return err

--- a/pkg/secrets/fetcher.go
+++ b/pkg/secrets/fetcher.go
@@ -135,7 +135,7 @@ func (m *MultiSourceSecretFetcher) readFromGSM(ctx context.Context, secName stri
 }
 
 // readFromAWS will fetch a secret from AWS Secrets Manager. The secretName
-// should be of the format awssm://<secret-arn>.
+// should be of the format awssm://<secret-arn> or awssm://<secret-arn>@<version-id>.
 func (m *MultiSourceSecretFetcher) readFromAWS(secretName string) (map[string][]byte, error) {
 	secretARNWithVersionID := RemovePathReference(secretName)
 	secretARN, versionID := getAWSSecretVersionID(secretARNWithVersionID)
@@ -149,7 +149,7 @@ func (m *MultiSourceSecretFetcher) readFromAWS(secretName string) (map[string][]
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ARN for AWS secret fetch: %w", err)
 	}
-	m.Log.Info("Reading secret from AWS", "secretARN", secretARN, "region", arnComp.Region)
+	m.Log.Info("Reading secret from AWS", "secretARN", secretARN, "region", arnComp.Region, "versionID", versionID)
 
 	awsSession, err := session.NewSession(&aws.Config{
 		Region: aws.String(arnComp.Region),


### PR DESCRIPTION
The issue is "reconcileTLSSecrets()" in obj_reconciler.go. That function must be used for k8s secrets only. When the secret is in awssm, we would try to get it using k8s api, which of course will fail. Now we first check if the tls secret is in k8s and skip it if that's not the case