### PR TITLE
Disable cache duration

### DIFF
--- a/local-libs/vcluster/vclusterops/set_tls_config.go
+++ b/local-libs/vcluster/vclusterops/set_tls_config.go
@@ -29,7 +29,7 @@ type VSetTLSConfigOptions struct {
 	HTTPSTLSConfig TLSConfig
 }
 
-const DefaultCacheDuration = 1 * 24 * 3600 // 1 day
+const DefaultCacheDuration = 0
 
 func VSetTLSConfigOptionsFactory() VSetTLSConfigOptions {
 	options := VSetTLSConfigOptions{}


### PR DESCRIPTION
Cache duration does not work and fails all the "cert" tests. This is a temporary change to allow tests to pass until it is fixed.