### PR TITLE
Temporary turn off leg-8-admintools-online

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -711,29 +711,6 @@ jobs:
           minimum-vertica-image: '24.2.0'
           e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
 
-  e2e-leg-8-admintools-online:
-    if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'leg 8' || inputs.e2e_test_suites == '')}}
-    needs: [build]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Test
-        uses: ./.github/actions/run-e2e-leg
-        with:
-          leg-identifier: 'leg-8-online'
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          vlogger-image: ${{ needs.build.outputs.vlogger-image }}
-          operator-image: ${{ needs.build.outputs.operator-image }}
-          vertica-image: ${{ needs.build.outputs.full-vertica-image }}
-          # The initial deployment method is admintools, and it eventually changes
-          # to vclusterops as the operator upgrades the server version
-          vertica-deployment-method: admintools
-          communal-storage-type: azb
-          minimum-vertica-image: '24.2.0'
-          e2e-retry-times: ${{ inputs.e2e_retry_times || 2 }}
-
   e2e-leg-8-vcluster-online:
     if: ${{ ! github.event.pull_request.head.repo.fork  && (inputs.e2e_test_suites == 'all' || inputs.e2e_test_suites == 'leg 8' || inputs.e2e_test_suites == '')}}
     needs: [build]
@@ -1279,7 +1256,6 @@ jobs:
       e2e-leg-4-admintools-vdb-gen, 
       e2e-leg-5-admintools,
       e2e-leg-8-admintools-offline,
-      e2e-leg-8-admintools-online,
       e2e-server-upgrade-admintools, 
       e2e-udx-admintools
     ]


### PR DESCRIPTION
leg-8-admintools-online: I found a panic in vclusterops during start_node. I am disabling this test to allow ci/cd runs to pass. This is temporary until that issue is fixed.