### PR TITLE
Create HTTPS/NMA TLS rollback skeleton

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -617,6 +617,38 @@ func (v *VerticaDB) IsCertRotationInProgress() bool {
 	return v.IsStatusConditionTrue(TLSCertRotationInProgress)
 }
 
+func (v *VerticaDB) IsTLSCertRollbackNeeded() bool {
+	return v.IsStatusConditionTrue(TLSCertRollbackNeeded)
+}
+
+func (v *VerticaDB) FindTLSCertRollbackNeededCondition() *metav1.Condition {
+	return v.FindStatusCondition(TLSCertRollbackNeeded)
+}
+
+// GetTLSCertRollbackReason returns the reason or the point
+// which cert rotation failed in. This is used to know the ops
+// needed to rollback
+func (v *VerticaDB) GetTLSCertRollbackReason() string {
+	cond := v.FindTLSCertRollbackNeededCondition()
+	if cond == nil {
+		return ""
+	}
+
+	return cond.Reason
+}
+
+// IsRollbackFailureBeforeCertHealthPolling returns true if https cert rotation failed
+// without altering the current tls config
+func (v *VerticaDB) IsRollbackFailureBeforeCertHealthPolling() bool {
+	return v.GetTLSCertRollbackReason() == FailureBeforeCertHealthPollingReason
+}
+
+// IsRollbackAfterNMACertRotation returns true if https cert rotation failed
+// but tls config changed
+func (v *VerticaDB) IsRollbackAfterNMACertRotation() bool {
+	return v.GetTLSCertRollbackReason() == RollbackAfterNMACertRotationReason
+}
+
 // IsStatusConditionTrue returns true when the conditionType is present and set to
 // `metav1.ConditionTrue`
 func (v *VerticaDB) IsStatusConditionTrue(statusCondition string) bool {
@@ -1554,6 +1586,17 @@ func (v *VerticaDB) GetHTTPSNMATLSSecretInUse() string {
 
 func (v *VerticaDB) GetClientServerTLSSecretInUse() string {
 	return v.GetSecretInUse(ClientServerTLSConfigName)
+}
+
+// GetNMATLSSecretNameForConfigMap returns the secret name to set in the
+// nma configmap
+func (v *VerticaDB) GetHTTPSNMATLSSecretForConfigMap() string {
+	name := v.GetHTTPSNMATLSSecretInUse()
+	if name != "" &&
+		(!v.IsStatusConditionTrue(HTTPSCertRotationFinished) || v.IsTLSCertRollbackNeeded()) {
+		return name
+	}
+	return v.GetHTTPSNMATLSSecret()
 }
 
 // IsCertNeededForClientServerAuth returns true if certificate is needed for client-server authentication

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -1081,6 +1081,15 @@ const (
 	HTTPSCertRotationFinished = "HTTPSCertRotationFinished"
 	// TLSCertRotationInProgress indicates the TLS cert rotation has started
 	TLSCertRotationInProgress = "TLSCertRotationInProgress"
+	// TLSCertRollbackNeeded indicates tls cert rotation failed and we need
+	// to rollback
+	TLSCertRollbackNeeded = "TLSCertRollbackNeeded"
+)
+
+const (
+	RollbackAfterHTTPSCertRotationReason = "HTTPSCertRotationFailed"
+	FailureBeforeCertHealthPollingReason = "HTTPSCertRotationFailedBeforeCertHealthPolling"
+	RollbackAfterNMACertRotationReason   = "NMACertRotationFailed"
 )
 
 const (

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -2196,8 +2196,13 @@ func GetTarballName(cmd []string) string {
 // The configmap will be mapped to two environmental variables in NMA pod
 func BuildNMATLSConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.ConfigMap {
 	secretMap := map[string]string{
-		NMASecretNamespaceEnv:       vdb.ObjectMeta.Namespace,
-		NMASecretNameEnv:            vdb.GetHTTPSNMATLSSecret(),
+		NMASecretNamespaceEnv: vdb.ObjectMeta.Namespace,
+		// https cert rotation comes before nma's. So, we don't want to
+		// (don't have to) change the secret name in the config map up until
+		// https cert rotation completes successfully. This makes nma rollback
+		// as if https cert rotation fails, we don't have to do anything to
+		// nma containers.
+		NMASecretNameEnv:            vdb.GetHTTPSNMATLSSecretForConfigMap(),
 		NMAClientSecretNamespaceEnv: vdb.ObjectMeta.Namespace,
 		NMAClientSecretNameEnv:      vdb.GetClientServerTLSSecret(),
 		NMAClientSecretTLSModeEnv:   vdb.GetNMAClientServerTLSMode(),

--- a/pkg/controllers/vdb/helpers.go
+++ b/pkg/controllers/vdb/helpers.go
@@ -1,0 +1,28 @@
+/*
+ (c) Copyright [2021-2025] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+)
+
+func traceActorReconcile(actor controllers.ReconcileActor, log logr.Logger, reason string) {
+	msg := fmt.Sprintf("starting actor for %s", reason)
+	log.Info(msg, "name", fmt.Sprintf("%T", actor))
+}

--- a/pkg/controllers/vdb/httpstls_reconciler.go
+++ b/pkg/controllers/vdb/httpstls_reconciler.go
@@ -71,7 +71,11 @@ func (h *HTTPSTLSReconciler) constructActors(log logr.Logger, vdb *vapi.VerticaD
 		MakeTLSConfigReconciler(h.VRec, log, vdb, prunner, dispatcher, pfacts, vapi.ClientServerTLSConfigName),
 		// rotate https tls cert when tls cert secret name is changed in vdb.spec
 		MakeHTTPSCertRotationReconciler(h.VRec, log, vdb, dispatcher, pfacts),
+		// updates nma config map with the name of the new secret
+		MakeObjReconciler(h.VRec, log, vdb, pfacts, ObjReconcileModeNMAConfigMap),
 		// rotate nma tls cert when tls cert secret name is changed in vdb.spec
 		MakeNMACertRotationReconciler(h.VRec, log, vdb, dispatcher, pfacts),
+		// rollback, in case of failure, any cert rotation op related to nmaTLSSecret
+		MakeRollbackAfterNMACertRotationReconciler(h.VRec, log, vdb, dispatcher, pfacts),
 	}
 }

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -56,6 +56,8 @@ const (
 	ObjReconcileModePreserveUpdateStrategy
 	// Reconcile for annotation only
 	ObjReconcileModeAnnotation
+	// Must reconcile only nma config map
+	ObjReconcileModeNMAConfigMap
 	// Reconcile to consider every change. Without this we will skip svc objects.
 	ObjReconcileModeAll
 )
@@ -127,6 +129,11 @@ func (o *ObjReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Re
 
 	if err := o.reconcileTLSSecrets(ctx); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if o.Mode&ObjReconcileModeNMAConfigMap != 0 {
+		// return since we only want to reconcile the nma config map
+		return ctrl.Result{}, nil
 	}
 
 	// Check the objects for subclusters that should exist.  This will create

--- a/pkg/controllers/vdb/rollbackafternmacertrotation_reconciler.go
+++ b/pkg/controllers/vdb/rollbackafternmacertrotation_reconciler.go
@@ -1,0 +1,131 @@
+/*
+ (c) Copyright [2021-2024] Open Text.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package vdb
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	vapi "github.com/vertica/vertica-kubernetes/api/v1"
+
+	"github.com/vertica/vertica-kubernetes/pkg/controllers"
+	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
+	"github.com/vertica/vertica-kubernetes/pkg/podfacts"
+	"github.com/vertica/vertica-kubernetes/pkg/vadmin"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type RollbackAfterNMACertRotationReconciler struct {
+	VRec       *VerticaDBReconciler
+	Vdb        *vapi.VerticaDB // Vdb is the CRD we are acting on.
+	Log        logr.Logger
+	Dispatcher vadmin.Dispatcher
+	PFacts     *podfacts.PodFacts
+}
+
+func MakeRollbackAfterNMACertRotationReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger, vdb *vapi.VerticaDB,
+	dispatcher vadmin.Dispatcher, pfacts *podfacts.PodFacts) controllers.ReconcileActor {
+	return &RollbackAfterNMACertRotationReconciler{
+		VRec:       vdbrecon,
+		Vdb:        vdb,
+		Log:        log.WithName("RollbackAfterNMACertRotationReconciler"),
+		Dispatcher: dispatcher,
+		PFacts:     pfacts,
+	}
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) Reconcile(ctx context.Context, _ *ctrl.Request) (ctrl.Result, error) {
+	if !r.Vdb.IsTLSCertRollbackNeeded() {
+		return ctrl.Result{}, nil
+	}
+
+	funcs := []func(context.Context) (ctrl.Result, error){
+		r.runObjReconciler,
+		r.shutdownNMA,
+		r.waitForNMAUp,
+		r.pollNMACertHealth,
+		r.httpsCertRotation,
+		r.updateNMATLSSecretInVdb,
+		r.cleanUpConditions,
+	}
+
+	for _, fn := range funcs {
+		if res, err := fn(ctx); verrors.IsReconcileAborted(res, err) {
+			return res, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) runObjReconciler(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+	rec := MakeObjReconciler(r.VRec, r.Log, r.Vdb, r.PFacts, ObjReconcileModeNMAConfigMap)
+	traceActorReconcile(rec, r.Log, "tls cert rollback")
+	return rec.Reconcile(ctx, &ctrl.Request{})
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) shutdownNMA(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: restart all nma containers so they can read the old cert.
+	// We want to do it once, so we need to add something (e.g: a status condition)
+	// that will set once we restart nma
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) waitForNMAUp(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: find all pods and wait for each pod's nma container to be ready
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) pollNMACertHealth(ctx context.Context) (ctrl.Result, error) {
+	if !r.Vdb.IsRollbackAfterNMACertRotation() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: call rotate_nma_certs vclusterops API. We only want to poll the cert health
+	// so we will skip kill NMA
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) httpsCertRotation(ctx context.Context) (ctrl.Result, error) {
+	if r.Vdb.IsRollbackFailureBeforeCertHealthPolling() {
+		return ctrl.Result{}, nil
+	}
+
+	// TODO: call httpscertrotation_reconciler. Changes are needed there so it can be
+	// reused for rollback
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) updateNMATLSSecretInVdb(ctx context.Context) (ctrl.Result, error) {
+	// TODO: change spec.NMATLSSecret to its original value before cert rotation
+	return ctrl.Result{}, nil
+}
+
+func (r *RollbackAfterNMACertRotationReconciler) cleanUpConditions(ctx context.Context) (ctrl.Result, error) {
+	// TODO: we can clean up all conditions set for cert rotation and rollback
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/vdb/upgrade.go
+++ b/pkg/controllers/vdb/upgrade.go
@@ -651,7 +651,7 @@ func (i *UpgradeManager) isPrimary(l map[string]string) bool {
 }
 
 func (i *UpgradeManager) traceActorReconcile(actor controllers.ReconcileActor) {
-	i.Log.Info("starting actor for upgrade", "name", fmt.Sprintf("%T", actor))
+	traceActorReconcile(actor, i.Log, "upgrade")
 }
 
 // isSubclusterIdle will run a query to see the number of connections


### PR DESCRIPTION
This lays the foundations for rollback after tls cert rotation failure. 
The failure scenarios are the following (simplified summary):
- https cert rotation fails but before any change was made in the tls config. We are still using the old cert so we just need to undo the secret name change. (no-op on nma)
- https cert rotation fails, we altered the tls config but polling the new cert health failed (it is unlikely): We need to rollback the rotation by re-running cert rotation with reverse params; to get back to the old cert. (no-op on nma)
- htts cert rotation succeeded but nma cert rotation failed: we need to roll back both nma and https. First nma, we need to restart nma containers with the old cert. Once nma is back running with old cert, we re-run cert rotation with reverse params;

I added a new reconciler that will incapsulate the rollback logic. In the cert rotation reconcilers, we will set a status condition with a specific "reason". The rollback reconciler will use that condition to decide how far it needs to go to undo what has been done.

This is only the skeleton and currently does not do any rollback. 