### PR TITLE
Allowed vsql connection without certs

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1997,6 +1997,9 @@ func buildCanaryQuerySQL(vdb *vapi.VerticaDB) string {
 		passwd = fmt.Sprintf("-w $(cat %s/%s)", paths.PodInfoPath, SuperuserPasswordPath)
 	}
 
+	if vmeta.UseTLSAuth(vdb.Annotations) {
+		return fmt.Sprintf("vsql %s -m allow -c 'select 1'", passwd)
+	}
 	return fmt.Sprintf("vsql %s -c 'select 1'", passwd)
 }
 

--- a/pkg/cmds/fake.go
+++ b/pkg/cmds/fake.go
@@ -39,6 +39,7 @@ type FakePodRunner struct {
 	VerticaSUName string
 	// fake password
 	VerticaSUPassword string
+	IsTLSEnabled      bool
 }
 
 // CmdResults stores the command result.  The key is the pod name.
@@ -85,7 +86,7 @@ func (f *FakePodRunner) ExecAdmintools(ctx context.Context, podName types.Namesp
 // ExecVSQL calls ExecInPod
 func (f *FakePodRunner) ExecVSQL(ctx context.Context, podName types.NamespacedName,
 	contName string, command ...string) (stdout, stderr string, err error) {
-	command = UpdateVsqlCmd(f.VerticaSUName, f.VerticaSUPassword, command...)
+	command = UpdateVsqlCmd(f.VerticaSUName, f.VerticaSUPassword, f.IsTLSEnabled, command...)
 	return f.ExecInPod(ctx, podName, contName, command...)
 }
 

--- a/pkg/controllers/sandbox/sandbox_controller.go
+++ b/pkg/controllers/sandbox/sandbox_controller.go
@@ -129,7 +129,7 @@ func (r *SandboxConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vdb.GetVerticaUser(), passwd)
+	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vdb.GetVerticaUser(), passwd, vmeta.UseTLSAuth(vdb.Annotations))
 	pfacts := podfacts.MakePodFactsForSandbox(r, prunner, log, passwd, sandboxName)
 	dispatcher := vadmin.MakeVClusterOps(log, vdb, r.Client, passwd, r.EVRec, vadmin.SetupVClusterOps)
 

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -137,7 +137,7 @@ func (r *VerticaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vdb.GetVerticaUser(), passwd)
+	prunner := cmds.MakeClusterPodRunner(log, r.Cfg, vdb.GetVerticaUser(), passwd, vmeta.UseTLSAuth(vdb.Annotations))
 	// We use the same pod facts for all reconcilers. This allows to reuse as
 	// much as we can. Some reconcilers will purposely invalidate the facts if
 	// it is known they did something to make them stale.

--- a/pkg/controllers/vrep/replication_reconciler.go
+++ b/pkg/controllers/vrep/replication_reconciler.go
@@ -278,6 +278,8 @@ func (r *ReplicationReconciler) determineSourceAndTargetHosts() (err error) {
 }
 
 // make podfacts for a cluster (either main or a sandbox) of a vdb
+//
+//nolint:dupl
 func (r *ReplicationReconciler) makePodFacts(ctx context.Context, vdb *vapi.VerticaDB,
 	sandboxName string) (*podfacts.PodFacts, error) {
 	username := vdb.GetVerticaUser()
@@ -285,7 +287,7 @@ func (r *ReplicationReconciler) makePodFacts(ctx context.Context, vdb *vapi.Vert
 	if err != nil {
 		return nil, err
 	}
-	prunner := cmds.MakeClusterPodRunner(r.Log, r.VRec.Cfg, username, password)
+	prunner := cmds.MakeClusterPodRunner(r.Log, r.VRec.Cfg, username, password, vmeta.UseTLSAuth(vdb.Annotations))
 	pFacts := podfacts.MakePodFactsForSandbox(r.VRec, prunner, r.Log, password, sandboxName)
 	return &pFacts, nil
 }

--- a/pkg/controllers/vrep/replication_status_reconciler.go
+++ b/pkg/controllers/vrep/replication_status_reconciler.go
@@ -206,6 +206,8 @@ func (r *ReplicationStatusReconciler) determineTargetHosts() (err error) {
 }
 
 // make podfacts for a cluster (either main or a sandbox) of a vdb
+//
+//nolint:dupl
 func (r *ReplicationStatusReconciler) makePodFacts(ctx context.Context, vdb *vapi.VerticaDB,
 	sandboxName string) (*podfacts.PodFacts, error) {
 	username := vdb.GetVerticaUser()
@@ -213,7 +215,7 @@ func (r *ReplicationStatusReconciler) makePodFacts(ctx context.Context, vdb *vap
 	if err != nil {
 		return nil, err
 	}
-	prunner := cmds.MakeClusterPodRunner(r.Log, r.VRec.Cfg, username, password)
+	prunner := cmds.MakeClusterPodRunner(r.Log, r.VRec.Cfg, username, password, vmeta.UseTLSAuth(vdb.Annotations))
 	pFacts := podfacts.MakePodFactsForSandbox(r.VRec, prunner, r.Log, password, sandboxName)
 	return &pFacts, nil
 }


### PR DESCRIPTION
This PR appended "-m allow" to vsql command when annotation "enable-tls-auth" is set to "true". This is for the user that needs to set tls version to 1.3 in Vertica. For tls 1.3, a connection with tls will fail immediately.