### PR TITLE
Make tls mode case insensitive

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -185,6 +185,13 @@ func MakeVDB() *VerticaDB {
 	}
 }
 
+// MakeVDBForTLS is a helper that constructs a VerticaDB struct with TLS enabled.
+func MakeVDBForTLS() *VerticaDB {
+	vdb := MakeVDB()
+	SetVDBForTLS(vdb)
+	return vdb
+}
+
 // MakeVDBForHTTP is a helper that constructs a VerticaDB struct with http enabled.
 // This is intended for test purposes.
 func MakeVDBForHTTP(httpServerTLSSecretName string) *VerticaDB {
@@ -1682,13 +1689,13 @@ func (v *VerticaDB) GetClientServerTLSSecretInUse() string {
 
 // IsCertNeededForClientServerAuth returns true if certificate is needed for client-server authentication
 func (v *VerticaDB) IsCertNeededForClientServerAuth() bool {
-	tlsMode := strings.ToLower(v.GetClientServerTLSMode())
+	tlsMode := v.GetClientServerTLSMode()
 	return tlsMode != tlsModeDisable && tlsMode != tlsModeEnable
 }
 
 // GetNMAClientServerTLSMode returns the tlsMode for NMA client-server communication
 func (v *VerticaDB) GetNMAClientServerTLSMode() string {
-	tlsMode := strings.ToLower(v.GetClientServerTLSMode())
+	tlsMode := v.GetClientServerTLSMode()
 	switch tlsMode {
 	case tlsModeDisable:
 		return nmaTLSModeDisable
@@ -1815,7 +1822,7 @@ func (v *VerticaDB) GetHTTPSNMATLSMode() string {
 	if v.Spec.HTTPSNMATLS == nil {
 		return ""
 	}
-	return v.Spec.HTTPSNMATLS.Mode
+	return strings.ToLower(v.Spec.HTTPSNMATLS.Mode)
 }
 
 // Get HTTPSNMATLS secret from spec or return "" if not found
@@ -1831,7 +1838,7 @@ func (v *VerticaDB) GetClientServerTLSMode() string {
 	if v.Spec.ClientServerTLS == nil {
 		return ""
 	}
-	return v.Spec.ClientServerTLS.Mode
+	return strings.ToLower(v.Spec.ClientServerTLS.Mode)
 }
 
 // Get ClientServerTLS secret from spec or return "" if not found

--- a/api/v1/verticadb_types.go
+++ b/api/v1/verticadb_types.go
@@ -937,7 +937,7 @@ type TLSConfigSpec struct {
 	// Everything after the prefix is the name of the secret in the service you
 	// are storing.
 	Secret string `json:"secret,omitempty"`
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:hidden"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:disable","urn:alm:descriptor:com.tectonic.ui:select:enable","urn:alm:descriptor:com.tectonic.ui:select:TRY_VERIFY","urn:alm:descriptor:com.tectonic.ui:select:VERIFY_CA","urn:alm:descriptor:com.tectonic.ui:select:Revive","urn:alm:descriptor:com.tectonic.ui:select:VERIFY_FULL"}
 	// +kubebuilder:default:=TRY_VERIFY
 	// +kubebuilder:validation:Optional
 	// This field configures the Vertica's connection mode for HTTPS/NMA or client-server TLS.

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -237,7 +237,7 @@ func (v *VerticaDB) validateVerticaDBSpec() field.ErrorList {
 	allErrs = v.isServiceTypeValid(allErrs)
 	allErrs = v.hasDuplicateScName(allErrs)
 	allErrs = v.hasValidVolumeName(allErrs)
-	allErrs = v.hasValidClientServerTLSMode(allErrs)
+	allErrs = v.hasValidTLSModes(allErrs)
 	allErrs = v.hasTLSSecretsSetForRevive(allErrs)
 	allErrs = v.hasValidVolumeMountName(allErrs)
 	allErrs = v.hasValidKerberosSetup(allErrs)
@@ -815,10 +815,15 @@ func (v *VerticaDB) hasDuplicateScName(allErrs field.ErrorList) field.ErrorList 
 	return allErrs
 }
 
-func (v *VerticaDB) hasValidClientServerTLSMode(allErrs field.ErrorList) field.ErrorList {
-	if v.Spec.ClientServerTLS != nil {
-		allErrs = v.hasValidTLSMode(v.GetClientServerTLSMode(), "clientServerTLS.Mode", allErrs)
+// hasValidTLSModes checks whether the TLS modes are valid
+func (v *VerticaDB) hasValidTLSModes(allErrs field.ErrorList) field.ErrorList {
+	if v.Spec.HTTPSNMATLS != nil {
+		allErrs = v.hasValidTLSMode(v.GetHTTPSNMATLSMode(), "httpsNMATLS", allErrs)
 	}
+	if v.Spec.ClientServerTLS != nil {
+		allErrs = v.hasValidTLSMode(v.GetClientServerTLSMode(), "clientServerTLS", allErrs)
+	}
+
 	return allErrs
 }
 
@@ -2427,7 +2432,7 @@ func (v *VerticaDB) hasValidTLSMode(tlsModeToValidate, fieldName string, allErrs
 			}
 		}
 		if !validMode {
-			err := field.Invalid(field.NewPath("spec").Child(fieldName), tlsModeToValidate, "invalid tls mode")
+			err := field.Invalid(field.NewPath("spec").Child(fieldName).Child("mode"), tlsModeToValidate, "invalid tls mode")
 			allErrs = append(allErrs, err)
 		}
 	}

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -2606,6 +2606,54 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(newVdb.validateImmutableFields(oldVdb)).Should(HaveLen(0))
 	})
 
+	It("should return no errors when both TLS configs are nil", func() {
+		vdb := MakeVDBForTLS()
+		vdb.Spec.HTTPSNMATLS = nil
+		vdb.Spec.ClientServerTLS = nil
+		allErrs := vdb.hasValidTLSModes(field.ErrorList{})
+		Expect(allErrs).To(BeEmpty())
+	})
+
+	It("should return no errors for valid HTTPSNMATLS mode", func() {
+		vdb := MakeVDBForTLS()
+		vdb.Spec.HTTPSNMATLS = &TLSConfigSpec{Mode: "verify_ca"}
+		vdb.Spec.ClientServerTLS = nil
+		allErrs := vdb.hasValidTLSModes(field.ErrorList{})
+		Expect(allErrs).To(BeEmpty())
+	})
+
+	It("should return no errors for valid ClientServerTLS mode", func() {
+		vdb := MakeVDBForTLS()
+		vdb.Spec.HTTPSNMATLS = nil
+		vdb.Spec.ClientServerTLS = &TLSConfigSpec{Mode: "verify_full"}
+		allErrs := vdb.hasValidTLSModes(field.ErrorList{})
+		Expect(allErrs).To(BeEmpty())
+	})
+
+	It("should return errors for invalid HTTPSNMATLS mode", func() {
+		vdb := MakeVDBForTLS()
+		vdb.Spec.HTTPSNMATLS = &TLSConfigSpec{Mode: "invalid_mode"}
+		vdb.Spec.ClientServerTLS = nil
+		allErrs := vdb.hasValidTLSModes(field.ErrorList{})
+		Expect(allErrs).ToNot(BeEmpty())
+	})
+
+	It("should return errors for invalid ClientServerTLS mode", func() {
+		vdb := MakeVDBForTLS()
+		vdb.Spec.HTTPSNMATLS = nil
+		vdb.Spec.ClientServerTLS = &TLSConfigSpec{Mode: "bad_mode"}
+		allErrs := vdb.hasValidTLSModes(field.ErrorList{})
+		Expect(allErrs).ToNot(BeEmpty())
+	})
+
+	It("should return errors for both invalid modes", func() {
+		vdb := MakeVDBForTLS()
+		vdb.Spec.HTTPSNMATLS = &TLSConfigSpec{Mode: "foo"}
+		vdb.Spec.ClientServerTLS = &TLSConfigSpec{Mode: "bar"}
+		allErrs := vdb.hasValidTLSModes(field.ErrorList{})
+		Expect(allErrs).To(HaveLen(2))
+	})
+
 })
 
 func createVDBHelper() *VerticaDB {


### PR DESCRIPTION
This makes the tls mode case insensitive. So now TRY_VERIFY and try_verify are the same and going from one to the other will not be considered as a transition.