### PR TITLE
Make scale out test stable

### DIFF
--- a/tests/e2e-leg-12/scale-out-with-threshold-keda/45-assert.yaml
+++ b/tests/e2e-leg-12/scale-out-with-threshold-keda/45-assert.yaml
@@ -30,7 +30,7 @@ kind: ScaledObject
 metadata:
   name: v-scale-out-keda-vas-keda
 spec:
-  maxReplicaCount: 5
+  maxReplicaCount: 4
   minReplicaCount: 3
   scaleTargetRef:
     apiVersion: vertica.com/v1

--- a/tests/e2e-leg-12/scale-out-with-threshold-keda/45-create-vas.yaml
+++ b/tests/e2e-leg-12/scale-out-with-threshold-keda/45-create-vas.yaml
@@ -23,7 +23,7 @@ spec:
     type: ScaledObject
     scaledObject:
       minReplicas: 3
-      maxReplicas: 5
+      maxReplicas: 4
       metrics:
       - name: vertica_sessions_running_total
         metricType: AverageValue


### PR DESCRIPTION
scale-out-with-threshold-keda sometimes fails at step 50 because the cluster is scale out to 5 instead of 4. This set max replicas to 4 so it can not scale out above 4.