### PR TITLE
Fix shutdown subcluster issue

### DIFF
--- a/pkg/controllers/vdb/subclustershutdown_reconciler_test.go
+++ b/pkg/controllers/vdb/subclustershutdown_reconciler_test.go
@@ -41,6 +41,13 @@ var _ = Describe("subclustershutdown_reconciler", func() {
 			{Name: subcluster3, Size: 3, Type: vapi.SecondarySubcluster},
 			{Name: subcluster4, Size: 3, Type: vapi.SecondarySubcluster},
 		}
+		vdb.Status.Subclusters = []vapi.SubclusterStatus{
+			{Name: maincluster},
+			{Name: subcluster1},
+			{Name: subcluster2},
+			{Name: subcluster3},
+			{Name: subcluster4},
+		}
 		// All subclusters are in main cluster.
 		// Shutting down secondaries
 		vdb.Spec.Subclusters[1].Shutdown = true


### PR DESCRIPTION
We found that restarting a subcluster after shutdown did not work because obj_reconciler will overwrite the expected size with the current size which in this case is zero. This fixes that issue.