### PR TITLE
Support scraping prometheus using tls cert

### DIFF
--- a/helm-charts/verticadb-operator/README.md
+++ b/helm-charts/verticadb-operator/README.md
@@ -35,10 +35,21 @@ This helm chart will install the operator and an admission controller webhook.  
 | serviceAccountAnnotations | A map of annotations that will be added to the serviceaccount created. | |
 | serviceAccountNameOverride | Controls the name given to the serviceaccount that is created. | |
 | tolerations | Any [tolerations and taints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) used to influence where a pod is scheduled. This parameter is provided as a list. | Not set |
-| webhook.caBundle | A PEM encoded CA bundle that will be used to validate the webhook's server certificate.  This option is deprecated in favour of providing the CA bundle in the webhook.tlsSecret with the ca.crt key. This option will be removed in a future release.| |
 | webhook.certSource | The webhook requires a TLS certificate to work. This parm defines how the cert is supplied. Valid values are:<br><br>- **internal**: The certs are generated internally by the operator prior to starting the managing controller. The generated cert is self-signed. When it expires, the operator pod will need to be restarted in order to generate a new certificate. This is the default.<br><br>- **cert-manager**: The certs are generated using the cert-manager operator.  This operator needs to be deployed before deploying the operator. Deployment of this chart will create a self-signed cert through cert-manager. The advantage of this over 'internal' is that cert-manager will automatically handle private key rotation when the certificate is about to expire.<br><br>- **secret**: The certs are created prior to installation of this chart and are provided to the operator through a secret. This option gives you the most flexibility as it is entirely up to you how the cert is created.  This option requires the webhook.tlsSecret option to be set. For backwards compatibility, if webhook.tlsSecret is set, it is implicit that this mode is selected. | internal |
 | webhook.tlsSecret | The webhook requires a TLS certficate to work. By default we create a cert internally. If you want full control over the cert that is created you can use this parameter to provide it. When set, it is a name of a secret in the same namespace the chart is being installed in.  The secret must have the keys: tls.key and tls.crt. It can also include the key ca.crt. When that key is included the operator will patch it in the CA bundle in the webhook configuration.| |
 | webhook.enable | If true, the webhook will be enabled and its configuration is setup by the helm chart. Setting this to false will disable the webhook. The webhook setup needs privileges to add validatingwebhookconfiguration and mutatingwebhookconfiguration, both are cluster scoped. If you do not have necessary privileges to add these configurations, then this option can be used to skip that and still deploy the operator. | true |
 | securityContext | Holds pod-level security attributes and common container settings. | <pre>fsGroup: 65532 <br>runAsGroup: 65532<br>runAsNonRoot: true <br>runAsUser: 65532 <br>seccompProfile:<br>  type: RuntimeDefault</pre> |
 | containerSecurityContext | Defines the security options the manager container should be run with. | <pre>allowPrivilegeEscalation: false <br>readOnlyRootFilesystem: true <br>capabilities:<br>  drop: <br>  - ALL</pre> |
 | keda.createRBACRules | Controls the creation of ClusterRole rules for KEDA objects. | true |
+|
+
+&nbsp;  
+&nbsp; 
+
+This table below describes monitoring configuration parameters including Grafana, Prometheus and Loki:
+
+| Parameter Name | Description | Default Value |
+|----------------|-------------|---------------|
+| grafana.enabled | Set to true if you want to deploy Grafana with the operator | false |
+| prometheus-server.enabled | Set to true if you want to deploy Prometheus server. | false |
+

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -984,12 +984,14 @@ func makeTLSConfigForServiceMonitor(vdb *vapi.VerticaDB) *monitoringv1.TLSConfig
 	}
 
 	key, cert, ca := genTLSKeys(vdb)
+	serverName := fmt.Sprintf("*.%s.svc.cluster.local", vdb.Namespace)
 	return &monitoringv1.TLSConfig{
 		SafeTLSConfig: monitoringv1.SafeTLSConfig{
 			InsecureSkipVerify: &insecureSkipVerify,
 			KeySecret:          key,
 			Cert:               cert,
 			CA:                 ca,
+			ServerName:         &serverName,
 		},
 	}
 }

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -870,6 +870,8 @@ var _ = Describe("builder", func() {
 		Ω(endpoint.TLSConfig).ShouldNot(BeNil())
 		Ω(endpoint.TLSConfig.InsecureSkipVerify).ShouldNot(BeNil())
 		Ω(*endpoint.TLSConfig.InsecureSkipVerify).Should(BeFalse())
+		Ω(endpoint.TLSConfig.ServerName).ShouldNot(BeNil())
+		Ω(*endpoint.TLSConfig.ServerName).Should(Equal(fmt.Sprintf("*.%s.svc.cluster.local", vdb.Namespace)))
 		Ω(endpoint.TLSConfig.KeySecret).ShouldNot(BeNil())
 		Ω(endpoint.TLSConfig.Cert.Secret).ShouldNot(BeNil())
 		Ω(endpoint.TLSConfig.CA.Secret).ShouldNot(BeNil())

--- a/pkg/controllers/vdb/verticadb_controller.go
+++ b/pkg/controllers/vdb/verticadb_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/controllers"
 	verrors "github.com/vertica/vertica-kubernetes/pkg/errors"
 	"github.com/vertica/vertica-kubernetes/pkg/events"
+	"github.com/vertica/vertica-kubernetes/pkg/opcfg"
 
 	vmeta "github.com/vertica/vertica-kubernetes/pkg/meta"
 	"github.com/vertica/vertica-kubernetes/pkg/metrics"
@@ -96,7 +97,7 @@ func (r *VerticaDBReconciler) SetupWithManager(mgr ctrl.Manager, options control
 		Owns(&appsv1.Deployment{})
 
 	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(mgr.GetConfig())
-	if isServiceMonitorObjectInstalled(discoveryClient) {
+	if opcfg.IsPrometheusEnabled() && isServiceMonitorObjectInstalled(discoveryClient) {
 		ctrlManager.Owns(&monitoringv1.ServiceMonitor{})
 	}
 

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/30-assert.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/30-assert.yaml
@@ -1,0 +1,92 @@
+# (c) Copyright [2021-2025] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: TLSConfigurationStarted
+message: Starting to configure TLS for httpsNMA
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-with-prom
+---
+apiVersion: v1
+kind: Event
+reason: TLSConfigurationSucceeded
+message: Successfully set HTTP tls config
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-with-prom
+---
+apiVersion: v1
+kind: Event
+reason: TLSConfigurationStarted
+message: Starting to configure TLS for clientServer
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-with-prom
+---
+apiVersion: v1
+kind: Event
+reason: TLSConfigurationSucceeded
+message: Successfully set Server tls config
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-with-prom
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: v-with-prom
+    app.kubernetes.io/managed-by: verticadb-operator
+    release: vdb-op
+    vertica.com/database: vertdb
+  name: v-with-prom-svc-monitor
+  ownerReferences:
+  - apiVersion: vertica.com/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: VerticaDB
+    name: v-with-prom
+spec:
+  endpoints:
+  - path: /v1/metrics
+    port: vertica-http
+    scheme: https
+    tlsConfig:
+      ca:
+        secret:
+          key: ca.crt
+      cert:
+        secret:
+          key: tls.crt
+      insecureSkipVerify: false
+      keySecret:
+        key: tls.key
+    interval: "5s"
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: v-with-prom

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/30-turn-on-tls.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/30-turn-on-tls.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2025] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-with-prom
+  annotations:
+    vertica.com/enable-tls-auth: "true"

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/35-wait-for-data-pull.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/35-wait-for-data-pull.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "sleep 30"

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/40-assert.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/40-assert.yaml
@@ -1,0 +1,23 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: script-verity-prometheus-metrics2
+status:
+  containerStatuses:
+    - name: test
+      state:
+        terminated:
+          exitCode: 0 

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/40-verify-prometheus-metrics.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/40-verify-prometheus-metrics.yaml
@@ -1,0 +1,59 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verity-prometheus-metrics2
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+    
+    # Setup start and end time for query, e.g: 2024-09-14
+    START_TIME=$(date +%Y-%m-%d) 
+    END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
+    NAMESPACE=$(kubectl get pod v-with-prom-pri1-0 -o=jsonpath='{.metadata.namespace}')
+    CMD="kubectl exec v-with-prom-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://vdb-op-prometheus-server-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    RESULT=$(eval $CMD)
+    METRICS=$(echo $RESULT | jq -r '.data.result') 
+    
+    # verify the metrics result
+    if [[ "$METRICS" == "" || "$METRICS" == "\[\]" ]]; then
+      echo "empty metrics result: $RESULT found."
+      exit 1
+    fi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: script-verity-prometheus-metrics2
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verity-prometheus-metrics2


### PR DESCRIPTION
Now prometheus can scrape metrics from the db using tls cert. When tls is disabled, it will use the user/password, when tls is enabled, it will the cert in httpsNMATLS.secret.