### PR TITLE
Pass host info to tls rotate api

### DIFF
--- a/local-libs/vcluster/vclusterops/tls_rotate_certs.go
+++ b/local-libs/vcluster/vclusterops/tls_rotate_certs.go
@@ -85,6 +85,11 @@ type VRotateTLSCertsOptions struct {
 
 	// internal use: controls NMA SQL op pw auth
 	usePasswordForNMA bool
+
+	// K8s-only: In K8s environments, the operator already knows "up hosts".
+	// Supplying them directly in the endpoint avoids fetching the VDB over HTTPS,
+	// reducing overhead and eliminating the need for certificate handling.
+	UpHostToSandbox map[string]string
 }
 
 type RotateTLSCertsData struct {
@@ -112,6 +117,7 @@ const (
 
 func VRotateTLSCertsOptionsFactory() VRotateTLSCertsOptions {
 	opt := VRotateTLSCertsOptions{}
+	opt.UpHostToSandbox = make(map[string]string)
 	// set default values to the params
 	opt.setDefaultValues()
 
@@ -191,22 +197,40 @@ func (vcc VClusterCommands) VRotateTLSCerts(options *VRotateTLSCertsOptions) err
 		return optError
 	}
 
-	// Construct a full vdb by enumerating main cluster node info and the sandbox list
-	// from the main cluster, then updating sandbox node status from sandbox nodes.
-	// Certs must be rotated across all sandboxes, so this operation will both retrieve
-	// the necessary node status and sandbox information, and enforce that every sandbox
-	vdb := makeVCoordinationDatabase()
-	err := vcc.getDeepVDBFromRunningDB(&vdb, &options.DatabaseOptions)
-	if err != nil {
-		return err
-	}
+	var upHosts, initiatorHosts, mainClusterHosts []string
+	hostsToSandboxes := make(map[string]string)
+	// when in k8s, we expect the user to include host info in options.UpHostToSandbox
+	if len(options.UpHostToSandbox) > 0 {
+		seenSandboxes := make(map[string]struct{})
+		for host, sandbox := range options.UpHostToSandbox {
+			upHosts = append(upHosts, host)
+			if _, exists := seenSandboxes[sandbox]; !exists {
+				initiatorHosts = append(initiatorHosts, host)
+			}
+			if len(mainClusterHosts) == 0 && sandbox == util.MainClusterSandbox {
+				mainClusterHosts = append(mainClusterHosts, host)
+			}
+			hostsToSandboxes[host] = sandbox
+		}
+		// when not in k8s, we need to retrieve host info by calling https endpoints
+	} else {
+		// Construct a full vdb by enumerating main cluster node info and the sandbox list
+		// from the main cluster, then updating sandbox node status from sandbox nodes.
+		// Certs must be rotated across all sandboxes, so this operation will both retrieve
+		// the necessary node status and sandbox information, and enforce that every sandbox
+		vdb := makeVCoordinationDatabase()
+		err := vcc.getDeepVDBFromRunningDB(&vdb, &options.DatabaseOptions)
+		if err != nil {
+			return err
+		}
 
-	// the rotation operations need one UP host from each sandbox + main cluster.  the
-	// polling operations should poll each previously UP host in the entire cluster
-	// for restart.
-	upHosts, initiatorHosts, mainClusterHosts, hostsToSandboxes, err := options.getVDBInfo(&vdb)
-	if err != nil {
-		return err
+		// the rotation operations need one UP host from each sandbox + main cluster.  the
+		// polling operations should poll each previously UP host in the entire cluster
+		// for restart.
+		upHosts, initiatorHosts, mainClusterHosts, hostsToSandboxes, err = options.getVDBInfo(&vdb)
+		if err != nil {
+			return err
+		}
 	}
 
 	// If we're rotating the https service config, cache the fingerprint of the updated

--- a/local-libs/vcluster/vclusterops/tls_rotate_certs.go
+++ b/local-libs/vcluster/vclusterops/tls_rotate_certs.go
@@ -206,6 +206,7 @@ func (vcc VClusterCommands) VRotateTLSCerts(options *VRotateTLSCertsOptions) err
 			upHosts = append(upHosts, host)
 			if _, exists := seenSandboxes[sandbox]; !exists {
 				initiatorHosts = append(initiatorHosts, host)
+				seenSandboxes[sandbox] = struct{}{}
 			}
 			if len(mainClusterHosts) == 0 && sandbox == util.MainClusterSandbox {
 				mainClusterHosts = append(mainClusterHosts, host)

--- a/pkg/controllers/vdb/clientservertlsupdate_reconciler.go
+++ b/pkg/controllers/vdb/clientservertlsupdate_reconciler.go
@@ -101,15 +101,21 @@ func (h *ClientServerTLSUpdateReconciler) Reconcile(ctx context.Context, req *ct
 		return res, err
 	}
 
-	initiatorPod, ok := h.PFacts.FindFirstUpPod(false, "")
-	if !ok {
+	upPods := h.PFacts.FindUpPods("")
+	if len(upPods) == 0 {
 		h.Log.Info("No up pod found to update tls config. Restarting.")
 		restartReconciler := MakeRestartReconciler(h.VRec, h.Log, h.Vdb, h.PFacts.PRunner, h.PFacts, true, h.Dispatcher)
 		res, err2 := restartReconciler.Reconcile(ctx, req)
 		return res, err2
 	}
 
-	err = h.Manager.updateTLSConfig(ctx, initiatorPod.GetPodIP())
+	upHostToSandbox := make(map[string]string)
+	initiator := upPods[0].GetPodIP()
+	for _, p := range upPods {
+		upHostToSandbox[p.GetPodIP()] = p.GetSandbox()
+	}
+
+	err = h.Manager.updateTLSConfig(ctx, initiator, upHostToSandbox)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/vdb/tls_config.go
+++ b/pkg/controllers/vdb/tls_config.go
@@ -125,7 +125,7 @@ func (t *TLSConfigManager) setPollingCertMetadata(ctx context.Context) (ctrl.Res
 
 // updateTLSConfig calls the vclusterops api that will update the tls config by cert
 // rotation and/or tls mode update
-func (t *TLSConfigManager) updateTLSConfig(ctx context.Context, initiatorIP string) error {
+func (t *TLSConfigManager) updateTLSConfig(ctx context.Context, initiator string, upHostToSandbox map[string]string) error {
 	switch t.TLSUpdateType {
 	case tlsModeAndCertChange:
 		// This type implies both a cert change and a TLS mode change
@@ -164,9 +164,10 @@ func (t *TLSConfigManager) updateTLSConfig(ctx context.Context, initiatorIP stri
 		rotatetlscerts.WithCert(secretName, certConfig),
 		rotatetlscerts.WithCaCert(secretName, caCertConfig),
 		rotatetlscerts.WithTLSMode(t.NewTLSMode),
-		rotatetlscerts.WithInitiator(initiatorIP),
+		rotatetlscerts.WithInitiator(initiator),
 		rotatetlscerts.WithTLSConfig(t.TLSConfig),
 		rotatetlscerts.WithNewSecretManager(secretManager),
+		rotatetlscerts.WithUpHostToSandbox(upHostToSandbox),
 	}
 	started, failed, succeeded := t.getEvents()
 	t.Rec.Eventf(t.Vdb, corev1.EventTypeNormal, started,

--- a/pkg/podfacts/podfacts.go
+++ b/pkg/podfacts/podfacts.go
@@ -1171,6 +1171,13 @@ func (p *PodFacts) FindFirstUpPodIP(allowReadOnly bool, scName string) (string, 
 	return "", false
 }
 
+// FindUpPods returns all pods that have an up vertica node in the given subcluster
+func (p *PodFacts) FindUpPods(scName string) []*PodFact {
+	return p.filterPods((func(v *PodFact) bool {
+		return (scName == "" || v.subclusterName == scName) && v.upNode
+	}))
+}
+
 // FindPodToRunAdminCmdAny returns the name of the pod we will exec into into
 // order to run admintools.
 // Will return false for second parameter if no pod could be found.

--- a/pkg/vadmin/opts/rotatetlscerts/opts.go
+++ b/pkg/vadmin/opts/rotatetlscerts/opts.go
@@ -44,6 +44,7 @@ type Params struct {
 	// This backdoor allows us to force a failure of cert rotation; this is used
 	// for testing purposes only. Can be set to "before_tls_update" or "after_tls_update"
 	NewForceFailure string
+	UpHostToSandbox map[string]string
 }
 
 type Option func(*Params)
@@ -121,5 +122,11 @@ func WithNewSecretManager(secretManager string) Option {
 func WithForceFailure(forceFailure string) Option {
 	return func(s *Params) {
 		s.NewForceFailure = forceFailure
+	}
+}
+
+func WithUpHostToSandbox(upHostToSandbox map[string]string) Option {
+	return func(s *Params) {
+		s.UpHostToSandbox = upHostToSandbox
 	}
 }

--- a/pkg/vadmin/rotate_tls_certs_vc.go
+++ b/pkg/vadmin/rotate_tls_certs_vc.go
@@ -81,7 +81,8 @@ func (v *VClusterOps) genRotateTLSCertsOptions(s *rotatetlscerts.Params, certs *
 	opts.IsEon = v.VDB.IsEON()
 
 	opts.RawHosts = append(opts.RawHosts, s.InitiatorIP)
-	v.Log.Info("Setup rotate tls cert options", "hosts", opts.RawHosts[0])
+	opts.UpHostToSandbox = s.UpHostToSandbox
+	v.Log.Info("Setup rotate tls cert options", "UpHostToSandbox", opts.UpHostToSandbox)
 	opts.IPv6 = net.IsIPv6(s.InitiatorIP)
 
 	opts.NewClientTLSConfig = vops.NewClientTLSConfig{


### PR DESCRIPTION
This PR enables passing host information directly to the TLS rotate API, eliminating the need for the API to fetch it from the HTTPS service. This allows rolling back HTTPS TLS certificates using only the old certificate.