### PR TITLE
Fix server upgrade

### DIFF
--- a/tests/e2e-server-upgrade/offline-upgrade-rename-cm/40-initiate-upgrade-and-mount-change.yaml
+++ b/tests/e2e-server-upgrade/offline-upgrade-rename-cm/40-initiate-upgrade-and-mount-change.yaml
@@ -14,5 +14,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: ../../../scripts/patch-image-in-vdb.sh -n $NAMESPACE v-base-upgrade
-  - command: kubectl patch -n $NAMESPACE vdb v-base-upgrade --type=json --patch-file cm-patch.json
+  - command: |
+      kubectl patch -n $NAMESPACE vdb v-base-upgrade --type=json --patch='[{"op": "replace", "path": "/spec/volumes/0/configMap/name", "value": "vdb-state-new-name"}, {"op": "replace", "path": "/spec/image", "value": "'$VERTICA_IMG'"}]'


### PR DESCRIPTION
offline-upgrade-rename-cm has a timing issue. We used to delete the current configmap (mounted), update the image first then replace the deleted configmap with a new one. The issue is if offline upgrade starts before the operator detects the cm change, the sts upgrade stratety will be changed to OnDelete, leading to the pod being unable to update the old configmap name (now deleted). 
This updates the image and the cm in one call getting rid of that timing issue. The goal of the test is to make sure  a server upgrade, accompanied with other CR changes, works. This change does not change that.
