### PR TITLE
Fix schedule-only test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ helm-charts/verticadb-operator/templates/*.yaml
 helm-charts/verticadb-operator/crds/*yaml
 helm-charts/verticadb-operator/charts/
 helm-charts/verticadb-operator/Chart.lock
+helm-charts/verticadb-operator/tmpcharts-*/
 helm-charts/verticadb-webhook/templates/*.yaml
 helm-charts/verticadb-webhook/crds/*
 

--- a/tests/e2e-leg-2-at-only/schedule-only/setup-managed-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-2-at-only/schedule-only/setup-managed-vdb/base/setup-vdb.yaml
@@ -36,3 +36,4 @@ spec:
   imagePullSecrets: []
   volumes: []
   volumeMounts: []
+  encryptSpreadComm: disabled


### PR DESCRIPTION
Before removing v1beta1, encryptSpreadComm's default value (when left empty) was "disabled". But the default value on v1 is "vertica". That will stop the db before step 40(add-node) which causes the failure.
The fix is to explicitely set encryptSpreadComm to disabled.