### PR TITLE
Support changing both TLS secrets (httpsNMA and clientServer) at the same time

### DIFF
--- a/api/v1/helpers.go
+++ b/api/v1/helpers.go
@@ -1903,27 +1903,49 @@ func (v *VerticaDB) GetClientServerTLSSecretInUse() string {
 	return v.GetSecretInUse(ClientServerTLSConfigName)
 }
 
-// GetValueForTLSConfigMap will return what value should be written to the TLS Config Map for
-// NMA: spec or status. In order to handle rollback after failed cert rotation, we should only
-// update from spec if a cert rotation has completed and not triggered a rollback. We should also
-// use spec if this status value is empty (for example, during create db). All other cases should
-// use status value.
+// GetValueForTLSConfigMap determines which value (spec or status) should be written to the NMA TLS ConfigMap.
+// The decision is made per certificate type (https or clientServer) to avoid prematurely updating NMA
+// with a new cert that hasn’t been rotated yet.
+//
+// Rules:
+//  1. If statusValue is empty (e.g., during initial create), use specValue.
+//  2. If a rollback is in progress, use statusValue to keep NMA pointing at the last known good cert.
+//  3. If this cert’s rotation is in progress (started but not yet marked finished), use specValue
+//     so NMA can start using the new cert.
+//  4. Otherwise, default to statusValue so we don’t break NMA communication by using an unready cert.
+//
+// This ensures that when rotating multiple certs in the same iteration, each configmap update
+// only changes the fields for the cert currently being rotated.
 func (v *VerticaDB) GetValueForTLSConfigMap(specValue, statusValue, tlsConfigName string) string {
-	// Use the status value if:
-	// - It is set (non-empty), and
-	// - Either the config update hasn't finished OR a rollback is needed.
-	rollbackInProgress := v.IsTLSCertRollbackNeeded()
-	updateNotFinished := !v.IsStatusConditionTrue(HTTPSTLSConfigUpdateFinished)
-	if tlsConfigName == ClientServerTLSConfigName {
-		updateNotFinished = !v.IsStatusConditionTrue(ClientServerTLSConfigUpdateFinished)
+	if statusValue == "" {
+		return specValue
 	}
 
-	if statusValue != "" && (updateNotFinished || rollbackInProgress) {
+	if v.IsTLSCertRollbackNeeded() {
 		return statusValue
 	}
 
-	// Otherwise, default to the spec value.
-	return specValue
+	// Only switch to spec if this cert’s rotation is in progress
+	updateNotFinished := v.IsStatusConditionTrue(HTTPSTLSConfigUpdateFinished)
+	if tlsConfigName == ClientServerTLSConfigName {
+		updateNotFinished = v.IsStatusConditionTrue(ClientServerTLSConfigUpdateFinished)
+	}
+
+	if updateNotFinished {
+		return specValue // rotation started, not done → point to new secret
+	}
+
+	return statusValue // rotation not started → keep old in-use secret
+}
+
+// NoClientServerRotationNeeded returns true if the ClientServer TLS configuration
+// does not require any further rotation, meaning both the desired TLS mode
+// and secret match the currently in-use values.
+func (v *VerticaDB) NoClientServerRotationNeeded() bool {
+	modeUpToDate := v.GetClientServerTLSMode() == v.GetClientServerTLSModeInUse()
+	secretUnchanged := v.GetClientServerTLSSecret() == v.GetClientServerTLSSecretInUse()
+
+	return modeUpToDate && secretUnchanged
 }
 
 // GetHTTPSNMATLSSecretForConfigMap returns the correct TLS secret name

--- a/api/v1/verticadb_webhook.go
+++ b/api/v1/verticadb_webhook.go
@@ -2506,19 +2506,6 @@ func (v *VerticaDB) checkTLSFieldsWhenTLSUpdateNotInProgress(oldObj *VerticaDB) 
 			"cannot change clientServerTLS.secret to empty value"))
 	}
 
-	httpsTLSConfigChanged := httpsTLSSecretChanged || oldObj.GetHTTPSNMATLSMode() != v.GetHTTPSNMATLSMode()
-	clientTLSConfigChanged := clientTLSSecretChanged || oldObj.GetClientServerTLSMode() != v.GetClientServerTLSMode()
-
-	// There is currently a limitation that we cannot change both httpsNMATLS and clientServerTLS at the same time.
-	// This is because of the current implementation of the TLS config update. Once the implementation is improved,
-	// we can remove this limitation.
-	tlsConfigsExistInStatus := v.GetTLSConfigByName(HTTPSNMATLSConfigName) != nil &&
-		v.GetTLSConfigByName(ClientServerTLSConfigName) != nil
-	if tlsConfigsExistInStatus && httpsTLSConfigChanged && clientTLSConfigChanged {
-		errs = append(errs, field.Forbidden(specFld,
-			"cannot change both httpsNMATLS and clientServerTLS at the same time"))
-	}
-
 	return errs
 }
 
@@ -2547,9 +2534,8 @@ func (v *VerticaDB) hasValidTLSMode(tlsModeToValidate, fieldName string, allErrs
 // checkValidTLSConfigUpdate enforces:
 // 1. If tls config update is in progress, all other operations are not allowed.
 // 2. Cannot disable mutual TLS after it's enabled.
-// 3. Cannot change both httpsNMATLS and clientServerTLS at the same time.
-// 4. Cannot change a secret to empty string.
-// 5. Prevent user from changing nmaTLSSecret.
+// 3. Cannot change a secret to empty string.
+// 4. Prevent user from changing nmaTLSSecret.
 func (v *VerticaDB) checkValidTLSConfigUpdate(oldObj *VerticaDB, allErrs field.ErrorList) field.ErrorList {
 	specFld := field.NewPath("spec")
 
@@ -2580,11 +2566,10 @@ func (v *VerticaDB) checkValidTLSConfigUpdate(oldObj *VerticaDB, allErrs field.E
 		}
 	}
 
-	// Rule 3 & 4: cannot change both tls configs at the same time.
-	// Cannot change a secret to empty string
+	// Rule 3: cannot change a secret to empty string
 	allErrs = append(allErrs, v.checkTLSFieldsWhenTLSUpdateNotInProgress(oldObj)...)
 
-	// Rule 5: nmaTLSSecret is immutable
+	// Rule 4: nmaTLSSecret is immutable
 	if oldObj.Spec.NMATLSSecret != "" && oldObj.Spec.NMATLSSecret != v.Spec.NMATLSSecret {
 		allErrs = append(allErrs, field.Forbidden(specFld.Child("nmaTLSSecret"),
 			"nmaTLSSecret cannot be changed"))

--- a/api/v1/verticadb_webhook_test.go
+++ b/api/v1/verticadb_webhook_test.go
@@ -631,7 +631,7 @@ var _ = Describe("verticadb_webhook", func() {
 		Ω(allErrs).ShouldNot(BeEmpty())
 	})
 
-	It("should return error if both httpsNMATLS and clientServerTLS are changed at the same time", func() {
+	It("should allow changing both httpsNMATLS and clientServerTLS at the same time", func() {
 		oldVdb := MakeVDBForCertRotationEnabled()
 		oldVdb.Spec.HTTPSNMATLS.Secret = oldSecret
 		oldVdb.Spec.ClientServerTLS.Secret = oldSecret
@@ -647,8 +647,7 @@ var _ = Describe("verticadb_webhook", func() {
 			{Name: ClientServerTLSConfigName, Secret: oldSecret, Mode: oldMode},
 		}
 		allErrs = newVdb.checkValidTLSConfigUpdate(oldVdb, nil)
-		Expect(allErrs).Should(HaveLen(1))
-		Expect(allErrs[0].Error()).To(ContainSubstring("cannot change both httpsNMATLS and clientServerTLS at the same time"))
+		Ω(allErrs).Should(BeEmpty())
 	})
 
 	It("should not change a tls secret to empty string", func() {

--- a/pkg/controllers/vdb/httpstlsupdate_reconciler.go
+++ b/pkg/controllers/vdb/httpstlsupdate_reconciler.go
@@ -132,9 +132,11 @@ func (h *HTTPSTLSUpdateReconciler) Reconcile(ctx context.Context, req *ctrl.Requ
 
 func (h *HTTPSTLSUpdateReconciler) handleConditions(ctx context.Context) error {
 	var cond *metav1.Condition
-	// Clear TLSConfigUpdateInProgress condition if only tls mode changed.
+	// Clear TLSConfigUpdateInProgress condition if:
+	// 1) Only tls mode changed and
+	// 2) ClientServer secret/mode is not changed
 	// This way, we will skip nma cert rotation
-	if h.Manager.TLSUpdateType == tlsModeChangeOnly {
+	if h.Manager.TLSUpdateType == tlsModeChangeOnly && h.Vdb.NoClientServerRotationNeeded() {
 		cond = vapi.MakeCondition(vapi.TLSConfigUpdateInProgress, metav1.ConditionFalse, "Completed")
 		return vdbstatus.UpdateCondition(ctx, h.VRec.GetClient(), h.Vdb, cond)
 	}

--- a/pkg/controllers/vdb/nmacertconfigmap_reconciler.go
+++ b/pkg/controllers/vdb/nmacertconfigmap_reconciler.go
@@ -86,8 +86,8 @@ func (h *NMACertConfigMapReconciler) Reconcile(ctx context.Context, _ *ctrl.Requ
 
 	err = h.VRec.GetClient().Update(ctx, configMap)
 	if err == nil {
-		h.Log.Info("updated tls cert secret configmap", "name", configMapName.Name, "nma-secret", h.Vdb.GetHTTPSNMATLSSecret(),
-			"clientserver-secret", h.Vdb.GetClientServerTLSSecret())
+		h.Log.Info("updated tls cert secret configmap", "name", configMapName.Name, "nma-secret", h.Vdb.GetHTTPSNMATLSSecretForConfigMap(),
+			"clientserver-secret", h.Vdb.GetClientServerTLSSecretForConfigMap())
 	}
 	return ctrl.Result{}, err
 }

--- a/pkg/controllers/vdb/tls_reconciler.go
+++ b/pkg/controllers/vdb/tls_reconciler.go
@@ -82,12 +82,15 @@ func (h *TLSReconciler) constructActors(log logr.Logger, vdb *vapi.VerticaDB, pf
 	return []controllers.ReconcileActor{
 		// update https tls by setting the tls config, rotating the cert and/or changing tls mode
 		MakeHTTPSTLSUpdateReconciler(h.VRec, log, vdb, dispatcher, pfacts, false),
+		// Update NMA config map for values related to HTTPS
+		MakeNMACertConfigMapReconciler(h.VRec, log, vdb),
+		// rotate nma tls cert only if httpsNMA secret name is changed in vdb.spec
+		MakeNMACertRotationReconciler(h.VRec, log, vdb, dispatcher, pfacts, false),
 		// update client server tls by setting the tls config, rotating the cert and/or changing tls mode
 		MakeClientServerTLSUpdateReconciler(h.VRec, log, vdb, dispatcher, pfacts, false),
-		// Set up configmap which stores env variables for NMA container
-		// Do this here to avoid writing config map in rollback case
+		// Update NMA config map for values related to ClientServer
 		MakeNMACertConfigMapReconciler(h.VRec, log, vdb),
-		// rotate nma tls cert when tls cert secret name is changed in vdb.spec
+		// rotate nma tls cert only if clientServer secret name is changed in vdb.spec
 		MakeNMACertRotationReconciler(h.VRec, log, vdb, dispatcher, pfacts, false),
 		// rollback, in case of failure, any cert rotation op related to https or client-server TLS
 		MakeRollbackAfterCertRotationReconciler(h.VRec, log, vdb, dispatcher, pfacts),

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -240,13 +240,15 @@ const (
 
 	// This annotation forces a failure of the next TLS update cert rotation. There
 	// are two places where this can be forced:
-	//   "before_tls_update": fail before the secret has been updated in the DB
-	//   "after_tls_update": fail before the secret has been updated in the DB
+	//   "https_before_tls_update": fail before HTTPS secret has been updated in the DB
+	//   "https_after_tls_update": fail after HTTPS secret has been updated in the DB
+	//   "client_server": fail during client-server cert (which is always before secret has been updated in the DB)
 	// This annotation is internal only and should only be used for testing the
 	// rollback after failed cert rotation functionality
-	TriggerTLSUpdateFailureAnnotation      = "vertica.com/trigger-tls-update-failure"
-	TriggerTLSUpdateFailureBeforeTLSUpdate = "before_tls_update"
-	TriggerTLSUpdateFailureAfterTLSUpdate  = "after_tls_update"
+	TriggerTLSUpdateFailureAnnotation                  = "vertica.com/trigger-tls-update-failure"
+	TriggerTLSUpdateFailureBeforeHTTPSTLSUpdate        = "https_before_tls_update"
+	TriggerTLSUpdateFailureAfterHTTPSTLSUpdate         = "https_after_tls_update"
+	TriggerTLSUpdateFailureDuringClientServerTLSUpdate = "client_server"
 
 	// This annotation forces the automatic cert rotation to trigger now, instead of on
 	// a timer. It is internal and should be used only for testing.

--- a/pkg/vadmin/rotate_tls_certs_vc.go
+++ b/pkg/vadmin/rotate_tls_certs_vc.go
@@ -52,8 +52,13 @@ func (v *VClusterOps) RotateTLSCerts(ctx context.Context, opts ...rotatetlscerts
 
 	// In order to test TLS rollback after failed rotate, this is a backdoor set via
 	// annotation to force a failure BEFORE the TLS cert has been updated in the DB
-	if vmeta.GetTriggerTLSUpdateFailureAnnotation(v.VDB.Annotations) == vmeta.TriggerTLSUpdateFailureBeforeTLSUpdate {
-		return fmt.Errorf("forced error in TLS cert rotation before updating TLS config")
+	if s.TLSConfig != tlsConfigServer &&
+		vmeta.GetTriggerTLSUpdateFailureAnnotation(v.VDB.Annotations) == vmeta.TriggerTLSUpdateFailureBeforeHTTPSTLSUpdate {
+		return fmt.Errorf("forced error in HTTPS TLS cert rotation before updating TLS config")
+	}
+	if s.TLSConfig == tlsConfigServer &&
+		vmeta.GetTriggerTLSUpdateFailureAnnotation(v.VDB.Annotations) == vmeta.TriggerTLSUpdateFailureDuringClientServerTLSUpdate {
+		return fmt.Errorf("forced error in Server TLS cert rotation before updating TLS config")
 	}
 
 	// call vclusterOps library to rotate nma cert
@@ -66,7 +71,7 @@ func (v *VClusterOps) RotateTLSCerts(ctx context.Context, opts ...rotatetlscerts
 
 	// In order to test TLS rollback after failed rotate, this is a backdoor set via
 	// annotation to force a failure AFTER the TLS cert has been updated in the DB
-	if vmeta.GetTriggerTLSUpdateFailureAnnotation(v.VDB.Annotations) == vmeta.TriggerTLSUpdateFailureAfterTLSUpdate {
+	if vmeta.GetTriggerTLSUpdateFailureAnnotation(v.VDB.Annotations) == vmeta.TriggerTLSUpdateFailureAfterHTTPSTLSUpdate {
 		return fmt.Errorf("forced error in TLS cert rotation after updating TLS config")
 	}
 

--- a/tests/e2e-leg-13/cert-rotate-both/00-create-creds.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/00-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-13/cert-rotate-both/05-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/05-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-13/cert-rotate-both/05-deploy-operator.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/05-deploy-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-13/cert-rotate-both/10-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-cert
+  name: custom-cert1
+  name: custom-cert2
+  name: custom-cert3

--- a/tests/e2e-leg-13/cert-rotate-both/10-create-cert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/10-create-cert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert1 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert2 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert3 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME

--- a/tests/e2e-leg-13/cert-rotate-both/15-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/15-assert.yaml
@@ -1,0 +1,27 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-cert-rotate-both-sc1
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+status:
+  subclusters:
+    - addedToDBCount: 3

--- a/tests/e2e-leg-13/cert-rotate-both/15-setup-vdb.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/cert-rotate-both/17-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/17-assert.yaml
@@ -1,0 +1,32 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-cert-rotate-both-sc1
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+status:
+  tlsConfigs:
+    - name: httpsNMA
+    - name: clientServer
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-13/cert-rotate-both/17-wait-for-createdb.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/17-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/cert-rotate-both/20-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/20-assert.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+---
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+---
+apiVersion: v1
+kind: Event
+reason: NMATLSCertRotationStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+---
+apiVersion: v1
+kind: Event
+reason: NMATLSCertRotationSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+status:
+  conditions:
+  - reason: Detected
+    status: "True"
+    type: AutoRestartVertica
+  - reason: Initialized
+    status: "True"
+    type: DBInitialized
+  - reason: Completed
+    status: "False"
+    type: TLSConfigUpdateInProgress
+  - reason: Completed
+    status: "False"
+    type: HTTPSTLSConfigUpdateFinished 
+  - reason: Completed
+    status: "False"
+    type: ClientServerTLSConfigUpdateFinished 
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+  tlsConfigs:
+    - name: httpsNMA
+      secret: custom-cert
+    - name: clientServer
+      secret: custom-cert1

--- a/tests/e2e-leg-13/cert-rotate-both/20-change-both-tls-secrets.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/20-change-both-tls-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+spec:
+  httpsNMATLS:
+    secret: custom-cert
+  clientServerTLS:
+    secret: custom-cert1

--- a/tests/e2e-leg-13/cert-rotate-both/25-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/25-assert.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Starting tls cert rotation for HTTP with secret name custom-cert2 and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Successfully rotated HTTP tls cert with secret name custom-cert2 and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Starting tls cert rotation for Server with secret name custom-cert3 and mode try_verify
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Successfully rotated Server tls cert with secret name custom-cert3 and mode try_verify
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+status:
+  conditions:
+  - reason: Detected
+    status: "True"
+    type: AutoRestartVertica
+  - reason: Initialized
+    status: "True"
+    type: DBInitialized
+  - reason: Completed
+    status: "False"
+    type: TLSConfigUpdateInProgress
+  - reason: Completed
+    status: "False"
+    type: HTTPSTLSConfigUpdateFinished 
+  - reason: Completed
+    status: "False"
+    type: ClientServerTLSConfigUpdateFinished 
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+  tlsConfigs:
+    - name: httpsNMA
+      secret: custom-cert2
+    - name: clientServer
+      secret: custom-cert3

--- a/tests/e2e-leg-13/cert-rotate-both/25-change-both-tls-secrets.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/25-change-both-tls-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+spec:
+  httpsNMATLS:
+    secret: custom-cert2
+  clientServerTLS:
+    secret: custom-cert3

--- a/tests/e2e-leg-13/cert-rotate-both/27-set-server-cert-fail-annotation.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/27-set-server-cert-fail-annotation.yaml
@@ -1,0 +1,6 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+  annotations:
+    vertica.com/trigger-tls-update-failure: "client_server"

--- a/tests/e2e-leg-13/cert-rotate-both/30-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/30-assert.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Successfully rotated HTTP tls cert with secret name custom-cert and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Starting tls cert rotation for Server with secret name custom-cert1 and mode try_verify
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateFailed
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Failed to rotate Server tls cert with secret name custom-cert1 and mode try_verify
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Starting Server TLS cert rollback after failed update
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Server TLS cert rollback completed successfully
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+spec:
+  httpsNMATLS:
+    secret: custom-cert
+  clientServerTLS:
+    secret: custom-cert3
+status:
+  conditions:
+  - reason: Detected
+    status: "True"
+    type: AutoRestartVertica
+  - reason: Initialized
+    status: "True"
+    type: DBInitialized
+  - reason: Completed
+    status: "False"
+    type: TLSConfigUpdateInProgress
+  - reason: Completed
+    status: "False"
+    type: HTTPSTLSConfigUpdateFinished 
+  - reason: Completed
+    status: "False"
+    type: ClientServerTLSConfigUpdateFinished 
+  - reason: Completed
+    status: "False"
+    type: TLSCertRollbackNeeded
+  - reason: Completed
+    status: "False"
+    type: TLSCertRollbackInProgress 
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+  tlsConfigs:
+    - name: httpsNMA
+      secret: custom-cert
+    - name: clientServer
+      secret: custom-cert3

--- a/tests/e2e-leg-13/cert-rotate-both/30-change-both-tls-secrets.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/30-change-both-tls-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+spec:
+  httpsNMATLS:
+    secret: custom-cert
+  clientServerTLS:
+    secret: custom-cert1

--- a/tests/e2e-leg-13/cert-rotate-both/35-set-https-cert-fail-annotation.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/35-set-https-cert-fail-annotation.yaml
@@ -1,0 +1,6 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+  annotations:
+    vertica.com/trigger-tls-update-failure: "https_before_tls_update"

--- a/tests/e2e-leg-13/cert-rotate-both/40-assert.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/40-assert.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Starting tls cert rotation for HTTP with secret name custom-cert1 and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateFailed
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Failed to rotate HTTP tls cert with secret name custom-cert1 and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Starting HTTP TLS cert rollback after failed update
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: HTTP TLS cert rollback completed successfully
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Starting tls cert rotation for Server with secret name custom-cert2 and mode try_verify
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-cert-rotate-both
+message: Successfully rotated Server tls cert with secret name custom-cert2 and mode try_verify
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+spec:
+  httpsNMATLS:
+    secret: custom-cert
+  clientServerTLS:
+    secret: custom-cert2
+status:
+  conditions:
+  - reason: Detected
+    status: "True"
+    type: AutoRestartVertica
+  - reason: Initialized
+    status: "True"
+    type: DBInitialized
+  - reason: Completed
+    status: "False"
+    type: TLSConfigUpdateInProgress
+  - reason: Completed
+    status: "False"
+    type: HTTPSTLSConfigUpdateFinished 
+  - reason: Completed
+    status: "False"
+    type: ClientServerTLSConfigUpdateFinished 
+  - reason: Completed
+    status: "False"
+    type: TLSCertRollbackNeeded
+  - reason: Completed
+    status: "False"
+    type: TLSCertRollbackInProgress 
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+  tlsConfigs:
+    - name: httpsNMA
+      secret: custom-cert
+    - name: clientServer
+      secret: custom-cert2

--- a/tests/e2e-leg-13/cert-rotate-both/40-change-server-tls-secret.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/40-change-server-tls-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+spec:
+  httpsNMATLS:
+    secret: custom-cert1
+  clientServerTLS:
+    secret: custom-cert2

--- a/tests/e2e-leg-13/cert-rotate-both/95-delete-cr.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-13/cert-rotate-both/95-errors.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/95-errors.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: vertica
+    app.kubernetes.io/component: database
+    vertica.com/database: vertdb
+    app.kubernetes.io/instance: v-cert-rotate-both

--- a/tests/e2e-leg-13/cert-rotate-both/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/cert-rotate-both/96-errors.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-13/cert-rotate-both/99-delete-ns.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-13/cert-rotate-both/compare_cert.sh
+++ b/tests/e2e-leg-13/cert-rotate-both/compare_cert.sh
@@ -1,0 +1,4 @@
+awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/ { print } NR > 1 && /-----END CERTIFICATE-----/ { exit }' $2 > $2_cut
+kubectl get secret/custom-cert -n $1 -o jsonpath='{.data.tls\.crt}'  | base64 --decode > /tmp/secret_cert.txt
+diff $2_cut  /tmp/secret_cert.txt
+exit $?

--- a/tests/e2e-leg-13/cert-rotate-both/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-13/cert-rotate-both/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-13/cert-rotate-both/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,43 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-cert-rotate-both
+  annotations:
+    vertica.com/k-safety: "1"
+    vertica.com/include-uid-in-path: "true"
+    vertica.com/remove-tls-secret-on-vdb-delete: "true"
+    vertica.com/disable-tls-rotation-failure-rollback: "false"
+spec:
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  communal: {}
+  local:
+    requestSize: 100Mi
+    catalogPath: /catalog
+  dbName: vertdb
+  encryptSpreadComm: vertica
+  httpsNMATLS:
+    mode: VERIFY_CA
+  subclusters:
+    - name: sc1
+      size: 3
+  securityContext:
+    capabilities:
+      add: ["SYS_PTRACE"]
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-leg-13/cert-rotate-both/vsql_verify.sh
+++ b/tests/e2e-leg-13/cert-rotate-both/vsql_verify.sh
@@ -1,0 +1,31 @@
+K8S_LOCAL_TLS_ENABLED=$(kubectl exec -n $NAMESPACE v-cert-rotate-rollback-before-update-sc1-0 -c server -- vsql -tAc "SELECT is_auth_enabled FROM client_auth where auth_name='k8s_local_tls_builtin_auth';")
+if [[ $K8S_LOCAL_TLS_ENABLED != "True" ]]; then
+    echo "ERROR: k8s_local_tls_builtin_auth not enabled"
+    exit 1
+fi
+K8S_REMOTE_IPv4_TLS_ENABLED=$(kubectl exec -n $NAMESPACE v-cert-rotate-rollback-before-update-sc1-0 -c server -- vsql -tAc "SELECT is_auth_enabled FROM client_auth where auth_name='k8s_remote_ipv4_tls_builtin_auth';")
+if [[ $K8S_REMOTE_IPv4_TLS_ENABLED != "True" ]]; then
+    echo "ERROR: k8s_remote_ipv4_tls_builtin_auth not enabled"
+    exit 1
+fi
+K8S_REMOTE_IPv6_TLS_ENABLED=$(kubectl exec -n $NAMESPACE v-cert-rotate-rollback-before-update-sc1-0 -c server -- vsql -tAc "SELECT is_auth_enabled FROM client_auth where auth_name='k8s_remote_ipv6_tls_builtin_auth';")
+if [[ $K8S_REMOTE_IPv6_TLS_ENABLED != "True" ]]; then
+    echo "ERROR: k8s_remote_ipv6_tls_builtin_auth not enabled"
+    exit 1
+fi
+CERT_NAME=$(kubectl exec -n $NAMESPACE v-cert-rotate-rollback-before-update-sc1-0 -c server -- vsql -tAc "select certificate from tls_configurations where name='https' and owner='dbadmin';")
+if [[ $CERT_NAME != "https_cert_1" ]]; then
+    echo "ERROR: cert https_cert_1 not found"
+    exit 1
+fi
+CA_CERT_NAME=$(kubectl exec -n $NAMESPACE v-cert-rotate-rollback-before-update-sc1-0 -c server -- vsql -tAc "select ca_certificate from tls_configurations where name='https' and owner='dbadmin';")
+if [[ $CA_CERT_NAME != "https_ca_cert_1" ]]; then
+    echo "ERROR: cert https_ca_cert_1 not found"
+    exit 1
+fi
+KEY_NAME=$(kubectl exec -n $NAMESPACE v-cert-rotate-rollback-before-update-sc1-0 -c server -- vsql -tAc "select name FROM cryptographic_keys WHERE secret_name='custom-cert';")
+if [[ $KEY_NAME != "https_key_1" ]]; then
+    echo "ERROR: key https_key_1 not found"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Previously, we had a webhook to block a user from changing both httpsNMATLS.secret and clientServerTLS.secret at the same time. This PR will now allow this. 

This required 3 changes:

1. Run NMA configmap update and NMA cert rotation between https and clientServer cert rotations, in addition to running them after clientServer
2. Update code that writes values to NMA configmap, such that it will only write https-related values after https rotate has finished and clientServer values after clientServer rotate has finished
3. Update the logic for TLSConfigUpdateInProgress. Previously, it was set during each rotation and unset after the NMA rotate; now, it will be set when the first rotation is triggered (whether this is https or clientServer), and then only be unset after BOTH are finished.

I also slightly changed the logic on the "trigger-tls-update-failure" testing annotation. We can now set the following values:

- client_server
- https_before_tls_update
- https_after_tls_update