### PR TITLE
Add basic auth for grafana

### DIFF
--- a/.github/actions/run-e2e-leg/action.yaml
+++ b/.github/actions/run-e2e-leg/action.yaml
@@ -225,6 +225,10 @@ runs:
             export HELM_OVERRIDES="${HELM_OVERRIDES} -f tests/e2e-leg-14-tls/prometheus-with-tls/values.yaml"
           fi
 
+          if [[ "${{ inputs.leg-identifier }}" == "leg-14" ]]; then
+            export HELM_OVERRIDES="${HELM_OVERRIDES} --set grafana.admin.existingSecret=grafana-admin-credentials --set grafana.admin.userKey=admin-user --set grafana.admin.passwordKey=admin-password"
+          fi
+
           if [[ "${{ inputs.leg-identifier }}" == "leg-14-loki" ]]; then
             export GRAFANA_ENABLED=true
             export LOKI_ENABLED=true

--- a/Makefile
+++ b/Makefile
@@ -753,7 +753,7 @@ port-forward-prometheus-server:  ## Expose the prometheus endpoint so that you c
 
 .PHONY: port-forward-grafana
 port-forward-grafana:  ## Expose the grafana endpoint so that you can connect to it through http://localhost:3000
-	kubectl port-forward -n $(NAMESPACE) svc/$(HELM_RELEASE_NAME)-grafana --address $(LOCALHOST) 3000:80
+	kubectl port-forward -n $(NAMESPACE) svc/$(HELM_RELEASE_NAME)-grafana 3000:80
 
 .PHONY: deploy-prometheus-service-monitor
 deploy-prometheus-service-monitor:

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -85,6 +85,7 @@ commands:
   # specific namespace. When deploying the operator at the namespace scope, we
   # only deploy the webhook here.
   - script: make undeploy || true
+  - script: if [ "$LEG" = "leg-14" ]; then kubectl apply -f tests/e2e-leg-14/deploy-with-grafana-prometheus/admin.yaml; fi
   - script: if [ "$CONTROLLERS_SCOPE" != "namespace" ]; then NAMESPACE=verticadb-operator make deploy; fi
   - script: if [ "$CONTROLLERS_SCOPE" = "namespace" ]; then NAMESPACE=verticadb-operator make deploy-webhook; fi
   - script: make undeploy-prometheus || true

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/45-check-grafana-basic-auth.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/45-check-grafana-basic-auth.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2025] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl exec -t v-with-prom-pri1-0 -n $NAMESPACE -- curl -f -s -u admin:topsecret http://vdb-op-grafana.verticadb-operator.svc:80/api/admin/stats

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/admin.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/admin.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin-credentials
+  namespace: verticadb-operator
+type: Opaque
+stringData:
+  admin-user: admin        # your chosen username
+  admin-password: topsecret  # your chosen password


### PR DESCRIPTION
This adds and test basic auth on grafana. The password and admin are set in a secret.