### PR TITLE
Rollback after invalid cert error

### DIFF
--- a/pkg/controllers/vdb/tlsservercertgen_reconciler.go
+++ b/pkg/controllers/vdb/tlsservercertgen_reconciler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vertica/vertica-kubernetes/pkg/paths"
 	"github.com/vertica/vertica-kubernetes/pkg/secrets"
 	"github.com/vertica/vertica-kubernetes/pkg/security"
+	"github.com/vertica/vertica-kubernetes/pkg/vdbstatus"
 	corev1 "k8s.io/api/core/v1"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -225,11 +226,12 @@ func (h *TLSServerCertGenReconciler) createSecret(secretFieldName, secretName st
 	// the name already present is the case where the name was filled in but the
 	// secret didn't exist.
 	if secretName == "" {
-		if secretFieldName == httpsNMATLSSecret {
+		switch secretFieldName {
+		case httpsNMATLSSecret:
 			secret.GenerateName = fmt.Sprintf("%s-https-tls-", h.Vdb.Name)
-		} else if secretFieldName == clientServerTLSSecret {
+		case clientServerTLSSecret:
 			secret.GenerateName = fmt.Sprintf("%s-clientserver-tls-", h.Vdb.Name)
-		} else if secretFieldName == nmaTLSSecret {
+		case nmaTLSSecret:
 			secret.GenerateName = fmt.Sprintf("%s-nma-tls-", h.Vdb.Name)
 		}
 	} else {
@@ -247,11 +249,12 @@ func (h *TLSServerCertGenReconciler) setSecretNameInVDB(ctx context.Context, sec
 		if err := h.VRec.Client.Get(ctx, nm, h.Vdb); err != nil {
 			return err
 		}
-		if secretFieldName == clientServerTLSSecret {
+		switch secretFieldName {
+		case clientServerTLSSecret:
 			h.Vdb.Spec.ClientServerTLS = &vapi.TLSConfigSpec{Secret: secretName, Mode: h.Vdb.GetSpecClientServerTLSMode()}
-		} else if secretFieldName == httpsNMATLSSecret {
+		case httpsNMATLSSecret:
 			h.Vdb.Spec.HTTPSNMATLS = &vapi.TLSConfigSpec{Secret: secretName, Mode: h.Vdb.GetSpecHTTPSNMATLSMode()}
-		} else if secretFieldName == nmaTLSSecret {
+		case nmaTLSSecret:
 			h.Vdb.Spec.NMATLSSecret = secretName
 		}
 		return h.VRec.Client.Update(ctx, h.Vdb)
@@ -278,15 +281,19 @@ func (h *TLSServerCertGenReconciler) ValidateSecretCertificate(
 
 	err := security.ValidateTLSSecret(certPEM, keyPEM)
 	if err != nil {
-		h.VRec.Eventf(h.Vdb, corev1.EventTypeWarning, events.TLSCertValidationFailed,
-			"Validation of TLS Certificate %q failed with secret %q", tlsConfigName, secretName)
+		err1 := h.InvalidCertRollback(ctx, "Validation of TLS Certificate %q failed with secret %q", tlsConfigName, secretName)
+		if err1 != nil || h.Vdb.IsTLSCertRollbackNeeded() {
+			return err1
+		}
 		return err
 	}
 
 	err = security.ValidateCertificateCommonName(certPEM, h.Vdb.GetExpectedCertCommonName(tlsConfigName))
 	if err != nil {
-		h.VRec.Eventf(h.Vdb, corev1.EventTypeWarning, events.TLSCertValidationFailed,
-			"Validation of common name for TLS Certificate %q failed with secret %q", tlsConfigName, secretName)
+		err1 := h.InvalidCertRollback(ctx, "Validation of common name for TLS Certificate %q failed with secret %q", tlsConfigName, secretName)
+		if err1 != nil || h.Vdb.IsTLSCertRollbackNeeded() {
+			return err1
+		}
 		return err
 	}
 
@@ -306,9 +313,27 @@ func (h *TLSServerCertGenReconciler) ValidateSecretCertificate(
 // ShouldGenerateCert determines whether TLS server certificates should be generated.
 // Returns true if either TLS config is missing in status or the expected secret differs from what's currently recorded.
 func (h *TLSServerCertGenReconciler) ShouldGenerateCert() bool {
+	if h.Vdb.IsTLSCertRollbackNeeded() {
+		return false
+	}
+
 	return vmeta.UseTLSAuth(h.Vdb.Annotations) &&
 		(h.Vdb.GetHTTPSNMATLSSecretInUse() == "" ||
 			h.Vdb.GetClientServerTLSSecretInUse() == "" ||
 			h.Vdb.GetHTTPSNMATLSSecretInUse() != h.Vdb.GetHTTPSNMATLSSecret() ||
 			h.Vdb.GetClientServerTLSSecretInUse() != h.Vdb.GetClientServerTLSSecret())
+}
+
+// InvalidCertRollback handles failures in cert validation, by producing an event and (if relevant) trigerring rollback
+func (h *TLSServerCertGenReconciler) InvalidCertRollback(ctx context.Context, message, tlsConfigName, secretName string) error {
+	h.VRec.Eventf(h.Vdb, corev1.EventTypeWarning, events.TLSCertValidationFailed, message, tlsConfigName, secretName)
+	if h.Vdb.IsTLSCertRollbackEnabled() && h.Vdb.GetSecretInUse(tlsConfigName) != "" {
+		reason := vapi.FailureBeforeHTTPSCertHealthPollingReason
+		if tlsConfigName == vapi.ClientServerTLSConfigName {
+			reason = vapi.RollbackAfterServerCertRotationReason
+		}
+		cond := vapi.MakeCondition(vapi.TLSCertRollbackNeeded, metav1.ConditionTrue, reason)
+		return vdbstatus.UpdateCondition(ctx, h.VRec.GetClient(), h.Vdb, cond)
+	}
+	return nil
 }

--- a/tests/e2e-leg-13/invalid-cert-rollback/00-create-creds.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/00-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-13/invalid-cert-rollback/05-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/05-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-13/invalid-cert-rollback/05-deploy-operator.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/05-deploy-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-13/invalid-cert-rollback/10-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/10-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-no-client-auth
+  name: custom-cert1
+  name: custom-cert2
+  name: custom-cert3

--- a/tests/e2e-leg-13/invalid-cert-rollback/10-create-certs.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/10-create-certs.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: sh -c "envsubst < cert-no-client-auth.yaml | kubectl apply -n $NAMESPACE -f -"
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert1 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert2 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert3 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME

--- a/tests/e2e-leg-13/invalid-cert-rollback/15-setup-vdb.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/invalid-cert-rollback/17-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/17-assert.yaml
@@ -1,0 +1,34 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-tls-certs-sc1
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+status:
+  tlsConfigs:
+    - name: httpsNMA
+      secret: custom-cert1
+    - name: clientServer
+      secret: custom-cert2
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-13/invalid-cert-rollback/17-wait-for-createdb.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/17-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/invalid-cert-rollback/20-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/20-assert.yaml
@@ -1,0 +1,59 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: TLSCertValidationFailed
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Validation of TLS Certificate "clientServer" failed with secret "cert-no-client-auth"
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Starting Server TLS cert rollback after failed update
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Server TLS cert rollback completed successfully
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+status:
+  tlsConfigs:
+    - name: httpsNMA
+      secret: custom-cert1
+    - name: clientServer
+      secret: custom-cert2
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-13/invalid-cert-rollback/20-set-invalid-server-cert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/20-set-invalid-server-cert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+spec:
+  clientServerTLS:
+    secret: cert-no-client-auth

--- a/tests/e2e-leg-13/invalid-cert-rollback/25-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/25-assert.yaml
@@ -1,0 +1,59 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: TLSCertValidationFailed
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Validation of TLS Certificate "httpsNMA" failed with secret "cert-no-client-auth"
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Starting HTTP TLS cert rollback after failed update
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertRollbackSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: HTTP TLS cert rollback completed successfully
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+status:
+  tlsConfigs:
+    - name: httpsNMA
+      secret: custom-cert1
+    - name: clientServer
+      secret: custom-cert3
+  subclusters:
+    - addedToDBCount: 1
+      upNodeCount: 1

--- a/tests/e2e-leg-13/invalid-cert-rollback/25-set-both-with-invalid-https.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/25-set-both-with-invalid-https.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+spec:
+  httpsNMATLS:
+    secret: cert-no-client-auth
+  clientServerTLS:
+    secret: custom-cert3

--- a/tests/e2e-leg-13/invalid-cert-rollback/30-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/30-assert.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: Event
+reason: TLSAutoRotateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Auto-rotate triggered for TLS config httpsNMA with secret custom-cert2
+---
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Starting tls cert rotation for HTTP with secret name custom-cert2 and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Successfully rotated HTTP tls cert with secret name custom-cert2 and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: NMATLSCertRotationStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Start rotating nma cert from custom-cert1 to custom-cert2
+---
+apiVersion: v1
+kind: Event
+reason: NMATLSCertRotationSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Successfully rotated nma cert from custom-cert1 to custom-cert2
+---
+apiVersion: v1
+kind: Event
+reason: TLSAutoRotateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Auto-rotate triggered for TLS config httpsNMA with secret cert-no-client-auth
+---
+apiVersion: v1
+kind: Event
+reason: TLSCertValidationFailed
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Validation of TLS Certificate "httpsNMA" failed with secret "cert-no-client-auth"

--- a/tests/e2e-leg-13/invalid-cert-rollback/30-set-auto-rotate-with-invalid.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/30-set-auto-rotate-with-invalid.yaml
@@ -1,0 +1,26 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+  annotations:
+    vertica.com/trigger-auto-tls-rotate: "true"
+spec:
+  httpsNMATLS:
+    autoRotate:
+      secrets:
+      - custom-cert2
+      - cert-no-client-auth
+      - custom-cert3

--- a/tests/e2e-leg-13/invalid-cert-rollback/31-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/31-assert.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Event
+reason: TLSAutoRotateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Auto-rotate triggered for TLS config httpsNMA with secret custom-cert3
+---
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Starting tls cert rotation for HTTP with secret name custom-cert3 and mode verify_ca
+---
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-tls-certs
+message: Successfully rotated HTTP tls cert with secret name custom-cert3 and mode verify_ca
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+spec:
+  httpsNMATLS:
+    secret: custom-cert3
+status:
+  tlsConfigs:
+  - name: httpsNMA
+    secret: custom-cert3
+  - name: clientServer

--- a/tests/e2e-leg-13/invalid-cert-rollback/31-unset-auto-rotate-annotation.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/31-unset-auto-rotate-annotation.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+  annotations:
+    vertica.com/trigger-auto-tls-rotate: ""

--- a/tests/e2e-leg-13/invalid-cert-rollback/85-delete-cr.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/85-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-13/invalid-cert-rollback/85-errors.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/85-errors.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB

--- a/tests/e2e-leg-13/invalid-cert-rollback/86-assert.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/86-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clean-communal
+status:
+  phase: Succeeded

--- a/tests/e2e-leg-13/invalid-cert-rollback/86-cleanup-storage.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/86-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/invalid-cert-rollback/86-errors.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/86-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-13/invalid-cert-rollback/99-delete-ns.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-13/invalid-cert-rollback/cert-cn-dbadmin.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/cert-cn-dbadmin.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is applied through envsubst so that the $NAMESPACE gets filled in
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+spec:
+  commonName: dbadmin
+  isCA: true
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: cert-cn-dbadmin
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/tests/e2e-leg-13/invalid-cert-rollback/cert-cn-test.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/cert-cn-test.yaml
@@ -1,0 +1,38 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is applied through envsubst so that the $NAMESPACE gets filled in
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+spec:
+  commonName: test
+  isCA: true
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: cert-cn-test
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/tests/e2e-leg-13/invalid-cert-rollback/cert-no-client-auth.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/cert-no-client-auth.yaml
@@ -1,0 +1,37 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is applied through envsubst so that the $NAMESPACE gets filled in
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+spec:
+  commonName: dbadmin
+  isCA: true
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: cert-no-client-auth
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/tests/e2e-leg-13/invalid-cert-rollback/gen-expired-cert.sh
+++ b/tests/e2e-leg-13/invalid-cert-rollback/gen-expired-cert.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > $TMPDIR/openssl.cnf <<EOF
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+dir               = $TMPDIR/demoCA
+database          = \$dir/index.txt
+new_certs_dir     = \$dir/newcerts
+serial            = \$dir/serial
+private_key       = \$dir/ca.key
+certificate       = \$dir/ca.crt
+default_md        = sha256
+policy            = policy_any
+email_in_dn       = no
+copy_extensions   = copy
+default_days      = 365
+
+[ policy_any ]
+commonName = supplied
+
+[ req ]
+distinguished_name = req_distinguished_name
+prompt = no
+
+[ req_distinguished_name ]
+CN = expired.example.com
+
+[ ext ]
+extendedKeyUsage = serverAuth, clientAuth
+EOF
+
+mkdir -p $TMPDIR/demoCA/newcerts
+touch $TMPDIR/demoCA/index.txt
+echo 1000 > $TMPDIR/demoCA/serial
+
+# Generate CA key and self-signed cert
+openssl genpkey -algorithm RSA -out $TMPDIR/demoCA/ca.key
+openssl req -x509 -new -nodes -key $TMPDIR/demoCA/ca.key -sha256 -days 3650 \
+  -subj "/CN=demo-ca" \
+  -out $TMPDIR/demoCA/ca.crt
+
+# Generate key and CSR for expired cert
+openssl genpkey -algorithm RSA -out $TMPDIR/expired.key
+openssl req -new -key $TMPDIR/expired.key -out $TMPDIR/expired.csr -config $TMPDIR/openssl.cnf
+
+# Sign the expired cert with custom start/end dates and EKU extensions
+openssl ca -config $TMPDIR/openssl.cnf -in $TMPDIR/expired.csr -out $TMPDIR/expired.crt \
+  -startdate "$(date -u -d '10 days ago' +%Y%m%d%H%M%SZ)" \
+  -enddate "$(date -u -d '5 days ago' +%Y%m%d%H%M%SZ)" \
+  -extensions ext -extfile $TMPDIR/openssl.cnf -batch
+
+# Output Kubernetes TLS secret YAML to stdout
+cat <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: expired-cert
+type: kubernetes.io/tls
+data:
+  tls.crt: $(base64 -w0 < $TMPDIR/expired.crt)
+  tls.key: $(base64 -w0 < $TMPDIR/expired.key)
+EOF

--- a/tests/e2e-leg-13/invalid-cert-rollback/gen-mismatched-cert.sh
+++ b/tests/e2e-leg-13/invalid-cert-rollback/gen-mismatched-cert.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SECRET_NAME="mismatched-cert"
+TMP_DIR=$(mktemp -d)
+
+# Generate first key/cert pair
+openssl genrsa -out "$TMP_DIR/key1.pem" 2048
+openssl req -x509 -new -nodes -key "$TMP_DIR/key1.pem" -sha256 -days 365 -out "$TMP_DIR/cert1.pem" -subj "/CN=cert-one"
+
+# Generate second key (this one won't match cert1.pem)
+openssl genrsa -out "$TMP_DIR/key2.pem" 2048
+
+# Base64 encode cert and mismatched key
+CERT_B64=$(base64 -w 0 "$TMP_DIR/cert1.pem")
+KEY_B64=$(base64 -w 0 "$TMP_DIR/key2.pem")
+
+# Output a Kubernetes TLS Secret with mismatched cert/key
+cat <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $SECRET_NAME
+  namespace: $NAMESPACE
+type: kubernetes.io/tls
+data:
+  tls.crt: $CERT_B64
+  tls.key: $KEY_B64
+EOF

--- a/tests/e2e-leg-13/invalid-cert-rollback/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-13/invalid-cert-rollback/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-13/invalid-cert-rollback/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,45 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-tls-certs
+  annotations:
+    vertica.com/k-safety: "0"
+    vertica.com/include-uid-in-path: "true"
+    vertica.com/enable-tls-auth: "true"
+spec:
+  httpsNMATLS:
+    secret: custom-cert1
+    mode: verify_ca
+  clientServerTLS:
+    secret: custom-cert2
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  communal: {}
+  local:
+    requestSize: 100Mi
+    catalogPath: /catalog
+  dbName: vertdb
+  encryptSpreadComm: vertica
+  subclusters:
+    - name: sc1
+      size: 1
+  securityContext:
+    capabilities:
+      add: ["SYS_PTRACE"]
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
When you change the clientServer or httpsNMA secret, we will run several checks to validate the secret's certificate. Previous, this failure would not trigger a rollback; it would just produce errors until the user changes to a valid secret. This is different than other cert rotation failures, where we would rollback.

Now, when cert validation fails, we will trigger a rollback to the last good secret. This will only apply when changing a secret; during create db, it will still produce an error and expect the user to fix it (since there is no last good secret).