### PR TITLE
Add annotation to disable "https" or "clientserver" TLS auth

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -2361,7 +2361,7 @@ func GetTarballName(cmd []string) string {
 }
 
 // BuildNMATLSConfigMap builds a configmap with tls secret name in it.
-// The configmap will be mapped to two environmental variables in NMA pod
+// The configmap will be mapped to environmental variables in NMA pod
 func BuildNMATLSConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.ConfigMap {
 	clientSecretName := vdb.GetClientServerTLSSecretForConfigMap()
 	clientSecretNamespace := vdb.ObjectMeta.Namespace
@@ -2370,6 +2370,8 @@ func BuildNMATLSConfigMap(nm types.NamespacedName, vdb *vapi.VerticaDB) *corev1.
 	if !vmeta.UseTLSAuth(vdb.Annotations) {
 		clientSecretName = vdb.GetNMATLSSecret()
 		clientSecretTLSMode = "enable"
+	} else if vdb.IsClientServerTLSAuthDisabled() {
+		clientSecretTLSMode = "disable"
 	}
 	secretMap := map[string]string{
 		NMASecretNamespaceEnv:       vdb.ObjectMeta.Namespace,

--- a/pkg/controllers/vdb/deploymentmethod_reconciler.go
+++ b/pkg/controllers/vdb/deploymentmethod_reconciler.go
@@ -75,7 +75,7 @@ func (d *DeploymentMethodReconciler) Reconcile(ctx context.Context, _ *ctrl.Requ
 	}
 
 	// when deployment is switching to vclusterOps, enable HTTPS TLS if needed
-	if d.Vdb.Status.DeploymentMethod != vapi.DeploymentMethodVC {
+	if d.Vdb.Status.DeploymentMethod != vapi.DeploymentMethodVC && !d.Vdb.IsHTTPSTLSAuthDisabled() {
 		res, err := d.reconcileHTTPSTLS(ctx)
 		if verrors.IsReconcileAborted(res, err) {
 			return res, err

--- a/pkg/controllers/vdb/httpstlsupdate_reconciler.go
+++ b/pkg/controllers/vdb/httpstlsupdate_reconciler.go
@@ -68,7 +68,7 @@ func MakeHTTPSTLSUpdateReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger
 func (h *HTTPSTLSUpdateReconciler) Reconcile(ctx context.Context, req *ctrl.Request) (ctrl.Result, error) {
 	// Skip if TLS not enabled, DB not initialized, or rotate has failed.
 	// However, if called from rollback reconciler, always run.
-	if h.Vdb.ShouldSkipTLSUpdateReconcile() && !h.FromRollback {
+	if h.Vdb.ShouldSkipTLSUpdateReconcile(vapi.HTTPSNMATLSConfigName, h.FromRollback) {
 		return ctrl.Result{}, nil
 	}
 
@@ -86,8 +86,7 @@ func (h *HTTPSTLSUpdateReconciler) Reconcile(ctx context.Context, req *ctrl.Requ
 		return rec.Reconcile(ctx, req)
 	}
 
-	if !h.Vdb.IsHTTPSConfigEnabled() ||
-		h.Vdb.IsStatusConditionTrue(vapi.HTTPSTLSConfigUpdateFinished) {
+	if !h.Vdb.IsHTTPSConfigEnabled() {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controllers/vdb/nmacertrotation_reconciler.go
+++ b/pkg/controllers/vdb/nmacertrotation_reconciler.go
@@ -154,6 +154,12 @@ func (h *NMACertRotationReconciler) rotateNmaTLSCert(ctx context.Context, newSec
 	}
 	newSecretName := h.Vdb.GetHTTPSNMATLSSecret()
 
+	// If HTTPS is disabled, we are just doing a restart for Client-Server cert rotate
+	if h.Vdb.IsHTTPSTLSAuthDisabled() {
+		currentSecretName = h.Vdb.GetNMATLSSecret()
+		newSecretName = currentSecretName
+	}
+
 	if currentSecretName == newSecretName {
 		// If the current and new secrets are the same, then we are just restarting
 		h.VRec.Eventf(h.Vdb, corev1.EventTypeNormal, events.NMATLSCertRotationStarted,

--- a/pkg/controllers/vdb/obj_reconciler.go
+++ b/pkg/controllers/vdb/obj_reconciler.go
@@ -261,7 +261,7 @@ func (o *ObjReconciler) checkTLSSecrets(ctx context.Context) (ctrl.Result, error
 	tlsSecrets := map[string]string{
 		"NMA TLS": o.Vdb.GetNMATLSSecret(),
 	}
-	if vmeta.UseTLSAuth(o.Vdb.Annotations) {
+	if vmeta.UseTLSAuth(o.Vdb.Annotations) && !o.Vdb.IsClientServerTLSAuthDisabled() {
 		tlsSecrets["Client Server TLS"] = o.Vdb.GetClientServerTLSSecret()
 	}
 	dbReconciler := o.Rec.(*VerticaDBReconciler)
@@ -836,7 +836,7 @@ func (o *ObjReconciler) shouldPreserveStsSize(curSts, expSts *appsv1.StatefulSet
 
 // reconcileTLSSecrets will update tls secrets
 func (o *ObjReconciler) reconcileTLSSecrets(ctx context.Context) error {
-	if !o.Vdb.IsSetForTLS() || o.Vdb.ShouldRemoveTLSSecret() {
+	if !o.Vdb.IsSetForTLS() || o.Vdb.IsClientServerTLSAuthDisabled() || o.Vdb.ShouldRemoveTLSSecret() {
 		return nil
 	}
 

--- a/pkg/controllers/vdb/onlineupgrade_reconciler.go
+++ b/pkg/controllers/vdb/onlineupgrade_reconciler.go
@@ -880,7 +880,7 @@ func (r *OnlineUpgradeReconciler) startReplicationToReplicaGroupB(ctx context.Co
 	}
 
 	tlsConfig := ""
-	if r.VDB.IsSetForTLS() {
+	if r.VDB.IsSetForTLS() && !r.VDB.IsClientServerTLSAuthDisabled() {
 		tlsConfig = "server"
 	}
 

--- a/pkg/controllers/vdb/tlsconfig_reconciler.go
+++ b/pkg/controllers/vdb/tlsconfig_reconciler.go
@@ -60,10 +60,13 @@ func MakeTLSConfigReconciler(vdbrecon *VerticaDBReconciler, log logr.Logger, vdb
 
 // Reconcile will create a TLS secret for the http server if one is missing
 func (h *TLSConfigReconciler) Reconcile(ctx context.Context, request *ctrl.Request) (ctrl.Result, error) {
-	if h.Vdb.IsSetForTLS() && h.Vdb.GetSecretInUse(h.TLSConfigName) != "" ||
-		!h.Vdb.IsSetForTLS() || !h.Vdb.IsStatusConditionTrue(vapi.DBInitialized) ||
-		h.Vdb.IsStatusConditionTrue(vapi.UpgradeInProgress) ||
-		h.Vdb.IsStatusConditionTrue(vapi.VerticaRestartNeeded) {
+	if h.shouldSkipTLSConfigReconcile() {
+		return ctrl.Result{}, nil
+	}
+
+	// If this config's TLS auth is disabled, then we skip the TLS configuration.
+	if h.Vdb.IsTLSAuthDisabledForTLSConfig(h.TLSConfigName) {
+		h.Log.Info("TLS auth is disabled. Skipping TLS configuration", "tlsConfigName", h.TLSConfigName)
 		return ctrl.Result{}, nil
 	}
 
@@ -101,6 +104,12 @@ func (h *TLSConfigReconciler) Reconcile(ctx context.Context, request *ctrl.Reque
 		if err2 != nil {
 			h.Log.Error(err2, "failed to check TLS authentication before running DDL")
 			return ctrl.Result{}, err2
+		}
+		// If HTTPS auth is disabled, this is client-server auth. Since vcluster defaults HTTPS
+		// to GrantAuth true, setting client-server to GrantTrue will result in an error, since both
+		// cannot have GrantAuth true. Thus, we set GrantAuth false in this case.
+		if !authCreated && h.Vdb.IsHTTPSTLSAuthDisabled() {
+			authCreated = true
 		}
 		h.Log.Info("Run DDL to set up TLS")
 		err = h.runDDLToConfigureTLS(ctx, initiatorPod, !authCreated)
@@ -154,4 +163,11 @@ func (h *TLSConfigReconciler) checkIfTLSAuthenticationCreatedInDB(ctx context.Co
 	lines := strings.Split(stdout, "\n")
 	res := strings.Trim(lines[0], " ")
 	return res == "True", nil
+}
+
+func (h *TLSConfigReconciler) shouldSkipTLSConfigReconcile() bool {
+	return (h.Vdb.IsSetForTLS() && h.Vdb.GetSecretInUse(h.TLSConfigName) != "") ||
+		!h.Vdb.IsSetForTLS() || !h.Vdb.IsStatusConditionTrue(vapi.DBInitialized) ||
+		h.Vdb.IsStatusConditionTrue(vapi.UpgradeInProgress) ||
+		h.Vdb.IsStatusConditionTrue(vapi.VerticaRestartNeeded)
 }

--- a/pkg/meta/annotations.go
+++ b/pkg/meta/annotations.go
@@ -83,6 +83,11 @@ const (
 	// This is a feature flag for enables authentication via Mutual TLS
 	EnableTLSAuthAnnotation = "vertica.com/enable-tls-auth"
 
+	// Disable TLS auth for one TLS config. Options are "https" or "clientserver".
+	DisableTLSAuthForConfigAnnotation = "vertica.com/disable-tls-auth-for-config"
+	DisableTLSAuthForConfigHTTPS      = "https"
+	DisableTLSAuthForConfigServer     = "clientserver"
+
 	// Two annotations that are set by the operator when creating objects.
 	OperatorDeploymentMethodAnnotation = "vertica.com/operator-deployment-method"
 	OperatorVersionAnnotation          = "vertica.com/operator-version"
@@ -510,6 +515,10 @@ func UseNMACertsMount(annotations map[string]string) bool {
 
 func UseTLSAuth(annotations map[string]string) bool {
 	return lookupBoolAnnotation(annotations, EnableTLSAuthAnnotation, false /* default value */)
+}
+
+func DisableTLSAuthForConfig(annotations map[string]string) string {
+	return lookupStringAnnotation(annotations, DisableTLSAuthForConfigAnnotation, "")
 }
 
 // IgnoreClusterLease returns true if revive/start should ignore the cluster lease

--- a/pkg/vadmin/rotate_tls_certs_vc.go
+++ b/pkg/vadmin/rotate_tls_certs_vc.go
@@ -44,6 +44,9 @@ func (v *VClusterOps) RotateTLSCerts(ctx context.Context, opts ...rotatetlscerts
 		v.Log.Info("HTTPS cert rotation has occurred but the status is not up to date yet. Using secret from spec")
 		secretName = v.VDB.GetHTTPSNMATLSSecret()
 	}
+	if v.VDB.IsHTTPSTLSAuthDisabled() {
+		secretName = v.VDB.GetNMATLSSecret()
+	}
 	certCache := v.CacheManager.GetCertCacheForVdb(v.VDB.Namespace, v.VDB.Name)
 	certs, err := certCache.ReadCertFromSecret(ctx, secretName)
 	if err != nil {

--- a/pkg/vadmin/vc.go
+++ b/pkg/vadmin/vc.go
@@ -125,7 +125,7 @@ func (v *VClusterOps) setAuthentication(opts *vops.DatabaseOptions, username str
 // when tls cert is used, it returns secert name saved in annotation
 func getHTTPSTLSSecretName(vdb *vapi.VerticaDB) (string, error) {
 	secretName := ""
-	if vdb.IsSetForTLS() {
+	if vdb.IsSetForTLS() && !vdb.IsHTTPSTLSAuthDisabled() {
 		secretName = vdb.GetHTTPSNMATLSSecretInUse()
 	}
 	if secretName == "" {

--- a/tests/e2e-leg-13/just-client-server-auth/00-create-creds.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/00-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-13/just-client-server-auth/01-assert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/01-assert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: su-passwd
+type: Opaque
+data:
+  password: c3VwZXJ1c2Vy

--- a/tests/e2e-leg-13/just-client-server-auth/01-password-secret.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/01-password-secret.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: su-passwd
+type: Opaque
+data:
+  ## Password for superuser, base64 encoded (echo -n 'superuser' | base64)
+  password: c3VwZXJ1c2Vy

--- a/tests/e2e-leg-13/just-client-server-auth/05-assert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/05-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-13/just-client-server-auth/05-deploy-operator.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/05-deploy-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-13/just-client-server-auth/10-assert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/10-assert.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-cert

--- a/tests/e2e-leg-13/just-client-server-auth/10-create-cert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/10-create-cert.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME

--- a/tests/e2e-leg-13/just-client-server-auth/15-assert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/15-assert.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-just-client-server-auth-sc1
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-client-server-auth

--- a/tests/e2e-leg-13/just-client-server-auth/15-setup-vdb.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/just-client-server-auth/17-assert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/17-assert.yaml
@@ -1,0 +1,31 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-just-client-server-auth-sc1
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-client-server-auth
+status:
+  tlsConfigs:
+    - name: clientServer
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-13/just-client-server-auth/17-wait-for-createdb.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/17-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/just-client-server-auth/25-verify-server-tls-certs-env.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/25-verify-server-tls-certs-env.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  # nma env variable should exist.
+  - command: kubectl exec -n $NAMESPACE v-just-client-server-auth-sc1-0 -c nma -- bash -c "env | grep NMA_CLIENT_SECRET_NAME=v-just-client-server-auth-clientserver-tls"
+  - command: kubectl exec -n $NAMESPACE v-just-client-server-auth-sc1-0 -c nma -- bash -c "env | grep NMA_CLIENT_SECRET_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-13/just-client-server-auth/30-assert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/30-assert.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-just-client-server-auth
+---
+apiVersion: v1
+kind: Event
+reason: ClientServerTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-just-client-server-auth
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-client-server-auth
+status:
+  conditions:
+  - reason: Detected
+    status: "True"
+    type: AutoRestartVertica
+  - reason: Initialized
+    status: "True"
+    type: DBInitialized
+  - reason: Completed
+    status: "False"
+    type: TLSConfigUpdateInProgress
+  - reason: Completed
+    status: "False"
+    type: ClientServerTLSConfigUpdateFinished 
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+  

--- a/tests/e2e-leg-13/just-client-server-auth/30-change-server-tls-secret.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/30-change-server-tls-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-client-server-auth
+spec:
+  clientServerTLS:
+    secret: custom-cert

--- a/tests/e2e-leg-13/just-client-server-auth/40-assert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/40-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-client-server-auth
+status:
+  tlsConfigs:
+    - name: clientServer
+      secret: custom-cert

--- a/tests/e2e-leg-13/just-client-server-auth/40-wait-for-restart.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/40-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/just-client-server-auth/45-verify-server-tls-certs-env.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/45-verify-server-tls-certs-env.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  # nma env variable should exist.
+  - command: kubectl exec -n $NAMESPACE v-just-client-server-auth-sc1-0 -c nma -- bash -c "env | grep NMA_CLIENT_SECRET_NAME=custom-cert"
+  - command: kubectl exec -n $NAMESPACE v-just-client-server-auth-sc1-0 -c nma -- bash -c "env | grep NMA_CLIENT_SECRET_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-13/just-client-server-auth/55-vsql-verify-nma-tls-cert.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/55-vsql-verify-nma-tls-cert.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: bash ./vsql_verify.sh
+

--- a/tests/e2e-leg-13/just-client-server-auth/95-delete-cr.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-13/just-client-server-auth/95-errors.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/95-errors.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator

--- a/tests/e2e-leg-13/just-client-server-auth/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/just-client-server-auth/96-errors.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-13/just-client-server-auth/99-delete-ns.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-13/just-client-server-auth/compare_cert.sh
+++ b/tests/e2e-leg-13/just-client-server-auth/compare_cert.sh
@@ -1,0 +1,4 @@
+awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/ { print } NR > 1 && /-----END CERTIFICATE-----/ { exit }' $2 > $2_cut
+kubectl get secret/custom-cert -n $1 -o jsonpath='{.data.tls\.crt}'  | base64 --decode > /tmp/secret_cert.txt
+diff $2_cut  /tmp/secret_cert.txt
+exit $?

--- a/tests/e2e-leg-13/just-client-server-auth/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-13/just-client-server-auth/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-13/just-client-server-auth/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,43 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-client-server-auth
+  annotations:
+    vertica.com/k-safety: "1"
+    vertica.com/include-uid-in-path: "true"
+    vertica.com/enable-tls-auth: "true"
+    vertica.com/disable-tls-auth-for-config: "https"
+spec:
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  passwordSecret: su-passwd
+  communal: {}
+  local:
+    requestSize: 100Mi
+    catalogPath: /catalog
+  dbName: vertdb
+  clientServerTLS:
+    mode: try_verify
+  subclusters:
+    - name: sc1
+      size: 3
+  securityContext:
+    capabilities:
+      add: ["SYS_PTRACE"]
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-leg-13/just-client-server-auth/vsql_verify.sh
+++ b/tests/e2e-leg-13/just-client-server-auth/vsql_verify.sh
@@ -1,0 +1,16 @@
+CERT_NAME=$(kubectl exec -n $NAMESPACE v-just-client-server-auth-sc1-0 -c server -- vsql -U dbadmin -w superuser -tAc "select certificate from tls_configurations where name='server' and owner='dbadmin';")
+if [[ $CERT_NAME != "server_cert_1" ]]; then
+    echo "ERROR: cert server_cert_1 not found"
+    exit 1
+fi
+CA_CERT_NAME=$(kubectl exec -n $NAMESPACE v-just-client-server-auth-sc1-0 -c server -- vsql -U dbadmin -w superuser -tAc "select ca_certificate from tls_configurations where name='server' and owner='dbadmin';")
+if [[ $CA_CERT_NAME != "server_ca_cert_1" ]]; then
+    echo "ERROR: cert server_ca_cert_1 not found"
+    exit 1
+fi
+KEY_NAME=$(kubectl exec -n $NAMESPACE v-just-client-server-auth-sc1-0 -c server -- vsql -U dbadmin -w superuser -tAc "select name FROM cryptographic_keys WHERE secret_name='custom-cert';")
+if [[ $KEY_NAME != "server_key_1" ]]; then
+    echo "ERROR: key server_key_1 not found"
+    exit 1
+fi
+exit 0

--- a/tests/e2e-leg-13/just-https-nma-auth/00-create-creds.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/00-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-13/just-https-nma-auth/05-assert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/05-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-13/just-https-nma-auth/05-deploy-operator.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/05-deploy-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-13/just-https-nma-auth/10-assert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/10-assert.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-cert

--- a/tests/e2e-leg-13/just-https-nma-auth/10-create-cert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/10-create-cert.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=custom-cert SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME

--- a/tests/e2e-leg-13/just-https-nma-auth/15-assert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/15-assert.yaml
@@ -1,0 +1,27 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-just-https-nma-auth-sc1
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-https-nma-auth
+status:
+  subclusters:
+    - addedToDBCount: 3

--- a/tests/e2e-leg-13/just-https-nma-auth/15-setup-vdb.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/15-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/just-https-nma-auth/17-assert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/17-assert.yaml
@@ -1,0 +1,31 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-just-https-nma-auth-sc1
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-https-nma-auth
+status:
+  tlsConfigs:
+    - name: httpsNMA
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-13/just-https-nma-auth/17-wait-for-createdb.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/17-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/just-https-nma-auth/25-verify-nma-tls-certs-env.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/25-verify-nma-tls-certs-env.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  # nma env variable should exist.
+  - command: kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c nma -- bash -c "env | grep NMA_SECRET_NAME=v-just-https-nma-auth-https-tls"
+  - command: kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c nma -- bash -c "env | grep NMA_SECRET_NAMESPACE=$NAMESPACE"

--- a/tests/e2e-leg-13/just-https-nma-auth/30-assert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/30-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-just-https-nma-auth

--- a/tests/e2e-leg-13/just-https-nma-auth/30-change-nma-tls-secret.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/30-change-nma-tls-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-https-nma-auth
+spec:
+  httpsNMATLS:
+    secret: custom-cert

--- a/tests/e2e-leg-13/just-https-nma-auth/32-verify-config-map-unchanged.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/32-verify-config-map-unchanged.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      echo "Verifying that ConfigMap has not yet been updated..."
+      ACTUAL=$(kubectl get configmap -n $NAMESPACE v-just-https-nma-auth-nma-tls-config -o jsonpath='{.data.NMA_SECRET_NAME}')
+      if [ "$ACTUAL" = "custom-cert" ]; then
+        echo "FAIL: ConfigMap was updated prematurely with custom-cert"
+        exit 1
+      fi
+      echo "PASS: ConfigMap still contains: $ACTUAL"

--- a/tests/e2e-leg-13/just-https-nma-auth/34-assert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/34-assert.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Event
+reason: HTTPSTLSUpdateSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-just-https-nma-auth
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: v-just-https-nma-auth-nma-tls-config
+data:
+  NMA_SECRET_NAME: custom-cert
+---
+apiVersion: v1
+kind: Event
+reason: NMATLSCertRotationStarted
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-just-https-nma-auth
+---
+apiVersion: v1
+kind: Event
+reason: NMATLSCertRotationSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-just-https-nma-auth
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-https-nma-auth
+status:
+  conditions:
+  - reason: Detected
+    status: "True"
+    type: AutoRestartVertica
+  - reason: Initialized
+    status: "True"
+    type: DBInitialized
+  - reason: Completed
+    status: "False"
+    type: TLSConfigUpdateInProgress  
+  - reason: Completed
+    status: "False"
+    type: HTTPSTLSConfigUpdateFinished 
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3
+  

--- a/tests/e2e-leg-13/just-https-nma-auth/34-wait-for-tls-update-finished.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/34-wait-for-tls-update-finished.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/just-https-nma-auth/40-assert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/40-assert.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-just-https-nma-auth-sc1-0
+status:
+  containerStatuses:
+  - name: nma
+    ready: true
+    restartCount: 1
+    started: true
+  - name: server
+    ready: true
+    restartCount: 0
+    started: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-just-https-nma-auth-sc1-1
+status:
+  containerStatuses:
+  - name: nma
+    ready: true
+    restartCount: 1
+    started: true
+  - name: server
+    ready: true
+    restartCount: 0
+    started: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v-just-https-nma-auth-sc1-2
+status:
+  containerStatuses:
+  - name: nma
+    ready: true
+    restartCount: 1
+    started: true
+  - name: server
+    ready: true
+    restartCount: 0
+    started: true
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-https-nma-auth
+status:
+  tlsConfigs:
+    - secret: custom-cert
+      name: httpsNMA

--- a/tests/e2e-leg-13/just-https-nma-auth/40-wait-for-restart.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/40-wait-for-restart.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/just-https-nma-auth/50-verify-https-tls-cert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/50-verify-https-tls-cert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- bash -c "openssl s_client -showcerts -connect localhost:8443 </dev/null > /tmp/tls_from_https.crt; exit 0"
+  - command: kubectl cp -n $NAMESPACE -c server v-just-https-nma-auth-sc1-0:tmp/tls_from_https.crt /tmp/tls_from_https.crt
+  - command: bash ./compare_cert.sh $NAMESPACE /tmp/tls_from_https.crt

--- a/tests/e2e-leg-13/just-https-nma-auth/55-vsql-verify-nma-tls-cert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/55-vsql-verify-nma-tls-cert.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: bash ./vsql_verify.sh
+

--- a/tests/e2e-leg-13/just-https-nma-auth/60-verify-nma-tls-cert.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/60-verify-nma-tls-cert.yaml
@@ -1,0 +1,20 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta2
+kind: TestStep
+commands:
+  - command: kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- bash -c "openssl s_client -showcerts -connect localhost:5554 </dev/null > /tmp/tls_from_nma.crt"
+  - command: kubectl cp -n $NAMESPACE -c server v-just-https-nma-auth-sc1-0:tmp/tls_from_nma.crt /tmp/tls_from_nma.crt
+  - command: bash ./compare_cert.sh $NAMESPACE /tmp/tls_from_nma.crt
+

--- a/tests/e2e-leg-13/just-https-nma-auth/95-delete-cr.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-13/just-https-nma-auth/95-errors.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/95-errors.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: vertica
+    app.kubernetes.io/component: database
+    vertica.com/database: vertdb
+    app.kubernetes.io/instance: v-just-https-nma-auth

--- a/tests/e2e-leg-13/just-https-nma-auth/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/just-https-nma-auth/96-errors.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-13/just-https-nma-auth/99-delete-ns.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-13/just-https-nma-auth/compare_cert.sh
+++ b/tests/e2e-leg-13/just-https-nma-auth/compare_cert.sh
@@ -1,0 +1,4 @@
+awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/ { print } NR > 1 && /-----END CERTIFICATE-----/ { exit }' $2 > $2_cut
+kubectl get secret/custom-cert -n $1 -o jsonpath='{.data.tls\.crt}'  | base64 --decode > /tmp/secret_cert.txt
+diff $2_cut  /tmp/secret_cert.txt
+exit $?

--- a/tests/e2e-leg-13/just-https-nma-auth/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-13/just-https-nma-auth/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-13/just-https-nma-auth/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,44 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-just-https-nma-auth
+  annotations:
+    vertica.com/k-safety: "1"
+    vertica.com/include-uid-in-path: "true"
+    vertica.com/remove-tls-secret-on-vdb-delete: "true"
+    vertica.com/disable-tls-auth-for-config: "clientserver"
+    vertica.com/vcluster-ops: true
+spec:
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  communal: {}
+  local:
+    requestSize: 100Mi
+    catalogPath: /catalog
+  dbName: vertdb
+  encryptSpreadComm: vertica
+  httpsNMATLS:
+    mode: VERIFY_CA
+  subclusters:
+    - name: sc1
+      size: 3
+  securityContext:
+    capabilities:
+      add: ["SYS_PTRACE"]
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []

--- a/tests/e2e-leg-13/just-https-nma-auth/vsql_verify.sh
+++ b/tests/e2e-leg-13/just-https-nma-auth/vsql_verify.sh
@@ -1,0 +1,31 @@
+K8S_LOCAL_TLS_ENABLED=$(kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- vsql -tAc "SELECT is_auth_enabled FROM client_auth where auth_name='k8s_local_tls_builtin_auth';")
+if [[ $K8S_LOCAL_TLS_ENABLED != "True" ]]; then
+    echo "ERROR: k8s_local_tls_builtin_auth not enabled"
+    exit 1
+fi
+K8S_REMOTE_IPv4_TLS_ENABLED=$(kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- vsql -tAc "SELECT is_auth_enabled FROM client_auth where auth_name='k8s_remote_ipv4_tls_builtin_auth';")
+if [[ $K8S_REMOTE_IPv4_TLS_ENABLED != "True" ]]; then
+    echo "ERROR: k8s_remote_ipv4_tls_builtin_auth not enabled"
+    exit 1
+fi
+K8S_REMOTE_IPv6_TLS_ENABLED=$(kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- vsql -tAc "SELECT is_auth_enabled FROM client_auth where auth_name='k8s_remote_ipv6_tls_builtin_auth';")
+if [[ $K8S_REMOTE_IPv6_TLS_ENABLED != "True" ]]; then
+    echo "ERROR: k8s_remote_ipv6_tls_builtin_auth not enabled"
+    exit 1
+fi
+CERT_NAME=$(kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- vsql -tAc "select certificate from tls_configurations where name='https' and owner='dbadmin';")
+if [[ $CERT_NAME != "https_cert_1" ]]; then
+    echo "ERROR: cert https_cert_1 not found"
+    exit 1
+fi
+CA_CERT_NAME=$(kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- vsql -tAc "select ca_certificate from tls_configurations where name='https' and owner='dbadmin';")
+if [[ $CA_CERT_NAME != "https_ca_cert_1" ]]; then
+    echo "ERROR: cert https_ca_cert_1 not found"
+    exit 1
+fi
+KEY_NAME=$(kubectl exec -n $NAMESPACE v-just-https-nma-auth-sc1-0 -c server -- vsql -tAc "select name FROM cryptographic_keys WHERE secret_name='custom-cert';")
+if [[ $KEY_NAME != "https_key_1" ]]; then
+    echo "ERROR: key https_key_1 not found"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Add a new annotation:

```
vertica.com/disable-tls-auth-for-config
```

Which accepts the values "https" or "clientserver". This allows us to turn on TLS auth (using ```vertica.com/enable-tls-auth```) but disable it for one of the two TLS configs.