### PR TITLE
add e2e test case for using multiple ca certs

### DIFF
--- a/tests/e2e-leg-13/multiple_ca/00-create-creds.yaml
+++ b/tests/e2e-leg-13/multiple_ca/00-create-creds.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kustomize build ../../manifests/communal-creds/overlay | kubectl apply -f - --namespace $NAMESPACE
+  - script: kustomize build ../../manifests/priv-container-creds/overlay | kubectl apply -f - --namespace $NAMESPACE

--- a/tests/e2e-leg-13/multiple_ca/05-assert.yaml
+++ b/tests/e2e-leg-13/multiple_ca/05-assert.yaml
@@ -1,0 +1,22 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: integration-test-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: integration-test-rb

--- a/tests/e2e-leg-13/multiple_ca/05-rbac.yaml
+++ b/tests/e2e-leg-13/multiple_ca/05-rbac.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl apply --namespace $NAMESPACE -f ../../manifests/rbac/base/rbac.yaml
+    ignoreFailure: true

--- a/tests/e2e-leg-13/multiple_ca/10-assert.yaml
+++ b/tests/e2e-leg-13/multiple_ca/10-assert.yaml
@@ -1,0 +1,21 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: verticadb-operator
+  labels:
+    control-plane: verticadb-operator
+status:
+  phase: Running

--- a/tests/e2e-leg-13/multiple_ca/10-deploy-operator.yaml
+++ b/tests/e2e-leg-13/multiple_ca/10-deploy-operator.yaml
@@ -1,0 +1,12 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/e2e-leg-13/multiple_ca/15-assert.yaml
+++ b/tests/e2e-leg-13/multiple_ca/15-assert.yaml
@@ -1,0 +1,19 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert1
+  name: cert2
+  name: cert3

--- a/tests/e2e-leg-13/multiple_ca/15-create-cert.yaml
+++ b/tests/e2e-leg-13/multiple_ca/15-create-cert.yaml
@@ -1,0 +1,25 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=cert1 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=cert2 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: cd ../../.. && make create-tls-secret SECRET_NAME=cert3 SECRET_NAMESPACE=$NAMESPACE DB_USER=$VERTICA_SUPERUSER_NAME
+  - script: mkdir -p /tmp/certs
+  - script: ./scripts/extract.sh cert1
+  - script: ./scripts/extract.sh cert2
+  - script: ./scripts/extract.sh cert3
+  - script: ./scripts/combine_update.sh
+  

--- a/tests/e2e-leg-13/multiple_ca/20-verify-ca-cert.yaml
+++ b/tests/e2e-leg-13/multiple_ca/20-verify-ca-cert.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: ./scripts/verify_ca.sh
+  

--- a/tests/e2e-leg-13/multiple_ca/25-assert.yaml
+++ b/tests/e2e-leg-13/multiple_ca/25-assert.yaml
@@ -1,0 +1,27 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-multiple-ca-sc1
+status:
+  replicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-multiple-ca
+status:
+  subclusters:
+    - addedToDBCount: 3

--- a/tests/e2e-leg-13/multiple_ca/25-setup-vdb.yaml
+++ b/tests/e2e-leg-13/multiple_ca/25-setup-vdb.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build setup-vdb/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/multiple_ca/30-assert.yaml
+++ b/tests/e2e-leg-13/multiple_ca/30-assert.yaml
@@ -1,0 +1,34 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-multiple-ca-sc1
+status:
+  replicas: 3
+  readyReplicas: 3
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-multiple-ca
+status:
+  tlsConfigs:
+    - secret: cert1
+      name: httpsNMA
+    - name: clientServer    
+      secret: cert1    
+  subclusters:
+    - addedToDBCount: 3
+      upNodeCount: 3

--- a/tests/e2e-leg-13/multiple_ca/30-wait-for-createdb.yaml
+++ b/tests/e2e-leg-13/multiple_ca/30-wait-for-createdb.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-13/multiple_ca/35-verify-https-verts.yaml
+++ b/tests/e2e-leg-13/multiple_ca/35-verify-https-verts.yaml
@@ -1,0 +1,82 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: script-verify-multiple-ca
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -o errexit
+    set -o xtrace
+    set -x 
+
+    for cert in cert1 cert2 cert3 
+    do
+      # kubectl get secret $cert -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/${cert}.crt
+      # kubectl get secret $cert -o jsonpath='{.data.tls\.key}' | base64 -d > /tmp/${cert}.key
+      # kubectl get secret $ceer -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/${cert}_ca.crt
+      line=$(kubectl get pod -o wide | grep v-multiple-ca-sc1-0)
+      array=($line)
+      curl -k --cert /etc/${cert}/tls.crt --key /etc/${cert}/tls.key --cacert /etc/${cert}/ca.crt https://${array[5]}:8443/api/v1/nodes
+      res=$?
+      if [ $res -ne 0 ]
+      then 
+        exit 1
+      fi
+    done
+    exit 0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: script-verify-multiple-ca
+  labels:
+    stern: include
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: bitnami/kubectl:1.20.4
+      command: ["/bin/entrypoint.sh"]
+      volumeMounts:
+        - name: entrypoint-volume
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+        - name: cert1
+          readOnly: true
+          mountPath: "/etc/cert1"          
+        - name: cert2
+          readOnly: true
+          mountPath: "/etc/cert2"
+        - name: cert3
+          readOnly: true
+          mountPath: "/etc/cert3"                    
+  volumes:
+    - name: entrypoint-volume
+      configMap:
+        defaultMode: 0777
+        name: script-verify-multiple-ca
+    - name: cert1
+      secret:
+        secretName: cert1
+    - name: cert2
+      secret:
+        secretName: cert2
+    - name: cert3
+      secret:
+        secretName: cert3
+
+

--- a/tests/e2e-leg-13/multiple_ca/95-delete-cr.yaml
+++ b/tests/e2e-leg-13/multiple_ca/95-delete-cr.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: vertica.com/v1
+    kind: VerticaDB

--- a/tests/e2e-leg-13/multiple_ca/95-errors.yaml
+++ b/tests/e2e-leg-13/multiple_ca/95-errors.yaml
@@ -1,0 +1,30 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: verticadb-operator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: vertica
+    app.kubernetes.io/component: database
+    vertica.com/database: vertdb
+    app.kubernetes.io/instance: v-auto-cert-rotate

--- a/tests/e2e-leg-13/multiple_ca/96-cleanup-storage.yaml
+++ b/tests/e2e-leg-13/multiple_ca/96-cleanup-storage.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: bash -c "kustomize build clean-communal/overlay | kubectl -n $NAMESPACE apply -f - "

--- a/tests/e2e-leg-13/multiple_ca/96-errors.yaml
+++ b/tests/e2e-leg-13/multiple_ca/96-errors.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim

--- a/tests/e2e-leg-13/multiple_ca/99-delete-ns.yaml
+++ b/tests/e2e-leg-13/multiple_ca/99-delete-ns.yaml
@@ -1,0 +1,17 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns $NAMESPACE

--- a/tests/e2e-leg-13/multiple_ca/scripts/combine_update.sh
+++ b/tests/e2e-leg-13/multiple_ca/scripts/combine_update.sh
@@ -1,0 +1,4 @@
+cat /tmp/certs/cert1_ca.crt /tmp/certs/cert2_ca.crt /tmp/certs/cert3_ca.crt > /tmp/certs/combined_raw
+base64 -i /tmp/certs/combined_raw > /tmp/certs/combined_base64
+tr -d "\n" < /tmp/certs/combined_base64 > /tmp/certs/combined_singleline
+kubectl patch secret cert1 -n $NAMESPACE --type='json'  -p="[{\"op\" : \"replace\" ,\"path\" : \"/data/ca.crt\", \"value\": \"$(cat /tmp/certs/combined_singleline)\"}]"

--- a/tests/e2e-leg-13/multiple_ca/scripts/extract.sh
+++ b/tests/e2e-leg-13/multiple_ca/scripts/extract.sh
@@ -1,0 +1,3 @@
+kubectl get secret $1 -n $NAMESPACE -o jsonpath='{.data.ca\.crt}' | base64 --decode  > /tmp/certs/$1_ca.crt
+kubectl get secret $1 -n $NAMESPACE -o jsonpath='{.data.tls\.crt}' | base64 --decode > /tmp/certs/$1.crt
+kubectl get secret $1 -n $NAMESPACE -o jsonpath='{.data.tls\.key}' | base64 --decode > /tmp/certs/$1.key

--- a/tests/e2e-leg-13/multiple_ca/scripts/verify_ca.sh
+++ b/tests/e2e-leg-13/multiple_ca/scripts/verify_ca.sh
@@ -1,0 +1,7 @@
+COUNT=$(kubectl get secret cert1 -n $NAMESPACE -o jsonpath='{.data.ca\.crt}' | base64 --decode | grep -c "BEGIN CERTIFICATE")
+if [ $COUNT -eq 3 ]
+then 
+    exit 0
+else 
+    exit 1
+fi

--- a/tests/e2e-leg-13/multiple_ca/setup-vdb/base/kustomization.yaml
+++ b/tests/e2e-leg-13/multiple_ca/setup-vdb/base/kustomization.yaml
@@ -1,0 +1,15 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - setup-vdb.yaml

--- a/tests/e2e-leg-13/multiple_ca/setup-vdb/base/setup-vdb.yaml
+++ b/tests/e2e-leg-13/multiple_ca/setup-vdb/base/setup-vdb.yaml
@@ -1,0 +1,46 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-multiple-ca
+  annotations:
+    vertica.com/k-safety: "1"
+    vertica.com/include-uid-in-path: "true"
+    vertica.com/remove-tls-secret-on-vdb-delete: "true"
+spec:
+  initPolicy: CreateSkipPackageInstall
+  image: kustomize-vertica-image
+  communal: {}
+  local:
+    requestSize: 100Mi
+    catalogPath: /catalog
+  dbName: vertdb
+  encryptSpreadComm: vertica
+  httpsNMATLS:
+    mode: VERIFY_CA
+    secret: cert1
+  clientServerTLS:
+    mode: VERIFY_CA
+    secret: cert1
+  subclusters:
+    - name: sc1
+      size: 3
+  securityContext:
+    capabilities:
+      add: ["SYS_PTRACE"]
+  certSecrets: []
+  imagePullSecrets: []
+  volumes: []
+  volumeMounts: []


### PR DESCRIPTION
Fen has added the support for using multiple ca certificates. 
No work needs to be done in Kubernetes code base.
To use multiple ca certificates, we simply concatenate those
ca certificates and put them in the certificate secret.
This new test case will verify that case.