### PR TITLE
Fixed sandbox restart issue

### DIFF
--- a/local-libs/vcluster/vclusterops/sandbox.go
+++ b/local-libs/vcluster/vclusterops/sandbox.go
@@ -146,9 +146,9 @@ func (vcc *VClusterCommands) produceSandboxSubclusterInstructions(options *VSand
 
 	username := options.UserName
 
-	// When the caller like K8s operator frequently re-ips the pods before sandboxing,
-	// we need to sync the latest config files from Sandbox initiator to the new nodes
-	// that are about to join the sandbox.
+	// In environments like Kubernetes, if sandbox nodes are re-IPed before sandboxing a new subcluster,
+	// the new subcluster might not have the latest config files. We need to ensure it retrieves them
+	// from the sandbox primary nodes.
 	if options.SandboxPrimaryUpHost != "" && len(options.NodeNameAddressMap) > 0 {
 		scHosts := []string{}
 		for _, ip := range options.NodeNameAddressMap {

--- a/local-libs/vcluster/vclusterops/sandbox.go
+++ b/local-libs/vcluster/vclusterops/sandbox.go
@@ -146,6 +146,27 @@ func (vcc *VClusterCommands) produceSandboxSubclusterInstructions(options *VSand
 
 	username := options.UserName
 
+	// When the caller like K8s operator frequently re-ips the pods before sandboxing,
+	// we need to sync the latest config files from Sandbox initiator to the new nodes
+	// that are about to join the sandbox.
+	if options.SandboxPrimaryUpHost != "" && len(options.NodeNameAddressMap) > 0 {
+		scHosts := []string{}
+		for _, ip := range options.NodeNameAddressMap {
+			scHosts = append(scHosts, ip)
+		}
+
+		vdb := makeVCoordinationDatabase()
+		// Override Hosts to only include the primary up host in the sandbox.
+		// This reduces the number of HTTPS calls by targeting a single, known-available node.
+		dbOptions := options.DatabaseOptions
+		dbOptions.Hosts = []string{options.SandboxPrimaryUpHost}
+		err := vcc.getVDBFromRunningDBIncludeSandbox(&vdb, &dbOptions, options.SandboxName)
+		if err != nil {
+			return instructions, err
+		}
+		produceTransferConfigOps(&instructions, dbOptions.Hosts, scHosts, &vdb, &options.SandboxName)
+	}
+
 	// Get all up nodes
 	httpsGetUpNodesOp, err := makeHTTPSGetUpScNodesOp(options.DBName, options.Hosts,
 		usePassword, username, options.Password, SandboxSCCmd, options.SCName)

--- a/pkg/controllers/vdb/dbtlsconfig_reconciler.go
+++ b/pkg/controllers/vdb/dbtlsconfig_reconciler.go
@@ -159,6 +159,9 @@ func (t *DBTLSConfigReconciler) updateTLSVersionAndReadCipherSuites(ctx context.
 		return err
 	}
 	hosts, mainClusterHosts := t.Pfacts.GetHostGroups()
+	if len(hosts) == 0 || mainClusterHosts == "" {
+		return fmt.Errorf("failed to find up host in the cluster")
+	}
 	err = t.pollHTTPS(ctx, hosts, mainClusterHosts)
 	if err != nil {
 		t.VRec.Eventf(t.Vdb, corev1.EventTypeWarning, events.DBTLSUpdateFailed,
@@ -195,6 +198,9 @@ func (t *DBTLSConfigReconciler) updateCipherSuites(ctx context.Context, initiato
 		return err
 	}
 	hosts, mainClusterHost := t.Pfacts.GetHostGroups()
+	if mainClusterHost == "" {
+		return fmt.Errorf("failed to find up host in main cluster")
+	}
 	err = t.pollHTTPS(ctx, hosts, mainClusterHost)
 	if err != nil {
 		t.VRec.Eventf(t.Vdb, corev1.EventTypeWarning, events.DBTLSUpdateFailed,

--- a/pkg/controllers/vdb/dbtlsconfig_reconciler.go
+++ b/pkg/controllers/vdb/dbtlsconfig_reconciler.go
@@ -158,11 +158,11 @@ func (t *DBTLSConfigReconciler) updateTLSVersionAndReadCipherSuites(ctx context.
 			"Failed to update tls version to %d", newTLSVersion)
 		return err
 	}
-	hosts, mainClusterHosts := t.Pfacts.GetHostGroups()
-	if len(hosts) == 0 || mainClusterHosts == "" {
+	hosts, mainClusterHost := t.Pfacts.GetHostGroups()
+	if len(hosts) == 0 || mainClusterHost == "" {
 		return fmt.Errorf("failed to find up host in the cluster")
 	}
-	err = t.pollHTTPS(ctx, hosts, mainClusterHosts)
+	err = t.pollHTTPS(ctx, hosts, mainClusterHost)
 	if err != nil {
 		t.VRec.Eventf(t.Vdb, corev1.EventTypeWarning, events.DBTLSUpdateFailed,
 			"Failed to update tls version to %d", newTLSVersion)
@@ -198,7 +198,7 @@ func (t *DBTLSConfigReconciler) updateCipherSuites(ctx context.Context, initiato
 		return err
 	}
 	hosts, mainClusterHost := t.Pfacts.GetHostGroups()
-	if mainClusterHost == "" {
+	if len(hosts) == 0 || mainClusterHost == "" {
 		return fmt.Errorf("failed to find up host in main cluster")
 	}
 	err = t.pollHTTPS(ctx, hosts, mainClusterHost)

--- a/pkg/controllers/vdb/deploymentmethod_reconciler.go
+++ b/pkg/controllers/vdb/deploymentmethod_reconciler.go
@@ -96,6 +96,11 @@ func (d *DeploymentMethodReconciler) reconcileHTTPSTLS(ctx context.Context) (ctr
 		if verrors.IsReconcileAborted(res, err) {
 			return res, err
 		}
+		// after restart, we need to recollect pfacts
+		err = d.PFacts.Collect(ctx, d.Vdb)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	return d.Manager.enableHTTPSTLSIfNeeded(ctx, d.PFacts, pf)

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/56-assert.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/56-assert.yaml
@@ -1,0 +1,67 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: SandboxSubclusterSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-subcluster-shutdown
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-subcluster-shutdown
+spec:
+  subclusters:
+  - name: pri1
+    type: primary
+  - name: pri2
+    type: primary
+  - name: sec1
+    type: secondary
+  - name: sec2
+    type: secondary
+  - name: sec3
+    type: secondary  
+status:
+  sandboxes:
+    - name: sandbox1
+      subclusters:
+        - sec1
+        - sec3
+        - sec2
+  subclusters:
+    - addedToDBCount: 4
+      upNodeCount: 4
+      name: pri1
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: pri2
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: sec1
+      type: sandboxprimary
+    - addedToDBCount: 1
+      upNodeCount: 1
+      name: sec2
+      type: sandboxsecondary
+    - addedToDBCount: 1
+      upNodeCount: 1
+      name: sec3
+      type: sandboxsecondary

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/56-sandbox-sec2.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/56-sandbox-sec2.yaml
@@ -1,0 +1,26 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-subcluster-shutdown
+spec:
+  sandboxes:
+  - name: sandbox1
+    subclusters:
+      - name: sec1
+      - name: sec2
+        type: secondary
+      - name: sec3
+        type: secondary

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/57-assert.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/57-assert.yaml
@@ -1,0 +1,47 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-subcluster-shutdown-sec2
+status:
+  availableReplicas: 0
+  replicas: 1
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-subcluster-shutdown
+status:
+  subclusters:
+    - addedToDBCount: 4
+      upNodeCount: 4
+      name: pri1
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: pri2
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: sec1
+      type: sandboxprimary
+    - addedToDBCount: 1
+      upNodeCount: 0
+      name: sec2
+      type: sandboxsecondary
+    - addedToDBCount: 1
+      upNodeCount: 1
+      name: sec3
+      type: sandboxsecondary

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/57-kill-sec2.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/57-kill-sec2.yaml
@@ -1,0 +1,18 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete pod v-subcluster-shutdown-sec2-0
+    namespaced: true

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/58-assert.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/58-assert.yaml
@@ -1,0 +1,47 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: v-subcluster-shutdown-sec2
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-subcluster-shutdown
+status:
+  subclusters:
+    - addedToDBCount: 4
+      upNodeCount: 4
+      name: pri1
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: pri2
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: sec1
+      type: sandboxprimary
+    - addedToDBCount: 1
+      upNodeCount: 1
+      name: sec2
+      type: sandboxsecondary
+    - addedToDBCount: 1
+      upNodeCount: 1
+      name: sec3
+      type: sandboxsecondary

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/58-wait-for-sec2-up.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/58-wait-for-sec2-up.yaml
@@ -1,0 +1,1 @@
+# Intentionally empty to give this step a name in kuttl

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/59-assert.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/59-assert.yaml
@@ -1,0 +1,66 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Event
+reason: UnsandboxSubclusterSucceeded
+source:
+  component: verticadb-operator
+involvedObject:
+  apiVersion: vertica.com/v1
+  kind: VerticaDB
+  name: v-subcluster-shutdown
+---
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-subcluster-shutdown
+spec:
+  subclusters:
+  - name: pri1
+    type: primary
+  - name: pri2
+    type: primary
+  - name: sec1
+    type: secondary
+  - name: sec2
+    type: secondary
+  - name: sec3
+    type: secondary  
+status:
+  sandboxes:
+    - name: sandbox1
+      subclusters:
+        - sec1
+        - sec3
+  subclusters:
+    - addedToDBCount: 4
+      upNodeCount: 4
+      name: pri1
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: pri2
+      type: primary
+    - addedToDBCount: 3
+      upNodeCount: 3
+      name: sec1
+      type: sandboxprimary
+    - addedToDBCount: 1
+      upNodeCount: 1
+      name: sec2
+      type: secondary
+    - addedToDBCount: 1
+      upNodeCount: 1
+      name: sec3
+      type: sandboxsecondary

--- a/tests/e2e-leg-10-shutdown/shutdown-subcluster/59-unsandbox-sec2.yaml
+++ b/tests/e2e-leg-10-shutdown/shutdown-subcluster/59-unsandbox-sec2.yaml
@@ -1,0 +1,24 @@
+# (c) Copyright [2021-2024] Open Text.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: vertica.com/v1
+kind: VerticaDB
+metadata:
+  name: v-subcluster-shutdown
+spec:
+  sandboxes:
+  - name: sandbox1
+    subclusters:
+      - name: sec1
+      - name: sec3
+        type: secondary


### PR DESCRIPTION
This PR addresses the following issue:  
Before sandboxing a subcluster, if the existing sandbox nodes restart with new IPs, the subcluster fails after sandboxing. This is a vcluster bug, so the fix is applied in vclusterOps. 

The solution ensures that config files are synchronized from the sandbox primary nodes to the new subcluster, allowing node restarts to succeed.  