### PR TITLE
Override prometheus name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -751,7 +751,7 @@ port-forward-prometheus:  ## Expose the prometheus endpoint so that you can conn
 
 .PHONY: port-forward-prometheus-server
 port-forward-prometheus-server:  ## Expose the prometheus endpoint so that you can connect to it through http://localhost:9090
-	kubectl port-forward -n $(NAMESPACE) svc/$(HELM_RELEASE_NAME)-prometheus-server-prometheus 9090
+	kubectl port-forward -n $(NAMESPACE) svc/verticadb-operator-prom-prometheus 9090
 
 .PHONY: port-forward-grafana
 port-forward-grafana:  ## Expose the grafana endpoint so that you can connect to it through http://localhost:3000

--- a/helm-charts/verticadb-operator/values.yaml
+++ b/helm-charts/verticadb-operator/values.yaml
@@ -330,11 +330,11 @@ grafana:
       datasources:
         - name: Prometheus
           type: prometheus
-          url: http://{{ .Release.Name }}-prometheus-server-prometheus.{{ .Release.Namespace }}.svc.cluster.local:9090
+          url: http://verticadb-operator-prom-prometheus.{{ .Release.Namespace }}.svc.cluster.local:9090
           access: proxy
           isDefault: true
           jsonData:
-            tlsSkipVerify: true 
+            tlsSkipVerify: true
         - name: Loki
           type: loki
           url: http://{{ .Release.Name }}-loki-gateway.{{ .Release.Namespace }}.svc.cluster.local:80
@@ -384,6 +384,10 @@ prometheusServer:
         enabled: false
 
   nameOverride: prometheus-server
+
+  # Override the full name of the Prometheus server deployment.
+  # This allow you to  control the name of the service created for Prometheus.
+  fullnameOverride: verticadb-operator-prom
   
   # Prometheus Operator - keep minimal
   prometheusOperator:

--- a/tests/e2e-leg-14-namespace/prometheus-namespace-scope/25-verify-prometheus-metrics.yaml
+++ b/tests/e2e-leg-14-namespace/prometheus-namespace-scope/25-verify-prometheus-metrics.yaml
@@ -25,7 +25,7 @@ data:
     START_TIME=$(date +%Y-%m-%d) 
     END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
     NAMESPACE=$(kubectl get pod v-with-prom-namespace-pri1-0 -o=jsonpath='{.metadata.namespace}')
-    CMD="kubectl exec v-with-prom-namespace-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://vdb-op-prometheus-server-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    CMD="kubectl exec v-with-prom-namespace-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://verticadb-operator-prom-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
     RESULT=$(eval $CMD)
     METRICS=$(echo $RESULT | jq -r '.data.result') 
     

--- a/tests/e2e-leg-14-namespace/prometheus-namespace-scope/40-verify-prometheus-metrics.yaml
+++ b/tests/e2e-leg-14-namespace/prometheus-namespace-scope/40-verify-prometheus-metrics.yaml
@@ -25,7 +25,7 @@ data:
     START_TIME=$(date +%Y-%m-%d) 
     END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
     NAMESPACE=$(kubectl get pod v-with-prom-namespace-pri1-0 -o=jsonpath='{.metadata.namespace}')
-    CMD="kubectl exec v-with-prom-namespace-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://vdb-op-prometheus-server-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    CMD="kubectl exec v-with-prom-namespace-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://verticadb-operator-prom-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
     RESULT=$(eval $CMD)
     METRICS=$(echo $RESULT | jq -r '.data.result') 
     

--- a/tests/e2e-leg-14-tls/prometheus-with-tls/25-verify-prometheus-metrics.yaml
+++ b/tests/e2e-leg-14-tls/prometheus-with-tls/25-verify-prometheus-metrics.yaml
@@ -29,7 +29,7 @@ data:
     # Setup start and end time for query, e.g: 2024-09-14
     START_TIME=$(date +%Y-%m-%d) 
     END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
-    CMD="curl -g --cert /tmp/tls.crt --key /tmp/tls.key https://vdb-op-prometheus-server-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    CMD="curl -g --cert /tmp/tls.crt --key /tmp/tls.key https://verticadb-operator-prom-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
     RESULT=$(eval $CMD)
     METRICS=$(echo $RESULT) 
     
@@ -41,7 +41,7 @@ data:
       exit 1
     fi
 
-    CMD="curl -g --cert /tmp/tls.crt --key /tmp/tls.key --cacert /tmp/ca.crt https://vdb-op-prometheus-server-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    CMD="curl -g --cert /tmp/tls.crt --key /tmp/tls.key --cacert /tmp/ca.crt https://verticadb-operator-prom-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
     echo $?
     RESULT=$(eval $CMD)
     METRICS=$(echo $RESULT | jq -r '.data.result')

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/25-verify-prometheus-metrics.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/25-verify-prometheus-metrics.yaml
@@ -25,7 +25,7 @@ data:
     START_TIME=$(date +%Y-%m-%d) 
     END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
     NAMESPACE=$(kubectl get pod v-with-prom-pri1-0 -o=jsonpath='{.metadata.namespace}')
-    CMD="kubectl exec v-with-prom-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://vdb-op-prometheus-server-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    CMD="kubectl exec v-with-prom-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://verticadb-operator-prom-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
     RESULT=$(eval $CMD)
     METRICS=$(echo $RESULT | jq -r '.data.result') 
     

--- a/tests/e2e-leg-14/deploy-with-grafana-prometheus/40-verify-prometheus-metrics.yaml
+++ b/tests/e2e-leg-14/deploy-with-grafana-prometheus/40-verify-prometheus-metrics.yaml
@@ -25,7 +25,7 @@ data:
     START_TIME=$(date +%Y-%m-%d) 
     END_TIME=$(date +%Y-%m-%d --date "$curr +1 day")
     NAMESPACE=$(kubectl get pod v-with-prom-pri1-0 -o=jsonpath='{.metadata.namespace}')
-    CMD="kubectl exec v-with-prom-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://vdb-op-prometheus-server-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
+    CMD="kubectl exec v-with-prom-pri1-0 -it -c server -n $NAMESPACE -- curl -g http://verticadb-operator-prom-prometheus.verticadb-operator.svc.cluster.local:9090/api/v1/query?query=vertica_build_info&start=${START_TIME}&end=${END_TIME}"
     RESULT=$(eval $CMD)
     METRICS=$(echo $RESULT | jq -r '.data.result') 
     


### PR DESCRIPTION
This sets a static name as a prefix for prometheus resources. It will make it easy for grafana to connect to prometheus.