### PR TITLE
Fix issues related cert gen rollback

### DIFF
--- a/pkg/controllers/vdb/rollbackaftercertrotation_reconciler.go
+++ b/pkg/controllers/vdb/rollbackaftercertrotation_reconciler.go
@@ -157,7 +157,9 @@ func (r *RollbackAfterCertRotationReconciler) updateTLSConfigInVdb(ctx context.C
 			return err
 		}
 		mode := ""
+		tlsConfigName := ""
 		if r.Vdb.GetTLSCertRollbackReason() == vapi.RollbackAfterServerCertRotationReason {
+			tlsConfigName = vapi.ClientServerTLSConfigName
 			mode = r.Vdb.GetClientServerTLSModeInUse()
 			if strings.EqualFold(r.Vdb.GetClientServerTLSMode(), mode) {
 				mode = r.Vdb.GetSpecClientServerTLSMode()
@@ -171,6 +173,7 @@ func (r *RollbackAfterCertRotationReconciler) updateTLSConfigInVdb(ctx context.C
 			spec.Mode = mode
 			r.Vdb.Spec.ClientServerTLS = spec
 		} else {
+			tlsConfigName = vapi.HTTPSNMATLSConfigName
 			mode = r.Vdb.GetHTTPSTLSModeInUse()
 			if strings.EqualFold(r.Vdb.GetHTTPSNMATLSMode(), mode) {
 				mode = r.Vdb.GetSpecHTTPSNMATLSMode()
@@ -184,6 +187,8 @@ func (r *RollbackAfterCertRotationReconciler) updateTLSConfigInVdb(ctx context.C
 			spec.Mode = mode
 			r.Vdb.Spec.HTTPSNMATLS = spec
 		}
+		r.Log.Info("Updating VDB spec during rollback", "tlsConfigName", tlsConfigName, "secret",
+			r.Vdb.GetTLSConfigSpecByName(tlsConfigName).Secret)
 		return r.VRec.Client.Update(ctx, r.Vdb)
 	})
 }

--- a/pkg/controllers/vdb/tlsservercertgen_reconciler.go
+++ b/pkg/controllers/vdb/tlsservercertgen_reconciler.go
@@ -361,7 +361,11 @@ func (h *TLSServerCertGenReconciler) InvalidCertRollback(ctx context.Context, me
 
 	// Run rollback now; otherwise, we will run all subsequent reconcilers with invalid cert.
 	// Podfacts and dispatcher can be nil, since they are only required when re-running cert rotation
+	h.Log.Info("Running rollback due to invalid cert", "tlsConfigName", tlsConfigName, "secretName",
+		h.Vdb.GetTLSConfigSpecByName(tlsConfigName).Secret)
 	rollbackRecon := MakeRollbackAfterCertRotationReconciler(h.VRec, h.Log, h.Vdb, nil, nil)
 	_, err := rollbackRecon.Reconcile(ctx, nil)
+	h.Log.Info("Finished running rollback", "tlsConfigName", tlsConfigName, "secretName",
+		h.Vdb.GetTLSConfigSpecByName(tlsConfigName).Secret)
 	return err
 }


### PR DESCRIPTION
Fix issues related to tlsservercertgen_reconciler:

1. In one case, we generated a new secret. We then ran validation on this secret. The validation failed, with the error "secret not found". It is not clear if the secret was not actually generated or the validation failed incorrectly. This resulted in... 
2. When validation failed for a new secret, we triggered rollback. This should not happen, since there is no good secret to rollback to.
3. In another case, DB was updated from a valid secret to an invalid one. This correctly triggered rollback. However, when we reached the tls update reconciler (eg clientservertlsreconciler), it still saw the invalid secret in the spec. This resulted in a failed rotate to the invalid secret.

PROGRESS:
- For 2, I add a check in cert validate rollback code. If secret is not set in both spec and status, exit rollback and return original error
- For 3, I have not been able to reproduce it. But I have added some logging. If it happens again in Github, we should have additional information about where the failure could be.
- Still trying to reproduce 1