### PR TITLE
Always cache last license validation time

### DIFF
--- a/pkg/cache/vdb_cache.go
+++ b/pkg/cache/vdb_cache.go
@@ -206,7 +206,7 @@ func makeVdbCache(namespace string, ttl int, fetcher *cloud.SecretFetcher, enabl
 	singleContext.enabled = enabled
 	singleContext.certCache = NewItemCache[map[string][]byte](time.Duration(ttl)*time.Second, enabled)
 	singleContext.passwordCache = NewItemCache[string](time.Duration(ttl)*time.Second, enabled)
-	singleContext.timestampCache = NewItemCache[metav1.Time](time.Duration(24*365)*time.Hour, enabled)
+	singleContext.timestampCache = NewItemCache[metav1.Time](time.Duration(24*365)*time.Hour, true /* always cached*/)
 	return singleContext
 }
 

--- a/pkg/controllers/vdb/licensevalidation_reconciler.go
+++ b/pkg/controllers/vdb/licensevalidation_reconciler.go
@@ -77,6 +77,7 @@ func (r *LicenseValidationReconciler) Reconcile(ctx context.Context, _ *ctrl.Req
 	}
 	// do validation for new license secret
 	if r.licenseValidationRequired() {
+		r.log.Info("Validating license", "secret name", r.vdb.Spec.LicenseSecret)
 		res, err := r.validateLicenses(ctx)
 		return res, err
 	}
@@ -86,17 +87,17 @@ func (r *LicenseValidationReconciler) Reconcile(ctx context.Context, _ *ctrl.Req
 	if !r.shouldDoDailyValidation(lastSuccessfulValidation) {
 		return ctrl.Result{}, nil
 	}
-	r.log.Info("Validate licenses at " + time.Now().String() + ", validated last time at " + lastSuccessfulValidation.String())
+	r.log.Info("Validating licenses", "last validation time", lastSuccessfulValidation.String(), "current time", time.Now().String())
 	return r.validateLicenses(ctx)
 }
 
-// shouldSkipLicenseValidattion() will return true when license validation should be skipped.
+// shouldSkipLicenseValidation() will return true when license validation should be skipped.
 func (r *LicenseValidationReconciler) shouldSkipLicenseValidation() bool {
 	return !r.vdb.UseVClusterOpsDeployment() || meta.GetAllowCELicense(r.vdb.Annotations) ||
 		r.vdb.IsStatusConditionTrue(vapi.UpgradeInProgress)
 }
 
-// licenseValidattionRequired() will return true when license validation is required.
+// licenseValidationRequired() will return true when license validation is required.
 func (r *LicenseValidationReconciler) licenseValidationRequired() bool {
 	// If no previous status, validation required
 	if r.vdb.Status.LicenseStatus == nil {

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -290,6 +290,25 @@ func BuildSuperuserPasswordSecret(vdb *vapi.VerticaDB, name, password string) *c
 	return secret
 }
 
+func CreateLicenseSecret(ctx context.Context, vdb *vapi.VerticaDB, c client.Client, name string, licenses []string) {
+	secret := BuildLicenseSecret(vdb, name, licenses)
+	Expect(c.Create(ctx, secret)).Should(Succeed())
+}
+
+func BuildLicenseSecret(vdb *vapi.VerticaDB, name string, licenses []string) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: vdb.Namespace,
+		},
+		Data: make(map[string][]byte, len(licenses)),
+	}
+	for i, l := range licenses {
+		secret.Data[fmt.Sprintf("license%d.dat", i)] = []byte(l)
+	}
+	return secret
+}
+
 func DeleteSecret(ctx context.Context, c client.Client, name string) {
 	nm := vapi.MakeVDBName() // The secret is expected to be created in the same namespace as the test standard vdb
 	secret := &corev1.Secret{}

--- a/pkg/vadmin/check_license_vc.go
+++ b/pkg/vadmin/check_license_vc.go
@@ -52,7 +52,7 @@ func (v *VClusterOps) genCheckLicenseOptions(s *checklicense.Parms,
 	certs *tls.HTTPSCerts) *vops.VCheckLicenseOptions {
 	opts := vops.VCheckLicenseOptionsFactory()
 
-	opts.Hosts = append(opts.Hosts, s.InitiatorIPs...)
+	opts.RawHosts = append(opts.RawHosts, s.InitiatorIPs...)
 	opts.DBName = v.VDB.Spec.DBName
 
 	opts.IsEon = v.VDB.IsEON()

--- a/pkg/vadmin/suite_test.go
+++ b/pkg/vadmin/suite_test.go
@@ -375,10 +375,6 @@ func (m *MockVClusterOps) VPollSubclusterState(_ *vops.VPollSubclusterStateOptio
 	return nil
 }
 
-func (m *MockVClusterOps) VCheckLicense(_ *vops.VCheckLicenseOptions) error {
-	return nil
-}
-
 // mockVClusterOpsDispatcher will create an vcluster-ops dispatcher for test
 // purposes. This uses a standard function to setup the API.
 func mockVClusterOpsDispatcher() *VClusterOps {


### PR DESCRIPTION
This always cache the last validation check time, so we do not have to validate the license for each reconciliation loop.